### PR TITLE
adding cloudformation package support for ServiceCatalog

### DIFF
--- a/samcli/commands/_utils/resources.py
+++ b/samcli/commands/_utils/resources.py
@@ -19,6 +19,7 @@ AWS_SERVERLESS_LAYERVERSION = "AWS::Serverless::LayerVersion"
 AWS_GLUE_JOB = "AWS::Glue::Job"
 AWS_SERVERLESS_STATEMACHINE = "AWS::Serverless::StateMachine"
 AWS_STEPFUNCTIONS_STATEMACHINE = "AWS::StepFunctions::StateMachine"
+AWS_SERVICECATALOG_PRODUCT = "AWS::ServiceCatalog::CloudFormationProduct"
 
 METADATA_WITH_LOCAL_PATHS = {AWS_SERVERLESSREPO_APPLICATION: ["LicenseUrl", "ReadmeUrl"]}
 
@@ -39,6 +40,7 @@ RESOURCES_WITH_LOCAL_PATHS = {
     AWS_SERVERLESS_LAYERVERSION: ["ContentUri"],
     AWS_GLUE_JOB: ["Command.ScriptLocation"],
     AWS_STEPFUNCTIONS_STATEMACHINE: ["DefinitionS3Location"],
+    AWS_SERVICECATALOG_PRODUCT: ["ProvisioningArtifactParameters.Info.LoadTemplateFromURL"],
 }
 
 

--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -5,9 +5,7 @@ Utilities to manipulate template
 import os
 import pathlib
 
-import jmespath
 import yaml
-from botocore.utils import set_value_from_jmespath
 
 from samcli.commands.exceptions import UserException
 from samcli.yamlhelper import yaml_parse, yaml_dump
@@ -119,6 +117,11 @@ def _update_relative_paths(template_dict, original_root, new_root):
 
     """
 
+    def transform(original_dict, original_path, property_name, value, context):
+        result = _resolve_relative_to(value, original_root, new_root)
+
+        return result if result else value
+
     for resource_type, properties in template_dict.get("Metadata", {}).items():
 
         if resource_type not in METADATA_WITH_LOCAL_PATHS:
@@ -143,22 +146,43 @@ def _update_relative_paths(template_dict, original_root, new_root):
             continue
 
         for path_prop_name in RESOURCES_WITH_LOCAL_PATHS[resource_type]:
-            properties = resource.get("Properties", {})
-
-            path = jmespath.search(path_prop_name, properties)
-            updated_path = _resolve_relative_to(path, original_root, new_root)
-
-            if not updated_path:
-                # This path does not need to get updated
+            if "Properties" not in resource:
                 continue
 
-            set_value_from_jmespath(properties, path_prop_name, updated_path)
+            resource["Properties"] = _transform_dict(resource["Properties"], path_prop_name, transform)
 
     # AWS::Includes can be anywhere within the template dictionary. Hence we need to recurse through the
     # dictionary in a separate method to find and update relative paths in there
     template_dict = _update_aws_include_relative_path(template_dict, original_root, new_root)
 
     return template_dict
+
+
+def _transform_dict(template_dict, path, transformation, context=None):
+    def visit(sub_dict, sub_path):
+        # pylint: disable=else-if-used
+
+        if not sub_path:
+            return sub_dict
+
+        next_prop = sub_path[0]
+        if not next_prop in sub_dict:
+            return sub_dict
+
+        value = sub_dict[next_prop]
+        if len(sub_path) == 1:
+            sub_dict[next_prop] = transformation(template_dict, path, next_prop, value, context)
+        else:
+            if isinstance(value, list):
+                sub_dict[next_prop] = [visit(v, sub_path[1:]) for v in value]
+            elif isinstance(value, dict):
+                sub_dict[next_prop] = visit(value, sub_path[1:])
+            else:
+                raise Exception("Unsupported path '%s' or dict structure '%s'" % path, template_dict)
+
+        return sub_dict
+
+    return visit(template_dict, path.split("."))
 
 
 def _update_aws_include_relative_path(template_dict, original_root, new_root):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
This relates to [AWS CLI issue 3388](https://github.com/aws/aws-cli/issues/3388), asking for Service Catalog to be added to the list of resources supporting CLoudFormation's `package` command

#### Why is this change necessary?
Current implementation of `package` does not exporting attributes that have arrays in its path (e.g. a.b[].c) due to a limitation with JMESPath library and boto's utility function `set_value_from_jmespath`, currently used by `package`.

This is an issue for resources like Service Catalog's products, which needs a [AWS::ServiceCatalog::CloudFormationProduct.ProvisioningArtifactParameters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationproduct.html#cfn-servicecatalog-cloudformationproduct-provisioningartifactparameters).

#### How does it address the issue?
This change allows for setting up attributes that have arrays in it's path, so "a.b.c" would act as JMESPath "a.b[].c".

#### What side effects does this change have?
There should be no side effect

#### Checklist

- [NA] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write unit tests
- [NA] Write/update functional tests
- [NA] Write/update integration tests
- [X] `make pr` passes
- [NA] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
