### PR TITLE
fix: command 'sam local generate [type]' do not have --config-file an…

### DIFF
--- a/samcli/commands/local/generate_event/event_generation.py
+++ b/samcli/commands/local/generate_event/event_generation.py
@@ -7,7 +7,7 @@ import functools
 import click
 
 import samcli.lib.generated_sample_events.events as events
-from samcli.cli.cli_config_file import TomlProvider, get_ctx_defaults
+from samcli.cli.cli_config_file import TomlProvider, get_ctx_defaults, configuration_option
 from samcli.cli.options import debug_option
 from samcli.lib.telemetry.metrics import track_command
 import samcli.lib.config.samconfig as samconfig
@@ -154,22 +154,14 @@ class EventTypeSubCommand(click.MultiCommand):
             self.cmd_implementation, self.events_lib, self.top_level_cmd_name, cmd_name
         )
 
-        config = get_ctx_defaults(
-            cmd_name=cmd_name,
-            provider=TomlProvider(section="parameters"),
-            ctx=ctx,
-            config_env_name=samconfig.DEFAULT_ENV,
-        )
-
         cmd = click.Command(
             name=cmd_name,
             short_help=self.subcmd_definition[cmd_name]["help"],
-            context_settings={"default_map": config},
             params=parameters,
             callback=command_callback,
         )
 
-        cmd = debug_option(cmd)
+        cmd = configuration_option(provider=TomlProvider(section="parameters"))(debug_option(cmd))
         return cmd
 
     def list_commands(self, ctx):

--- a/tests/unit/commands/local/generate_event/test_event_generation.py
+++ b/tests/unit/commands/local/generate_event/test_event_generation.py
@@ -159,11 +159,7 @@ class TestEventTypeSubCommand(TestCase):
         s = EventTypeSubCommand(self.events_lib_mock, "hello", all_commands)
         s.get_command(None, "hi")
         click_mock.Command.assert_called_once_with(
-            name="hi",
-            short_help="Generates a hello Event",
-            params=[],
-            callback=callback_object_mock,
-            context_settings={"default_map": {}},
+            name="hi", short_help="Generates a hello Event", params=[], callback=callback_object_mock,
         )
 
     def test_subcommand_list_return_value(self):

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -720,7 +720,7 @@ class TestSamConfigWithOverrides(TestCase):
 
     @patch("samcli.commands.validate.validate.do_cli")
     def test_secondary_option_name_template_validate(self, do_cli_mock):
-        # "--tempalte" is an alias of "--template-file"
+        # "--template" is an alias of "--template-file"
         config_values = {"template": "mytemplate.yaml"}
 
         with samconfig_parameters(["validate"], self.scratch_dir, **config_values) as config_path:


### PR DESCRIPTION
…d --config-env options

*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
