### PR TITLE
chore: Remove python patch version in AppVeyor to be more robust

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
   matrix:
 
     - PYTHON_HOME: "C:\\Python36-x64"
-      PYTHON_VERSION: '3.6.10'
+      PYTHON_VERSION: '3.6'
       PYTHON_ARCH: '64'
       NOSE_PARAMETERIZED_NO_WARN: 1
       INSTALL_PY_37_PIP: 1
@@ -19,7 +19,7 @@ environment:
       APPVEYOR_CONSOLE_DISABLE_PTY: true
 
     - PYTHON_HOME: "C:\\Python37-x64"
-      PYTHON_VERSION: '3.7.7'
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '64'
       RUN_SMOKE: 1
       NOSE_PARAMETERIZED_NO_WARN: 1
@@ -29,7 +29,7 @@ environment:
       APPVEYOR_CONSOLE_DISABLE_PTY: true
 
     - PYTHON_HOME: "C:\\Python38-x64"
-      PYTHON_VERSION: '3.8.2'
+      PYTHON_VERSION: '3.8'
       PYTHON_ARCH: '64'
       RUN_SMOKE: 1
       NOSE_PARAMETERIZED_NO_WARN: 1


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

When AppVeyor updates their python env, like from 3.7.7 to 3.7.9, 3.7.7 won't be available, and builds will fail due to the error:
```
/opt/appveyor/build-agent/bash-shell.sh: line 51: /home/appveyor/venv3.7.7/bin/activate: No such file or directory
```

According to AppVeyor doc, we don't have to specify patch version: https://www.appveyor.com/docs/linux-images-software/#python

<img width="750" alt="image" src="https://user-images.githubusercontent.com/3804518/99479104-6ec8d780-290a-11eb-8d29-a41063180925.png">

#### How does it address the issue?

Remove patch version so it can handle patch version python upgrade on AppVeyor side.

#### What side effects does this change have?

nothing

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
