### PR TITLE
README Update IAM Credentials link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -539,7 +539,7 @@ option.
    $ sam validate
    <path-to-file>/template.yml is a valid SAM Template
 
-Note: The validate command requires AWS credentials to be configured. See IAMCreds_.
+Note: The validate command requires AWS credentials to be configured. See `IAM Credentials <#iam-credentials>`__.
 
 Package and Deploy to Lambda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The `IAMCreds_` link was dead. Fixes #466.

Issue #466

*Description of changes:*

The `IAMCreds_` link on `Note: The validate command requires AWS credentials to be configured. See IAMCreds_.` in the README is a dead link.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
