### PR TITLE
feat: Type hinting for for nodejs hello-world template

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/app.js
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/app.js
@@ -5,13 +5,13 @@ let response;
 /**
  *
  * Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
- * @param {Object} event - API Gateway Lambda Proxy Input Format
+ * @param {AWSLambda.APIGatewayEvent} event - API Gateway Lambda Proxy Input Format
  *
  * Context doc: https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html 
- * @param {Object} context
+ * @param {AWSLambda.Context} context
  *
  * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
- * @returns {Object} object - API Gateway Lambda Proxy Output Format
+ * @returns {Promise<Object>} object - API Gateway Lambda Proxy Output Format
  * 
  */
 exports.lambdaHandler = async (event, context) => {

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/package.json
@@ -13,6 +13,7 @@
     "test": "mocha tests/unit/"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.34",
     "chai": "^4.2.0",
     "mocha": "^6.1.4"
   }

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/tsconfig.json
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "checkJs": true,
+    "allowJs": true,
+    "noEmit": true
+  },
+  "exclude": ["**/node_modules", "tests/**"]
+}


### PR DESCRIPTION
*Description of changes:*
Adds type hints and autocomplete for context, and event parameters on the lambdaHandler.

Knowing what values exist in these parameters can be daunting, and usually require going to the links provided in the jsdoc. Having types here reduces that friction and keeps the developer in the editor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
