### PR TITLE
Allow building lambda functions which do not support containers, even if -u is specified.

### DIFF
--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -81,7 +81,9 @@ $ sam build && sam package --s3-bucket <bucketname>
     "-u",
     is_flag=True,
     help="If your functions depend on packages that have natively compiled dependencies, use this flag "
-    "to build your function inside an AWS Lambda-like Docker container",
+    "to build your function inside an AWS Lambda-like Docker container.  IFF the runtime does not support "
+    "building inside a container, a warning will be logged, and the function will attempt to be built "
+    "outside the container.",
 )
 @click.option(
     "--manifest",

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -186,7 +186,11 @@ class ApplicationBuilder:
             # By default prefer to build in-process for speed
             build_method = self._build_function_in_process
             if self._container_manager:
-                build_method = self._build_function_on_container
+                container_build_supported, reason = supports_build_in_container(config)
+                if container_build_supported:
+                    build_method = self._build_function_on_container
+                else:
+                    LOG.warning("Container Build Skipped: '%s'", reason)
 
             options = ApplicationBuilder._get_build_options(config.language, handler)
 

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -457,14 +457,18 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
 
     @parameterized.expand(
         [
-            ("dotnetcore2.0", "Dotnetcore2.0", None),
-            ("dotnetcore2.1", "Dotnetcore2.1", None),
-            ("dotnetcore2.0", "Dotnetcore2.0", "debug"),
-            ("dotnetcore2.1", "Dotnetcore2.1", "debug"),
+            ("dotnetcore2.0", "Dotnetcore2.0", None, False),
+            ("dotnetcore2.1", "Dotnetcore2.1", None, False),
+            ("dotnetcore2.0", "Dotnetcore2.0", "debug", False),
+            ("dotnetcore2.1", "Dotnetcore2.1", "debug", False),
+            ("dotnetcore2.0", "Dotnetcore2.0", None, "use_container"),
+            ("dotnetcore2.1", "Dotnetcore2.1", None, "use_container"),
+            ("dotnetcore2.0", "Dotnetcore2.0", "debug", "use_container"),
+            ("dotnetcore2.1", "Dotnetcore2.1", "debug", "use_container"),
         ]
     )
     @pytest.mark.flaky(reruns=3)
-    def test_with_dotnetcore(self, runtime, code_uri, mode):
+    def test_with_dotnetcore(self, runtime, code_uri, mode, use_container):
         overrides = {
             "Runtime": runtime,
             "CodeUri": code_uri,
@@ -557,9 +561,16 @@ class TestBuildCommand_Go_Modules(BuildIntegBase):
     FUNCTION_LOGICAL_ID = "Function"
     EXPECTED_FILES_PROJECT_MANIFEST = {"hello-world"}
 
-    @parameterized.expand([("go1.x", "Go", None), ("go1.x", "Go", "debug")])
+    @parameterized.expand(
+        [
+            ("go1.x", "Go", None, False),
+            ("go1.x", "Go", "debug", False),
+            ("go1.x", "Go", None, "use_container"),
+            ("go1.x", "Go", "debug", "use_container"),
+        ]
+    )
     @pytest.mark.flaky(reruns=3)
-    def test_with_go(self, runtime, code_uri, mode):
+    def test_with_go(self, runtime, code_uri, mode, use_container):
         overrides = {"Runtime": runtime, "CodeUri": code_uri, "Handler": "hello-world"}
         cmdlist = self.get_command_list(use_container=False, parameter_overrides=overrides)
 


### PR DESCRIPTION
*Issue #, if available:*
#1825

*Why is this change necessary?*
If you have a project that mixes lambda functions with the need to build inside a container (say a python project with a native library) and say a Go function which is not supported by container build.  Then the build fails, and there is no effective workaround.

*How does it address the issue?*
I simply check if the runtime attempting to be built supports building inside a container, BEFORE i change the build to be a containered build. Currently the code checks after and raises an exception which terminates the build.

*What side effects does this change have?*
Builds which are currently broken will build properly.  No other side effects.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [X ] Write unit tests
- [? ] Write/update functional tests
- [X ] Write/update integration tests
- [X ] `make pr` passes
- [X ] Write documentation

I didn't write any functional tests, because I didn't see any functional tests which exercise container builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
