### PR TITLE
refactor: Use dataclasses to make type safer

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,3 +15,4 @@ requests==2.23.0
 serverlessrepo==0.1.10
 aws_lambda_builders==1.1.0
 tomlkit==0.7.0
+dataclasses~=0.8; python_version<"3.7"

--- a/samcli/lib/init/__init__.py
+++ b/samcli/lib/init/__init__.py
@@ -52,10 +52,10 @@ def generate_project(
     template = None
 
     if runtime:
-        for mapping in list(itertools.chain(*(RUNTIME_DEP_TEMPLATE_MAPPING.values()))):
-            if runtime in mapping["runtimes"] or any([r.startswith(runtime) for r in mapping["runtimes"]]):
-                if not dependency_manager or dependency_manager == mapping["dependency_manager"]:
-                    template = mapping["init_location"]
+        for mapping in list(itertools.chain.from_iterable(RUNTIME_DEP_TEMPLATE_MAPPING.values())):
+            if runtime in mapping.runtimes or any([r.startswith(runtime) for r in mapping.runtimes]):
+                if not dependency_manager or dependency_manager == mapping.dependency_manager:
+                    template = mapping.init_location
                     break
 
         if not template:

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -5,67 +5,76 @@ All-in-one metadata about runtimes
 import itertools
 import os
 import pathlib
-from typing import Set
+from dataclasses import dataclass
+from typing import List, Dict
 
 _init_path = str(pathlib.Path(os.path.dirname(__file__)).parent)
 _templates = os.path.join(_init_path, "init", "templates")
 
 
+@dataclass
+class RuntimeDepInfo:
+    runtimes: List[str]
+    dependency_manager: str
+    init_location: str
+    build: bool
+
+
 # Note(TheSriram): The ordering of the runtimes list per language is based on the latest to oldest.
-RUNTIME_DEP_TEMPLATE_MAPPING = {
+RUNTIME_DEP_TEMPLATE_MAPPING: Dict[str, List[RuntimeDepInfo]] = {
     "python": [
-        {
-            "runtimes": ["python3.8", "python3.7", "python3.6", "python2.7"],
-            "dependency_manager": "pip",
-            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-python"),
-            "build": True,
-        }
+        RuntimeDepInfo(
+            ["python3.8", "python3.7", "python3.6", "python2.7"],
+            "pip",
+            os.path.join(_templates, "cookiecutter-aws-sam-hello-python"),
+            True,
+        )
     ],
     "ruby": [
-        {
-            "runtimes": ["ruby2.5", "ruby2.7"],
-            "dependency_manager": "bundler",
-            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-ruby"),
-            "build": True,
-        }
+        RuntimeDepInfo(
+            ["ruby2.5", "ruby2.7"],
+            "bundler",
+            os.path.join(_templates, "cookiecutter-aws-sam-hello-ruby"),
+            True,
+        )
     ],
     "nodejs": [
-        {
-            "runtimes": ["nodejs12.x", "nodejs10.x"],
-            "dependency_manager": "npm",
-            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-nodejs"),
-            "build": True,
-        }
+        RuntimeDepInfo(
+            ["nodejs12.x", "nodejs10.x"],
+            "npm",
+            os.path.join(_templates, "cookiecutter-aws-sam-hello-nodejs"),
+            True,
+        )
     ],
     "dotnet": [
-        {
-            "runtimes": ["dotnetcore3.1", "dotnetcore2.1"],
-            "dependency_manager": "cli-package",
-            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),
-            "build": True,
-        }
+        RuntimeDepInfo(
+            ["dotnetcore3.1", "dotnetcore2.1"],
+            "cli-package",
+            os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),
+            True,
+        )
     ],
     "go": [
-        {
-            "runtimes": ["go1.x"],
-            "dependency_manager": "mod",
-            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-golang"),
-            "build": False,
-        }
+        RuntimeDepInfo(
+            ["go1.x"],
+            "mod",
+            os.path.join(_templates, "cookiecutter-aws-sam-hello-golang"),
+            False,
+        )
     ],
     "java": [
-        {
-            "runtimes": ["java11", "java8", "java8.al2"],
-            "dependency_manager": "maven",
-            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-java-maven"),
-            "build": True,
-        },
-        {
-            "runtimes": ["java11", "java8", "java8.al2"],
-            "dependency_manager": "gradle",
-            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-java-gradle"),
-            "build": True,
-        },
+        RuntimeDepInfo(
+            ["java11", "java8", "java8.al2"],
+            "maven",
+            os.path.join(_templates, "cookiecutter-aws-sam-hello-java-maven"),
+            True,
+        ),
+        RuntimeDepInfo(
+            ["java11", "java8", "java8.al2"],
+            "gradle",
+            os.path.join(_templates, "cookiecutter-aws-sam-hello-java-gradle"),
+            True,
+        ),
     ],
 }
 
@@ -86,15 +95,16 @@ RUNTIME_TO_DEPENDENCY_MANAGERS = {
     "java8.al2": ["maven", "gradle"],
 }
 
-SUPPORTED_DEP_MANAGERS: Set[str] = {
-    c["dependency_manager"]  # type: ignore
-    for c in list(itertools.chain(*(RUNTIME_DEP_TEMPLATE_MAPPING.values())))
-    if c["dependency_manager"]
+
+SUPPORTED_DEP_MANAGERS = {
+    c.dependency_manager
+    for c in list(itertools.chain.from_iterable(RUNTIME_DEP_TEMPLATE_MAPPING.values()))
+    if c.dependency_manager
 }
 
-RUNTIMES: Set[str] = set(
-    itertools.chain(
-        *[c["runtimes"] for c in list(itertools.chain(*(RUNTIME_DEP_TEMPLATE_MAPPING.values())))]  # type: ignore
+RUNTIMES = set(
+    itertools.chain.from_iterable(
+        [c.runtimes for c in list(itertools.chain.from_iterable(RUNTIME_DEP_TEMPLATE_MAPPING.values()))]
     )
 )
 

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -5,7 +5,7 @@ import botocore.exceptions
 import click
 from click.testing import CliRunner
 
-from samcli.commands.init.init_templates import InitTemplates
+from samcli.commands.init.init_templates import InitTemplates, TemplateOption
 from samcli.commands.init import cli as init_cmd
 from samcli.commands.init import do_cli as init_cli
 from samcli.lib.init import GenerateProjectFailedError
@@ -404,19 +404,19 @@ class TestCli(TestCase):
         init_options_from_manifest_mock,
     ):
         init_options_from_manifest_mock.return_value = [
-            {
-                "directory": "java8/cookiecutter-aws-sam-hello-java-maven",
-                "displayName": "Hello World Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "hello-world",
-            },
-            {
-                "directory": "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
-                "displayName": "Hello World Schema example Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "eventBridge-schema-app",
-                "isDynamicTemplate": "True",
-            },
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-hello-java-maven",
+                "Hello World Example: Maven",
+                "maven",
+                "hello-world",
+            ),
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
+                "Hello World Schema example Example: Maven",
+                "maven",
+                "eventBridge-schema-app",
+                is_dynamic_template="True",
+            ),
         ]
         session_mock.return_value.profile_name = "test"
         session_mock.return_value.region_name = "ap-northeast-1"
@@ -508,19 +508,19 @@ Y
         init_options_from_manifest_mock,
     ):
         init_options_from_manifest_mock.return_value = [
-            {
-                "directory": "java8/cookiecutter-aws-sam-hello-java-maven",
-                "displayName": "Hello World Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "hello-world",
-            },
-            {
-                "directory": "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
-                "displayName": "Hello World Schema example Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "eventBridge-schema-app",
-                "isDynamicTemplate": "True",
-            },
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-hello-java-maven",
+                "Hello World Example: Maven",
+                "maven",
+                "hello-world",
+            ),
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
+                "Hello World Schema example Example: Maven",
+                "maven",
+                "eventBridge-schema-app",
+                is_dynamic_template="True",
+            ),
         ]
         session_mock.return_value.profile_name = "default"
         session_mock.return_value.region_name = "ap-south-1"
@@ -609,19 +609,19 @@ us-east-1
         self, get_schemas_client_mock, schemas_api_caller_mock, session_mock, init_options_from_manifest_mock
     ):
         init_options_from_manifest_mock.return_value = [
-            {
-                "directory": "java8/cookiecutter-aws-sam-hello-java-maven",
-                "displayName": "Hello World Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "hello-world",
-            },
-            {
-                "directory": "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
-                "displayName": "Hello World Schema example Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "eventBridge-schema-app",
-                "isDynamicTemplate": "True",
-            },
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-hello-java-maven",
+                "Hello World Example: Maven",
+                "maven",
+                "hello-world",
+            ),
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
+                "Hello World Schema example Example: Maven",
+                "maven",
+                "eventBridge-schema-app",
+                is_dynamic_template="True",
+            ),
         ]
         session_mock.return_value.profile_name = "default"
         session_mock.return_value.region_name = "ap-south-1"
@@ -680,19 +680,19 @@ invalid-region
         init_options_from_manifest_mock,
     ):
         init_options_from_manifest_mock.return_value = [
-            {
-                "directory": "java8/cookiecutter-aws-sam-hello-java-maven",
-                "displayName": "Hello World Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "hello-world",
-            },
-            {
-                "directory": "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
-                "displayName": "Hello World Schema example Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "eventBridge-schema-app",
-                "isDynamicTemplate": "True",
-            },
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-hello-java-maven",
+                "Hello World Example: Maven",
+                "maven",
+                "hello-world",
+            ),
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
+                "Hello World Schema example Example: Maven",
+                "maven",
+                "eventBridge-schema-app",
+                is_dynamic_template="True",
+            ),
         ]
         session_mock.return_value.profile_name = "test"
         session_mock.return_value.region_name = "ap-northeast-1"
@@ -786,19 +786,19 @@ Y
         init_options_from_manifest_mock,
     ):
         init_options_from_manifest_mock.return_value = [
-            {
-                "directory": "java8/cookiecutter-aws-sam-hello-java-maven",
-                "displayName": "Hello World Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "hello-world",
-            },
-            {
-                "directory": "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
-                "displayName": "Hello World Schema example Example: Maven",
-                "dependencyManager": "maven",
-                "appTemplate": "eventBridge-schema-app",
-                "isDynamicTemplate": "True",
-            },
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-hello-java-maven",
+                "Hello World Example: Maven",
+                "maven",
+                "hello-world",
+            ),
+            TemplateOption(
+                "java8/cookiecutter-aws-sam-eventbridge-schema-app-java-maven",
+                "Hello World Schema example Example: Maven",
+                "maven",
+                "eventBridge-schema-app",
+                is_dynamic_template="True",
+            ),
         ]
         session_mock.return_value.profile_name = "test"
         session_mock.return_value.region_name = "ap-northeast-1"

--- a/tests/unit/lib/init/test_init.py
+++ b/tests/unit/lib/init/test_init.py
@@ -18,7 +18,7 @@ class TestInit(TestCase):
         self.name = "testing project"
         self.no_input = True
         self.extra_context = {"project_name": "testing project", "runtime": self.runtime}
-        self.template = RUNTIME_DEP_TEMPLATE_MAPPING["python"][0]["init_location"]
+        self.template = RUNTIME_DEP_TEMPLATE_MAPPING["python"][0].init_location
 
     @patch("samcli.lib.init.cookiecutter")
     def test_init_successful(self, cookiecutter_patch):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

This was originally a part of #2385

With the intro of the following dataclass, mypy can typecheck them so we won't mis-spell dict keys.
- `TemplateOption`
- `RuntimeDepInfo`

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
