### PR TITLE
add spec file for pyinstaller and circleci config to build package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2.1
+
+executors:
+  docker-cimg:
+    docker:
+      - image: circleci/python:3.6-jessie
+  # macos-11-4:
+  #   macos:
+  #     xcode: 11.4.0
+  # machine-16:
+  #   machine:
+  #     image: ubuntu-1604:201903-01
+
+
+jobs:
+  build-sam-package:
+    # executor: <<parameters.executor>>
+    executor: docker-cimg
+    steps:
+      - checkout
+      - run:
+          name: install pyinstaller
+          command: |
+            sudo pip install pyinstaller
+      - run:
+          name: install dependencies and run pyinstaller
+          command: |
+            sudo pip install -r requirements/base.txt
+            pyinstaller sam.spec --onefile
+      - run:
+          name: test sam
+          command: ./dist/sam --version
+      # need to publish the 'dist/sam' file
+
+
+workflows:
+  pyinstaller:
+    jobs:
+      - build-sam-package

--- a/.gitignore
+++ b/.gitignore
@@ -251,7 +251,6 @@ pip-wheel-metadata/
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/sam.spec
+++ b/sam.spec
@@ -1,0 +1,33 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(['samcli/__main__.py'],
+             pathex=['/home/circleci/project'],
+             binaries=[],
+             datas=[('samcli/lib/generated_sample_events/event-mapping.json', 'samcli/lib/generated_sample_events')],
+             hiddenimports=['samcli.commands.publish', 'samcli.commands.logs', 'samcli.commands.deploy', 'samcli.commands.package','samcli.commands.local.local','samcli.commands.build','samcli.commands.validate.validate','samcli.commands.init'],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='sam',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=True )


### PR DESCRIPTION
*Issue #, if available:* #1424 

*Why is this change necessary?* 
Linuxbrew is not ideal

*How does it address the issue?*
This uses pyinstaller to provide a reproducible package. 
With the way it's build in the current circleci config, systems with Debian GLIBC 2.19 would be able to use this pacakge sam application. (This is most modern debian distros)

There's still plenty of work to be done.

- [ ] a location to upload the resulting artifact
- [ ] building for other systems/distros

*What side effects does this change have?*
None of the aws-sam-cli itself

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
n/a

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
