### PR TITLE
fix(package): regression with "Fn::Transform"

### DIFF
--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -151,7 +151,9 @@ class Template:
         """
         for key, val in template_dict.items():
             if key in GLOBAL_EXPORT_DICT:
-                template_dict[key] = GLOBAL_EXPORT_DICT[key](val, self.uploader, self.template_dir)
+                template_dict[key] = GLOBAL_EXPORT_DICT[key](
+                    val, self.uploader.get(ResourceZip.EXPORT_DESTINATION), self.template_dir
+                )
             elif isinstance(val, dict):
                 self.export_global_artifacts(val)
             elif isinstance(val, list):

--- a/tests/integration/package/test_package_command_zip.py
+++ b/tests/integration/package/test_package_command_zip.py
@@ -56,6 +56,7 @@ class TestPackageZip(PackageIntegBase):
             "aws-serverlessrepo-application.yaml",
             "aws-serverless-statemachine.yaml",
             "aws-stepfunctions-statemachine.yaml",
+            "aws-include-transform.yaml",
         ]
     )
     def test_package_barebones(self, template_file):

--- a/tests/integration/testdata/package/aws-include-transform.yaml
+++ b/tests/integration/testdata/package/aws-include-transform.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Transform only app
+
+Resources:
+  'Fn::Transform':
+    Name: 'AWS::Include'
+    Parameters:
+      Location : ./main.py


### PR DESCRIPTION
- default to s3 based uploader
- added integration test for Fn::Transform which was missing before.

#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/2432

#### Why is this change necessary?
* AWS Include defaults to s3 as the export mechanism. there was a bug in not supplying the correct uploader.

#### How does it address the issue?
* Specified AWS Include macro now packages to s3
#### What side effects does this change have?
* Its a regression fix
#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
