### PR TITLE
[WIP] sam local support for InlineCode key

### DIFF
--- a/designs/sam_local_inlinecode.rst
+++ b/designs/sam_local_inlinecode.rst
@@ -1,0 +1,82 @@
+.. contents:: **Table of Contents**
+   :depth: 2
+   :local:
+
+
+
+``InlineCode`` debug
+=====================
+This is the design for a feature to provide local testing capabilities to functions defined via **InlineCode** key schema.
+
+What is the problem?
+--------------------
+When new functions are started an absolute path of the folder/file containing AWS Lambda code package need to be passed
+to docker deamon in order to bind-mount the path inside the container running the AWs Lambda runtime.
+
+As of today you can only test locally your AWS Lambda Functions if defined via ``CodeUri`` key and not ``InlineCode``.
+From now on we will use ``InlineCode`` to refer to both ``Serverless::Funnction`` and ``Lambda::Function`` inline code implementation (Where ``Code`` is used as the property).
+
+What will be changed?
+---------------------
+In this proposal, we will change the code in a way that, if the tested AWS Lambda function is codified with
+``InlineCode`` key, we will create a temporary local file based on the ``InlineCode`` value, passing the temp
+file to bind-mount inside the container and make it possible to locally test ``InlineCode`` authored Functions.
+
+Success criteria for the change
+-------------------------------
+#. Support all programming languages supported by ``InlineCode``
+
+#. Local testing should just work for Functions authored with ``InlineCode``
+
+Out-of-Scope
+------------
+
+#. Anything not specifically related to ``InlineCode`` and sam local commands
+#. Provide support for Functions authored with ``InlineCode`` and leveraging ``!Sub`` pseudo function; in this case the local testing will fail
+#. Provide explicit support for ``build`` action; that means you cannot build with sam when an ``InlineCode`` function is present in the template
+
+User Experience Walkthrough
+---------------------------
+
+
+Implementation
+==============
+
+Design
+------
+*Explain how this feature will be implemented. Highlight the components of your implementation, relationships*
+*between components, constraints, etc.*
+
+Design should be pretty simple. Write a tempfile in ``./.aws-sam/build/<logical_id>`` and passing it to the Docker daemon as a bind-mount.
+File is handled inside a context-manager and cleaned out after invocation.
+
+
+Security
+--------
+
+*Tip: How does this change impact security? Answer the following questions to help answer this question better:*
+
+**What new dependencies (libraries/cli) does this change require?**
+None: InlineCode is handled transparently; no additional libraries are required beside python standard libraries
+
+**Are you reading/writing to a temporary folder? If so, what is this used for and when do you clean up?**
+Yes, I'm writing the ``InlineCode`` function string to a temporary file (inside the SAM project folder)
+If cleanup need to be performed, a context manager solution should be adopted
+
+Documentation Changes
+---------------------
+TBD
+
+Open Issues
+-----------
+
+Task Breakdown
+--------------
+- [x] Send a Pull Request with this design document
+- [ ] Build the required functions
+- [ ] Hook functions in actual code
+- [ ] Unit tests
+- [ ] Functional Tests
+- [ ] Integration tests
+- [ ] Run all tests also on Windows
+- [ ] Update documentation (if required)

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -86,7 +86,8 @@ class LocalLambdaRunner(object):
         config = self._get_invoke_config(function)
 
         # Invoke the function
-        self.local_runtime.invoke(config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr)
+        with function.codeuri:
+            self.local_runtime.invoke(config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr)
 
     def is_debugging(self):
         """

--- a/samcli/commands/local/lib/sam_function_code_provider.py
+++ b/samcli/commands/local/lib/sam_function_code_provider.py
@@ -1,0 +1,176 @@
+"""
+Class that provides codeuri from a given Function definition
+"""
+
+import logging
+import os
+import six
+
+LOG = logging.getLogger(__name__)
+
+
+class SamFunctionCodeProvider(object):
+    """
+    Lambda Function Code provider
+
+        Parameters
+        ----------
+        function_name str
+            FunctionId
+        resource_properties dict
+            Function dictionary
+        function_type str
+            Either Serverless::Function or Lambda::Function
+    """
+
+    _SERVERLESS_FUNCTION = "AWS::Serverless::Function"
+    _LAMBDA_FUNCTION = "AWS::Lambda::Function"
+    _DEFAULT_CODEURI = "."
+
+    def __init__(self, function_name, resource_properties, function_type):
+        """ Store Function info
+        This Class is a Provider for the codeuri property hold the path to an existing file/folder
+        or a pointer to a folder used to store InlineCode/ZipFile string property (Inline Lambdas)
+        It also provide a context manager function to dump the code inside a cache path and remove it
+        after invocation
+        """
+        self.function_name = function_name
+        self.handler = resource_properties.get('Handler')
+        self.runtime = resource_properties.get('Runtime')
+        self.index = self._setup_postfix(self.runtime)
+
+        self.inlinecode = self._extract_inline_code(resource_properties, function_type)
+        if self.inlinecode:
+            self.codeuri = './.aws-sam/inline/{}/'.format(function_name)
+        else:
+            self.codeuri = self._extract_code_uri(function_name, resource_properties, function_type)
+
+    def __enter__(self):
+        """ Dump Inline Code, if present for this Code Provider """
+        if self.inlinecode:
+            self._dump_code(self.inlinecode, self.codeuri, self.index)
+        return self
+
+    def __exit__(self, *exc):
+        """ CleanUp Resources created when using Inline code """
+        if self.inlinecode:
+            self._cleanup(self.codeuri, self.index)
+
+    def __repr__(self):
+        return repr(self.codeuri)
+
+    def __fspath__(self):
+        return self.codeuri
+
+    @staticmethod
+    def _setup_postfix(runtime):
+        index = 'index'
+        if runtime and runtime.startswith('python'):
+            return index + '.py'
+        return index
+
+    @staticmethod
+    def _extract_inline_code(resource_properties, function_type):
+        """ Parse InlineCode from and return the content or None """
+        code = None
+        if function_type == SamFunctionCodeProvider._SERVERLESS_FUNCTION:
+            code = resource_properties.get('InlineCode')
+        elif function_type == SamFunctionCodeProvider._LAMBDA_FUNCTION:
+            code = resource_properties.get('Code')
+            if isinstance(code, dict):
+                code = code.get('ZipFile')
+        if code:
+            return SamFunctionCodeProvider._sanitize_inlinecode(code)
+        return code
+
+    @staticmethod
+    def _extract_code_uri(function_name, resource_properties, function_type):
+        """ Based off Function Type, normalize the structure to return a path """
+        if function_type == SamFunctionCodeProvider._SERVERLESS_FUNCTION:
+            return SamFunctionCodeProvider.extract_codeuri(function_name, resource_properties, 'CodeUri')
+        elif function_type == SamFunctionCodeProvider._LAMBDA_FUNCTION:
+            return SamFunctionCodeProvider.extract_code(resource_properties, 'Code')
+
+    @staticmethod
+    def extract_codeuri(name, resource_properties, code_property_key):
+        """
+        Extracts the SAM Function CodeUri from the Resource Properties
+
+        Parameters
+        ----------
+        name str
+            LogicalId of the resource
+        resource_properties dict
+            Dictionary representing the Properties of the Resource
+        code_property_key str
+            Property Key of the code on the Resource
+
+        Returns
+        -------
+        str
+            Representing the local code path
+        """
+        codeuri = resource_properties.get(code_property_key, SamFunctionCodeProvider._DEFAULT_CODEURI)
+        # CodeUri can be a dictionary of S3 Bucket/Key or a S3 URI, neither of which are supported
+        if isinstance(codeuri, dict) or \
+                (isinstance(codeuri, six.string_types) and codeuri.startswith("s3://")):
+            codeuri = SamFunctionCodeProvider._DEFAULT_CODEURI
+            LOG.warning("Lambda function '%s' has specified S3 location for CodeUri which is unsupported. "
+                        "Using default value of '%s' instead", name, codeuri)
+        return codeuri
+
+    @staticmethod
+    def extract_code(resource_properties, code_property_key):
+        """
+        Extracts the Lambda Function Code from the Resource Properties
+
+        Parameters
+        ----------
+        resource_properties dict
+            Dictionary representing the Properties of the Resource
+        code_property_key str
+            Property Key of the code on the Resource
+
+        Returns
+        -------
+        str
+            Representing the local code path
+        """
+
+        codeuri = resource_properties.get(code_property_key, SamFunctionCodeProvider._DEFAULT_CODEURI)
+
+        if isinstance(codeuri, dict):
+            codeuri = SamFunctionCodeProvider._DEFAULT_CODEURI
+
+        return codeuri
+
+    @staticmethod
+    def _dump_code(inlinecode, path, index='index'):
+        """ Dump InlineCode to specified cache file """
+        if not os.path.exists(path):
+            os.makedirs(path)
+            os.chmod(path, 0o755)
+        with open(path + index, 'w') as code:
+            code.write(inlinecode)
+
+    @staticmethod
+    def _cleanup(path, index='index'):
+        """ Delete InlineCode file """
+        try:
+            os.remove(path + index)
+        except IOError:
+            # We don't care as we use here to cleanup resources
+            pass
+
+    @staticmethod
+    def _sanitize_inlinecode(inlinecode):
+        """
+        Verify if InlineCode has runtime substitution
+        """
+        # InlineCode isn't type safe
+        if isinstance(inlinecode, dict):
+            # We expect to have only 1 keypair..
+            inlinecode = list(inlinecode.values())[0]
+            # Not sopporting !Sub as of now
+            raise NotImplementedError('Not able to parse inline code because of !Sub presence')
+        return inlinecode

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -432,6 +432,8 @@ class TestLocalLambda_invoke(TestCase):
         stdout = "stdout"
         stderr = "stderr"
         function = Mock()
+        function.codeuri.__enter__ = Mock()
+        function.codeuri.__exit__ = Mock()
         invoke_config = "config"
 
         self.function_provider_mock.get.return_value = function

--- a/tests/unit/commands/local/lib/test_sam_function_code_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_code_provider.py
@@ -1,0 +1,144 @@
+from unittest import TestCase
+from parameterized import parameterized
+
+from samcli.commands.local.lib.sam_function_code_provider import SamFunctionCodeProvider
+
+
+class TestSamFunctionCodeProvider(TestCase):
+    """
+    Test all public methods with an input template
+    """
+
+    TEMPLATE = {
+        "Resources": {
+
+            "SamFunc1": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "CodeUri": "/usr/foo/bar",
+                    "Runtime": "nodejs4.3",
+                    "Handler": "index.handler"
+                }
+            },
+            "SamFunc2": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    # CodeUri is unsupported S3 location
+                    "CodeUri": "s3://bucket/key",
+                    "Runtime": "nodejs4.3",
+                    "Handler": "index.handler"
+                }
+            },
+            "SamFunc3": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    # CodeUri is unsupported S3 location
+                    "CodeUri": {
+                        "Bucket": "bucket",
+                        "Key": "key"
+                    },
+                    "Runtime": "nodejs4.3",
+                    "Handler": "index.handler"
+                }
+            },
+            "LambdaFunc1": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "Code": {
+                        "S3Bucket": "bucket",
+                        "S3Key": "key"
+                    },
+                    "Runtime": "nodejs4.3",
+                    "Handler": "index.handler"
+                }
+            },
+            "LambdaFuncWithLocalPath": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "Code": "./some/path/to/code",
+                    "Runtime": "nodejs4.3",
+                    "Handler": "index.handler"
+                }
+            },
+            "OtherResource": {
+                "Type": "AWS::Serverless::Api",
+                "Properties": {
+                    "StageName": "prod",
+                    "DefinitionUri": "s3://bucket/key"
+                }
+            }
+        }
+    }
+
+    EXPECTED_FUNCTIONS = ["SamFunc1", "SamFunc2", "SamFunc3", "LambdaFunc1"]
+
+    @parameterized.expand([
+        ("SamFunc1", dict(
+            name="SamFunc1",
+            runtime="nodejs4.3",
+            handler="index.handler",
+            codeuri="/usr/foo/bar",
+            memory=None,
+            timeout=None,
+            environment=None,
+            rolearn=None,
+            layers=[]
+        )),
+        ("SamFunc2", dict(
+            name="SamFunc2",
+            runtime="nodejs4.3",
+            handler="index.handler",
+            codeuri=".",
+            memory=None,
+            timeout=None,
+            environment=None,
+            rolearn=None,
+            layers=[]
+        )),
+        ("SamFunc3", dict(
+            name="SamFunc3",
+            runtime="nodejs4.3",
+            handler="index.handler",
+            codeuri=".",
+            memory=None,
+            timeout=None,
+            environment=None,
+            rolearn=None,
+            layers=[]
+        )),
+        ("LambdaFunc1", dict(
+            name="LambdaFunc1",
+            runtime="nodejs4.3",
+            handler="index.handler",
+            codeuri=".",
+            memory=None,
+            timeout=None,
+            environment=None,
+            rolearn=None,
+            layers=[]
+        )),
+        ("LambdaFuncWithLocalPath", dict(
+            name="LambdaFuncWithLocalPath",
+            runtime="nodejs4.3",
+            handler="index.handler",
+            codeuri="./some/path/to/code",
+            memory=None,
+            timeout=None,
+            environment=None,
+            rolearn=None,
+            layers=[]
+        ))
+    ])
+    def test_every_function_type(self, name, expected_output):
+
+        codeuri = SamFunctionCodeProvider(name, self.TEMPLATE, '')
+        codeuri.__repr__()
+        codeuri.__fspath__()
+
+    def test__sanitize_inlinecode(self):
+        SamFunctionCodeProvider._sanitize_inlinecode('')
+        SamFunctionCodeProvider._extract_code_uri('', {}, SamFunctionCodeProvider._SERVERLESS_FUNCTION)
+
+    def test_extract_code(self):
+        SamFunctionCodeProvider.extract_code({}, '')
+        SamFunctionCodeProvider.extract_codeuri('', {}, '')


### PR DESCRIPTION
*Issue #, if available:*

#790 

*Description of changes:*

Possibility to run `sam local invoke` for Functions authored via `InlineCode` or `Code` key

*Checklist:*

- [X] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write actual code
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
