### PR TITLE
feat: update sam-translator version to 1.29.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ boto3~=1.14.0, >=1.14.23
 jmespath~=0.10.0
 PyYAML~=5.3
 cookiecutter~=1.7.2
-aws-sam-translator==1.28.1
+aws-sam-translator==1.29.0
 #docker minor version updates can include breaking changes. Auto update micro version only.
 docker~=4.2.0
 dateparser~=0.7

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -12,10 +12,10 @@ attrs==19.3.0 \
     --hash=sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c \
     --hash=sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72 \
     # via jsonschema
-aws-sam-translator==1.28.1 \
-    --hash=sha256:149e620854897bcb5b8f6ddc3cdcfafc125c360561612159ba82af1acc82a29b \
-    --hash=sha256:9d591c2b37fdd9b050428b135c8d7abc9641551bbfc7bb7fcb4009efba92184d \
-    --hash=sha256:d463fbafd1a32bab36a942d1a5d800dd9130718b96cf5dd55e9ddb74bcea8c6b \
+aws-sam-translator==1.29.0 \
+    --hash=sha256:0e7aee471d35a4f700d24bca3f351287ff6ba72ab4718d475fb7a5eb96697551 \
+    --hash=sha256:5f7e122738537acd6aa42605a166cf08c45a91f52e22a705c67d5c0e5d692f13 \
+    --hash=sha256:bb557e08b39f9bce6a5a0ec87e086b420846e285295e39ce86842f4e371bbb77 \
     # via aws-sam-cli (setup.py)
 aws_lambda_builders==1.1.0 \
     --hash=sha256:2b40a0003c2c05143e1aa816fed758c7d78f3e5c8e115be681aa2478f2655056 \

--- a/tests/functional/commands/validate/lib/models/amq.yaml
+++ b/tests/functional/commands/validate/lib/models/amq.yaml
@@ -1,0 +1,17 @@
+Resources:
+  MQFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      CodeUri: s3://sam-demo-bucket/queues.zip
+      Handler: queue.mq_handler
+      Runtime: python2.7
+      Events:
+        MyMQQueue:
+          Type: MQ
+          Properties:
+            Broker: arn:aws:mq:us-east-2:123456789012:broker:MyBroker:b-1234a5b6-78cd-901e-2fgh-3i45j6k178l9
+            Queues:
+              - "Queue1"
+            SourceAccessConfigurations:
+              - Type: BASIC_AUTH
+                URI: arn:aws:secretsmanager:us-west-2:123456789012:secret:my-path/my-secret-name-1a2b3c

--- a/tests/functional/commands/validate/lib/models/api_with_basic_custom_domain.yaml
+++ b/tests/functional/commands/validate/lib/models/api_with_basic_custom_domain.yaml
@@ -62,6 +62,11 @@ Resources:
         CertificateArn: 'my-api-cert-arn'
         EndpointConfiguration: 'EDGE'
         BasePath: [ "/get", "/fetch" ]
+        MutualTlsAuthentication:
+          TruststoreUri: 'my-api-truststore-uri'
+          TruststoreVersion: 'my-api-truststore-version'
+        SecurityPolicy: TLS_1_2
+
 
   MyAnotherApi:
     Type: AWS::Serverless::Api

--- a/tests/functional/commands/validate/lib/models/api_with_basic_custom_domain_http.yaml
+++ b/tests/functional/commands/validate/lib/models/api_with_basic_custom_domain_http.yaml
@@ -13,6 +13,10 @@ Globals:
       DomainName: !Ref MyDomainName
       CertificateArn: !Ref MyDomainCert
       EndpointConfiguration: REGIONAL
+      MutualTlsAuthentication:
+        TruststoreUri: 'my-api-v2-truststore-uri'
+        TruststoreVersion: 'my-api-v2-truststore-version'
+      SecurityPolicy: TLS_1_2
       BasePath: ["/basic", "/begin-here"]
       Route53:
         HostedZoneName: sam-example.com.
@@ -47,4 +51,5 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      DisableExecuteApiEndpoint: true
       StageName: Prod

--- a/tests/functional/commands/validate/lib/models/api_with_basic_custom_domain_intrinsics.yaml
+++ b/tests/functional/commands/validate/lib/models/api_with_basic_custom_domain_intrinsics.yaml
@@ -12,6 +12,14 @@ Parameters:
     Type: String
     Default: REGIONAL
 
+  MyMTLSUri:
+    Default: another-api-truststore-uri
+    Type: String
+
+  MyMTLSVersion:
+    Default: another-api-truststore-version
+    Type: String
+
 Resources:
   MyFunction:
     Condition: C1
@@ -51,4 +59,8 @@ Resources:
         CertificateArn: !Ref MyDomainCert
         EndpointConfiguration: !Ref EndpointConf
         BasePath: [ "/get", "/fetch" ]
+        MutualTlsAuthentication:
+          TruststoreUri: !Ref MyMTLSUri
+          TruststoreVersion: !Ref MyMTLSVersion
+        SecurityPolicy: TLS_1_2
 

--- a/tests/functional/commands/validate/lib/models/api_with_basic_custom_domain_intrinsics_http.yaml
+++ b/tests/functional/commands/validate/lib/models/api_with_basic_custom_domain_intrinsics_http.yaml
@@ -12,6 +12,14 @@ Parameters:
     Type: String
     Default: REGIONAL
 
+  MyMTLSUriHTTP:
+    Default: another-api-v2-truststore-uri
+    Type: String
+
+  MyMTLSVersionHTTP:
+    Default: another-api-v2-truststore-version
+    Type: String
+
 Resources:
   MyFunction:
     Condition: C1
@@ -50,4 +58,8 @@ Resources:
         CertificateArn: !Ref MyDomainCert
         EndpointConfiguration: !Ref EndpointConf
         BasePath: [ "/get", "/fetch" ]
+        MutualTlsAuthentication:
+          TruststoreUri: !Ref MyMTLSUriHTTP
+          TruststoreVersion: !Ref MyMTLSVersionHTTP
+        SecurityPolicy: TLS_1_2
 

--- a/tests/functional/commands/validate/lib/models/http_api_lambda_auth.yaml
+++ b/tests/functional/commands/validate/lib/models/http_api_lambda_auth.yaml
@@ -1,0 +1,45 @@
+Resources:
+  HttpApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/todo_list.zip
+      Handler: index.restapi
+      Runtime: python3.7
+      Events:
+        Basic: # integration exists
+          Type: HttpApi
+          Properties:
+            PayloadFormatVersion: "2.0"
+            Path: /basic
+            Method: post
+            ApiId: !Ref MyApi
+        Basic2: # integration exists, auth doesn't
+          Type: HttpApi
+          Properties:
+            Path: /basic
+            Method: get
+            ApiId: !Ref MyApi
+        SimpleCase: # path exists, integration doesn't
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+
+  MyAuthFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: index.handler
+      Runtime: nodejs12.x
+
+  MyApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Tags:
+        Tag1: value1
+        Tag2: value2
+      Auth:
+        Authorizers:
+          LambdaAuth:
+            FunctionArn: !GetAtt MyAuthFn.Arn
+            AuthorizerPayloadFormatVersion: 1.0
+        DefaultAuthorizer: LambdaAuth

--- a/tests/functional/commands/validate/lib/models/http_api_lambda_auth_full.yaml
+++ b/tests/functional/commands/validate/lib/models/http_api_lambda_auth_full.yaml
@@ -1,0 +1,57 @@
+Resources:
+  HttpApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/todo_list.zip
+      Handler: index.restapi
+      Runtime: python3.7
+      Events:
+        Basic: # integration exists
+          Type: HttpApi
+          Properties:
+            PayloadFormatVersion: "2.0"
+            Path: /basic
+            Method: post
+            ApiId: !Ref MyApi
+        Basic2: # integration exists, auth doesn't
+          Type: HttpApi
+          Properties:
+            Path: /basic
+            Method: get
+            ApiId: !Ref MyApi
+        SimpleCase: # path exists, integration doesn't
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+
+  MyAuthFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: index.handler
+      Runtime: nodejs12.x
+
+  MyApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Tags:
+        Tag1: value1
+        Tag2: value2
+      Auth:
+        Authorizers:
+          LambdaAuth:
+            FunctionArn: !GetAtt MyAuthFn.Arn
+            FunctionInvokeRole: !GetAtt MyAuthFnRole.Arn
+            Identity:
+              Context:
+                - contextVar
+              Headers:
+                - Authorization
+              QueryStrings:
+                - petId
+              StageVariables:
+                - stageVar
+              ReauthorizeEvery: 60
+            AuthorizerPayloadFormatVersion: 2.0
+            EnableSimpleResponses: true
+        DefaultAuthorizer: LambdaAuth

--- a/tests/functional/commands/validate/lib/models/layers_with_intrinsics.yaml
+++ b/tests/functional/commands/validate/lib/models/layers_with_intrinsics.yaml
@@ -7,6 +7,9 @@ Parameters:
     Default: MIT-0 License
   LayerRuntimeList:
     Type: CommaDelimitedList
+  LayerRuntimeRefString:
+    Type: String
+    Default: SomeRuntimeName
 
 Resources:
   LayerWithLicenseIntrinsic:
@@ -21,6 +24,21 @@ Resources:
       ContentUri: s3://sam-demo-bucket/layer.zip
       CompatibleRuntimes:
         Ref: LayerRuntimeList
+
+  LayerWithSingleListRefRuntimesIntrinsic:
+    Type: 'AWS::Serverless::LayerVersion'
+    Properties:
+      ContentUri: s3://sam-demo-bucket/layer.zip
+      CompatibleRuntimes:
+        - Ref: LayerRuntimeRefString
+
+  LayerWithMixedListRefRuntimesIntrinsic:
+    Type: 'AWS::Serverless::LayerVersion'
+    Properties:
+      ContentUri: s3://sam-demo-bucket/layer.zip
+      CompatibleRuntimes:
+        - Ref: LayerRuntimeString
+        - 'SomeRuntimeNameString'
 
   LayerWithNameIntrinsic:
     Type: AWS::Serverless::LayerVersion
@@ -45,4 +63,5 @@ Resources:
     Properties:
       ContentUri: s3://sam-demo-bucket/layer.zip
       LayerName: !Sub 'layer-${AWS::Region}'
+
 

--- a/tests/functional/commands/validate/lib/models/state_machine_with_xray.yaml
+++ b/tests/functional/commands/validate/lib/models/state_machine_with_xray.yaml
@@ -1,0 +1,10 @@
+Resources:
+  StateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: MyStateMachineWithXRayTracing
+      Type: STANDARD
+      DefinitionUri: s3://sam-demo-bucket/my-state-machine.asl.json
+      Role: arn:aws:iam::123456123456:role/service-role/SampleRole
+      Tracing:
+        Enabled: true


### PR DESCRIPTION
Update sam-translator version to 1.29.0

*Why is this change necessary?*
To support MQ and MTLS changes in sam-translator

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
   Yes

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [x] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
