### PR TITLE
fix: flaky test and ingegration tests

### DIFF
--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -457,7 +457,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\n\n\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\n\n\n\n\n\n\n\n".format(stack_name).encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -477,7 +477,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\nSuppliedParameter\n\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\nSuppliedParameter\n\n\n\n\n\n\n".format(stack_name).encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -498,7 +498,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
         deploy_process_execute = run_command_with_input(
             deploy_command_list,
-            "{}\n\nSuppliedParameter\n\nn\nCAPABILITY_IAM CAPABILITY_NAMED_IAM\n\n".format(stack_name).encode(),
+            "{}\n\nSuppliedParameter\n\nn\nCAPABILITY_IAM CAPABILITY_NAMED_IAM\n\n\n\n".format(stack_name).encode(),
         )
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
@@ -518,7 +518,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
         # Set no for Allow SAM CLI IAM role creation, but allow default of ["CAPABILITY_IAM"] by just hitting the return key.
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\nSuppliedParameter\n\nn\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\nSuppliedParameter\n\nn\n\n\n\n\n\n".format(stack_name).encode()
         )
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
@@ -537,7 +537,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\nSuppliedParameter\nY\n\n\nY\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\nSuppliedParameter\nY\n\nY\n\n\n\n".format(stack_name).encode()
         )
 
         # Deploy should succeed with a managed stack

--- a/tests/integration/local/invoke/test_integrations_do_cli.py
+++ b/tests/integration/local/invoke/test_integrations_do_cli.py
@@ -50,5 +50,5 @@ class TestSamPython36HelloWorldNonUTF8Integration(InvokeIntegBase):
         runner = CliRunner()
         self._caplog.set_level(100000)  # https://github.com/pallets/click/issues/824
         result = runner.invoke(cli, [function_name, "-t", self.template_path, "-e", self.event_path])
-        cli_stdout = result.output.strip().split("\n")[-1]
-        self.assertEqual(cli_stdout, '"Hello world"')
+        cli_stdout_lines = result.output.strip().split("\n")
+        self.assertIn('"Hello world"', cli_stdout_lines)


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*
1. UI changes from #2176 introduce extra command line prompts, which fails guided tests in test_deploy_command.py. 

2. The lines console output changes run by run, for example: 
```
Loading function
[32mSTART RequestId: 4b4bf033-f0e5-15ff-5852-f4d216476c0e Version: $LATEST[0m
value1 = value1
value2 = value2
value3 = value3
Docker Lambda is writing to stderr
"Hello world"
[32mEND RequestId: 4b4bf033-f0e5-15ff-5852-f4d216476c0e[0m
[32mREPORT RequestId: 4b4bf033-f0e5-15ff-5852-f4d216476c0e	Init Duration: 128.38 ms	Duration: 3.01 ms	Billed Duration: 100 ms	Memory Size: 128 MB	Max Memory Used: 26 MB	[0m
```
and
```
Loading function
[32mSTART RequestId: 33e1c9c8-b775-134b-3ef1-9fee0345e9b6 Version: $LATEST[0m
value1 = value1
value2 = value2
value3 = value3
Docker Lambda is writing to stderr[32mEND RequestId: 33e1c9c8-b775-134b-3ef1-9fee0345e9b6[0m
[32mREPORT RequestId: 33e1c9c8-b775-134b-3ef1-9fee0345e9b6	Init Duration: 135.09 ms	Duration: 2.91 ms	Billed Duration: 100 ms	Memory Size: 128 MB	Max Memory Used: 26 MB	[0m

"Hello world"

```
`"Hello world"` is not always in the last line
*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
