### PR TITLE
chore: Fix black misses some files during formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,10 @@ lint:
 dev: lint test
 
 black:
-    # command "black <directory>" will skip some files, it is a bug, see https://github.com/psf/black/issues/1820
-	find setup.py samcli tests -type f -name "*.py" | xargs black
+	black setup.py samcli tests
 
 black-check:
-	find setup.py samcli tests -type f -name "*.py" | xargs black --check
+	black --check setup.py samcli tests
 
 # Verifications to run before sending a pull request
 pr: init dev black-check

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,11 @@ lint:
 dev: lint test
 
 black:
-	black setup.py samcli tests
+    # command "black <directory>" will skip some files, it is a bug, see https://github.com/psf/black/issues/1820
+	find setup.py samcli tests -type f -name "*.py" | xargs black
 
 black-check:
-	black --check setup.py samcli tests
+	find setup.py samcli tests -type f -name "*.py" | xargs black --check
 
 # Verifications to run before sending a pull request
 pr: init dev black-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,9 @@ exclude = '''
     | \.git          # root of the project
     | \.tox
     | \.venv
-    | build
     | dist
     | pip-wheel-metadata
     | samcli/lib/init/templates
-    | tests/integration/testdata
   )/
 )
 '''

--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -90,23 +90,27 @@ class DefaultBuildStrategy(BuildStrategy):
         Build the unique definition and then copy the artifact to the corresponding function folder
         """
         function_build_results = {}
-        LOG.info("Building codeuri: %s runtime: %s metadata: %s functions: %s",
-                 build_definition.codeuri,
-                 build_definition.runtime,
-                 build_definition.metadata,
-                 [function.name for function in build_definition.functions])
+        LOG.info(
+            "Building codeuri: %s runtime: %s metadata: %s functions: %s",
+            build_definition.codeuri,
+            build_definition.runtime,
+            build_definition.metadata,
+            [function.name for function in build_definition.functions],
+        )
 
         # build into one of the functions from this build definition
         single_function_name = build_definition.get_function_name()
         single_build_dir = str(pathlib.Path(self._build_dir, single_function_name))
 
         LOG.debug("Building to following folder %s", single_build_dir)
-        self._build_function(build_definition.get_function_name(),
-                             build_definition.codeuri,
-                             build_definition.runtime,
-                             build_definition.get_handler_name(),
-                             single_build_dir,
-                             build_definition.metadata)
+        self._build_function(
+            build_definition.get_function_name(),
+            build_definition.codeuri,
+            build_definition.runtime,
+            build_definition.get_handler_name(),
+            single_build_dir,
+            build_definition.metadata,
+        )
         function_build_results[single_function_name] = single_build_dir
 
         # copy results to other functions
@@ -128,11 +132,9 @@ class DefaultBuildStrategy(BuildStrategy):
         LOG.info("Building layer '%s'", layer.name)
         if layer.build_method is None:
             raise MissingBuildMethodException(
-                f"Layer {layer.name} cannot be build without BuildMethod. Please provide BuildMethod in Metadata.")
-        return {layer.name: self._build_layer(layer.name,
-                                              layer.codeuri,
-                                              layer.build_method,
-                                              layer.compatible_runtimes)}
+                f"Layer {layer.name} cannot be build without BuildMethod. Please provide BuildMethod in Metadata."
+            )
+        return {layer.name: self._build_layer(layer.name, layer.codeuri, layer.build_method, layer.compatible_runtimes)}
 
 
 class CachedBuildStrategy(BuildStrategy):
@@ -144,8 +146,9 @@ class CachedBuildStrategy(BuildStrategy):
     For actual building, it uses delegate implementation
     """
 
-    def __init__(self, build_graph, delegate_build_strategy, base_dir, build_dir, cache_dir,
-                 is_building_specific_resource):
+    def __init__(
+        self, build_graph, delegate_build_strategy, base_dir, build_dir, cache_dir, is_building_specific_resource
+    ):
         super().__init__(build_graph)
         self._delegate_build_strategy = delegate_build_strategy
         self._base_dir = base_dir
@@ -172,8 +175,10 @@ class CachedBuildStrategy(BuildStrategy):
         function_build_results = {}
 
         if not cache_function_dir.exists() or build_definition.source_md5 != source_md5:
-            LOG.info("Cache is invalid, running build and copying resources to function build definition of %s",
-                     build_definition.uuid)
+            LOG.info(
+                "Cache is invalid, running build and copying resources to function build definition of %s",
+                build_definition.uuid,
+            )
             build_result = self._delegate_build_strategy.build_single_function_definition(build_definition)
             function_build_results.update(build_result)
 
@@ -186,8 +191,10 @@ class CachedBuildStrategy(BuildStrategy):
                 osutils.copytree(value, cache_function_dir)
                 break
         else:
-            LOG.info("Valid cache found, copying previously built resources from function build definition of %s",
-                     build_definition.uuid)
+            LOG.info(
+                "Valid cache found, copying previously built resources from function build definition of %s",
+                build_definition.uuid,
+            )
             for function in build_definition.functions:
                 # artifacts directory will be created by the builder
                 artifacts_dir = str(pathlib.Path(self._build_dir, function.name))
@@ -207,8 +214,10 @@ class CachedBuildStrategy(BuildStrategy):
         layer_build_result = {}
 
         if not cache_function_dir.exists() or layer_definition.source_md5 != source_md5:
-            LOG.info("Cache is invalid, running build and copying resources to layer build definition of %s",
-                     layer_definition.uuid)
+            LOG.info(
+                "Cache is invalid, running build and copying resources to layer build definition of %s",
+                layer_definition.uuid,
+            )
             build_result = self._delegate_build_strategy.build_single_layer_definition(layer_definition)
             layer_build_result.update(build_result)
 
@@ -221,8 +230,10 @@ class CachedBuildStrategy(BuildStrategy):
                 osutils.copytree(value, cache_function_dir)
                 break
         else:
-            LOG.info("Valid cache found, copying previously built resources from layer build definition of %s",
-                     layer_definition.uuid)
+            LOG.info(
+                "Valid cache found, copying previously built resources from layer build definition of %s",
+                layer_definition.uuid,
+            )
             # artifacts directory will be created by the builder
             artifacts_dir = str(pathlib.Path(self._build_dir, layer_definition.layer.name))
             LOG.debug("Copying artifacts from %s to %s", cache_function_dir, artifacts_dir)
@@ -276,8 +287,7 @@ class ParallelBuildStrategy(BuildStrategy):
         Passes single function build into async context, no actual result returned from this function
         """
         self._async_context.add_async_task(
-            self._delegate_build_strategy.build_single_function_definition,
-            build_definition
+            self._delegate_build_strategy.build_single_function_definition, build_definition
         )
         return {}
 
@@ -286,7 +296,6 @@ class ParallelBuildStrategy(BuildStrategy):
         Passes single layer build into async context, no actual result returned from this function
         """
         self._async_context.add_async_task(
-            self._delegate_build_strategy.build_single_layer_definition,
-            layer_definition
+            self._delegate_build_strategy.build_single_layer_definition, layer_definition
         )
         return {}

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -188,11 +188,11 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         statement_raising_exception = 'raise Exception("Lambda is raising an exception")'
         statement_raising_exception_line_no = 0
         with open("tests/integration/testdata/invoke/main.py", "r") as f:
-            for i, line in enumerate(f):
+            for line_no, line in enumerate(f, 1):
                 if line.strip() == statement_raising_exception:
-                    statement_raising_exception_line_no = i + 1
+                    statement_raising_exception_line_no = line_no
         if not statement_raising_exception:
-            raise Exception(f'Cannot find statement "{statement_raising_exception}" in invoke/main.py')
+            self.fail(f'Cannot find statement "{statement_raising_exception}" in invoke/main.py')
 
         self.assertEqual(
             response_data,

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -184,13 +184,28 @@ class TestLambdaService(StartLambdaIntegBaseClass):
 
         print(response_data)
 
+        # determine the line number of the statement that will raise the error
+        statement_raising_exception = 'raise Exception("Lambda is raising an exception")'
+        statement_raising_exception_line_no = 0
+        with open("tests/integration/testdata/invoke/main.py", "r") as f:
+            for i, line in enumerate(f):
+                if line.strip() == statement_raising_exception:
+                    statement_raising_exception_line_no = i + 1
+        if not statement_raising_exception:
+            raise Exception(f'Cannot find statement "{statement_raising_exception}" in invoke/main.py')
+
         self.assertEqual(
             response_data,
             {
                 "errorMessage": "Lambda is raising an exception",
                 "errorType": "Exception",
                 "stackTrace": [
-                    ["/var/task/main.py", 51, "raise_exception", 'raise Exception("Lambda is raising an exception")']
+                    [
+                        "/var/task/main.py",
+                        statement_raising_exception_line_no,
+                        "raise_exception",
+                        statement_raising_exception,
+                    ]
                 ],
             },
         )

--- a/tests/integration/testdata/buildcmd/Provided/main.py
+++ b/tests/integration/testdata/buildcmd/Provided/main.py
@@ -1,4 +1,5 @@
 import requests
 
+
 def handler(event, context):
     return requests.__version__

--- a/tests/integration/testdata/invoke/main.py
+++ b/tests/integration/testdata/invoke/main.py
@@ -3,20 +3,22 @@ import os
 import sys
 import subprocess
 
-print ("Loading function")
+print("Loading function")
 
 
 def handler(event, context):
-    print ("value1 = " + event["key1"])
-    print ("value2 = " + event["key2"])
-    print ("value3 = " + event["key3"])
+    print("value1 = " + event["key1"])
+    print("value2 = " + event["key2"])
+    print("value3 = " + event["key3"])
 
     sys.stdout.write("Docker Lambda is writing to stderr")
 
     return "Hello world"
 
+
 def intrinsics_handler(event, context):
     return os.environ.get("ApplicationId")
+
 
 def sleep_handler(event, context):
     time.sleep(10)
@@ -52,7 +54,7 @@ def raise_exception(event, context):
 
 
 def execute_git(event, context):
-    return_code = subprocess.call(['git', 'init', '/tmp/samtesting'])
+    return_code = subprocess.call(["git", "init", "/tmp/samtesting"])
     assert return_code == 0
 
     return "git init passed"

--- a/tests/integration/testdata/package/main.py
+++ b/tests/integration/testdata/package/main.py
@@ -1,4 +1,5 @@
 import json
 
+
 def handler(event, context):
     return {"statusCode": 200, "body": json.dumps({"hello": "world"})}

--- a/tests/integration/testdata/start_api/main.py
+++ b/tests/integration/testdata/start_api/main.py
@@ -59,11 +59,14 @@ def write_to_stdout(event, context):
 def invalid_response_returned(event, context):
     return "This is invalid"
 
+
 def integer_response_returned(event, context):
     return 2
 
+
 def invalid_v2_respose_returned(event, context):
     return {"statusCode": 200, "body": json.dumps({"hello": "world"}), "key": "value"}
+
 
 def invalid_hash_response(event, context):
     return {"foo": "bar"}


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

Some files that was left behind by black, caused by a bug in black: https://github.com/psf/black/issues/1820

#### Why is this change necessary?

Use `find` to list all python files instead of relying on black for directory traversal. 

#### How does it address the issue?

No files will be missed:

```
$ make black
find setup.py samcli tests -type f -name "*.py" | xargs black
reformatted /Users/xinhol/Projects/aws-sam-cli/tests/integration/testdata/buildcmd/Provided/main.py
reformatted /Users/xinhol/Projects/aws-sam-cli/tests/integration/testdata/package/main.py
reformatted /Users/xinhol/Projects/aws-sam-cli/tests/integration/testdata/invoke/main.py
reformatted /Users/xinhol/Projects/aws-sam-cli/tests/integration/testdata/start_api/main.py
reformatted /Users/xinhol/Projects/aws-sam-cli/samcli/commands/build/build_context.py
reformatted /Users/xinhol/Projects/aws-sam-cli/samcli/commands/build/command.py
reformatted /Users/xinhol/Projects/aws-sam-cli/samcli/lib/build/build_strategy.py
reformatted /Users/xinhol/Projects/aws-sam-cli/samcli/lib/build/app_builder.py
All done! ✨ 🍰 ✨
8 files reformatted, 418 files left unchanged.

```


#### What side effects does this change have?

no side effect

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
