### PR TITLE
fix HttpApi event V2 route key

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -37,7 +37,9 @@ class Route:
     HTTP = "HttpApi"
     ANY_HTTP_METHODS = ["GET", "DELETE", "PUT", "POST", "HEAD", "OPTIONS", "PATCH"]
 
-    def __init__(self, function_name, path, methods, event_type=API, payload_format_version=None):
+    def __init__(
+        self, function_name, path, methods, event_type=API, payload_format_version=None, is_default_route=False
+    ):
         """
         Creates an ApiGatewayRoute
 
@@ -46,12 +48,14 @@ class Route:
         :param str path: Path off the base url
         :param str event_type: Type of the event. "Api" or "HttpApi"
         :param str payload_format_version: version of payload format
+        :param bool is_default_route: determines if the default route or not
         """
         self.methods = self.normalize_method(methods)
         self.function_name = function_name
         self.path = path
         self.event_type = event_type
         self.payload_format_version = payload_format_version
+        self.is_default_route = is_default_route
 
     def __eq__(self, other):
         return (
@@ -197,6 +201,7 @@ class LocalApigwService(BaseLocalService):
                 methods=methods,
                 event_type=Route.HTTP,
                 payload_format_version=route.payload_format_version,
+                is_default_route=True,
             )
 
     def _generate_route_keys(self, methods, path):
@@ -210,6 +215,12 @@ class LocalApigwService(BaseLocalService):
         """
         for method in methods:
             yield self._route_key(method, path)
+
+    @staticmethod
+    def _v2_route_key(method, path, is_default_route):
+        if is_default_route:
+            return "$default"
+        return "{} {}".format(method, path)
 
     @staticmethod
     def _route_key(method, path):
@@ -254,7 +265,6 @@ class LocalApigwService(BaseLocalService):
         cors_headers = Cors.cors_to_headers(self.api.cors)
 
         method, endpoint = self.get_request_methods_endpoints(request)
-        route_key = self._route_key(method, endpoint)
         if method == "OPTIONS" and self.api.cors:
             headers = Headers(cors_headers)
             return self.service_response("", headers, 200)
@@ -264,6 +274,7 @@ class LocalApigwService(BaseLocalService):
             # or none, as the default value to be used is 2.0
             # https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-integrations.html#apis-apiid-integrations-prop-createintegrationinput-payloadformatversion
             if route.event_type == Route.HTTP and route.payload_format_version in [None, "2.0"]:
+                route_key = self._v2_route_key(method, endpoint, route.is_default_route)
                 event = self._construct_v_2_0_event_http(
                     request,
                     self.port,

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -1491,7 +1491,11 @@ class TestCFNTemplateQuickCreatedHttpApiWithDefaultRoute(StartApiIntegBaseClass)
         response = requests.patch(self.url + "/anypath/anypath", timeout=300)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"hello": "world"})
+        response_data = response.json()
+        self.assertEqual(response_data.get("version", {}), "2.0")
+        self.assertEqual(response_data.get("routeKey", {}), "$default")
+        self.assertIsNone(response_data.get("multiValueHeaders"))
+        self.assertIsNotNone(response_data.get("cookies"))
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -1549,6 +1553,7 @@ class TestCFNTemplateQuickCreatedHttpApiWithOneRoute(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         self.assertEqual(response_data.get("version", {}), "2.0")
+        self.assertEqual(response_data.get("routeKey", {}), "GET /echoeventbody")
         self.assertIsNone(response_data.get("multiValueHeaders"))
         self.assertIsNotNone(response_data.get("cookies"))
 

--- a/tests/integration/testdata/start_api/cfn-quick-created-http-api-with-default-route.yaml
+++ b/tests/integration/testdata/start_api/cfn-quick-created-http-api-with-default-route.yaml
@@ -7,7 +7,7 @@ Description: 'sam-app
 Resources:
   HelloWorldFunction:
     Properties:
-      Handler: main.handler
+      Handler: main.echo_event_handler
       Code: '.'
       Role:
         Fn::GetAtt:

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -1143,6 +1143,14 @@ class TestService_construct_event_http(TestCase):
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
 
+    def test_v2_route_key(self):
+        route_key = LocalApigwService._v2_route_key("GET", "/path", False)
+        self.assertEquals(route_key, "GET /path")
+
+    def test_v2_default_route_key(self):
+        route_key = LocalApigwService._v2_route_key("GET", "/path", True)
+        self.assertEquals(route_key, "$default")
+
     @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._should_base64_encode")
     def test_construct_event_with_binary_data(self, should_base64_encode_patch):
         should_base64_encode_patch.return_value = True


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sam-cli/issues/2345

*Why is this change necessary?* to fix the Http APi event route key

*How does it address the issue?* it fixes the used route format"{path}:{method}", and use the correct format "{method} {path}"

*What side effects does this change have?* no side effects

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
no

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
