### PR TITLE
feat(event-invocation-type): Add support for Event invocation type 

### DIFF
--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -95,7 +95,7 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
 
     def test_invoke_with_invocation_type_not_RequestResponse(self):
         expected_error_message = "An error occurred (NotImplemented) when calling the Invoke operation: " \
-                                 "invocation-type: DryRun is not supported. RequestResponse is only supported."
+                                 "invocation-type: DryRun is not supported. Supported types: Event, RequestResponse."
 
         with self.assertRaises(ClientError) as error:
             self.lambda_client.invoke(FunctionName="EchoEventFunction", InvocationType="DryRun")


### PR DESCRIPTION

*Issue #, if available:*
This is mentioned in several different issues:
#510
#207 
#12 

*Description of changes:*
This adds support for the event invocation type. #508 made it possible to call local lambda using AWS CLI, but only for `RequestResponse` invocation type. This adds on to the local lambda invocation functionality by allowing `Event` invocation type.

This allows multiple lambda functions to call other lambda functions without having to wait for them to return (i.e. `RequestResponse` invocation type).

*Usage*
Run local lambda service:

```
samdev local start-lambda --debug
```

You'll see that local lambda service is at 127.0.0.1:3001:
```
2018-11-05 15:48:24 Starting the Local Lambda Service. You can now invoke your Lambda 
Functions defined in your template through the endpoint.
2018-11-05 15:48:24 Localhost server is starting up. Multi-threading = True
 * Tip: There are .env files present. Do "pip install python-dotenv" to use them.
2018-11-05 15:48:24  * Running on http://127.0.0.1:3001/ (Press CTRL+C to quit)
```

Test invocation using CLI:
```
aws --endpoint-url http://127.0.0.1:3001 lambda invoke --function-name 'MyFunctionName' --payload '{}' --invocation-type Event function_output.txt
```

This can also be done within a lambda function. Note that the endpoint referenced cannot be 127.0.0.1 since the function code will be running within a container. Docker for Mac has a special hostname for the underlying host machine named `host.docker.internal`. Additional documentation for that can be found [here](https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host):

```
// since this is running in a container, must reference the host machine
// on Mac this is host.docker.internal.
// https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
var ep = new aws.Endpoint('http://host.docker.internal:3001');

// configure lambda to use local endpoint
var lambda = new aws.Lambda({endpoint: ep});

// invoke using Event InvocationType
lambda.invoke({
	FunctionName: 'MyFunctionName',
	InvocationType: 'Event'
}, (err,data) => {
	if (err) {
		console.log('Error: ', err);
		console.log(err);
	}

	console.log('Function Result: ', JSON.stringify(data));		
	
	callback(null, {statusCode: 200, body: 'Done.'});
})
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
