### PR TITLE
fix: apply PayloadFormationVersion in httpapi event

### DIFF
--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -1034,25 +1034,31 @@ class TestPayloadVersionWithStageAndSwaggerWithHttpApi(StartApiIntegBaseClass):
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
-    def test_swagger_stage_variable_httpapi(self):
+    def test_payload_version_v1_swagger_inline_httpapi(self):
         response = requests.get(self.url + "/httpapi-payload-format-v1", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
-        self.assertEqual(response_data.get("version", {}), "2.0")
-        self.assertIsNone(response_data.get("multiValueHeaders"))
-        self.assertIsNotNone(response_data.get("cookies"))
+        self.assertEqual(response_data.get("version", {}), "1.0")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
-    def test_swagger_stage_variable_httpapi(self):
+    def test_payload_version_v2_swagger_inline_httpapi(self):
         response = requests.get(self.url + "/httpapi-payload-format-v2", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         self.assertEqual(response_data.get("version", {}), "2.0")
-        self.assertIsNone(response_data.get("multiValueHeaders"))
-        self.assertIsNotNone(response_data.get("cookies"))
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_payload_version_v1_property_httpapi(self):
+        response = requests.get(self.url + "/httpapi-payload-format-v1-property", timeout=300)
+
+        self.assertEqual(response.status_code, 200)
+        response_data = response.json()
+        print(response_data)
+        self.assertEqual(response_data.get("version", {}), "1.0")
 
 
 class TestOptionsHandler(StartApiIntegBaseClass):

--- a/tests/integration/testdata/start_api/swagger-template-http-api.yaml
+++ b/tests/integration/testdata/start_api/swagger-template-http-api.yaml
@@ -24,11 +24,11 @@ Resources:
           - "origin"
         MaxAge: 42
       DefinitionBody:
-        swagger: "2.0"
-        openapi: "3.0.0"
+        openapi: '3.0.1'
         info:
           title:
             Ref: AWS::StackName
+          version: '1.0'
         paths:
           "/httpapi-anyandall":
             x-amazon-apigateway-any-method:
@@ -43,22 +43,22 @@ Resources:
               x-amazon-apigateway-integration:
                 httpMethod: POST
                 type: aws_proxy
-                uri:
-                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EchoEventHandlerHttpApiFunction.Arn}/invocations
           "/httpapi-payload-format-v1":
-            post:
+            get:
+              responses: {}
               x-amazon-apigateway-integration:
                 httpMethod: GET
                 type: aws_proxy
-                payloadFormatVersion: 1.0
+                payloadFormatVersion: '1.0'
                 uri:
                   Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EchoEventHandlerHttpApiFunction.Arn}/invocations
           "/httpapi-payload-format-v2":
-            post:
+            get:
+              responses: {}
               x-amazon-apigateway-integration:
                 httpMethod: GET
                 type: aws_proxy
-                payloadFormatVersion: 2.0
+                payloadFormatVersion: '2.0'
                 uri:
                   Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EchoEventHandlerHttpApiFunction.Arn}/invocations
           "/httpapi-echobase64eventbody":
@@ -85,11 +85,28 @@ Resources:
             ApiId:
               Ref: MyHttpApi
 
+  PayLoadFormatV1InPropertyHttpApiFunction:
+    Type:  AWS::Serverless::Function
+    Properties:
+      Handler: main.echo_event_handler
+      Runtime: python3.7
+      CodeUri: .
+      Timeout: 600
+      Events:
+        GetApi:
+          Type: HttpApi
+          Properties:
+            PayloadFormatVersion: "1.0"
+            Path: /httpapi-payload-format-v1-property
+            Method: GET
+            ApiId:
+              Ref: MyHttpApi
+
   EchoEventHandlerHttpApiFunction:
     Type:  AWS::Serverless::Function
     Properties:
       Handler: main.echo_event_handler
-      Runtime: python3.6
+      Runtime: python3.7
       CodeUri: .
       Timeout: 600
       Events:


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
