### PR TITLE
docs: fix simple typo, utlity -> utility

### DIFF
--- a/samcli/commands/_utils/resources.py
+++ b/samcli/commands/_utils/resources.py
@@ -1,5 +1,5 @@
 """
-Enums for Resources and thier Location Properties, along with utlity functions
+Enums for Resources and thier Location Properties, along with utility functions
 """
 
 from collections import defaultdict


### PR DESCRIPTION
There is a small typo in samcli/commands/_utils/resources.py.

Should read `utility` rather than `utlity`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md