### PR TITLE
ci: Disable local invoke in integ test on AppVeyor except for Canary

### DIFF
--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -11,11 +11,14 @@ import pytest
 
 from samcli.lib.utils import osutils
 from .build_integ_base import BuildIntegBase, DedupBuildIntegBase, CachedBuildIntegBase, BuildIntegRubyBase
-from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, CI_OVERRIDE, run_command, RUN_BY_CANARY
-
-# Tests require docker suffers from Docker Hub request limit
-SKIP_DOCKER_TESTS = RUNNING_ON_CI and not RUN_BY_CANARY
-SKIP_DOCKER_MESSAGE = "The test which sends requests to docker hub is likely to fail due to request limit"
+from tests.testing_utils import (
+    IS_WINDOWS,
+    RUNNING_ON_CI,
+    CI_OVERRIDE,
+    run_command,
+    SKIP_DOCKER_TESTS,
+    SKIP_DOCKER_MESSAGE,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -93,9 +96,10 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
         )
 
         expected = {"pi": "3.14"}
-        self._verify_invoke_built_function(
-            self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
+            )
         self.verify_docker_container_cleanedup(runtime)
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files):
@@ -379,9 +383,13 @@ class TestBuildCommand_Java(BuildIntegBase):
         # If we are testing in the container, invoke the function as well. Otherwise we cannot guarantee docker is on appveyor
         if use_container:
             expected = "Hello World"
-            self._verify_invoke_built_function(
-                self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
-            )
+            if not SKIP_DOCKER_TESTS:
+                self._verify_invoke_built_function(
+                    self.built_template,
+                    self.FUNCTION_LOGICAL_ID,
+                    self._make_parameter_override_arg(overrides),
+                    expected,
+                )
 
             self.verify_docker_container_cleanedup(runtime)
 
@@ -484,9 +492,10 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
         )
 
         expected = "{'message': 'Hello World'}"
-        self._verify_invoke_built_function(
-            self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
+            )
 
         self.verify_docker_container_cleanedup(runtime)
 
@@ -570,9 +579,10 @@ class TestBuildCommand_Go_Modules(BuildIntegBase):
         )
 
         expected = "{'message': 'Hello World'}"
-        self._verify_invoke_built_function(
-            self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
+            )
 
         self.verify_docker_container_cleanedup(runtime)
 
@@ -658,9 +668,10 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
         self._verify_built_artifact(self.default_build_dir, function_identifier, self.EXPECTED_FILES_PROJECT_MANIFEST)
 
         expected = {"pi": "3.14"}
-        self._verify_invoke_built_function(
-            self.built_template, function_identifier, self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, function_identifier, self._make_parameter_override_arg(overrides), expected
+            )
         self.verify_docker_container_cleanedup(runtime)
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files):
@@ -787,9 +798,10 @@ class TestBuildCommand_LayerBuilds(BuildIntegBase):
         )
 
         expected = {"pi": "3.14"}
-        self._verify_invoke_built_function(
-            self.built_template, "FunctionOne", self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, "FunctionOne", self._make_parameter_override_arg(overrides), expected
+            )
         self.verify_docker_container_cleanedup(runtime)
 
     @parameterized.expand([("python3.7", False), ("python3.7", "use_container")])
@@ -821,9 +833,10 @@ class TestBuildCommand_LayerBuilds(BuildIntegBase):
         )
 
         expected = {"pi": "3.14"}
-        self._verify_invoke_built_function(
-            self.built_template, "FunctionOne", self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, "FunctionOne", self._make_parameter_override_arg(overrides), expected
+            )
         self.verify_docker_container_cleanedup(runtime)
 
     def _verify_built_artifact(
@@ -891,9 +904,10 @@ class TestBuildCommand_ProvidedFunctions(BuildIntegBase):
         expected = "2.23.0"
         # Building was done with a makefile, but invoke should be checked with corresponding python image.
         overrides["Runtime"] = self._get_python_version()
-        self._verify_invoke_built_function(
-            self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
+            )
         self.verify_docker_container_cleanedup(runtime)
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files):
@@ -959,9 +973,10 @@ class TestBuildWithBuildMethod(BuildIntegBase):
 
         expected = "2.23.0"
         # Building was done with a makefile, invoke is checked with the same runtime image.
-        self._verify_invoke_built_function(
-            self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
+            )
         self.verify_docker_container_cleanedup(runtime)
 
     @parameterized.expand([(False,), ("use_container")])
@@ -992,9 +1007,10 @@ class TestBuildWithBuildMethod(BuildIntegBase):
 
         expected = "2.23.0"
         # Building was done with a `python-pip` builder, invoke is checked with the same runtime image.
-        self._verify_invoke_built_function(
-            self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected
+            )
         self.verify_docker_container_cleanedup(runtime)
 
     @parameterized.expand([(False,), ("use_container")])
@@ -1091,9 +1107,10 @@ class TestBuildWithDedupBuilds(DedupBuildIntegBase):
 
         expected_messages = ["World", "Mars"]
 
-        self._verify_build_and_invoke_functions(
-            expected_messages, command_result, self._make_parameter_override_arg(overrides)
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_build_and_invoke_functions(
+                expected_messages, command_result, self._make_parameter_override_arg(overrides)
+            )
 
 
 @skipIf(
@@ -1116,7 +1133,8 @@ class TestBuildWithDedupBuildsMakefile(DedupBuildIntegBase):
 
         expected_messages = ["World", "Mars"]
 
-        self._verify_build_and_invoke_functions(expected_messages, command_result, "")
+        if not SKIP_DOCKER_TESTS:
+            self._verify_build_and_invoke_functions(expected_messages, command_result, "")
 
     def _verify_process_code_and_output(self, command_result):
         """
@@ -1175,9 +1193,10 @@ class TestBuildWithCacheBuilds(CachedBuildIntegBase):
 
         expected_messages = ["World", "Mars"]
 
-        self._verify_build_and_invoke_functions(
-            expected_messages, command_result, self._make_parameter_override_arg(overrides)
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_build_and_invoke_functions(
+                expected_messages, command_result, self._make_parameter_override_arg(overrides)
+            )
 
 
 @skipIf(
@@ -1230,6 +1249,7 @@ class TestParallelBuilds(DedupBuildIntegBase):
 
         expected_messages = ["World", "Mars"]
 
-        self._verify_build_and_invoke_functions(
-            expected_messages, command_result, self._make_parameter_override_arg(overrides)
-        )
+        if not SKIP_DOCKER_TESTS:
+            self._verify_build_and_invoke_functions(
+                expected_messages, command_result, self._make_parameter_override_arg(overrides)
+            )

--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -1,8 +1,11 @@
 import os
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from pathlib import Path
 
+from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS
 
+
+@skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
 class InvokeIntegBase(TestCase):
     template = None
 

--- a/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
+++ b/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
@@ -4,15 +4,20 @@ import os
 import tempfile
 
 from subprocess import Popen, PIPE, TimeoutExpired
+from unittest import skipIf
+
 from parameterized import parameterized, param
 import pytest
 
 from tests.integration.local.invoke.invoke_integ_base import InvokeIntegBase
 from pathlib import Path
 
+from tests.testing_utils import SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE
+
 TIMEOUT = 300
 
 
+@skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
 class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
     template = Path("runtimes", "template.yaml")
 

--- a/tests/integration/local/start_api/start_api_integ_base.py
+++ b/tests/integration/local/start_api/start_api_integ_base.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, skipIf
 import threading
 from subprocess import Popen
 import time
@@ -6,7 +6,10 @@ import os
 import random
 from pathlib import Path
 
+from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS
 
+
+@skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
 class StartApiIntegBaseClass(TestCase):
     template = None
     binary_data_file = None

--- a/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
+++ b/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, skipIf
 import threading
 from subprocess import Popen
 import time
@@ -7,7 +7,10 @@ import random
 
 from pathlib import Path
 
+from tests.testing_utils import SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE
 
+
+@skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
 class StartLambdaIntegBaseClass(TestCase):
     template = None
     binary_data_file = None

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -12,6 +12,10 @@ RUNNING_TEST_FOR_MASTER_ON_CI = os.environ.get("APPVEYOR_REPO_BRANCH", "master")
 CI_OVERRIDE = os.environ.get("APPVEYOR_CI_OVERRIDE", False)
 RUN_BY_CANARY = os.environ.get("BY_CANARY", False)
 
+# Tests require docker suffers from Docker Hub request limit
+SKIP_DOCKER_TESTS = RUNNING_ON_CI and not RUN_BY_CANARY
+SKIP_DOCKER_MESSAGE = "The test which sends requests to docker hub is likely to fail due to request limit"
+
 LOG = logging.getLogger(__name__)
 
 CommandResult = namedtuple("CommandResult", "process stdout stderr")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

Follow up #2395, disable local invoke that requires docker images.
Without disabling them, these tests are likely to fail: https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli/builds/36418448/job/o43404pa7i1awh3r

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
