### PR TITLE
Fix: Make API Gateway infer Lambda function response for HttpApi with PayloadFormatVersion 2.0

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -161,14 +161,13 @@ class LocalApigwService(BaseLocalService):
         if default_route:
             LOG.debug("add catch-all route")
             all_methods = Route.ANY_HTTP_METHODS
-            done_looping = False
-            rules_iter = self._app.url_map.iter_rules("/")
-            while not done_looping:
-                try:
+            try:
+                rules_iter = self._app.url_map.iter_rules("/")
+                while True:
                     rule = next(rules_iter)
                     all_methods = [method for method in all_methods if method not in rule.methods]
-                except StopIteration:
-                    done_looping = True
+            except (KeyError, StopIteration):
+                pass
 
             self._add_catch_all_path(all_methods, "/", default_route)
             self._add_catch_all_path(Route.ANY_HTTP_METHODS, "/<path:any_path>", default_route)

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -359,7 +359,6 @@ class LocalApigwService(BaseLocalService):
             json_output.get("headers") or {}, json_output.get("multiValueHeaders") or {}
         )
         body = json_output.get("body") if "statusCode" in json_output else json.dumps(json_output)
-
         if body is None:
             LOG.warning("Lambda returned empty body!")
         is_base_64_encoded = json_output.get("isBase64Encoded") or False

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -308,6 +308,72 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_valid_v2_lambda_json_response(self):
+        """
+        Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
+        """
+        response = requests.get(self.url + "/validv2responsehash", timeout=300)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"foo": "bar"})
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_invalid_v1_lambda_json_response(self):
+        """
+        Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
+        """
+        response = requests.get(self.url + "/invalidv1responsehash", timeout=300)
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.json(), {"message": "Internal server error"})
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_valid_v2_lambda_string_response(self):
+        """
+        Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
+        """
+        response = requests.get(self.url + "/validv2responsestring", timeout=300)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "This is invalid")
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_valid_v2_lambda_integer_response(self):
+        """
+        Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
+        """
+        response = requests.get(self.url + "/validv2responseinteger", timeout=300)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "2")
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_invalid_v2_lambda_response(self):
+        """
+        Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
+        """
+        response = requests.get(self.url + "/invalidv2response", timeout=300)
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.json(), {"message": "Internal server error"})
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_invalid_v1_lambda_string_response(self):
+        """
+        Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
+        """
+        response = requests.get(self.url + "/invalidv1responsestring", timeout=300)
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.json(), {"message": "Internal server error"})
+
 
 class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     template_path = "/testdata/start_api/swagger-template.yaml"

--- a/tests/integration/testdata/start_api/main.py
+++ b/tests/integration/testdata/start_api/main.py
@@ -59,6 +59,11 @@ def write_to_stdout(event, context):
 def invalid_response_returned(event, context):
     return "This is invalid"
 
+def integer_response_returned(event, context):
+    return 2
+
+def invalid_v2_respose_returned(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"}), "key": "value"}
 
 def invalid_hash_response(event, context):
     return {"foo": "bar"}

--- a/tests/integration/testdata/start_api/template-http-api.yaml
+++ b/tests/integration/testdata/start_api/template-http-api.yaml
@@ -204,21 +204,7 @@ Resources:
             Method: GET
             Path: /writetostdout
 
-  InvalidResponseFromLambdaFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: main.invalid_response_returned
-      Runtime: python3.6
-      CodeUri: .
-      Timeout: 600
-      Events:
-        InvalidResponseReturned:
-          Type: HttpApi
-          Properties:
-            Method: GET
-            Path: /invalidresponsereturned
-
-  InvalidResponseHashFromLambdaFunction:
+  ValidV2ResponseHashFromLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.invalid_hash_response
@@ -230,7 +216,79 @@ Resources:
           Type: HttpApi
           Properties:
             Method: GET
-            Path: /invalidresponsehash
+            Path: /validv2responsehash
+
+  InValidV1ResponseHashFromLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.invalid_hash_response
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+      Events:
+        InvalidResponseReturned:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /invalidv1responsehash
+            PayloadFormatVersion: 1.0
+
+  ValidV2StringResponseFromLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.invalid_response_returned
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+      Events:
+        InvalidResponseReturned:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /validv2responsestring
+
+  ValidV2IntegerResponseFromLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.integer_response_returned
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+      Events:
+        InvalidResponseReturned:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /validv2responseinteger
+
+  InValidV2ResponseFromLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.invalid_v2_respose_returned
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+      Events:
+        InvalidResponseReturned:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /invalidv2response
+
+  InValidV1StringResponseFromLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.invalid_response_returned
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+      Events:
+        InvalidResponseReturned:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /invalidv1responsestring
+            PayloadFormatVersion: 1.0
 
   Base64ResponseFunction:
     Type: AWS::Serverless::Function

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -666,6 +666,17 @@ class TestServiceParsingLambdaOutput(TestCase):
 
         (_, headers, _) = LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
 
+    def test_inferring_response_for_format_2(self):
+        lambda_output = '{"message": "Hello from Lambda!"}'
+
+        (status_code, headers, body) = LocalApigwService._parse_lambda_output(
+            lambda_output, binary_types=[], flask_request=Mock()
+        )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(body, lambda_output)
+
 
 class TestService_construct_event(TestCase):
     def setUp(self):

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -62,7 +62,7 @@ class TestApiGatewayService(TestCase):
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
-        self.api_service._parse_lambda_output = parse_output_mock
+        self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
@@ -90,7 +90,7 @@ class TestApiGatewayService(TestCase):
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
-        self.http_service._parse_lambda_output = parse_output_mock
+        self.http_service._parse_v2_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
@@ -118,7 +118,7 @@ class TestApiGatewayService(TestCase):
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
-        self.http_service._parse_lambda_output = parse_output_mock
+        self.http_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
@@ -146,7 +146,7 @@ class TestApiGatewayService(TestCase):
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
-        self.http_service._parse_lambda_output = parse_output_mock
+        self.http_service._parse_v2_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
@@ -171,7 +171,7 @@ class TestApiGatewayService(TestCase):
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
-        self.api_service._parse_lambda_output = parse_output_mock
+        self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
@@ -195,7 +195,7 @@ class TestApiGatewayService(TestCase):
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
-        self.http_service._parse_lambda_output = parse_output_mock
+        self.http_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
@@ -221,7 +221,7 @@ class TestApiGatewayService(TestCase):
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
-        self.api_service._parse_lambda_output = parse_output_mock
+        self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         lambda_logs = "logs"
         lambda_response = "response"
@@ -252,7 +252,7 @@ class TestApiGatewayService(TestCase):
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
-        self.api_service._parse_lambda_output = parse_output_mock
+        self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
@@ -355,7 +355,7 @@ class TestApiGatewayService(TestCase):
     ):
         parse_output_mock = Mock()
         parse_output_mock.side_effect = LambdaResponseParseException()
-        self.api_service._parse_lambda_output = parse_output_mock
+        self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         failure_response_mock = Mock()
 
@@ -484,7 +484,9 @@ class TestServiceParsingLambdaOutput(TestCase):
             '{"statusCode": 200, "body": "{\\"message\\":\\"Hello from Lambda\\"}", ' '"isBase64Encoded": false}'
         )
 
-        (_, headers, _) = LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+        (_, headers, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
+            lambda_output, binary_types=[], flask_request=Mock()
+        )
 
         self.assertIn("Content-Type", headers)
         self.assertEqual(headers["Content-Type"], "application/json")
@@ -495,7 +497,9 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false}'
         )
 
-        (_, headers, _) = LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+        (_, headers, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
+            lambda_output, binary_types=[], flask_request=Mock()
+        )
 
         self.assertIn("Content-Type", headers)
         self.assertEqual(headers["Content-Type"], "application/json")
@@ -505,7 +509,9 @@ class TestServiceParsingLambdaOutput(TestCase):
             '{"statusCode": 200, "headers":{"Content-Type": "text/xml"}, "body": "{}", ' '"isBase64Encoded": false}'
         )
 
-        (_, headers, _) = LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+        (_, headers, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
+            lambda_output, binary_types=[], flask_request=Mock()
+        )
 
         self.assertIn("Content-Type", headers)
         self.assertEqual(headers["Content-Type"], "text/xml")
@@ -516,7 +522,9 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false}'
         )
 
-        (_, headers, _) = LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+        (_, headers, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
+            lambda_output, binary_types=[], flask_request=Mock()
+        )
 
         self.assertIn("Content-Type", headers)
         self.assertEqual(headers["Content-Type"], "text/xml")
@@ -527,7 +535,9 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"body": "{\\"message\\":\\"Hello from Lambda\\"}", "isBase64Encoded": false}'
         )
 
-        (_, headers, _) = LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+        (_, headers, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
+            lambda_output, binary_types=[], flask_request=Mock()
+        )
 
         self.assertEqual(headers, Headers({"Content-Type": "application/json", "X-Foo": ["bar", "42"]}))
 
@@ -538,7 +548,9 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"body": "{\\"message\\":\\"Hello from Lambda\\"}", "isBase64Encoded": false}'
         )
 
-        (_, headers, _) = LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+        (_, headers, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
+            lambda_output, binary_types=[], flask_request=Mock()
+        )
 
         self.assertEqual(
             headers, Headers({"Content-Type": "application/json", "X-Bar": "bar", "X-Foo": ["bar", "42", "foo"]})
@@ -551,7 +563,9 @@ class TestServiceParsingLambdaOutput(TestCase):
         )
 
         with self.assertRaises(LambdaResponseParseException):
-            LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+            LocalApigwService._parse_v1_payload_format_lambda_output(
+                lambda_output, binary_types=[], flask_request=Mock()
+            )
 
     def test_parse_returns_correct_tuple(self):
         lambda_output = (
@@ -559,7 +573,7 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false}'
         )
 
-        (status_code, headers, body) = LocalApigwService._parse_lambda_output(
+        (status_code, headers, body) = LocalApigwService._parse_v1_payload_format_lambda_output(
             lambda_output, binary_types=[], flask_request=Mock()
         )
 
@@ -574,7 +588,9 @@ class TestServiceParsingLambdaOutput(TestCase):
         )
 
         with self.assertRaises(LambdaResponseParseException):
-            LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+            LocalApigwService._parse_v1_payload_format_lambda_output(
+                lambda_output, binary_types=[], flask_request=Mock()
+            )
 
     @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._should_base64_decode_body")
     def test_parse_returns_decodes_base64_to_binary(self, should_decode_body_patch):
@@ -589,7 +605,7 @@ class TestServiceParsingLambdaOutput(TestCase):
             "isBase64Encoded": False,
         }
 
-        (status_code, headers, body) = LocalApigwService._parse_lambda_output(
+        (status_code, headers, body) = LocalApigwService._parse_v1_payload_format_lambda_output(
             json.dumps(lambda_output), binary_types=["*/*"], flask_request=Mock()
         )
 
@@ -604,7 +620,9 @@ class TestServiceParsingLambdaOutput(TestCase):
         )
 
         with self.assertRaises(LambdaResponseParseException):
-            LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+            LocalApigwService._parse_v1_payload_format_lambda_output(
+                lambda_output, binary_types=[], flask_request=Mock()
+            )
 
     def test_status_code_int_str(self):
         lambda_output = (
@@ -612,7 +630,7 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false}'
         )
 
-        (status_code, _, _) = LocalApigwService._parse_lambda_output(
+        (status_code, _, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
             lambda_output, binary_types=[], flask_request=Mock()
         )
         self.assertEqual(status_code, 200)
@@ -624,7 +642,9 @@ class TestServiceParsingLambdaOutput(TestCase):
         )
 
         with self.assertRaises(LambdaResponseParseException):
-            LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+            LocalApigwService._parse_v1_payload_format_lambda_output(
+                lambda_output, binary_types=[], flask_request=Mock()
+            )
 
     def test_status_code_negative_int_str(self):
         lambda_output = (
@@ -633,24 +653,30 @@ class TestServiceParsingLambdaOutput(TestCase):
         )
 
         with self.assertRaises(LambdaResponseParseException):
-            LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+            LocalApigwService._parse_v1_payload_format_lambda_output(
+                lambda_output, binary_types=[], flask_request=Mock()
+            )
 
     def test_lambda_output_list_not_dict(self):
         lambda_output = "[]"
 
         with self.assertRaises(LambdaResponseParseException):
-            LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+            LocalApigwService._parse_v1_payload_format_lambda_output(
+                lambda_output, binary_types=[], flask_request=Mock()
+            )
 
     def test_lambda_output_not_json_serializable(self):
         lambda_output = "some str"
 
         with self.assertRaises(LambdaResponseParseException):
-            LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+            LocalApigwService._parse_v1_payload_format_lambda_output(
+                lambda_output, binary_types=[], flask_request=Mock()
+            )
 
     def test_properties_are_null(self):
         lambda_output = '{"statusCode": 0, "headers": null, "body": null, ' '"isBase64Encoded": null}'
 
-        (status_code, headers, body) = LocalApigwService._parse_lambda_output(
+        (status_code, headers, body) = LocalApigwService._parse_v1_payload_format_lambda_output(
             lambda_output, binary_types=[], flask_request=Mock()
         )
 
@@ -664,12 +690,14 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false, "cookies":{}}'
         )
 
-        (_, headers, _) = LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
+        (_, headers, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
+            lambda_output, binary_types=[], flask_request=Mock()
+        )
 
     def test_inferring_response_for_format_2(self):
         lambda_output = '{"message": "Hello from Lambda!"}'
 
-        (status_code, headers, body) = LocalApigwService._parse_lambda_output(
+        (status_code, headers, body) = LocalApigwService._parse_v2_payload_format_lambda_output(
             lambda_output, binary_types=[], flask_request=Mock()
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
It's great to see that #1942 and #2326 are now merged into develop so we can run HttpApi locally!
Another great thing is to let the API Gateway infer Lambda function responses as described in https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.v2.
Since it doesn't work when running "sam local start-api", this pr tries to fix it.

*How does it address the issue?*
It adds functionality to make API Gateway infer Lambda function response for HttpApi with PayloadFormatVersion 2.0.

*What side effects does this change have?*
None

*Did you change a dependency in `requirements/base.txt`?*
No

    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
