### PR TITLE
fix: cors support for "Access-Control-Allow-Credentials" header in local api

### DIFF
--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -249,12 +249,13 @@ class Api:
         return list(self.binary_media_types_set)
 
 
-_CorsTuple = namedtuple("Cors", ["allow_origin", "allow_methods", "allow_headers", "max_age"])
+_CorsTuple = namedtuple("Cors", ["allow_origin", "allow_methods", "allow_headers", "allow_credentials", "max_age"])
 
 _CorsTuple.__new__.__defaults__ = (
     None,  # Allow Origin defaults to None
     None,  # Allow Methods is optional and defaults to empty
     None,  # Allow Headers is optional and defaults to empty
+    None,  # Allow Credentials is optional and defaults to empty
     None,  # MaxAge is optional and defaults to empty
 )
 
@@ -278,6 +279,7 @@ class Cors(_CorsTuple):
             "Access-Control-Allow-Origin": cors.allow_origin,
             "Access-Control-Allow-Methods": cors.allow_methods,
             "Access-Control-Allow-Headers": cors.allow_headers,
+            "Access-Control-Allow-Credentials": cors.allow_credentials,
             "Access-Control-Max-Age": cors.max_age,
         }
         # Filters out items in the headers dictionary that isn't empty.

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -859,6 +859,7 @@ class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")
         self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), "origin, x-requested-with")
         self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), "GET,OPTIONS")
+        self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"), "true")
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), "510")
 
 
@@ -884,6 +885,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")
         self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), None)
         self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), ",".join(sorted(Route.ANY_HTTP_METHODS)))
+        self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"), None)
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), None)
 
     @pytest.mark.flaky(reruns=3)
@@ -900,6 +902,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), None)
         self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), None)
         self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), None)
+        self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"), None)
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), None)
 
 

--- a/tests/integration/testdata/start_api/swagger-template.yaml
+++ b/tests/integration/testdata/start_api/swagger-template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 
 Globals:
@@ -18,6 +18,7 @@ Resources:
         AllowOrigin: "'*''"
         AllowMethods: "'GET'"
         AllowHeaders: "'origin, x-requested-with'"
+        AllowCredentials: "'true'"
         MaxAge: "'510'"
       DefinitionBody:
         swagger: "2.0"
@@ -82,7 +83,6 @@ Resources:
                 uri:
                   Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EchoEventHandlerFunction.Arn}/invocations
 
-
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -132,7 +132,7 @@ Resources:
       Timeout: 600
 
   EchoEventHandlerFunction:
-    Type:  AWS::Serverless::Function
+    Type: AWS::Serverless::Function
     Properties:
       Handler: main.echo_event_handler
       Runtime: python3.6

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -662,7 +662,11 @@ class TestService_should_base64_encode(TestCase):
 class TestServiceCorsToHeaders(TestCase):
     def test_basic_conversion(self):
         cors = Cors(
-            allow_origin="*", allow_methods=",".join(["POST", "OPTIONS"]), allow_headers="UPGRADE-HEADER", max_age=6
+            allow_origin="*",
+            allow_methods=",".join(["POST", "OPTIONS"]),
+            allow_headers="UPGRADE-HEADER",
+            allow_credentials="true",
+            max_age=6,
         )
         headers = Cors.cors_to_headers(cors)
 
@@ -672,6 +676,28 @@ class TestServiceCorsToHeaders(TestCase):
                 "Access-Control-Allow-Origin": "*",
                 "Access-Control-Allow-Methods": "POST,OPTIONS",
                 "Access-Control-Allow-Headers": "UPGRADE-HEADER",
+                "Access-Control-Allow-Credentials": "true",
+                "Access-Control-Max-Age": 6,
+            },
+        )
+
+    def test_basic_conversion_allowcredentials_boolean(self):
+        cors = Cors(
+            allow_origin="*",
+            allow_methods=",".join(["POST", "OPTIONS"]),
+            allow_headers="UPGRADE-HEADER",
+            allow_credentials=True,
+            max_age=6,
+        )
+        headers = Cors.cors_to_headers(cors)
+
+        self.assertEqual(
+            headers,
+            {
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "POST,OPTIONS",
+                "Access-Control-Allow-Headers": "UPGRADE-HEADER",
+                "Access-Control-Allow-Credentials": True,
                 "Access-Control-Max-Age": 6,
             },
         )


### PR DESCRIPTION
*Issue #, if available:*
fix for #1645 

*Why is this change necessary?*
AllowCredentials is not working for any of True, true, or "'true'" while using the local start-api command. This setting is necessary for making requests to the local api while using the withCredentials flag in the request.

*How does it address the issue?*
While parsing the other cors options, we will now also pars AllowCredentials and add it to the "Access-Control-Allow-Credentials". AllowCredentials should accept the values True, true, and "'true'" (note the required nested single quotes).

*What side effects does this change have?*
No known side effects of this change.

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
No change.

*Checklist:*

- [x] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [x] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Title: Design document
====================================

Use this as a template to write a design document when adding new
commands or major features to SAM CLI. It helps other developers
understand the scope of the project, validate technical complexity and
feasibility. It also serves as a public documentation of how the feature
actually works.

**Process:** 

1. Copy this template to another file in the `designs` folder.
2. Fill out the sections in the template.
3. Send a "Work In Progress" Pull Request with your design document. We can discuss the
designs in more detail and iterate on the requirements. Feel free to
start implementing a prototype if you think it will help flush out
design.
4. Once the PR is approved, create Github Issues for each task
listed in the document and start implementing them.

What is the problem?
--------------------

AllowCredentials is not working for any of True, true, or "'true'" while using the local start-api command. This setting is necessary for making requests to the local api while using the withCredentials flag in the request.

Current behavior: Log from the Chrome developer tools console is "Access to XMLHttpRequest at [local-api-url] from origin [clien-url] has been blocked by CORS policy: Response to preflight request doesn't pass access control check: The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute." 

Expected behavior: The request should complete successfully when using the withCredentials attribute.

Note: this is an extension to the solution implemented in #1648 which could not be fully tested at the time and were thus reverted.

What will be changed?
---------------------

The AllowCredentials setting will be parsed from the Cors section of the template file and sent along with the header "Access-Control-Allow-Credentials" when specified.

Success criteria for the change
-------------------------------

As a user, I would like to specify the value of "Access-Control-Allow-Credentials" in the API response by setting the flag AllowCredentials under the Properties -> Cors section of an API definition so that I can successfully make requests to the API while utilizing the withCredentials flag in the request. 

Out-of-Scope
------------

N/A

User Experience Walkthrough
---------------------------

N/A

Implementation
==============

The source will be modified to parse the AllowCredentials setting, similar to how all other CORS options are parsed. The difference here is that AllowCredentials may optionally be the boolean values true/True, or the nested single-quote string value "'true'". Once the value is parsed, it will be appended to the headers section as "Access-Control-Allow-Credentials" as is the case with other CORS options.

CLI Changes
-----------

*Explain the changes to command line interface, including adding new
commands, modifying arguments etc*

### Breaking Change

*Are there any breaking changes to CLI interface? Explain*

N/A

Design
------

*Explain how this feature will be implemented. Highlight the components
of your implementation, relationships* *between components, constraints,
etc.*

The "cors_to_headers" function of the "samcli/lib/providers/provider.py" file will be modified to set the "Access-Control-Allow-Credentials" from the allow_credentials attribute of the CorsTuple.

The "extract_cors" function of the "samcli/lib/providers/sam_api_provider.py" file will be modified to parse the value of "AllowCredentials" from the cors_prop and store it in the CorsTuple as allow_credentials. Additionally, the "_get_cors_prop" method must be modified to handle the case where the value is parsed as a boolean, rather than a string. This is done with an added optional parameter is_boolean_allowed which acts as a boolean flag to indicate whether the value may be a boolean value.

`.samrc` Changes
----------------

*Explain the new configuration entries, if any, you want to add to
.samrc*

Security
--------

*Tip: How does this change impact security? Answer the following
questions to help answer this question better:*

**What new dependencies (libraries/cli) does this change require?**

N/A

**What other Docker container images are you using?**

N/A

**Are you creating a new HTTP endpoint? If so explain how it will be
created & used**

N/A

**Are you connecting to a remote API? If so explain how is this
connection secured**

N/A

**Are you reading/writing to a temporary folder? If so, what is this
used for and when do you clean up?**

N/A

**How do you validate new .samrc configuration?**

N/A

What is your Testing Plan (QA)?
===============================

Goal
----

Complete end-to-end verification of this change, including parsing an API yaml file, to receiving the corresponding response headers from the request.

Pre-requesites
--------------

N/A

Test Scenarios/Cases
--------------------

1. An omission of the Cors property in the yaml file.
2. An omission of the AllowCredentials property in the yaml file.
3. A Cors value of "'*'" in the yaml file.
4. AllowCredentials has a value True/true in the yaml file.
5. AllowCredentials has a value False/false in the yaml file.
6. AllowCredentials has a value "'true'" in the yaml file.
7. AllowCredentials has a value "'false'" in the yaml file.
8. AllowCredentials has a value "true"/"false".
9. AllowCredentials has a value not equivalent to any of those explicitly defined above.

Expected Results
----------------

1. The Access-Control-Allow-Credentials header should not be appended to the response.
2. The Access-Control-Allow-Credentials header should not be appended to the response.
3. The Access-Control-Allow-Credentials header should not be appended to the response.
4. The Access-Control-Allow-Credentials header should be sent in the response with the value "true".
5. The Access-Control-Allow-Credentials header should be sent in the response with the value "false".
6. The Access-Control-Allow-Credentials header should be sent in the response with the value "true".
7. The Access-Control-Allow-Credentials header should be sent in the response with the value "false".
8. The InvalidSamDocumentException should be thrown.
9. The Access-Control-Allow-Credentials header should not be appended to the response.

Pass/Fail
---------

1. Pass
2. Pass
3. Pass
4. Pass
5. Pass
6. Pass
7. Pass
8. Pass
9. Pass

Documentation Changes
=====================

Documentation already exists. No changes required.

Open Issues
============

#1645, #1648

Task Breakdown
==============

-   \[x\] Send a Pull Request with this design document
-   \[x\] Build the command line interface
-   \[x\] Build the underlying library
-   \[x\] Unit tests
-   \[x\] Functional Tests
-   \[x\] Integration tests
-   \[x\] Run all tests on Windows
-   \[x\] Update documentation