### PR TITLE
fix: Fix canary failures and update help text for build command

### DIFF
--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -74,7 +74,8 @@ $ sam build && sam package --s3-bucket <bucketname>
     "-cd",
     default=DEFAULT_CACHE_DIR,
     type=click.Path(file_okay=False, dir_okay=True, writable=True),  # Must be a directory
-    help="Path to a folder where the cache artifacts will be stored.",
+    help="The folder where the cache artifacts will be stored when --cached is specified. "
+         "The default cache directory is .aws-sam/cache",
 )
 @click.option(
     "--base-dir",
@@ -96,7 +97,8 @@ $ sam build && sam package --s3-bucket <bucketname>
     "--parallel",
     "-p",
     is_flag=True,
-    help="Use this flag to run builds of each function/layer in parallel",
+    help="Enabled parallel builds. Use this flag to build your AWS SAM template's functions and layers in parallel. "
+         "By default the functions and layers are built in sequence",
 )
 @click.option(
     "--manifest",
@@ -109,7 +111,13 @@ $ sam build && sam package --s3-bucket <bucketname>
     "--cached",
     "-c",
     is_flag=True,
-    help="Use this flag to enable cached build",
+    help="Enable cached builds. Use this flag to reuse build artifacts that have not changed from previous builds. "
+         "AWS SAM evaluates whether you have made any changes to files in your project directory. \n\n"
+         "Note: AWS SAM does not evaluate whether changes have been made to third party modules "
+         "that your project depends on, where you have not provided a specific version. "
+         "For example, if your Python function includes a requirements.txt file with the following entry "
+         "requests=1.x and the latest request module version changes from 1.1 to 1.2, "
+         "SAM will not pull the latest version until you run a non-cached build.",
 )
 @template_option_without_build
 @parameter_override_option

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -36,7 +36,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         shutil.rmtree(os.path.join(os.getcwd(), ".aws-sam", "build"), ignore_errors=True)
         for stack_name in self.stack_names:
             # because of the termination protection, do not delete aws-sam-cli-managed-default stack
-            if stack_name is not SAM_CLI_STACK_NAME:
+            if stack_name != SAM_CLI_STACK_NAME:
                 self.cf_client.delete_stack(StackName=stack_name)
         super().tearDown()
 

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -35,7 +35,9 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def tearDown(self):
         shutil.rmtree(os.path.join(os.getcwd(), ".aws-sam", "build"), ignore_errors=True)
         for stack_name in self.stack_names:
-            self.cf_client.delete_stack(StackName=stack_name)
+            # because of the termination protection, do not delete aws-sam-cli-managed-default stack
+            if stack_name is not SAM_CLI_STACK_NAME:
+                self.cf_client.delete_stack(StackName=stack_name)
         super().tearDown()
 
     @parameterized.expand(["aws-serverless-function.yaml"])


### PR DESCRIPTION
This change will stop removing the default stack for aws-sam-cli which is aws-sam-cli-managed-default stack.

*Why is this change necessary?*
Since CFN termination protection is enabled, this is causing failures in Canaries

*How does it address the issue?*
By not removing the default AWS SAM CLI stack

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
