### PR TITLE
Remove six usage

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -259,7 +259,7 @@ ignore-mixin-members=yes
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis
-ignored-modules=six.moves
+ignored-modules=
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,5 +15,3 @@ requests==2.23.0
 serverlessrepo==0.1.10
 aws_lambda_builders==1.1.0
 tomlkit==0.7.0
-# TODO: remove six and its usage since we don't support Python 2
-six==1.15.0

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -203,7 +203,7 @@ serverlessrepo==0.1.10 \
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
-    # via aws-lambda-builders, aws-sam-cli (setup.py), aws-sam-translator, cookiecutter, docker, jsonschema, pyrsistent, python-dateutil, serverlessrepo, websocket-client
+    # via aws-lambda-builders, aws-sam-translator, cookiecutter, docker, jsonschema, pyrsistent, python-dateutil, serverlessrepo, websocket-client
 text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
     --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93 \

--- a/samcli/commands/local/lib/swagger/integration_uri.py
+++ b/samcli/commands/local/lib/swagger/integration_uri.py
@@ -7,7 +7,6 @@ import re
 import logging
 
 from enum import Enum
-from six import string_types
 
 LOG = logging.getLogger(__name__)
 
@@ -113,7 +112,7 @@ class LambdaUri:
             LOG.debug("Resolved Sub intrinsic function: %s", uri_data)
 
         # Even after processing intrinsics, this is not a string. Give up.
-        if not isinstance(uri_data, string_types):
+        if not isinstance(uri_data, str):
             LOG.debug("This Integration URI format is not supported: %s", uri_data)
             return None
 
@@ -233,7 +232,7 @@ class LambdaUri:
             # Get the ARN out of the list
             arn = arn[0]
 
-        if not isinstance(arn, string_types):
+        if not isinstance(arn, str):
             # Even after all the processing, ARN is still not a string. Probably customer provided wrong syntax
             # for Fn::Sub. Let's skip this altogether
             LOG.debug("Unable to resolve Fn::Sub value for integration URI: %s", uri_data)

--- a/samcli/commands/local/lib/swagger/reader.py
+++ b/samcli/commands/local/lib/swagger/reader.py
@@ -6,8 +6,8 @@ import os
 import tempfile
 import logging
 
-from six.moves.urllib.parse import urlparse, parse_qs
-from six import string_types
+from urllib.parse import urlparse, parse_qs
+
 import boto3
 import botocore
 
@@ -162,7 +162,7 @@ class SwaggerReader:
             swagger_str = self._download_from_s3(bucket, key, version)
             return yaml_parse(swagger_str)
 
-        if not isinstance(location, string_types):
+        if not isinstance(location, str):
             # This is not a string and not a S3 Location dictionary. Probably something invalid
             LOG.debug("Unable to download Swagger file. Invalid location: %s", location)
             return None
@@ -262,7 +262,7 @@ class SwaggerReader:
             # this dictionary has none of the fields we expect. Return None if the fields don't exist.
             bucket, key, version = (location.get("Bucket"), location.get("Key"), location.get("Version"))
 
-        elif isinstance(location, string_types) and location.startswith("s3://"):
+        elif isinstance(location, str) and location.startswith("s3://"):
             # This is a S3 URI. Parse it using a standard URI parser to extract the components
 
             parsed = urlparse(location)

--- a/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
+++ b/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
@@ -8,8 +8,6 @@ import base64
 import re
 from collections import OrderedDict
 
-from six import string_types
-
 from samcli.lib.intrinsic_resolver.invalid_intrinsic_validation import (
     verify_intrinsic_type_list,
     verify_non_null,
@@ -663,7 +661,7 @@ class IntrinsicResolver:
                 (logical_id, attribute_type) = intrinsic_item, IntrinsicResolver.REF
             return symbol_resolver.resolve_symbols(logical_id, attribute_type, ignore_errors=True)
 
-        if isinstance(intrinsic_value, string_types):
+        if isinstance(intrinsic_value, str):
             intrinsic_value = [intrinsic_value, {}]
 
         verify_intrinsic_type_list(

--- a/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
+++ b/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
@@ -4,8 +4,6 @@ The symbol table that is used in IntrinsicResolver in order to resolve runtime a
 import logging
 import os
 
-from six import string_types
-
 from samcli.lib.intrinsic_resolver.intrinsic_property_resolver import IntrinsicResolver
 from samcli.lib.intrinsic_resolver.invalid_intrinsic_exception import InvalidSymbolException
 
@@ -320,7 +318,7 @@ class IntrinsicsSymbolTable:
 
         """
         logical_id_item = self.logical_id_translator.get(logical_id, {})
-        if any(isinstance(logical_id_item, object_type) for object_type in [string_types, list, bool, int]):
+        if any(isinstance(logical_id_item, object_type) for object_type in [str, list, bool, int]):
             if resource_attributes not in (IntrinsicResolver.REF, ""):
                 return None
             return logical_id_item

--- a/samcli/lib/intrinsic_resolver/invalid_intrinsic_validation.py
+++ b/samcli/lib/intrinsic_resolver/invalid_intrinsic_validation.py
@@ -1,8 +1,6 @@
 """
 A list of helper functions that cleanup the processing in IntrinsicResolver and IntrinsicSymbolTable
 """
-from six import string_types
-
 from samcli.lib.intrinsic_resolver.invalid_intrinsic_exception import InvalidIntrinsicException
 
 
@@ -28,7 +26,7 @@ def verify_intrinsic_type_int(argument, property_type="", message="", position_i
 
 
 def verify_intrinsic_type_str(argument, property_type="", message="", position_in_list=""):
-    verify_intrinsic_type(argument, property_type, message, position_in_list, primitive_type=string_types)
+    verify_intrinsic_type(argument, property_type, message, position_in_list, primitive_type=str)
 
 
 def verify_non_null(argument, property_type="", message="", position_in_list=""):
@@ -39,7 +37,7 @@ def verify_non_null(argument, property_type="", message="", position_in_list="")
         )
 
 
-def verify_intrinsic_type(argument, property_type="", message="", position_in_list="", primitive_type=string_types):
+def verify_intrinsic_type(argument, property_type="", message="", position_in_list="", primitive_type=str):
     verify_non_null(argument, property_type, message, position_in_list)
     if not isinstance(argument, primitive_type):
         raise InvalidIntrinsicException(

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -6,8 +6,6 @@ routes in a standardized format
 import logging
 from collections import defaultdict
 
-from six import string_types
-
 from samcli.local.apigw.local_apigw_service import Route
 from samcli.lib.providers.provider import Api
 
@@ -208,7 +206,7 @@ class ApiCollector:
             Normalized value. If the input was not a string, then None is returned
         """
 
-        if not isinstance(value, string_types):
+        if not isinstance(value, str):
             # It is possible that user specified a dict value for one of the binary media types. We just skip them
             return None
 

--- a/samcli/lib/providers/cfn_api_provider.py
+++ b/samcli/lib/providers/cfn_api_provider.py
@@ -1,8 +1,6 @@
 """Parses SAM given a template"""
 import logging
 
-from six import string_types
-
 from samcli.commands.local.lib.swagger.integration_uri import LambdaUri
 from samcli.local.apigw.local_apigw_service import Route
 from samcli.commands.local.cli_common.user_exceptions import InvalidSamTemplateException
@@ -163,7 +161,7 @@ class CfnApiProvider(CfnBaseApiProvider):
         method = properties.get("HttpMethod")
 
         resource_path = "/"
-        if isinstance(resource_id, string_types):  # If the resource_id resolves to a string
+        if isinstance(resource_id, str):  # If the resource_id resolves to a string
             resource = resources.get(resource_id)
 
             if resource:
@@ -392,7 +390,7 @@ class CfnApiProvider(CfnBaseApiProvider):
             properties = integration_resource.get("Properties", {})
             integration_uri = properties.get("IntegrationUri")
             payload_format_version = properties.get("PayloadFormatVersion")
-            if integration_uri and isinstance(integration_uri, string_types):
+            if integration_uri and isinstance(integration_uri, str):
                 return LambdaUri.get_function_name(integration_uri), payload_format_version
 
         return None, None

--- a/samcli/lib/providers/cfn_base_api_provider.py
+++ b/samcli/lib/providers/cfn_base_api_provider.py
@@ -1,7 +1,6 @@
 """Class that parses the CloudFormation Api Template"""
 import logging
 
-from six import string_types, integer_types
 from samcli.commands.local.lib.swagger.parser import SwaggerParser
 from samcli.commands.local.lib.swagger.reader import SwaggerReader
 
@@ -96,7 +95,7 @@ class CfnBaseApiProvider:
             cors = Cors(
                 allow_origin=allow_origin, allow_methods=allow_methods, allow_headers=allow_headers, max_age=max_age
             )
-        elif cors_prop and isinstance(cors_prop, string_types):
+        elif cors_prop and isinstance(cors_prop, str):
             allow_origin = cors_prop
             if not (allow_origin.startswith("'") and allow_origin.endswith("'")):
                 raise InvalidSamDocumentException(
@@ -128,7 +127,7 @@ class CfnBaseApiProvider:
         """
         prop = cors_dict.get(prop_name)
         if prop:
-            if not isinstance(prop, string_types) or prop.startswith("!"):
+            if not isinstance(prop, str) or prop.startswith("!"):
                 LOG.warning(
                     "CORS Property %s was not fully resolved. Will proceed as if the Property was not defined.",
                     prop_name,
@@ -166,7 +165,7 @@ class CfnBaseApiProvider:
             allow_headers = self._get_cors_prop_http(cors_prop, "AllowHeaders", list)
             if isinstance(allow_headers, list):
                 allow_headers = ",".join(allow_headers)
-            max_age = self._get_cors_prop_http(cors_prop, "MaxAge", integer_types)
+            max_age = self._get_cors_prop_http(cors_prop, "MaxAge", str)
 
             cors = Cors(
                 allow_origin=allow_origins, allow_methods=allow_methods, allow_headers=allow_headers, max_age=max_age

--- a/samcli/lib/providers/cfn_base_api_provider.py
+++ b/samcli/lib/providers/cfn_base_api_provider.py
@@ -165,7 +165,7 @@ class CfnBaseApiProvider:
             allow_headers = self._get_cors_prop_http(cors_prop, "AllowHeaders", list)
             if isinstance(allow_headers, list):
                 allow_headers = ",".join(allow_headers)
-            max_age = self._get_cors_prop_http(cors_prop, "MaxAge", str)
+            max_age = self._get_cors_prop_http(cors_prop, "MaxAge", int)
 
             cors = Cors(
                 allow_origin=allow_origins, allow_methods=allow_methods, allow_headers=allow_headers, max_age=max_age


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*

A followup mentioned in https://github.com/aws/aws-sam-cli/pull/2304#discussion_r508755968

*How does it address the issue?*

Use https://six.readthedocs.io/ as a reference to remove `six` usage and keep only the Python 3 part.

*What side effects does this change have?*

None

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
