### PR TITLE
Export the ApplicationBuilder parallel option to the cli

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -33,6 +33,7 @@ class BuildContext:
             manifest_path=None,
             clean=False,
             use_container=False,
+            parallel=False,
             parameter_overrides=None,
             docker_network=None,
             skip_pull_image=False,
@@ -45,6 +46,7 @@ class BuildContext:
         self._manifest_path = manifest_path
         self._clean = clean
         self._use_container = use_container
+        self._parallel = parallel
         self._parameter_overrides = parameter_overrides
         self._docker_network = docker_network
         self._skip_pull_image = skip_pull_image
@@ -122,6 +124,10 @@ class BuildContext:
     @property
     def use_container(self):
         return self._use_container
+
+    @property
+    def parallel(self):
+        return self._parallel
 
     @property
     def output_template_path(self):

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -78,6 +78,12 @@ $ sam build && sam package --s3-bucket <bucketname>
     "are resolved with respect to the SAM template's location",
 )
 @click.option(
+    "--parallel",
+    "-p",
+    is_flag=True,
+    help="Set to True to build each function in parallel to improve performance",
+)
+@click.option(
     "--use-container",
     "-u",
     is_flag=True,
@@ -106,6 +112,7 @@ def cli(
     base_dir,
     build_dir,
     use_container,
+    parallel,
     manifest,
     docker_network,
     skip_pull_image,
@@ -124,6 +131,7 @@ def cli(
         build_dir,
         True,
         use_container,
+        parallel,
         manifest,
         docker_network,
         skip_pull_image,
@@ -139,6 +147,7 @@ def do_cli(  # pylint: disable=too-many-locals, too-many-statements
     build_dir,
     clean,
     use_container,
+    parallel,
     manifest_path,
     docker_network,
     skip_pull_image,
@@ -189,6 +198,7 @@ def do_cli(  # pylint: disable=too-many-locals, too-many-statements
                 ctx.is_building_specific_resource,
                 manifest_path_override=ctx.manifest_path_override,
                 container_manager=ctx.container_manager,
+                parallel=ctx.parallel,
                 mode=ctx.mode,
             )
         except FunctionNotFound as ex:


### PR DESCRIPTION
*Issue #, if available:* no issue

*Why is this change necessary?*
The application builder supports building the different function parallelly.
Yet, this option was always set to false. This commit adds the option to toggle
it to true from the command line as a flag.
To keep backward compatibility, the default value is False - single thread.

*What side effects does this change have?* none

*Did you change a dependency in `requirements/base.txt`?* no - no reason
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
