### PR TITLE
[WIP] Verify local layer file exists whenever LayerVersion inits

### DIFF
--- a/samcli/commands/local/cli_common/user_exceptions.py
+++ b/samcli/commands/local/cli_common/user_exceptions.py
@@ -53,6 +53,12 @@ class InvalidLayerVersionArn(UserException):
     """
 
 
+class InvalidLayerVersionContentUri(UserException):
+    """
+    The LayerVersion ContentUri given in the template is Invalid
+    """
+
+
 class UnsupportedIntrinsic(UserException):
     """
     Value from a template has an Intrinsic that is unsupported

--- a/tests/unit/commands/local/lib/test_provider.py
+++ b/tests/unit/commands/local/lib/test_provider.py
@@ -3,7 +3,11 @@ from unittest import TestCase
 from parameterized import parameterized
 
 from samcli.lib.providers.provider import LayerVersion
-from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn, UnsupportedIntrinsic
+from samcli.commands.local.cli_common.user_exceptions import (
+    InvalidLayerVersionArn,
+    UnsupportedIntrinsic,
+    InvalidLayerVersionContentUri,
+)
 
 
 class TestLayerVersion(TestCase):
@@ -58,3 +62,7 @@ class TestLayerVersion(TestCase):
 
         with self.assertRaises(UnsupportedIntrinsic):
             LayerVersion(intrinsic_arn, ".")
+
+    def test_invalid_content_uri(self):
+        with self.assertRaises(InvalidLayerVersionContentUri):
+            LayerVersion("arn:aws:lambda:region:account-id:layer:layer-name:1", "/non-exist-path")

--- a/tests/unit/commands/local/lib/test_sam_layer_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_layer_provider.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase
 
 from parameterized import parameterized
@@ -74,6 +75,7 @@ class TestSamLayerProvider(TestCase):
     def setUp(self):
         self.parameter_overrides = {}
         self.provider = SamLayerProvider(self.TEMPLATE, parameter_overrides=self.parameter_overrides)
+        os.makedirs("PyLayer/")
 
     @parameterized.expand(
         [


### PR DESCRIPTION
*Issue #, if available:*

#2252 

*Why is this change necessary?*

Quote original issue:

> If I specify a layer in my template pointing to a local zip file and that file does not exist, I should get the warning from sam build instead of running into it later in sam local invoke or sam deploy.

For invalid ARN, an `InvalidLayerVersionArn` is thrown when creating a `LayerVersion` with an invalid ARN. To make it consistent with that, I think it should also raise an exception when the `ContentUri` does not exist.

*How does it address the issue?*

By checking the content uri at the LayerVersion creation time, we can ensure the verification is at at its earliest time.

*What side effects does this change have?*

I am not sure about that. Can someone evaluate it?

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [x] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
