### PR TITLE
fix: use a lock when pulling different images

### DIFF
--- a/tests/unit/local/docker/test_manager.py
+++ b/tests/unit/local/docker/test_manager.py
@@ -5,11 +5,10 @@ Tests container manager
 import io
 import importlib
 from unittest import TestCase
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock, ANY, call
 
 import requests
 from docker.errors import APIError, ImageNotFound
-from mock import ANY, call
 from samcli.local.docker.manager import ContainerManager, DockerImagePullFailedException
 
 

--- a/tests/unit/local/docker/test_manager.py
+++ b/tests/unit/local/docker/test_manager.py
@@ -5,10 +5,11 @@ Tests container manager
 import io
 import importlib
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import requests
 from docker.errors import APIError, ImageNotFound
+from mock import ANY, call
 from samcli.local.docker.manager import ContainerManager, DockerImagePullFailedException
 
 
@@ -238,6 +239,31 @@ class TestContainerManager_pull_image(TestCase):
 
         ex = context.exception
         self.assertEqual(str(ex), msg)
+
+    @patch("samcli.local.docker.manager.threading")
+    def test_must(self, mock_threading):
+        self.mock_docker_client.api.pull.return_value = [1, 2, 3]
+
+        # mock general lock
+        mock_lock = MagicMock()
+        self.manager._lock = mock_lock
+
+        # mock locks per image
+        mock_image1_lock = MagicMock()
+        mock_image2_lock = MagicMock()
+        mock_threading.Lock.side_effect = [mock_image1_lock, mock_image2_lock]
+
+        # pull 2 different images for multiple times
+        self.manager.pull_image("image1")
+        self.manager.pull_image("image1")
+        self.manager.pull_image("image2")
+
+        # assert that image1 lock have been used twice and image2 lock only used once
+        mock_image1_lock.assert_has_calls(2 * [call.__enter__(), call.__exit__(ANY, ANY, ANY)], any_order=True)
+        mock_image2_lock.assert_has_calls([call.__enter__(), call.__exit__(ANY, ANY, ANY)])
+
+        # assert that general lock have been used three times for all the image pulls
+        mock_lock.assert_has_calls(3 * [call.__enter__(), call.__exit__(ANY, ANY, ANY)], any_order=True)
 
 
 class TestContainerManager_is_docker_reachable(TestCase):

--- a/tests/unit/local/docker/test_manager.py
+++ b/tests/unit/local/docker/test_manager.py
@@ -241,7 +241,7 @@ class TestContainerManager_pull_image(TestCase):
         self.assertEqual(str(ex), msg)
 
     @patch("samcli.local.docker.manager.threading")
-    def test_must(self, mock_threading):
+    def test_multiple_image_pulls_must_use_locks(self, mock_threading):
         self.mock_docker_client.api.pull.return_value = [1, 2, 3]
 
         # mock general lock


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/2446

#### Why is this change necessary?
If build images are not downloaded before, running build command in parallel might cause docker to start pulling same image more than once.

#### How does it address the issue?
By adding a thread lock for different images. That means each image should only be pulled once during a parallel operation. Different images (ex: nodejs, python) can be pulled at the same time.

#### What side effects does this change have?
Adding a lock per image pull might add small performance decrease (around hundreds of milliseconds).

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
