### PR TITLE
Loose the boto3 version requirement

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ chevron~=0.12
 click~=7.1
 Flask~=1.1.2
 #Need to add Schemas latest SDK.
-boto3~=1.14.23
+boto3~=1.14
 jmespath~=0.10.0
 PyYAML~=5.3
 cookiecutter~=1.7.2


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

boto3 has been stable among minor version upgrades,
we can make the version requirement loose as we do in
https://github.com/aws/serverless-application-model/pull/1812

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
