### PR TITLE
fix: accepting large input requests

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -226,7 +226,7 @@ class InvokeContext:
 
         def initialize_function_container(function):
             function_config = self.local_lambda_runner.get_invoke_config(function)
-            self.lambda_runtime.run(None, function_config, self._debug_context, None)
+            self.lambda_runtime.run(None, function_config, self._debug_context)
 
         try:
             async_context = AsyncContext()

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -39,8 +39,8 @@ class Container:
     _STDERR_FRAME_TYPE = 2
     RAPID_PORT_CONTAINER = "8080"
     URL = "http://localhost:{port}/2015-03-31/functions/{function_name}/invocations"
-    # NOTE(sriram-mv): 100ms Connection Timeout for http requests talking to `aws-lambda-rie` HTTP APIs
-    RAPID_CONNECTION_TIMEOUT = 0.1
+    # Set connection timeout to 1 sec to support the large input.
+    RAPID_CONNECTION_TIMEOUT = 1
 
     def __init__(
         self,

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -40,7 +40,7 @@ class LambdaRuntime:
         self._image_builder = image_builder
         self._temp_uncompressed_paths_to_be_cleaned = []
 
-    def create(self, function_config, debug_context=None, event=None):
+    def create(self, function_config, debug_context=None):
         """
         Create a new Container for the passed function, then store it in a dictionary using the function name,
         so it can be retrieved later and used in the other functions. Make sure to use the debug_context only
@@ -52,20 +52,14 @@ class LambdaRuntime:
             Configuration of the function to create a new Container for it.
         debug_context DebugContext
             Debugging context for the function (includes port, args, and path)
-        event str
-            input event passed to Lambda function
 
         Returns
         -------
         Container
             the created container
         """
-        environ = function_config.env_vars
-        if event:
-            # Update with event input
-            environ.add_lambda_event_body(event)
         # Generate a dictionary of environment variable key:values
-        env_vars = environ.resolve()
+        env_vars = function_config.env_vars.resolve()
 
         code_dir = self._get_code_dir(function_config.code_abs_path)
         container = LambdaContainer(
@@ -90,7 +84,7 @@ class LambdaRuntime:
             LOG.debug("Ctrl+C was pressed. Aborting container creation")
             raise
 
-    def run(self, container, function_config, debug_context, event=None):
+    def run(self, container, function_config, debug_context):
         """
         Find the created container for the passed Lambda function, then using the
         ContainerManager run this container.
@@ -104,8 +98,6 @@ class LambdaRuntime:
             Configuration of the function to run its created container.
         debug_context DebugContext
             Debugging context for the function (includes port, args, and path)
-        event str
-            input event passed to Lambda function
         Returns
         -------
         Container
@@ -113,7 +105,7 @@ class LambdaRuntime:
         """
 
         if not container:
-            container = self.create(function_config, debug_context, event)
+            container = self.create(function_config, debug_context)
 
         if container.is_running():
             LOG.info("Lambda function '%s' is already running", function_config.name)
@@ -150,8 +142,8 @@ class LambdaRuntime:
         container = None
         try:
             # Start the container. This call returns immediately after the container starts
-            container = self.create(function_config, debug_context, event)
-            container = self.run(container, function_config, debug_context, event)
+            container = self.create(function_config, debug_context)
+            container = self.run(container, function_config, debug_context)
             # Setup appropriate interrupt - timeout or Ctrl+C - before function starts executing.
             #
             # Start the timer **after** container starts. Container startup takes several seconds, only after which,
@@ -297,7 +289,7 @@ class WarmLambdaRuntime(LambdaRuntime):
 
         super().__init__(container_manager, image_builder)
 
-    def create(self, function_config, debug_context=None, event=None):
+    def create(self, function_config, debug_context=None):
         """
         Create a new Container for the passed function, then store it in a dictionary using the function name,
         so it can be retrieved later and used in the other functions. Make sure to use the debug_context only
@@ -309,8 +301,6 @@ class WarmLambdaRuntime(LambdaRuntime):
             Configuration of the function to create a new Container for it.
         debug_context DebugContext
             Debugging context for the function (includes port, args, and path)
-        event str
-            input event passed to Lambda function
 
         Returns
         -------
@@ -334,7 +324,7 @@ class WarmLambdaRuntime(LambdaRuntime):
             )
             debug_context = None
 
-        container = super().create(function_config, debug_context, None)
+        container = super().create(function_config, debug_context)
         self._containers[function_config.name] = container
         self._add_function_to_observer(function_config)
         return container

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -217,6 +217,18 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_large_input_request(self):
+        # not exact 6 mega, as local start-api sends extra data with the input data
+        around_six_mega = 6 * 1024 * 1024 - 2 * 1024
+        data = "a" * around_six_mega
+        response = requests.post(self.url + "/echoeventbody", data=data, timeout=300)
+
+        self.assertEqual(response.status_code, 200)
+        response_data = response.json()
+        self.assertEqual(response_data.get("body"), data)
+
 
 class TestServiceWithHttpApi(StartApiIntegBaseClass):
     """

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -457,7 +457,7 @@ class TestContainer_wait_for_result(TestCase):
         self.container.id = "someid"
 
         self.container.is_created = Mock()
-        self.timeout = 0.1
+        self.timeout = 1
 
     @patch("samcli.local.docker.container.requests")
     def test_wait_for_result_no_error(self, mock_requests):

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -46,7 +46,6 @@ class LambdaRuntime_create(TestCase):
 
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_must_create_lambda_container(self, LambdaContainerMock):
-        event = "event"
         code_dir = "some code dir"
 
         container = Mock()
@@ -61,10 +60,7 @@ class LambdaRuntime_create(TestCase):
 
         LambdaContainerMock.return_value = container
 
-        self.runtime.create(self.func_config, debug_context=debug_options, event=event)
-
-        # Verify if Lambda Event data is set
-        self.env_vars.add_lambda_event_body.assert_called_with(event)
+        self.runtime.create(self.func_config, debug_context=debug_options)
 
         # Make sure env-vars get resolved
         self.env_vars.resolve.assert_called_with()
@@ -91,7 +87,6 @@ class LambdaRuntime_create(TestCase):
 
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_keyboard_interrupt_must_raise(self, LambdaContainerMock):
-        event = "event"
         code_dir = "some code dir"
 
         container = Mock()
@@ -109,7 +104,7 @@ class LambdaRuntime_create(TestCase):
         self.manager_mock.create.side_effect = KeyboardInterrupt("some exception")
 
         with self.assertRaises(KeyboardInterrupt):
-            self.runtime.create(self.func_config, debug_context=debug_options, event=event)
+            self.runtime.create(self.func_config, debug_context=debug_options)
 
 
 class LambdaRuntime_run(TestCase):
@@ -144,7 +139,6 @@ class LambdaRuntime_run(TestCase):
         self.env_vars.resolve.return_value = self.env_var_value
 
     def test_must_run_passed_container(self):
-        event = "event"
         container = Mock()
         container.is_running.return_value = False
         debug_options = Mock()
@@ -152,11 +146,10 @@ class LambdaRuntime_run(TestCase):
 
         self.runtime = LambdaRuntime(self.manager_mock, lambda_image_mock)
 
-        self.runtime.run(container, self.func_config, debug_context=debug_options, event=event)
+        self.runtime.run(container, self.func_config, debug_context=debug_options)
         self.manager_mock.run.assert_called_with(container)
 
     def test_must_create_container_first_if_passed_container_is_none(self):
-        event = "event"
         container = Mock()
         container.is_running.return_value = False
         debug_options = Mock()
@@ -167,12 +160,11 @@ class LambdaRuntime_run(TestCase):
         self.runtime.create = create_mock
         create_mock.return_value = container
 
-        self.runtime.run(None, self.func_config, debug_context=debug_options, event=event)
-        create_mock.assert_called_with(self.func_config, debug_options, event)
+        self.runtime.run(None, self.func_config, debug_context=debug_options)
+        create_mock.assert_called_with(self.func_config, debug_options)
         self.manager_mock.run.assert_called_with(container)
 
     def test_must_skip_run_running_container(self):
-        event = "event"
         container = Mock()
         container.is_running.return_value = True
         debug_options = Mock()
@@ -180,11 +172,10 @@ class LambdaRuntime_run(TestCase):
 
         self.runtime = LambdaRuntime(self.manager_mock, lambda_image_mock)
 
-        self.runtime.run(container, self.func_config, debug_context=debug_options, event=event)
+        self.runtime.run(container, self.func_config, debug_context=debug_options)
         self.manager_mock.run.assert_not_called()
 
     def test_keyboard_interrupt_must_raise(self):
-        event = "event"
         container = Mock()
         container.is_running.return_value = False
         debug_options = Mock()
@@ -195,7 +186,7 @@ class LambdaRuntime_run(TestCase):
         self.manager_mock.run.side_effect = KeyboardInterrupt("some exception")
 
         with self.assertRaises(KeyboardInterrupt):
-            self.runtime.run(container, self.func_config, debug_context=debug_options, event=event)
+            self.runtime.run(container, self.func_config, debug_context=debug_options)
 
 
 class LambdaRuntime_invoke(TestCase):
@@ -258,9 +249,6 @@ class LambdaRuntime_invoke(TestCase):
         container.is_running.return_value = False
 
         self.runtime.invoke(self.func_config, event, debug_context=debug_options, stdout=stdout, stderr=stderr)
-
-        # Verify if Lambda Event data is set
-        self.env_vars.add_lambda_event_body.assert_called_with(event)
 
         # Make sure env-vars get resolved
         self.env_vars.resolve.assert_called_with()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/188

#### Why is this change necessary?
to allow of local testing with large input request

#### How does it address the issue?
After the use of rapid-rie server, no need to send the input event as part of the container environment variables.

#### What side effects does this change have?
N/A

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write unit tests
- [ ] Write/update functional tests
- [X] Write/update integration tests
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
