### PR TITLE
Adding integ test for serverlessrepo 1.10.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,6 @@ docker~=4.0
 dateparser~=0.7
 python-dateutil~=2.6, <2.8.1
 requests==2.23.0
-serverlessrepo==0.1.9
+serverlessrepo==0.1.10
 aws_lambda_builders==0.9.0
 tomlkit==0.5.8

--- a/tests/integration/publish/test_command_integ.py
+++ b/tests/integration/publish/test_command_integ.py
@@ -37,7 +37,7 @@ class TestPublishExistingApp(PublishAppIntegBase):
     def tearDown(self):
         super(TestPublishExistingApp, self).tearDown()
         # Delete application for each test
-        # self.sar_client.delete_application(ApplicationId=self.application_id)
+        self.sar_client.delete_application(ApplicationId=self.application_id)
 
     def test_update_application(self):
         template_path = self.temp_dir.joinpath("template_update_app.yaml")

--- a/tests/integration/publish/test_command_integ.py
+++ b/tests/integration/publish/test_command_integ.py
@@ -1,18 +1,23 @@
 import re
 import time
 import json
+import logging
 from subprocess import Popen, PIPE, TimeoutExpired
+from parameterized import parameterized
 
 from unittest import skipIf
 
 from samcli.commands.publish.command import SEMANTIC_VERSION
 from .publish_app_integ_base import PublishAppIntegBase
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
+from tests.testing_utils import run_command
 
 # Publish tests require credentials and CI/CD will only add credentials to the env if the PR is from the same repo.
 # This is to restrict publish tests to run outside of CI/CD, when the branch is not master and tests are not run by Canary.
 SKIP_PUBLISH_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_BY_CANARY
 TIMEOUT = 300
+
+LOG = logging.getLogger(__name__)
 
 
 @skipIf(SKIP_PUBLISH_TESTS, "Skip publish tests in CI/CD only")
@@ -32,67 +37,65 @@ class TestPublishExistingApp(PublishAppIntegBase):
     def tearDown(self):
         super(TestPublishExistingApp, self).tearDown()
         # Delete application for each test
-        self.sar_client.delete_application(ApplicationId=self.application_id)
+        # self.sar_client.delete_application(ApplicationId=self.application_id)
 
     def test_update_application(self):
         template_path = self.temp_dir.joinpath("template_update_app.yaml")
         command_list = self.get_command_list(template_path=template_path, region=self.region_name)
 
-        process = Popen(command_list, stdout=PIPE)
-        try:
-            stdout, _ = process.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            process.kill()
-            raise
-        process_stdout = stdout.strip()
-
+        result = run_command(command_list)
         expected_msg = 'The following metadata of application "{}" has been updated:'.format(self.application_id)
-        self.assertIn(expected_msg, process_stdout.decode("utf-8"))
+        self.assertIn(expected_msg, result.stdout.decode("utf-8"))
 
         app_metadata_text = self.temp_dir.joinpath("metadata_update_app.json").read_text()
         app_metadata = json.loads(app_metadata_text)
-        self.assert_metadata_details(app_metadata, process_stdout.decode("utf-8"))
+        self.assert_metadata_details(app_metadata, result.stdout.decode("utf-8"))
 
     def test_create_application_version(self):
         template_path = self.temp_dir.joinpath("template_create_app_version.yaml")
         command_list = self.get_command_list(template_path=template_path, region=self.region_name)
-
-        process = Popen(command_list, stdout=PIPE)
-        try:
-            stdout, _ = process.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            process.kill()
-            raise
-        process_stdout = stdout.strip()
+        result = run_command(command_list)
 
         expected_msg = 'The following metadata of application "{}" has been updated:'.format(self.application_id)
-        self.assertIn(expected_msg, process_stdout.decode("utf-8"))
+        self.assertIn(expected_msg, result.stdout.decode("utf-8"))
 
         app_metadata_text = self.temp_dir.joinpath("metadata_create_app_version.json").read_text()
         app_metadata = json.loads(app_metadata_text)
-        self.assert_metadata_details(app_metadata, process_stdout.decode("utf-8"))
+        self.assert_metadata_details(app_metadata, result.stdout.decode("utf-8"))
 
     def test_create_application_version_with_semantic_version_option(self):
         template_path = self.temp_dir.joinpath("template_create_app_version.yaml")
         command_list = self.get_command_list(
             template_path=template_path, region=self.region_name, semantic_version="0.1.0"
         )
-
-        process = Popen(command_list, stdout=PIPE)
-        try:
-            stdout, _ = process.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            process.kill()
-            raise
-        process_stdout = stdout.strip()
-
+        result = run_command(command_list)
         expected_msg = 'The following metadata of application "{}" has been updated:'.format(self.application_id)
-        self.assertIn(expected_msg, process_stdout.decode("utf-8"))
+        self.assertIn(expected_msg, result.stdout.decode("utf-8"))
 
         app_metadata_text = self.temp_dir.joinpath("metadata_create_app_version.json").read_text()
         app_metadata = json.loads(app_metadata_text)
         app_metadata[SEMANTIC_VERSION] = "0.1.0"
-        self.assert_metadata_details(app_metadata, process_stdout.decode("utf-8"))
+        self.assert_metadata_details(app_metadata, result.stdout.decode("utf-8"))
+
+    @parameterized.expand(
+        [
+            ("template_create_app_with_readme_bodies.yaml", "metadata_create_app_with_readme_bodies.json"),
+        ]
+    )
+    def test_create_application_version_with_read_and_license_bodies(self, template_filename, expected_template_filename):
+        template_path = self.temp_dir.joinpath(template_filename)
+        command_list = self.get_command_list(
+            template_path=template_path, region=self.region_name, semantic_version="0.1.0"
+        )
+        result = run_command(command_list)
+        expected_msg = 'The following metadata of application "{}" has been updated:'.format(self.application_id)
+        result_msg = result.stdout.decode("utf-8")
+        self.assertIn(expected_msg, result_msg)
+
+        app_metadata_text = self.temp_dir.joinpath(expected_template_filename).read_text()
+        app_metadata = json.loads(app_metadata_text)
+        app_metadata[SEMANTIC_VERSION] = "0.1.0"
+        self.assert_metadata_details(app_metadata, result_msg)
 
 
 @skipIf(SKIP_PUBLISH_TESTS, "Skip publish tests in CI/CD only")
@@ -113,24 +116,17 @@ class TestPublishNewApp(PublishAppIntegBase):
         template_path = self.temp_dir.joinpath("template_create_app.yaml")
         command_list = self.get_command_list(template_path=template_path, region=self.region_name)
 
-        process = Popen(command_list, stdout=PIPE)
-        try:
-            stdout, _ = process.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            process.kill()
-            raise
-        process_stdout = stdout.strip()
-
+        result = run_command(command_list)
         expected_msg = "Created new application with the following metadata:"
-        self.assertIn(expected_msg, process_stdout.decode("utf-8"))
+        self.assertIn(expected_msg, result.stdout.decode("utf-8"))
 
         app_metadata_text = self.temp_dir.joinpath("metadata_create_app.json").read_text()
         app_metadata = json.loads(app_metadata_text)
-        self.assert_metadata_details(app_metadata, process_stdout.decode("utf-8"))
+        self.assert_metadata_details(app_metadata, result.stdout.decode("utf-8"))
 
         # Get console link application id from stdout
         pattern = r"arn:[\w\-]+:serverlessrepo:[\w\-]+:[0-9]+:applications\~[\S]+"
-        match = re.search(pattern, process_stdout.decode("utf-8"))
+        match = re.search(pattern, result.stdout.decode("utf-8"))
         self.application_id = match.group().replace("~", "/")
 
     def test_publish_not_packaged_template(self):
@@ -152,19 +148,13 @@ class TestPublishNewApp(PublishAppIntegBase):
         template_path = self.temp_dir.joinpath("template_create_app.yaml")
         command_list = self.get_command_list(template_path=template_path)
 
-        process = Popen(command_list, stdout=PIPE)
-        try:
-            stdout, _ = process.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            process.kill()
-            raise
-        process_stdout = stdout.strip()
+        result = run_command(command_list)
 
         expected_msg = "Created new application with the following metadata:"
-        self.assertIn(expected_msg, process_stdout.decode("utf-8"))
+        self.assertIn(expected_msg, result.stdout.decode("utf-8"))
 
         # Get console link application id from stdout
         pattern = r"arn:[\w\-]+:serverlessrepo:[\w\-]+:[0-9]+:applications\~[\S]+"
-        match = re.search(pattern, process_stdout.decode("utf-8"))
+        match = re.search(pattern, result.stdout.decode("utf-8"))
         self.application_id = match.group().replace("~", "/")
         self.assertIn(self.region_name, self.application_id)

--- a/tests/integration/publish/test_command_integ.py
+++ b/tests/integration/publish/test_command_integ.py
@@ -78,11 +78,11 @@ class TestPublishExistingApp(PublishAppIntegBase):
         self.assert_metadata_details(app_metadata, result.stdout.decode("utf-8"))
 
     @parameterized.expand(
-        [
-            ("template_create_app_with_readme_bodies.yaml", "metadata_create_app_with_readme_bodies.json"),
-        ]
+        [("template_create_app_with_readme_bodies.yaml", "metadata_create_app_with_readme_bodies.json"),]
     )
-    def test_create_application_version_with_read_and_license_bodies(self, template_filename, expected_template_filename):
+    def test_create_application_version_with_read_and_license_bodies(
+        self, template_filename, expected_template_filename
+    ):
         template_path = self.temp_dir.joinpath(template_filename)
         command_list = self.get_command_list(
             template_path=template_path, region=self.region_name, semantic_version="0.1.0"

--- a/tests/integration/testdata/publish/metadata_create_app_with_readme_bodies.json
+++ b/tests/integration/testdata/publish/metadata_create_app_with_readme_bodies.json
@@ -1,0 +1,9 @@
+{
+    "Author": "user",
+    "Description": "description",
+    "HomePageUrl": "https://github.com/test/test",
+    "Labels": ["test-app"],
+    "ReadmeBody": "readme-body",
+    "SemanticVersion": "0.1.0",
+    "SourceCodeUrl": "https://github.com/test/test-new-version"
+}

--- a/tests/integration/testdata/publish/template_create_app_with_readme_bodies.yaml
+++ b/tests/integration/testdata/publish/template_create_app_with_readme_bodies.yaml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "sam-app
+
+  Sample SAM Template for sam-app
+
+  "
+Globals:
+  Function:
+    Timeout: 3
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Author: user
+    Description: description
+    HomePageUrl: https://github.com/test/test
+    Labels:
+      - test-app
+    Name: <application-name>
+    ReadmeBody: "readme-body"
+    SemanticVersion: 0.1.0
+    SourceCodeUrl: "https://github.com/test/test-new-version"
+Resources:
+  HelloWorldFunction:
+    Properties:
+      CodeUri: s3://<bucket-name>/main.py
+      Environment:
+        Variables:
+          PARAM1: VALUE
+      Events:
+        HelloWorld:
+          Properties:
+            Method: get
+            Path: /hello
+          Type: Api
+      Handler: main.lambda_handler
+      Runtime: python3.6
+    Type: AWS::Serverless::Function
+Transform: AWS::Serverless-2016-10-31


### PR DESCRIPTION
*Issue #, if available:*
Integration test for https://github.com/awslabs/aws-sam-cli/pull/1344
*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
