### PR TITLE
Add shutdown Option to sam local invoke

### DIFF
--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -40,6 +40,12 @@ STDIN_FILE_NAME = "-"
     "is not specified, no event is assumed. Pass in the value '-' to input JSON via stdin",
 )
 @click.option("--no-event", is_flag=True, default=True, help="DEPRECATED: By default no event is assumed.", hidden=True)
+@click.option(
+    "--shutdown",
+    is_flag=True,
+    default=False,
+    help="If set, will emulate a shutdown event after the invoke completes, in order to test extension handling of shutdown behavior. Must set ENABLE_LAMBDA_EXTENSIONS_PREVIEW=1 for this to have an effect.",
+)
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options
@@ -52,6 +58,7 @@ def cli(
     template_file,
     event,
     no_event,
+    shutdown,
     env_vars,
     debug_port,
     debug_args,
@@ -75,6 +82,7 @@ def cli(
         template_file,
         event,
         no_event,
+        shutdown,
         env_vars,
         debug_port,
         debug_args,
@@ -95,6 +103,7 @@ def do_cli(  # pylint: disable=R0914
     template,
     event,
     no_event,
+    shutdown,
     env_vars,
     debug_port,
     debug_args,
@@ -150,7 +159,7 @@ def do_cli(  # pylint: disable=R0914
 
             # Invoke the function
             context.local_lambda_runner.invoke(
-                context.function_name, event=event_data, stdout=context.stdout, stderr=context.stderr
+                context.function_name, event=event_data, stdout=context.stdout, stderr=context.stderr, shutdown=shutdown
             )
 
     except FunctionNotFound as ex:

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -58,7 +58,7 @@ class LocalLambdaRunner:
         self._boto3_session_creds = None
         self._boto3_region = None
 
-    def invoke(self, function_name, event, stdout=None, stderr=None):
+    def invoke(self, function_name, event, stdout=None, stderr=None, shutdown=False):
         """
         Find the Lambda function with given name and invoke it. Pass the given event to the function and return
         response through the given streams.
@@ -100,7 +100,9 @@ class LocalLambdaRunner:
 
         # Invoke the function
         try:
-            self.local_runtime.invoke(config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr)
+            self.local_runtime.invoke(
+                config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr, shutdown=shutdown
+            )
         except ContainerResponseException as ex:
             raise InvokeContextException(
                 f"No response from invoke container for {function.name}", wrapped_from=ex.__class__.__name__

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -170,6 +170,20 @@ class Container:
 
         return self.id
 
+    def stop(self, time=3):
+        """
+        Stop a container, with a given number of seconds between sending SIGTERM and SIGKILL.
+        """
+        if not self.is_created():
+            LOG.debug("Container was not created. Cannot run stop")
+            return
+
+        try:
+            self.docker_client.containers.get(self.id).stop(timeout=time)
+        except docker.errors.NotFound:
+            # Container is already not there
+            LOG.debug("Container with ID %s does not exist. Cannot stop", self.id)
+
     def delete(self):
         """
         Removes a container that was created earlier.

--- a/samcli/local/docker/manager.py
+++ b/samcli/local/docker/manager.py
@@ -109,12 +109,15 @@ class ContainerManager:
 
         container.start(input_data=input_data)
 
-    def stop(self, container):
+    def stop(self, container, do_shutdown_event=False):
         """
         Stop and delete the container
 
         :param samcli.local.docker.container.Container container: Container to stop
         """
+        if do_shutdown_event:
+            LOG.debug("Sending shutdown event to execution environment!")
+            container.stop()
         container.delete()
 
     def pull_image(self, image_name, stream=None):

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -38,6 +38,7 @@ class TestCli(TestCase):
         self.force_image_build = True
         self.region_name = "region"
         self.profile = "profile"
+        self.shutdown = False
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
@@ -59,6 +60,7 @@ class TestCli(TestCase):
             template=self.template,
             event=self.eventfile,
             no_event=self.no_event,
+            shutdown=self.shutdown,
             env_vars=self.env_vars,
             debug_port=self.debug_ports,
             debug_args=self.debug_args,
@@ -91,7 +93,11 @@ class TestCli(TestCase):
         )
 
         context_mock.local_lambda_runner.invoke.assert_called_with(
-            context_mock.function_name, event=event_data, stdout=context_mock.stdout, stderr=context_mock.stderr
+            context_mock.function_name,
+            event=event_data,
+            stdout=context_mock.stdout,
+            stderr=context_mock.stderr,
+            shutdown=False,
         )
         get_event_mock.assert_called_with(self.eventfile)
 
@@ -113,6 +119,7 @@ class TestCli(TestCase):
             template=self.template,
             event=self.event,
             no_event=self.no_event,
+            shutdown=self.shutdown,
             env_vars=self.env_vars,
             debug_port=self.debug_ports,
             debug_args=self.debug_args,
@@ -146,7 +153,11 @@ class TestCli(TestCase):
 
         get_event_mock.assert_not_called()
         context_mock.local_lambda_runner.invoke.assert_called_with(
-            context_mock.function_name, event="{}", stdout=context_mock.stdout, stderr=context_mock.stderr
+            context_mock.function_name,
+            event="{}",
+            stdout=context_mock.stdout,
+            stderr=context_mock.stderr,
+            shutdown=False,
         )
 
     @parameterized.expand(
@@ -181,6 +192,7 @@ class TestCli(TestCase):
                 template=self.template,
                 event=self.eventfile,
                 no_event=self.no_event,
+                shutdown=self.shutdown,
                 env_vars=self.env_vars,
                 debug_port=self.debug_ports,
                 debug_args=self.debug_args,
@@ -229,6 +241,7 @@ class TestCli(TestCase):
                 template=self.template,
                 event=self.eventfile,
                 no_event=self.no_event,
+                shutdown=self.shutdown,
                 env_vars=self.env_vars,
                 debug_port=self.debug_ports,
                 debug_args=self.debug_args,
@@ -265,6 +278,7 @@ class TestCli(TestCase):
                 template=self.template,
                 event=self.eventfile,
                 no_event=self.no_event,
+                shutdown=self.shutdown,
                 env_vars=self.env_vars,
                 debug_port=self.debug_ports,
                 debug_args=self.debug_args,

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -456,6 +456,7 @@ class TestLocalLambda_invoke(TestCase):
         stderr = "stderr"
         function = Mock(functionname="name")
         invoke_config = "config"
+        shutdown = False
 
         self.function_provider_mock.get_all.return_value = [function]
         self.local_lambda._get_invoke_config = Mock()
@@ -464,7 +465,7 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr
+            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, shutdown=shutdown
         )
 
     def test_must_raise_if_function_not_found(self):

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -159,6 +159,7 @@ class TestSamConfigForAllCommands(TestCase):
             "skip_pull_image": True,
             "force_image_build": True,
             "parameter_overrides": "ParameterKey=Key,ParameterValue=Value ParameterKey=Key2,ParameterValue=Value2",
+            "shutdown": False,
         }
 
         # NOTE: Because we don't load the full Click BaseCommand here, this is mounted as top-level command
@@ -181,6 +182,7 @@ class TestSamConfigForAllCommands(TestCase):
                 "foo",
                 str(Path(os.getcwd(), "mytemplate.yaml")),
                 "event",
+                False,
                 False,
                 "envvar.json",
                 (1, 2, 3),


### PR DESCRIPTION
In concert with the `ENABLE_LAMBDA_EXTENSIONS_PREVIEW` flag, setting this option will trigger a shutdown event in the execution environment after completing an invocation, which in turn allows for local testing of extensions which subscribe to the "SHUTDOWN" event and have shutdown behavior.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
