### PR TITLE
feat: Added a column in print changeset to show if replacement happened

### DIFF
--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -52,9 +52,14 @@ DESCRIBE_STACK_EVENTS_DEFAULT_ARGS = OrderedDict(
 
 DESCRIBE_STACK_EVENTS_TABLE_HEADER_NAME = "CloudFormation events from changeset"
 
-DESCRIBE_CHANGESET_FORMAT_STRING = "{Operation:<{0}} {LogicalResourceId:<{1}} {ResourceType:<{2}}"
+DESCRIBE_CHANGESET_FORMAT_STRING = "{Operation:<{0}} {LogicalResourceId:<{1}} {ResourceType:<{2}} {Replacement:<{3}}"
 DESCRIBE_CHANGESET_DEFAULT_ARGS = OrderedDict(
-    {"Operation": "Operation", "LogicalResourceId": "LogicalResourceId", "ResourceType": "ResourceType"}
+    {
+        "Operation": "Operation",
+        "LogicalResourceId": "LogicalResourceId",
+        "ResourceType": "ResourceType",
+        "Replacement": "Replacement",
+    }
 )
 
 DESCRIBE_CHANGESET_TABLE_HEADER_NAME = "CloudFormation stack changeset"
@@ -222,6 +227,9 @@ class Deployer:
                     {
                         "LogicalResourceId": resource_props.get("LogicalResourceId"),
                         "ResourceType": resource_props.get("ResourceType"),
+                        "Replacement": "N/A"
+                        if resource_props.get("Replacement") is None
+                        else resource_props.get("Replacement"),
                     }
                 )
 
@@ -229,7 +237,12 @@ class Deployer:
             for value in v:
                 row_color = self.deploy_color.get_changeset_action_color(action=k)
                 pprint_columns(
-                    columns=[changes_showcase.get(k, k), value["LogicalResourceId"], value["ResourceType"]],
+                    columns=[
+                        changes_showcase.get(k, k),
+                        value["LogicalResourceId"],
+                        value["ResourceType"],
+                        value["Replacement"],
+                    ],
                     width=kwargs["width"],
                     margin=kwargs["margin"],
                     format_string=DESCRIBE_CHANGESET_FORMAT_STRING,
@@ -242,7 +255,7 @@ class Deployer:
             # There can be cases where there are no changes,
             # but could be an an addition of a SNS notification topic.
             pprint_columns(
-                columns=["-", "-", "-"],
+                columns=["-", "-", "-", "-"],
                 width=kwargs["width"],
                 margin=kwargs["margin"],
                 format_string=DESCRIBE_CHANGESET_FORMAT_STRING,

--- a/tests/unit/lib/deploy/test_deployer.py
+++ b/tests/unit/lib/deploy/test_deployer.py
@@ -237,9 +237,9 @@ class TestDeployer(TestCase):
             changes,
             {
                 "Add": [
-                    {"LogicalResourceId": "resource_id1", "ResourceType": "s3"},
-                    {"LogicalResourceId": "resource_id2", "ResourceType": "kms"},
-                    {"LogicalResourceId": "resource_id3", "ResourceType": "lambda"},
+                    {"LogicalResourceId": "resource_id1", "ResourceType": "s3", "Replacement": "N/A"},
+                    {"LogicalResourceId": "resource_id2", "ResourceType": "kms", "Replacement": "N/A"},
+                    {"LogicalResourceId": "resource_id3", "ResourceType": "lambda", "Replacement": "N/A"},
                 ],
                 "Modify": [],
                 "Remove": [],


### PR DESCRIPTION
*Issue #, if available:*
Issue #1844

*Why is this change necessary?*
To satisfy customer requirement for to see if replacement happened when deploying

*How does it address the issue?*
Added a column to show if replacement happened (reading from boto3 client response)

*What side effects does this change have?*
Not known so far

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
No

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
