### PR TITLE
fix: use name instead of functionname when creating build graph

### DIFF
--- a/samcli/lib/build/build_graph.py
+++ b/samcli/lib/build/build_graph.py
@@ -36,7 +36,7 @@ def _build_definition_to_toml_table(build_definition):
     toml_table[CODE_URI_FIELD] = build_definition.codeuri
     toml_table[RUNTIME_FIELD] = build_definition.runtime
     toml_table[FUNCTIONS_FIELD] = \
-        list(map(lambda f: f.functionname, build_definition.functions))
+        list(map(lambda f: f.name, build_definition.functions))
 
     if build_definition.metadata:
         toml_table[METADATA_FIELD] = build_definition.metadata

--- a/tests/unit/lib/build_module/test_build_graph.py
+++ b/tests/unit/lib/build_module/test_build_graph.py
@@ -49,7 +49,7 @@ class TestConversionFunctions(TestCase):
         self.assertEqual(toml_table[CODE_URI_FIELD], build_definition.codeuri)
         self.assertEqual(toml_table[RUNTIME_FIELD], build_definition.runtime)
         self.assertEqual(toml_table[METADATA_FIELD], build_definition.metadata)
-        self.assertEqual(toml_table[FUNCTIONS_FIELD], [f.functionname for f in build_definition.functions])
+        self.assertEqual(toml_table[FUNCTIONS_FIELD], [f.name for f in build_definition.functions])
 
     def test_toml_table_to_build_definition(self):
         toml_table = tomlkit.table()


### PR DESCRIPTION
*Issue #, if available:*
#2293

*Why is this change necessary?*
Projects that uses mapping for function name, fails to build.

*How does it address the issue?*
To update generation of build graph. Instead of using functionname, it should use name property of the function resource

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write/update unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
