### PR TITLE
feat: Add support for customized message body in generated SQS message

### DIFF
--- a/samcli/lib/generated_sample_events/event-mapping.json
+++ b/samcli/lib/generated_sample_events/event-mapping.json
@@ -971,12 +971,12 @@
         },
         "body": {
           "default": "Hello from SQS!",
-          "children": [{
-            "md5-of-body": {
+          "children": {
+            "md5_of_body": {
               "type": "string",
-              "hash": "md5"
+              "hashing": "md5"
             }
-          }]
+          }
         }
       }
     }

--- a/samcli/lib/generated_sample_events/event-mapping.json
+++ b/samcli/lib/generated_sample_events/event-mapping.json
@@ -968,6 +968,15 @@
         },
         "queue-name": {
           "default": "MyQueue"
+        },
+        "body": {
+          "default": "Hello from SQS!",
+          "children": [{
+            "md5-of-body": {
+              "type": "string",
+              "hash": "md5"
+            }
+          }]
         }
       }
     }

--- a/samcli/lib/generated_sample_events/events.py
+++ b/samcli/lib/generated_sample_events/events.py
@@ -5,9 +5,9 @@ Methods to expose the event types and generate the event jsons for use in SAM CL
 import os
 import json
 import base64
-from requests.utils import quote
-
+from requests.utils import quote as url_quote
 from chevron import renderer
+from samcli.lib.utils.hash import str_checksum
 
 
 class Events:
@@ -33,63 +33,106 @@ class Events:
         with open(file_name) as f:
             self.event_mapping = json.load(f)
 
-    def encode(self, tags, encoding, values_to_sub):
+    def transform(self, tags, values_to_sub):
         """
-        reads the encoding type from the event-mapping.json
-        and determines whether a value needs encoding
+        transform (if needed) values_to_sub with given tags
 
         Parameters
         ----------
         tags: dict
             the values of a particular event that can be substituted
             within the event json
-        encoding: string
-            string that helps navigate to the encoding field of the json
         values_to_sub: dict
             key/value pairs that will be substituted into the json
         Returns
         -------
-        values_to_sub: dict
-            the encoded (if need be) values to substitute into the json.
+        transformed_values_to_sub: dict
+            the transformed (if needed) values to substitute into the json.
         """
-
-        for tag in tags:
-            if tags[tag].get(encoding) != "None":
-                if tags[tag].get(encoding) == "url":
-                    values_to_sub[tag] = self.url_encode(values_to_sub[tag])
-                if tags[tag].get(encoding) == "base64":
-                    values_to_sub[tag] = self.base64_utf_encode(values_to_sub[tag])
+        for tag, properties in tags.items():
+            val = values_to_sub.get(tag)
+            values_to_sub[tag] = self.transform_val(properties, val)
+            if properties.get("children") is not None:
+                children = properties.get("children")
+                for child_tag, child_properties in children.items():
+                    child_val = self.transform_val(child_properties, val)
+                    values_to_sub[child_tag] = child_val
         return values_to_sub
 
-    def url_encode(self, value):
+    def transform_val(self, properties, val):
         """
-        url encodes the value passed in
+        transform (if needed) given val with given properties
 
         Parameters
         ----------
-        value: string
-            the value that needs to be encoded in the json
+        properties: dict
+            set of properties to be used for transformation
+        val: string
+            the value to undergo transformation
         Returns
         -------
-        string: the url encoded value
+        transformed
+            the transformed value
         """
+        transformed = val
 
-        return quote(value)
+        # encode if needed
+        encoding = properties.get("encoding")
+        if encoding is not None:
+            transformed = self.encode(encoding, transformed)
 
-    def base64_utf_encode(self, value):
+        # hash if needed
+        hashing = properties.get("hashing")
+        if hashing is not None:
+            transformed = self.hash(hashing, transformed)
+
+        return transformed
+
+    def encode(self, encoding_scheme, val):
         """
-        base64 utf8 encodes the value passed in
+        encodes a given val with given encoding scheme
 
         Parameters
         ----------
-        value: string
-            value that needs to be encoded in the json
+        encoding_scheme: string
+            the encoding scheme
+        val: string
+            the value to be encoded
         Returns
         -------
-        string: the base64_utf encoded value
+        encoded: string
+            the encoded value
         """
+        if encoding_scheme == "url":
+            return url_quote(val)
 
-        return base64.b64encode(value.encode("utf8")).decode("utf-8")
+        # base64 utf8
+        if encoding_scheme == "base64":
+            return base64.b64encode(val.encode("utf8")).decode("utf-8")
+
+        # returns original val if encoding_scheme not recognized
+        return val
+
+    def hash(self, hashing_scheme, val):
+        """
+        hashes a given val using given hashing_scheme
+
+        Parameters
+        ----------
+        hashing_scheme: string
+            the hashing scheme
+        val: string
+            the value to be hashed
+        Returns
+        -------
+        hashed: string
+            the hashed value
+        """
+        if hashing_scheme == "md5":
+            return str_checksum(val)
+
+        # returns original val if hashing_scheme not recognized
+        return val
 
     def generate_event(self, service_name, event_type, values_to_sub):
         """
@@ -112,7 +155,7 @@ class Events:
 
         # set variables for easy calling
         tags = self.event_mapping[service_name][event_type]["tags"]
-        values_to_sub = self.encode(tags, "encoding", values_to_sub)
+        values_to_sub = self.transform(tags, values_to_sub)
 
         # construct the path to the Events json file
         this_folder = os.path.dirname(os.path.abspath(__file__))

--- a/samcli/lib/generated_sample_events/events.py
+++ b/samcli/lib/generated_sample_events/events.py
@@ -131,8 +131,8 @@ class Events:
         if hashing_scheme == "md5":
             return str_checksum(val)
 
-        # returns original val if hashing_scheme not recognized
-        return val
+        # raise exception if hashing_scheme is unsupported
+        raise ValueError("Hashing_scheme {} is not supported.".format(hashing_scheme))
 
     def generate_event(self, service_name, event_type, values_to_sub):
         """

--- a/samcli/lib/generated_sample_events/events/sqs/Sqs.json
+++ b/samcli/lib/generated_sample_events/events/sqs/Sqs.json
@@ -3,7 +3,7 @@
     {
       "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
       "receiptHandle": "MessageReceiptHandle",
-      "body": "Hello from SQS!",
+      "body": "{{{body}}}",
       "attributes": {
         "ApproximateReceiveCount": "1",
         "SentTimestamp": "1523232000000",
@@ -11,7 +11,7 @@
         "ApproximateFirstReceiveTimestamp": "1523232000001"
       },
       "messageAttributes": {},
-      "md5OfBody": "7b270e59b47ff90a553787216d55d91d",
+      "md5OfBody": "{{{md5_of_body}}}",
       "eventSource": "aws:sqs",
       "eventSourceARN": "arn:{{{partition}}}:sqs:{{{region}}}:{{{account_id}}}:{{{queue_name}}}",
       "awsRegion": "{{{region}}}"

--- a/samcli/lib/utils/hash.py
+++ b/samcli/lib/utils/hash.py
@@ -67,3 +67,20 @@ def dir_checksum(directory, followlinks=True):
         md5_dir.update(filepath_checksum.encode("utf-8"))
 
     return md5_dir.hexdigest()
+
+
+def str_checksum(content):
+    """
+    return a md5 checksum of a given string
+
+    Parameters
+    ----------
+    content: string
+        the string to be hashed
+    Returns
+    -------
+    md5 checksum of content
+    """
+    md5 = hashlib.md5()
+    md5.update(content.encode("utf-8"))
+    return md5.hexdigest()

--- a/tests/unit/commands/local/generate_event/test_event_generation.py
+++ b/tests/unit/commands/local/generate_event/test_event_generation.py
@@ -13,30 +13,70 @@ class TestEvents(TestCase):
         self.values_to_sub = {"hello": "world"}
 
     def test_base64_encoding(self):
-        tags = {"hello": {"encoding": "base64"}}
-        e = events.Events().encode(tags, "encoding", self.values_to_sub)
-        self.assertEqual(e, {"hello": "d29ybGQ="})
+        result = events.Events().encode("base64", "world")
+        self.assertEqual(result, "d29ybGQ=")
 
     def test_url_encoding(self):
-        tags = {"hello": {"encoding": "url"}}
-        e = events.Events().encode(tags, "encoding", self.values_to_sub)
-        self.assertEqual(e, {"hello": "world"})
+        result = events.Events().encode("url", "http://www.example.com/?a=1&b=2")
+        self.assertEqual(result, "http%3A//www.example.com/%3Fa%3D1%26b%3D2")
 
     def test_if_encoding_is_none(self):
-        tags = {"hello": {"encoding": "None"}}
-        e = events.Events().encode(tags, "encoding", self.values_to_sub)
-        self.assertEqual(e, {"hello": "world"})
+        result = events.Events().encode(None, "hello")
+        self.assertEqual(result, "hello")
 
-    def test_if_tags_is_empty(self):
-        tags = {}
-        e = events.Events().encode(tags, "encoding", {})
-        self.assertEqual(e, {})
+    def test_if_encoding_is_other(self):
+        result = events.Events().encode("other", "hello")
+        self.assertEqual(result, "hello")
 
-    def test_if_tags_is_two_or_more(self):
-        tags = {"hello": {"encoding": "base64"}, "hi": {"encoding": "url"}, "bop": {"encoding": "None"}}
-        values_to_sub = {"bop": "dop", "hello": "world", "hi": "yo"}
-        e = events.Events().encode(tags, "encoding", values_to_sub)
-        self.assertEqual(e, {"bop": "dop", "hello": "d29ybGQ=", "hi": "yo"})
+    def test_md5_hashing(self):
+        result = events.Events().hash("md5", "hello, world!")
+        self.assertEqual(result, "3adbbad1791fbae3ec908894c4963870")
+
+    def test_if_hashing_is_none(self):
+        result = events.Events().hash(None, "hello, world!")
+        self.assertEqual(result, "hello, world!")
+
+    def test_if_hashing_is_other(self):
+        result = events.Events().hash("other", "hello, world!")
+        self.assertEqual(result, "hello, world!")
+
+    def test_transform_val_encoding(self):
+        properties = {"encoding": "base64"}
+        val = "world"
+        result = events.Events().transform_val(properties, val)
+        self.assertEqual(result, "d29ybGQ=")
+
+    def test_transform_val_hashing(self):
+        properties = {"hashing": "md5"}
+        val = "hello, world!"
+        result = events.Events().transform_val(properties, val)
+        self.assertEqual(result, "3adbbad1791fbae3ec908894c4963870")
+
+    def test_transform_val_both(self):
+        properties = {"encoding": "url", "hashing": "md5"}
+        val = "http://www.example.com/?a=1&b=2"
+        result = events.Events().transform_val(properties, val)
+        self.assertEqual(result, "d878d5aa4c79b8f2b3e2c5d4e9d45beb")
+
+    def test_transform(self):
+        tags = {
+            "hello": {"encoding": "base64"},
+            "url": {"encoding": "url"},
+            "foo": {"children": {"baz": {"hashing": "md5"}}},
+        }
+        values_to_sub = {
+            "hello": "world",
+            "url": "http://www.example.com/?a=1&b=2",
+            "foo": "bar",
+        }
+        result = events.Events().transform(tags, values_to_sub)
+        expected = {
+            "hello": "d29ybGQ=",
+            "url": "http%3A//www.example.com/%3Fa%3D1%26b%3D2",
+            "foo": "bar",
+            "baz": "37b51d194a7513e45b56f6524f2d51f2",
+        }
+        self.assertEqual(result, expected)
 
 
 class TestServiceCommand(TestCase):

--- a/tests/unit/commands/local/generate_event/test_event_generation.py
+++ b/tests/unit/commands/local/generate_event/test_event_generation.py
@@ -32,13 +32,8 @@ class TestEvents(TestCase):
         result = events.Events().hash("md5", "hello, world!")
         self.assertEqual(result, "3adbbad1791fbae3ec908894c4963870")
 
-    def test_if_hashing_is_none(self):
-        result = events.Events().hash(None, "hello, world!")
-        self.assertEqual(result, "hello, world!")
-
-    def test_if_hashing_is_other(self):
-        result = events.Events().hash("other", "hello, world!")
-        self.assertEqual(result, "hello, world!")
+    def test_if_hashing_is_not_supported(self):
+        self.assertRaises(ValueError, events.Events().hash, "unsupported", "hello, world!")
 
     def test_transform_val_encoding(self):
         properties = {"encoding": "base64"}

--- a/tests/unit/lib/utils/test_hash.py
+++ b/tests/unit/lib/utils/test_hash.py
@@ -4,7 +4,7 @@ import tempfile
 from unittest import TestCase
 from unittest.mock import patch
 
-from samcli.lib.utils.hash import dir_checksum
+from samcli.lib.utils.hash import dir_checksum, str_checksum
 
 
 class TestHash(TestCase):
@@ -72,3 +72,7 @@ class TestHash(TestCase):
         with self.assertRaises(OSError) as ex:
             dir_checksum(os.path.dirname(_file.name))
             self.assertIn("Too many levels of symbolic links", ex.message)
+
+    def test_str_checksum(self):
+        checksum = str_checksum("Hello, World!")
+        self.assertEqual(checksum, "65a8e27d8879283831b664bd8b7f0ad4")


### PR DESCRIPTION
*Issue #, if available:*
#758 

*Why is this change necessary?*
Customer wants to be able to customize message body when generating an SQS event

*How does it address the issue?*
To support customized `body` in the SQS was straightforward, but customizing `body` would also trigger an update in `md5OfBody`. (see [here](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html))
I introduced an additional `children` attribute in `event-mapping.json` to describe such relation, and made corresponding update in `events.py` to consume the `children` attribute. I also added supported for calculating the md5 digest of `body`.

*What side effects does this change have?*
No, the change is mostly contained with the `Events` class in `samcli/lib/generated_sample_events/events.py` and the class is only used in `samcli/commands/local/generate_event/event_generation.py`

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
No 
*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
