### PR TITLE
[WIP] build: added support for building using 'provided' runtime.

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -234,7 +234,7 @@ class ApplicationBuilder(object):
         if not self._container_manager.is_docker_reachable:
             raise BuildError("Docker is unreachable. Docker needs to be running to build inside a container.")
 
-        container_build_supported, reason = supports_build_in_container(config)
+        container_build_supported, reason = supports_build_in_container(config, runtime)
         if not container_build_supported:
             raise ContainerBuildNotSupported(reason)
 

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -111,12 +111,22 @@ def get_workflow_config(runtime, code_dir, project_dir):
             JAVA_KOTLIN_GRADLE_CONFIG._replace(executable_search_paths=[code_dir, project_dir]),
             JAVA_MAVEN_CONFIG
         ]),
+
+         "provided": ManifestWorkflowSelector([
+            PYTHON_PIP_CONFIG,
+            RUBY_BUNDLER_CONFIG,
+            DOTNET_CLIPACKAGE_CONFIG,
+            NODEJS_NPM_CONFIG,
+        ]),
     }
 
     if runtime not in selectors_by_runtime:
         raise UnsupportedRuntimeException("'{}' runtime is not supported".format(runtime))
 
     selector = selectors_by_runtime[runtime]
+
+    if runtime == "provided":
+        LOG.info("Building resource using 'provided' runtime")
 
     try:
         config = selector.get_config(code_dir, project_dir)

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -112,11 +112,14 @@ def get_workflow_config(runtime, code_dir, project_dir):
             JAVA_MAVEN_CONFIG
         ]),
 
-         "provided": ManifestWorkflowSelector([
+        "provided": ManifestWorkflowSelector([
             PYTHON_PIP_CONFIG,
             RUBY_BUNDLER_CONFIG,
             DOTNET_CLIPACKAGE_CONFIG,
             NODEJS_NPM_CONFIG,
+            JAVA_GRADLE_CONFIG._replace(executable_search_paths=[code_dir, project_dir]),
+            JAVA_KOTLIN_GRADLE_CONFIG._replace(executable_search_paths=[code_dir, project_dir]),
+            JAVA_MAVEN_CONFIG,
         ]),
     }
 

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -128,18 +128,18 @@ def get_workflow_config(runtime, code_dir, project_dir):
 
     selector = selectors_by_runtime[runtime]
 
-    if runtime == "provided":
-        LOG.info("Building resource using 'provided' runtime")
-
     try:
         config = selector.get_config(code_dir, project_dir)
+        if runtime == "provided":
+            LOG.info("Building resource using 'provided' runtime.")
+            LOG.info("%s workflow detected. Please make sure you are using the appropriate layer ARN.", config.language)
         return config
     except ValueError as ex:
         raise UnsupportedRuntimeException("Unable to find a supported build workflow for runtime '{}'. Reason: {}"
                                           .format(runtime, str(ex)))
 
 
-def supports_build_in_container(config):
+def supports_build_in_container(config, runtime=None):
     """
     Given a workflow config, this method provides a boolean on whether the workflow can run within a container or not.
 
@@ -166,9 +166,11 @@ def supports_build_in_container(config):
         _key(DOTNET_CLIPACKAGE_CONFIG): "We do not support building .NET Core Lambda functions within a container. "
                                         "Try building without the container. Most .NET Core functions will build "
                                         "successfully.",
+        "provided": "We do not support building Lambda functions with 'provided' runtime within a container. "
+                    "Try building without the container.",
     }
 
-    thiskey = _key(config)
+    thiskey = "provided" if runtime == "provided" else _key(config)
     if thiskey in unsupported:
         return False, unsupported[thiskey]
 


### PR DESCRIPTION
Issue #1099

*Description of changes:*

Allow for the building of a lambda function when specifying `Runtime: provided`, with a corresponding layer ARN. SAM will automagically determine the runtime by determining the workflow configuration based off of the project manifest.

For example, with the sample `sam-app`:
```yml
...
      Runtime: provided
      Layers:
        - <YOUR-PROVIDED-RUNTIME-ARN>
...
```


* Added a `ManifestWorkflowSelector` to add support for building using the `provided` runtime flag, as suggested [here](https://github.com/awslabs/aws-sam-cli/issues/1099#issuecomment-488877333). 
* Added logging to inform user that the `provided` runtime is being used. 
* Fails when attempting to build Lambda Function within a container. (can't determine an appropriate image to pull)


*Checklist:*

- [x] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [-] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
