### PR TITLE
Debugging support for dotnet3.1

### DIFF
--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -73,6 +73,16 @@ class LambdaDebugSettings:
                 ],
                 debug_env_vars={"_AWS_LAMBDA_DOTNET_DEBUGGING": "1"},
             ),
+            Runtime.dotnetcore31.value: DebugSettings(
+                [
+                    "/var/rapid/init",
+                    "--bootstrap",
+                    "/var/runtime/bootstrap",
+                    "--bootstrap-args",
+                    json.dumps(debug_args_list),
+                ],
+                debug_env_vars={"_AWS_LAMBDA_DOTNET_DEBUGGING": "1"},
+            ),
             Runtime.go1x.value: DebugSettings(
                 ["/var/runtime/aws-lambda-go"]
                 + debug_args_list

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -12,7 +12,7 @@ from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.local.docker.lambda_container import LambdaContainer, Runtime
 from samcli.local.docker.lambda_debug_settings import DebuggingNotSupported
 
-RUNTIMES_WITH_ENTRYPOINT = [Runtime.dotnetcore21.value, Runtime.go1x.value]
+RUNTIMES_WITH_ENTRYPOINT = [Runtime.dotnetcore21.value, Runtime.dotnetcore31.value, Runtime.go1x.value]
 
 RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT = [
     Runtime.nodejs10x.value,
@@ -28,6 +28,7 @@ RUNTIMES_WITH_DEBUG_ENV_VARS_ONLY = [
     Runtime.java8.value,
     Runtime.java8al2.value,
     Runtime.dotnetcore21.value,
+    Runtime.dotnetcore31.value,
 ]
 
 RUNTIMES_WITH_ENTRYPOINT_OVERRIDES = RUNTIMES_WITH_ENTRYPOINT + RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT
@@ -208,7 +209,7 @@ class TestLambdaContainer_get_debug_settings(TestCase):
 
         self.assertIsNotNone(debug_env_vars)
 
-    @parameterized.expand([param(r) for r in set(RUNTIMES_WITH_ENTRYPOINT) if not r.startswith("dotnetcore2")])
+    @parameterized.expand([param(r) for r in set(RUNTIMES_WITH_ENTRYPOINT) if not r.startswith("dotnetcore")])
     def test_debug_arg_must_be_split_by_spaces_and_appended_to_entrypoint(self, runtime):
         """
         Debug args list is appended starting at second position in the array


### PR DESCRIPTION
*Issue #, if available:*
Debugging config for dotnet3.1

*Why is this change necessary?*
Debugging support for dotnet3.1

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
No

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
