### PR TITLE
fix: bug when validation resource with no type.

### DIFF
--- a/samcli/lib/warnings/sam_cli_warning.py
+++ b/samcli/lib/warnings/sam_cli_warning.py
@@ -72,7 +72,7 @@ mitigate it, please read these docs[1]
         functions = [
             resource
             for (_, resource) in template_dict.get("Resources", {}).items()
-            if resource["Type"] == "AWS::Serverless::Function"
+            if resource.get("Type", "") == "AWS::Serverless::Function"
         ]
         deployment_features_enabled_count = sum(
             1 for function in functions if _get_deployment_preferences_status(function)

--- a/tests/unit/lib/warnings/test_sam_cli_warnings.py
+++ b/tests/unit/lib/warnings/test_sam_cli_warnings.py
@@ -71,6 +71,14 @@ Resources:
         Random: Property
 """
 
+NO_TYPE_RESOURCE = """
+Resources:
+  Fn::Transform:
+    Name: AWS::Include
+    Parameters:
+      Location: ./deploy/queries.yaml
+"""
+
 
 class TestWarnings(TestCase):
     def setUp(self):
@@ -118,6 +126,7 @@ class TestCodeDeployWarning(TestCase):
             param(ALL_DISABLED_TEMPLATE, False),
             param(ALL_ENABLED_TEMPLATE, False),
             param(NO_PROPERTY_TEMPLATE, False),
+            param(NO_TYPE_RESOURCE, False),
         ]
     )
     def test_code_deploy_warning(self, template, expected):


### PR DESCRIPTION
*Issue #, if available:*
#2206 

*Why is this change necessary?*
We recently published a change with bug where we assume all resources in CFN will have `Type`. This is failing when we are trying to validate warning messages from template. This change will fix that assumption.

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
