### PR TITLE
fix: fail on invalid config

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import click
 
 from samcli.commands.exceptions import ConfigException
-from samcli.lib.config.exceptions import SamConfigVersionException
 from samcli.cli.context import get_cmd_names
 from samcli.lib.config.samconfig import SamConfig, DEFAULT_ENV, DEFAULT_CONFIG_FILE_NAME
 
@@ -76,7 +75,6 @@ class TomlProvider:
 
             # NOTE(TheSriram): change from tomlkit table type to normal dictionary,
             # so that click defaults work out of the box.
-            samconfig.sanity_check()
             resolved_config = dict(samconfig.get_all(cmd_names, self.section, env=config_env).items())
             LOG.debug("Configuration values successfully loaded.")
             LOG.debug("Configuration values are: %s", resolved_config)
@@ -92,12 +90,9 @@ class TomlProvider:
                 str(ex),
             )
 
-        except SamConfigVersionException as ex:
-            LOG.debug("%s %s", samconfig.path(), str(ex))
-            raise ConfigException("Syntax invalid in samconfig.toml") from ex
-
         except Exception as ex:
             LOG.debug("Error reading configuration file: %s %s", samconfig.path(), str(ex))
+            raise ConfigException(f"Error reading configuration: {ex}") from ex
 
         return resolved_config
 

--- a/tests/integration/deploy/deploy_integ_base.py
+++ b/tests/integration/deploy/deploy_integ_base.py
@@ -41,6 +41,7 @@ class DeployIntegBase(TestCase):
         region=None,
         guided=False,
         resolve_s3=False,
+        config_file=None,
     ):
         command_list = [self.base_command(), "deploy"]
 
@@ -86,6 +87,8 @@ class DeployIntegBase(TestCase):
             command_list = command_list + ["--profile", str(profile)]
         if resolve_s3:
             command_list = command_list + ["--resolve-s3"]
+        if config_file:
+            command_list = command_list + ["--config-file", str(config_file)]
 
         return command_list
 

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -568,6 +568,17 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_process_execute = run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
+    @parameterized.expand([("aws-serverless-function.yaml", "samconfig-invalid-syntax.toml")])
+    def test_deploy_with_invalid_config(self, template_file, config_file):
+        template_path = self.test_data_path.joinpath(template_file)
+        config_path = self.test_data_path.joinpath(config_file)
+
+        deploy_command_list = self.get_deploy_command_list(template_file=template_path, config_file=config_path)
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
+        self.assertIn("Error reading configuration: Unexpected character", str(deploy_process_execute.stderr))
+
     def _method_to_stack_name(self, method_name):
         """Method expects method name which can be a full path. Eg: test.integration.test_deploy_command.method_name"""
         method_name = method_name.split(".")[-1]

--- a/tests/integration/testdata/package/samconfig-invalid-syntax.toml
+++ b/tests/integration/testdata/package/samconfig-invalid-syntax.toml
@@ -1,0 +1,2 @@
+[default.deploy.parameters]
+stack_name=my_stack"

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -60,7 +60,16 @@ class TestTomlProvider(TestCase):
         config_path.write_text("version=0.1\n[config_env.topic.parameters]\nword='clarity'\n")
         config_path_invalid = Path(config_dir, "samconfig.toml")
 
-        self.assertEqual(self.toml_provider(config_path_invalid, self.config_env, [self.cmd_name]), {})
+        with self.assertRaises(ConfigException):
+            self.toml_provider(config_path_invalid, self.config_env, [self.cmd_name])
+
+    def test_toml_invalid_syntax(self):
+        config_dir = tempfile.gettempdir()
+        config_path = Path(config_dir, "samconfig.toml")
+        config_path.write_text("version=0.1\n[config_env.topic.parameters]\nword=_clarity'\n")
+
+        with self.assertRaises(ConfigException):
+            self.toml_provider(config_path, self.config_env, [self.cmd_name])
 
 
 class TestCliConfiguration(TestCase):


### PR DESCRIPTION
*Issue #, if available:* #2311 

### Why is this change necessary?

- Prevent issues in the config from being ignored.
- Improve UX by stating the root cause as early as possible.

### How does it address the issue?

Fail immediately if a non-`KeyError` exception is thrown when processing the config.

For example, with the following `samconfig.toml`:

```toml
version = 0.1
[default.deploy.parameters]
stack_name = _sam-app"
```

Instead of cryptic error messages as in #2311, `sam deploy` and `sam deploy --guided` will now show the following output:

```bash
Error: Error reading configuration: Unexpected character: '_' at line 3 col 13
```

A few notes regarding the PR:
- Keeping the `KeyError` handling as-is for now as it's not directly relevant to the issue and there might be marginal benefit to it (e.g. allow specifying a custom `config_env` without the corresponding TOML table).
- Removed the [`sanity_check()`](https://github.com/aws/aws-sam-cli/blob/3edb55cd8dba9898ddf2e1c8bd9eeba0434c08de/samcli/lib/config/samconfig.py#L134)  as the `get_all()` below it already validates the config by calling `_read()` (which is also what `sanity_check()` does, except by swallowing exceptions).

### What side effects does this change have?

`sam deploy` fails early if there's a problem reading the config.

### Did you change a dependency in `requirements/base.txt`?

No.

### Checklist

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
