### PR TITLE
fix: add AWS_EXECUTION_ENV to debug env variables for json runtimes

### DIFF
--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -96,6 +96,7 @@ class LambdaDebugSettings:
                 container_env_vars={
                     "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node10/node_modules:/var/runtime/node_module",
                     "NODE_OPTIONS": f"--inspect-brk=0.0.0.0:{str(debug_port)} --max-http-header-size 81920",
+                    "AWS_EXECUTION_ENV": "AWS_Lambda_nodejs10.x",
                     **_container_env_vars,
                 },
             ),
@@ -108,6 +109,7 @@ class LambdaDebugSettings:
                 container_env_vars={
                     "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node12/node_modules:/var/runtime/node_module",
                     "NODE_OPTIONS": f"--inspect-brk=0.0.0.0:{str(debug_port)} --max-http-header-size 81920",
+                    "AWS_EXECUTION_ENV": "AWS_Lambda_nodejs12.x",
                     **_container_env_vars,
                 },
             ),


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#2384 
#### Why is this change necessary?

#### How does it address the issue?
Add AWS_EXECUTION_ENV to debug env variable list.

#### What side effects does this change have?

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
