### PR TITLE
Update command line document for new config file options

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -228,7 +228,12 @@ def decorator_customize_config_file(f):
     """
     config_file_attrs = {}
     config_file_param_decls = ("--config-file",)
-    config_file_attrs["help"] = "Name of configuration file. By default, it is samconfig.toml in project directory."
+    config_file_attrs["help"] = (
+        "The path and file name of the configuration file containing default parameter values to use. "
+        "Its default value is 'samconfig.toml' in project directory. For more information about configuration files, "
+        "see: "
+        "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-config.html."
+    )
     config_file_attrs["default"] = "samconfig.toml"
     config_file_attrs["is_eager"] = True
     config_file_attrs["required"] = False
@@ -245,7 +250,11 @@ def decorator_customize_config_env(f):
     """
     config_env_attrs = {}
     config_env_param_decls = ("--config-env",)
-    config_env_attrs["help"] = "Name of configuration environment. By default, its name is 'default'."
+    config_env_attrs["help"] = (
+        "The environment name specifying the default parameter values in the configuration file to use. "
+        "Its default value is 'default'. For more information about configuration files, see: "
+        "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-config.html."
+    )
     config_env_attrs["default"] = "default"
     config_env_attrs["is_eager"] = True
     config_env_attrs["required"] = False

--- a/samcli/commands/deploy/guided_config.py
+++ b/samcli/commands/deploy/guided_config.py
@@ -34,7 +34,7 @@ class GuidedConfig:
         )
         config_sanity = samconfig.sanity_check()
         click.secho("\nConfiguring SAM deploy\n======================", fg="yellow")
-        click.echo(f"\n\tLooking for samconfig.toml :  {status}")
+        click.echo(f"\n\tLooking for config file [{config_file}] :  {status}")
         if samconfig.exists():
             click.echo("\tReading default arguments  :  {}".format("Success" if config_sanity else "Failure"))
 


### PR DESCRIPTION
Update command line `--help` information to match AWS document.

*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
