### PR TITLE
Record all functions that use the newly built image

### DIFF
--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -111,7 +111,8 @@ class DefaultBuildStrategy(BuildStrategy):
                              single_build_dir,
                              build_definition.metadata
         )
-        function_build_results[single_function_name] = result
+        for function in build_definition.functions:
+          function_build_results[function.name] = result
 
         # copy results to other functions
         if build_definition.packagetype == ZIP:

--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -112,7 +112,7 @@ class DefaultBuildStrategy(BuildStrategy):
                              build_definition.metadata
         )
         for function in build_definition.functions:
-          function_build_results[function.name] = result
+            function_build_results[function.name] = result
 
         # copy results to other functions
         if build_definition.packagetype == ZIP:

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -69,6 +69,55 @@ class TestBuildCommand_PythonFunctions_Images(BuildIntegBase):
     ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
     "Skip build tests on windows when running in CI unless overridden",
 )
+class TestBuildCommand_PythonFunctions_Shared_Image(BuildIntegBase):
+    template = "template_shared_image.yaml"
+
+    EXPECTED_FILES_GLOBAL_MANIFEST = set()
+    EXPECTED_FILES_PROJECT_MANIFEST = {
+        "__init__.py",
+        "main.py",
+        "numpy",
+        # 'cryptography',
+        "requirements.txt",
+    }
+
+    FUNCTION_LOGICAL_ID_IMAGE = "ImageFunction"
+    FUNCTION_TWO_LOGICAL_ID_IMAGE = "ImageFunctionTwo"
+
+    @parameterized.expand([("3.6", False), ("3.7", False), ("3.8", False)])
+    @pytest.mark.flaky(reruns=3)
+    def test_with_default_requirements(self, runtime, use_container):
+        overrides = {
+            "Runtime": runtime,
+            "Handler": "main.handler",
+            "HandlerTwo": "main.handler_two",
+            "DockerFile": "Dockerfile",
+            "Tag": f"{random.randint(1,100)}",
+        }
+        cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
+
+        LOG.info("Running Command: ")
+        LOG.info(cmdlist)
+        run_command(cmdlist, cwd=self.working_dir)
+
+        expected = {"pi": "3.14"}
+        self._verify_invoke_built_function(
+            self.built_template, self.FUNCTION_LOGICAL_ID_IMAGE, self._make_parameter_override_arg(overrides), expected
+        )
+
+        expected = {"2pi": "6.28"}
+        self._verify_invoke_built_function(
+            self.built_template,
+            self.FUNCTION_TWO_LOGICAL_ID_IMAGE,
+            self._make_parameter_override_arg(overrides),
+            expected,
+        )
+
+
+@skipIf(
+    ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
 class TestBuildCommand_PythonFunctions(BuildIntegBase):
     EXPECTED_FILES_GLOBAL_MANIFEST = set()
     EXPECTED_FILES_PROJECT_MANIFEST = {

--- a/tests/integration/testdata/buildcmd/PythonImage/main.py
+++ b/tests/integration/testdata/buildcmd/PythonImage/main.py
@@ -1,11 +1,7 @@
 import numpy
 
-# from cryptography.fernet import Fernet
-
-
 def handler(event, context):
-
-    # Try using some of the modules to make sure they work & don't crash the process
-    # print(Fernet.generate_key())
-
     return {"pi": "{0:.2f}".format(numpy.pi)}
+
+def handler_two(event, context):
+    return {"2pi": "{0:.2f}".format(numpy.pi * 2)}

--- a/tests/integration/testdata/buildcmd/template_shared_image.yaml
+++ b/tests/integration/testdata/buildcmd/template_shared_image.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameteres:
+  Runtime:
+    Type: String
+  DockerFile:
+    Type: String
+  Handler:
+    Type: String
+  HandlerTwo:
+    Type: String
+  Tag:
+    Type: String
+
+Resources:
+
+  ImageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - !Ref Handler
+      Timeout: 600
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: ./PythonImage
+      Dockerfile: !Ref DockerFile
+      DockerBuildArgs:
+        BASE_RUNTIME: !Ref Runtime
+  ImageFunctionTwo:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - !Ref HandlerTwo
+      Timeout: 600
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: ./PythonImage
+      Dockerfile: !Ref DockerFile
+      DockerBuildArgs:
+        BASE_RUNTIME: !Ref Runtime


### PR DESCRIPTION

#### Which issue(s) does this change fix?
#2466 

#### Why is this change necessary?

Currently, if multiple functions have the same Docker build metadata, only the first one will get an ImageUri tag in the updated template.yaml.  As a result, package will fail.

#### How does it address the issue?

This causes the resulting DockerTag to get recorded as "built" for all of the functions it applies to instead of just the first one.

#### What side effects does this change have?

During package, it will try to upload the image once for each function that uses it.  Because of how Docker works though, only a single image actually ends up in ECR.  It's more a visual annoyance and a small performance hit during packaging.

#### Checklist

- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
