### PR TITLE
fix: create signer client with region definition

### DIFF
--- a/samcli/commands/package/package_context.py
+++ b/samcli/commands/package/package_context.py
@@ -109,7 +109,9 @@ class PackageContext:
         self.s3_uploader.artifact_metadata = self.metadata
         self.ecr_uploader = ECRUploader(docker_client, ecr_client, self.image_repository)
 
-        code_signer_client = boto3.client("signer")
+        code_signer_client = boto3.client(
+            "signer", config=get_boto_config_with_user_agent(region_name=region_name)
+        )
         self.code_signer = CodeSigner(code_signer_client, self.signing_profiles)
 
         # NOTE(srirammv): move this to its own class.

--- a/samcli/commands/package/package_context.py
+++ b/samcli/commands/package/package_context.py
@@ -109,9 +109,7 @@ class PackageContext:
         self.s3_uploader.artifact_metadata = self.metadata
         self.ecr_uploader = ECRUploader(docker_client, ecr_client, self.image_repository)
 
-        code_signer_client = boto3.client(
-            "signer", config=get_boto_config_with_user_agent(region_name=region_name)
-        )
+        code_signer_client = boto3.client("signer", config=get_boto_config_with_user_agent(region_name=region_name))
         self.code_signer = CodeSigner(code_signer_client, self.signing_profiles)
 
         # NOTE(srirammv): move this to its own class.

--- a/tests/unit/commands/package/test_package_context.py
+++ b/tests/unit/commands/package/test_package_context.py
@@ -1,6 +1,6 @@
 """Test sam package command"""
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock, call, ANY
 import tempfile
 
 
@@ -92,3 +92,21 @@ class TestPackageCommand(TestCase):
                 profile=None,
             )
             package_command_context.run()
+
+    @patch.object(Template, "export", MagicMock(return_value={}))
+    @patch("boto3.Session")
+    @patch("boto3.client")
+    @patch("samcli.commands.package.package_context.get_boto_config_with_user_agent")
+    def test_boto_clients_created_with_config(self, patched_get_config, patched_boto_client, patched_boto_session):
+        with self.assertRaises(PackageFailedError):
+            self.package_command_context.run()
+
+        patched_boto_client.assert_has_calls([call("s3", config=ANY)])
+        patched_boto_client.assert_has_calls([call("ecr", config=ANY)])
+        patched_boto_client.assert_has_calls([call("signer", config=ANY)])
+
+        patched_get_config.assert_has_calls(
+            [call(region_name=ANY, signature_version=ANY), call(region_name=ANY), call(region_name=ANY)]
+        )
+
+        print("hello")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/2433

#### Why is this change necessary?
If user doesn't have any default region setting (env variable or in ~/.aws folder) guided deploy command will fail.

#### How does it address the issue?
This change sets region from guided deploy parameters

#### What side effects does this change have?
None

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
