### PR TITLE
fix: for de-dup builds, build into one of the function folder instead of temporary folder

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -153,8 +153,8 @@ class ApplicationBuilder:
 
         for build_definition in build_graph.get_build_definitions():
             LOG.info("Building codeuri: %s runtime: %s metadata: %s functions: %s",
-                     build_definition.codeuri, 
-                     build_definition.runtime, 
+                     build_definition.codeuri,
+                     build_definition.runtime,
                      build_definition.metadata,
                      [function.name for function in build_definition.functions])
 

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -153,20 +153,27 @@ class ApplicationBuilder:
             LOG.info("Building codeuri: %s runtime: %s metadata: %s functions: %s",
                      build_definition.codeuri, build_definition.runtime, build_definition.metadata,
                      [function.name for function in build_definition.functions])
-            with osutils.mkdir_temp() as temporary_build_dir:
-                LOG.debug("Building to following folder %s", temporary_build_dir)
-                self._build_function(build_definition.get_function_name(),
-                                     build_definition.codeuri,
-                                     build_definition.runtime,
-                                     build_definition.get_handler_name(),
-                                     temporary_build_dir,
-                                     build_definition.metadata)
 
-                for function in build_definition.functions:
+            # build into one of the functions from this build definition
+            single_function_name = build_definition.get_function_name()
+            single_build_dir = str(pathlib.Path(self._build_dir, single_function_name))
+
+            LOG.debug("Building to following folder %s", single_build_dir)
+            self._build_function(build_definition.get_function_name(),
+                                 build_definition.codeuri,
+                                 build_definition.runtime,
+                                 build_definition.get_handler_name(),
+                                 single_build_dir,
+                                 build_definition.metadata)
+            function_build_results[single_function_name] = single_build_dir
+
+            # copy results to other functions
+            for function in build_definition.functions:
+                if function.name is not single_function_name:
                     # artifacts directory will be created by the builder
                     artifacts_dir = str(pathlib.Path(self._build_dir, function.name))
-                    LOG.debug("Copying artifacts from %s to %s", temporary_build_dir, artifacts_dir)
-                    osutils.copytree(temporary_build_dir, artifacts_dir)
+                    LOG.debug("Copying artifacts from %s to %s", single_build_dir, artifacts_dir)
+                    osutils.copytree(single_build_dir, artifacts_dir)
                     function_build_results[function.name] = artifacts_dir
 
         return function_build_results

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -28,7 +28,7 @@ class BuildIntegBase(TestCase):
         cls.template_path = str(Path(cls.test_data_path, cls.template))
 
     def setUp(self):
-        # To invoke a function creaated by the build command, we need the built artifacts to be in a
+        # To invoke a function created by the build command, we need the built artifacts to be in a
         # location that is shared in Docker. Most temp directories are not shared. Therefore we are
         # using a scratch space within the test folder that is .gitignored. Contents of this folder
         # is also deleted after every test run
@@ -134,6 +134,88 @@ class BuildIntegBase(TestCase):
 
         process_stdout = process_execute.stdout.decode("utf-8")
         self.assertEqual(json.loads(process_stdout), expected_result)
+
+
+class BuildIntegRubyBase(BuildIntegBase):
+    EXPECTED_FILES_GLOBAL_MANIFEST = set()
+    EXPECTED_FILES_PROJECT_MANIFEST = {"app.rb"}
+    EXPECTED_RUBY_GEM = "aws-record"
+
+    FUNCTION_LOGICAL_ID = "Function"
+
+    def _test_with_default_gemfile(self, runtime, use_container, code_uri, relative_path):
+        overrides = {"Runtime": runtime, "CodeUri": code_uri, "Handler": "ignored"}
+        cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
+
+        LOG.info("Running Command:")
+        LOG.info(cmdlist)
+        run_command(cmdlist, cwd=self.working_dir)
+
+        self._verify_built_artifact(
+            self.default_build_dir,
+            self.FUNCTION_LOGICAL_ID,
+            self.EXPECTED_FILES_PROJECT_MANIFEST,
+            self.EXPECTED_RUBY_GEM,
+        )
+
+        self._verify_resource_property(
+            str(self.built_template),
+            "OtherRelativePathResource",
+            "BodyS3Location",
+            os.path.relpath(
+                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")),
+                str(self.default_build_dir),
+            ),
+        )
+
+        self._verify_resource_property(
+            str(self.built_template),
+            "GlueResource",
+            "Command.ScriptLocation",
+            os.path.relpath(
+                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")),
+                str(self.default_build_dir),
+            ),
+        )
+
+        self.verify_docker_container_cleanedup(runtime)
+
+    def _verify_built_artifact(self, build_dir, function_logical_id, expected_files, expected_modules):
+        self.assertTrue(build_dir.exists(), "Build directory should be created")
+
+        build_dir_files = os.listdir(str(build_dir))
+        self.assertIn("template.yaml", build_dir_files)
+        self.assertIn(function_logical_id, build_dir_files)
+
+        template_path = build_dir.joinpath("template.yaml")
+        resource_artifact_dir = build_dir.joinpath(function_logical_id)
+
+        # Make sure the template has correct CodeUri for resource
+        self._verify_resource_property(str(template_path), function_logical_id, "CodeUri", function_logical_id)
+
+        all_artifacts = set(os.listdir(str(resource_artifact_dir)))
+        actual_files = all_artifacts.intersection(expected_files)
+        self.assertEqual(actual_files, expected_files)
+
+        ruby_version = None
+        ruby_bundled_path = None
+
+        # Walk through ruby version to get to the gem path
+        for dirpath, dirname, _ in os.walk(str(resource_artifact_dir.joinpath("vendor", "bundle", "ruby"))):
+            ruby_version = dirname
+            ruby_bundled_path = Path(dirpath)
+            break
+
+        # If Gemfile is in root folder, vendor folder will also be created there
+        if ruby_version is None:
+            for dirpath, dirname, _ in os.walk(str(Path(self.working_dir).joinpath("vendor", "bundle", "ruby"))):
+                ruby_version = dirname
+                ruby_bundled_path = Path(dirpath)
+                break
+
+        gem_path = ruby_bundled_path.joinpath(ruby_version[0], "gems")
+
+        self.assertTrue(any([True if self.EXPECTED_RUBY_GEM in gem else False for gem in os.listdir(str(gem_path))]))
 
 
 class DedupBuildIntegBase(BuildIntegBase):

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -163,8 +163,7 @@ class BuildIntegRubyBase(BuildIntegBase):
             "OtherRelativePathResource",
             "BodyS3Location",
             os.path.relpath(
-                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")),
-                str(self.default_build_dir),
+                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")), str(self.default_build_dir),
             ),
         )
 
@@ -173,8 +172,7 @@ class BuildIntegRubyBase(BuildIntegBase):
             "GlueResource",
             "Command.ScriptLocation",
             os.path.relpath(
-                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")),
-                str(self.default_build_dir),
+                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")), str(self.default_build_dir),
             ),
         )
 

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 import sys
 import os
 import logging
@@ -8,7 +9,8 @@ from parameterized import parameterized
 
 import pytest
 
-from .build_integ_base import BuildIntegBase, DedupBuildIntegBase
+from samcli.lib.utils import osutils
+from .build_integ_base import BuildIntegBase, DedupBuildIntegBase, BuildIntegRubyBase
 from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, CI_OVERRIDE, run_command
 
 LOG = logging.getLogger(__name__)
@@ -207,88 +209,52 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
     ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
     "Skip build tests on windows when running in CI unless overridden",
 )
-class TestBuildCommand_RubyFunctions(BuildIntegBase):
-    EXPECTED_FILES_GLOBAL_MANIFEST = set()
-    EXPECTED_FILES_PROJECT_MANIFEST = {"app.rb"}
-    EXPECTED_RUBY_GEM = "aws-record"
+class TestBuildCommand_RubyFunctions(BuildIntegRubyBase):
 
-    FUNCTION_LOGICAL_ID = "Function"
-
-    @parameterized.expand([("ruby2.5"), ("ruby2.7")])
+    @parameterized.expand(["ruby2.5", "ruby2.7"])
     @pytest.mark.flaky(reruns=3)
     def test_building_ruby_in_container(self, runtime):
-        self._test_with_default_gemfile(runtime, "use_container")
+        self._test_with_default_gemfile(runtime, "use_container", "Ruby", self.test_data_path)
+
+    @parameterized.expand(["ruby2.5", "ruby2.7"])
+    @pytest.mark.flaky(reruns=3)
+    def test_building_ruby_in_process(self, runtime):
+        self._test_with_default_gemfile(runtime, False, "Ruby", self.test_data_path)
+
+
+@skipIf(
+    ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
+class TestBuildCommand_RubyFunctionsWithGemfileInTheRoot(BuildIntegRubyBase):
+    """
+    Tests use case where Gemfile will present in the root of the project folder.
+    This doesn't apply to containerized build, since it copies only the function folder to the container
+    """
 
     @parameterized.expand([("ruby2.5"), ("ruby2.7")])
     @pytest.mark.flaky(reruns=3)
-    def test_building_ruby_in_process(self, runtime):
-        self._test_with_default_gemfile(runtime, False)
+    def test_building_ruby_in_process_with_root_gemfile(self, runtime):
+        self._prepare_application_environment()
+        self._test_with_default_gemfile(runtime, False, "RubyWithRootGemfile", self.working_dir)
 
-    def _test_with_default_gemfile(self, runtime, use_container):
-        overrides = {"Runtime": runtime, "CodeUri": "Ruby", "Handler": "ignored"}
-        cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
-
-        LOG.info("Running Command:")
-        LOG.info(cmdlist)
-        run_command(cmdlist, cwd=self.working_dir)
-
-        self._verify_built_artifact(
-            self.default_build_dir,
-            self.FUNCTION_LOGICAL_ID,
-            self.EXPECTED_FILES_PROJECT_MANIFEST,
-            self.EXPECTED_RUBY_GEM,
-        )
-
-        self._verify_resource_property(
-            str(self.built_template),
-            "OtherRelativePathResource",
-            "BodyS3Location",
-            os.path.relpath(
-                os.path.normpath(os.path.join(str(self.test_data_path), "SomeRelativePath")),
-                str(self.default_build_dir),
-            ),
-        )
-
-        self._verify_resource_property(
-            str(self.built_template),
-            "GlueResource",
-            "Command.ScriptLocation",
-            os.path.relpath(
-                os.path.normpath(os.path.join(str(self.test_data_path), "SomeRelativePath")),
-                str(self.default_build_dir),
-            ),
-        )
-
-        self.verify_docker_container_cleanedup(runtime)
-
-    def _verify_built_artifact(self, build_dir, function_logical_id, expected_files, expected_modules):
-        self.assertTrue(build_dir.exists(), "Build directory should be created")
-
-        build_dir_files = os.listdir(str(build_dir))
-        self.assertIn("template.yaml", build_dir_files)
-        self.assertIn(function_logical_id, build_dir_files)
-
-        template_path = build_dir.joinpath("template.yaml")
-        resource_artifact_dir = build_dir.joinpath(function_logical_id)
-
-        # Make sure the template has correct CodeUri for resource
-        self._verify_resource_property(str(template_path), function_logical_id, "CodeUri", function_logical_id)
-
-        all_artifacts = set(os.listdir(str(resource_artifact_dir)))
-        actual_files = all_artifacts.intersection(expected_files)
-        self.assertEqual(actual_files, expected_files)
-
-        ruby_version = None
-        ruby_bundled_path = None
-
-        # Walk through ruby version to get to the gem path
-        for dirpath, dirname, _ in os.walk(str(resource_artifact_dir.joinpath("vendor", "bundle", "ruby"))):
-            ruby_version = dirname
-            ruby_bundled_path = Path(dirpath)
-            break
-        gem_path = ruby_bundled_path.joinpath(ruby_version[0], "gems")
-
-        self.assertTrue(any([True if self.EXPECTED_RUBY_GEM in gem else False for gem in os.listdir(str(gem_path))]))
+    def _prepare_application_environment(self):
+        """
+        Create an application environment where Gemfile will be in the root folder of the app;
+        ├── RubyWithRootGemfile
+        │   └── app.rb
+        ├── Gemfile
+        └── template.yaml
+        """
+        # copy gemfile to the root of the project
+        shutil.copyfile(Path(self.template_path).parent.joinpath("Gemfile"), Path(self.working_dir).joinpath("Gemfile"))
+        # copy function source code in its folder
+        osutils.copytree(Path(self.template_path).parent.joinpath("RubyWithRootGemfile"),
+                         Path(self.working_dir).joinpath("RubyWithRootGemfile"))
+        # copy template to the root folder
+        shutil.copyfile(Path(self.template_path), Path(self.working_dir).joinpath("template.yaml"))
+        # update template path with new location
+        self.template_path = str(Path(self.working_dir).joinpath("template.yaml"))
 
 
 @skipIf(

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -210,7 +210,6 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
     "Skip build tests on windows when running in CI unless overridden",
 )
 class TestBuildCommand_RubyFunctions(BuildIntegRubyBase):
-
     @parameterized.expand(["ruby2.5", "ruby2.7"])
     @pytest.mark.flaky(reruns=3)
     def test_building_ruby_in_container(self, runtime):
@@ -249,8 +248,10 @@ class TestBuildCommand_RubyFunctionsWithGemfileInTheRoot(BuildIntegRubyBase):
         # copy gemfile to the root of the project
         shutil.copyfile(Path(self.template_path).parent.joinpath("Gemfile"), Path(self.working_dir).joinpath("Gemfile"))
         # copy function source code in its folder
-        osutils.copytree(Path(self.template_path).parent.joinpath("RubyWithRootGemfile"),
-                         Path(self.working_dir).joinpath("RubyWithRootGemfile"))
+        osutils.copytree(
+            Path(self.template_path).parent.joinpath("RubyWithRootGemfile"),
+            Path(self.working_dir).joinpath("RubyWithRootGemfile"),
+        )
         # copy template to the root folder
         shutil.copyfile(Path(self.template_path), Path(self.working_dir).joinpath("template.yaml"))
         # update template path with new location

--- a/tests/integration/testdata/buildcmd/Gemfile
+++ b/tests/integration/testdata/buildcmd/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "aws-record", "~> 2"

--- a/tests/integration/testdata/buildcmd/RubyWithRootGemfile/app.rb
+++ b/tests/integration/testdata/buildcmd/RubyWithRootGemfile/app.rb
@@ -1,0 +1,6 @@
+require 'json'
+require 'httparty'
+
+def lambda_handler(event:, context:)
+  "Hello World"
+end

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -93,7 +93,8 @@ class TestApplicationBuilder_build(TestCase):
 
     @patch("samcli.lib.build.build_graph.BuildGraph._write")
     @patch("samcli.lib.build.build_graph.BuildGraph._read")
-    def test_should_run_build_for_only_unique_builds(self, persist_mock, read_mock):
+    @patch("samcli.lib.build.app_builder.osutils")
+    def test_should_run_build_for_only_unique_builds(self, persist_mock, read_mock, osutils_mock):
         build_function_mock = Mock()
 
         # create 3 function resources where 2 of them would have same codeuri, runtime and metadata


### PR DESCRIPTION
*Issue #, if available:*
#2292

*Why is this change necessary?*
Building some of the ruby projects into temp folder is not working because of shared Gemfile in the root folder

*How does it address the issue?*
Instead of building into temp folder, it is building into one of the functions for same build definition

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
