### PR TITLE
chore: Fix inconsistent black version in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/python/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
       - id: black
         language_version: python3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/python/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
         language_version: python3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
 repos:
-  - repo: https://github.com/python/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-        language_version: python3.7
-        exclude_types: ['markdown', 'ini', 'toml']
+- repo: local
+  hooks:
+    - id: black
+      name: black
+      entry: black
+      language: system
+      require_serial: true
+      types: [python]

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -52,6 +52,28 @@ in Appveyor during PRs. Black will be installed automatically with `make init`.
 
 After installing, you can run our formatting through our Makefile by `make black` or integrating Black directly in your favorite IDE (instructions
 can be found [here](https://black.readthedocs.io/en/stable/editor_integration.html))
+ 
+##### (workaround) Integrating Black directly in your favorite IDE
+Since black is installed in virtualenv, when you follow [this intruction](https://black.readthedocs.io/en/stable/editor_integration.html), `which black` might give you this
+
+```bash
+(samcli37) $ where black
+/Users/<username>/.pyenv/shims/black
+```
+
+However, IDEs such PyChaim (using FileWatcher) will have a hard time invoking `/Users/<username>/.pyenv/shims/black` 
+and this will happen:
+
+```
+pyenv: black: command not found
+
+The `black' command exists in these Python versions:
+  3.7.2/envs/samcli37
+  samcli37
+``` 
+
+A simple workaround is to use `/Users/<username>/.pyenv/versions/samcli37/bin/black` 
+instead of `/Users/<username>/.pyenv/shims/black`.
 
 #### Pre-commit
 If you don't wish to manually run black on each pr or install black manually, we have integrated black into git hooks through [pre-commit](https://pre-commit.com/).

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -48,10 +48,9 @@ easily setup multiple Python versions.
 ### 2. Install Additional Tooling
 #### Black
 We format our code using [Black](https://github.com/python/black) and verify the source code is black compliant
-in Appveyor during PRs. You can find installation instructions on [Black's docs](https://black.readthedocs.io/en/stable/installation_and_usage.html).
-Install version 19.10b0 as this is what is currently used in the CI/CD pipeline.
+in Appveyor during PRs. Black will be installed automatically with `make init`.
 
-After installing, you can run our formatting through our Makefile by `make black-format` or integrating Black directly in your favorite IDE (instructions
+After installing, you can run our formatting through our Makefile by `make black` or integrating Black directly in your favorite IDE (instructions
 can be found [here](https://black.readthedocs.io/en/stable/editor_integration.html))
 
 #### Pre-commit

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ lint:
 dev: lint test
 
 black:
-	black samcli/* tests/*
+	black setup.py samcli tests
 
 black-check:
-	black --check samcli/* tests/*
+	black --check setup.py samcli tests
 
 # Verifications to run before sending a pull request
 pr: init dev black-check

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,11 +99,6 @@ for:
       - sh: "sudo unzip -d /opt/gradle /tmp/gradle-*.zip"
       - sh: "PATH=/opt/gradle/gradle-5.5/bin:$PATH"
 
-      # Install black
-      - sh: "wget -O /tmp/black https://github.com/python/black/releases/download/19.10b0/black"
-      - sh: "chmod +x /tmp/black"
-      - sh: "/tmp/black --version"
-
       # Install AWS CLI
       - sh: "virtualenv aws_cli"
       - sh: "./aws_cli/bin/python -m pip install awscli"
@@ -139,7 +134,7 @@ for:
       # Runs only in Linux
       - sh: "pytest -vv tests/integration"
       - sh: "pytest -vv tests/regression"
-      - sh: "/tmp/black --check setup.py tests samcli"
+      - sh: "black --check setup.py tests samcli"
 
       # Set JAVA_HOME to java11
       - sh: "JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,3 +9,6 @@ pytest-xdist==1.30.0
 pytest-forked==1.1.3
 pytest-timeout==1.3.3
 pytest-rerunfailures==7.0
+
+# formatter
+black==20.8b1

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -129,7 +129,13 @@ def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx,
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
     # If --config-file is an absolute path, use it, if not, start from config_dir
     config_file_name = config_file if os.path.isabs(config_file) else os.path.join(config_dir, config_file)
-    config = get_ctx_defaults(cmd_name, provider, ctx, config_env_name=config_env_name, config_file=config_file_name,)
+    config = get_ctx_defaults(
+        cmd_name,
+        provider,
+        ctx,
+        config_env_name=config_env_name,
+        config_file=config_file_name,
+    )
     ctx.default_map.update(config)
 
     return saved_callback(ctx, param, config_env_name) if saved_callback else config_env_name

--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -194,7 +194,9 @@ class GuidedContext:
             raise GuidedDeployFailedError(str(ex)) from ex
 
         guided_config = GuidedConfig(template_file=self.template_file, section=self.config_section)
-        guided_config.read_config_showcase(self.config_file or DEFAULT_CONFIG_FILE_NAME,)
+        guided_config.read_config_showcase(
+            self.config_file or DEFAULT_CONFIG_FILE_NAME,
+        )
 
         self.guided_prompts(_parameter_override_keys)
 

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -76,7 +76,15 @@ $ sam logs -n HelloWorldFunction --stack-name mystack --filter "error" \n
 @pass_context
 @track_command
 def cli(
-    ctx, name, stack_name, filter, tail, start_time, end_time, config_file, config_env,
+    ctx,
+    name,
+    stack_name,
+    filter,
+    tail,
+    start_time,
+    end_time,
+    config_file,
+    config_env,
 ):  # pylint: disable=redefined-builtin
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -49,7 +49,11 @@ SEMANTIC_VERSION = "SemanticVersion"
 @pass_context
 @track_command
 def cli(
-    ctx, template_file, semantic_version, config_file, config_env,
+    ctx,
+    template_file,
+    semantic_version,
+    config_file,
+    config_env,
 ):
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -21,7 +21,10 @@ from samcli.cli.cli_config_file import configuration_option, TomlProvider
 @pass_context
 @track_command
 def cli(
-    ctx, template_file, config_file, config_env,
+    ctx,
+    template_file,
+    config_file,
+    config_env,
 ):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing

--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -70,14 +70,24 @@ class LambdaDebugSettings:
                     debug_env_vars={},
                 ),
                 Runtime.nodejs10x.value: DebugSettings(
-                    entry + ["/var/lang/bin/node"] + debug_args_list + ["/var/runtime/index.js",],
+                    entry
+                    + ["/var/lang/bin/node"]
+                    + debug_args_list
+                    + [
+                        "/var/runtime/index.js",
+                    ],
                     debug_env_vars={
                         "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node10/node_modules:/var/runtime/node_module",
                         "NODE_OPTIONS": f"--inspect-brk=0.0.0.0:{str(debug_port)} --no-lazy --expose-gc --max-http-header-size 81920",
                     },
                 ),
                 Runtime.nodejs12x.value: DebugSettings(
-                    entry + ["/var/lang/bin/node"] + debug_args_list + ["/var/runtime/index.js",],
+                    entry
+                    + ["/var/lang/bin/node"]
+                    + debug_args_list
+                    + [
+                        "/var/runtime/index.js",
+                    ],
                     debug_env_vars={
                         "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node12/node_modules:/var/runtime/node_module",
                         "NODE_OPTIONS": f"--inspect-brk=0.0.0.0:{str(debug_port)} --no-lazy --expose-gc --max-http-header-size 81920",

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -163,7 +163,8 @@ class BuildIntegRubyBase(BuildIntegBase):
             "OtherRelativePathResource",
             "BodyS3Location",
             os.path.relpath(
-                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")), str(self.default_build_dir),
+                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")),
+                str(self.default_build_dir),
             ),
         )
 
@@ -172,7 +173,8 @@ class BuildIntegRubyBase(BuildIntegBase):
             "GlueResource",
             "Command.ScriptLocation",
             os.path.relpath(
-                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")), str(self.default_build_dir),
+                os.path.normpath(os.path.join(str(relative_path), "SomeRelativePath")),
+                str(self.default_build_dir),
             ),
         )
 

--- a/tests/integration/package/test_package_command.py
+++ b/tests/integration/package/test_package_command.py
@@ -466,11 +466,13 @@ class TestPackage(PackageIntegBase):
             upload_message = bytes("Uploading to", encoding="utf-8")
             if no_progressbar:
                 self.assertNotIn(
-                    upload_message, process_stderr,
+                    upload_message,
+                    process_stderr,
                 )
             else:
                 self.assertIn(
-                    upload_message, process_stderr,
+                    upload_message,
+                    process_stderr,
                 )
 
     @parameterized.expand(

--- a/tests/unit/commands/deploy/test_guided_context.py
+++ b/tests/unit/commands/deploy/test_guided_context.py
@@ -86,7 +86,14 @@ class TestGuidedContext(TestCase):
         [
             param((("CAPABILITY_IAM",),)),
             param((("CAPABILITY_AUTO_EXPAND",),)),
-            param((("CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM",),)),
+            param(
+                (
+                    (
+                        "CAPABILITY_AUTO_EXPAND",
+                        "CAPABILITY_IAM",
+                    ),
+                )
+            ),
         ]
     )
     @patch("samcli.commands.deploy.guided_context.prompt")

--- a/tests/unit/commands/local/generate_event/test_event_generation.py
+++ b/tests/unit/commands/local/generate_event/test_event_generation.py
@@ -159,7 +159,10 @@ class TestEventTypeSubCommand(TestCase):
         s = EventTypeSubCommand(self.events_lib_mock, "hello", all_commands)
         s.get_command(None, "hi")
         click_mock.Command.assert_called_once_with(
-            name="hi", short_help="Generates a hello Event", params=[], callback=callback_object_mock,
+            name="hi",
+            short_help="Generates a hello Event",
+            params=[],
+            callback=callback_object_mock,
         )
 
     def test_subcommand_list_return_value(self):

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -100,10 +100,12 @@ class TestSamConfig(TestCase):
         self.samconfig.flush()
         self._check_config_file()
         self.assertEqual(
-            {"testKey1": True}, self.samconfig.get_all(cmd_names=["myCommand"], section="mySection1", env="myEnv"),
+            {"testKey1": True},
+            self.samconfig.get_all(cmd_names=["myCommand"], section="mySection1", env="myEnv"),
         )
         self.assertEqual(
-            {"testKey2": False}, self.samconfig.get_all(cmd_names=["myCommand"], section="mySection2", env="myEnv"),
+            {"testKey2": False},
+            self.samconfig.get_all(cmd_names=["myCommand"], section="mySection2", env="myEnv"),
         )
 
     def test_add_params_from_different_keys(self):

--- a/tests/unit/lib/utils/test_hash.py
+++ b/tests/unit/lib/utils/test_hash.py
@@ -38,13 +38,27 @@ class TestHash(TestCase):
         dir_checksums = {}
         with patch("os.walk") as mockwalk:
             mockwalk.return_value = [
-                (self.temp_dir, (), (file1.name, file2.name,),),
+                (
+                    self.temp_dir,
+                    (),
+                    (
+                        file1.name,
+                        file2.name,
+                    ),
+                ),
             ]
             dir_checksums["first"] = dir_checksum(self.temp_dir)
 
         with patch("os.walk") as mockwalk:
             mockwalk.return_value = [
-                (self.temp_dir, (), (file2.name, file1.name,),),
+                (
+                    self.temp_dir,
+                    (),
+                    (
+                        file2.name,
+                        file1.name,
+                    ),
+                ),
             ]
             dir_checksums["second"] = dir_checksum(self.temp_dir)
 


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*

to make black version consistent with appveyor and dev guide. Even better, by only specifying black version in one place , we can reduce our maintenance cost. 

*How does it address the issue?*

- make black installation managed
- only specify black version in one place
- avoid installing black in pre-commit (reuse existing black installed by `make init`)
- simplify dev guide

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
