### PR TITLE
PoC: build & package functions in nested SAM stacks

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -1,15 +1,13 @@
 """
 Context object used by build command
 """
-import itertools
+
 import logging
 import os
 import shutil
 import pathlib
-from typing import Dict
 
 from samcli.lib.providers.provider import ResourcesToBuildCollector
-from samcli.lib.providers.sam_application_provider import SamApplicationProvider
 from samcli.local.docker.manager import ContainerManager
 from samcli.lib.providers.sam_function_provider import SamFunctionProvider
 from samcli.lib.providers.sam_layer_provider import SamLayerProvider
@@ -56,7 +54,7 @@ class BuildContext:
         self._mode = mode
         self._cached = cached
 
-        self._function_providers: Dict[str, SamFunctionProvider] = dict()
+        self._function_provider = None
         self._layer_provider = None
         self._template_dict = None
         self._app_builder = None
@@ -65,9 +63,7 @@ class BuildContext:
     def __enter__(self):
         self._template_dict = get_template_data(self._template_file)
 
-        self._function_providers = BuildContext._get_function_providers_in_application_recursively(
-            self._template_dict, self._parameter_overrides
-        )
+        self._function_provider = SamFunctionProvider(self._template_dict, self._parameter_overrides)
         self._layer_provider = SamLayerProvider(self._template_dict, self._parameter_overrides)
 
         if not self._base_dir:
@@ -90,25 +86,6 @@ class BuildContext:
 
     def __exit__(self, *args):
         pass
-
-    @staticmethod
-    def _get_function_providers_in_application_recursively(template_dict, parameter_overrides=None):
-        """
-        Traverse the nested applications to find all functions
-        """
-        function_providers = {"": SamFunctionProvider(template_dict, parameter_overrides)}
-
-        application_provider = SamApplicationProvider(template_dict, parameter_overrides)
-        for application in application_provider.get_all():
-            application_template_dict = get_template_data(application.location)
-
-            providers = BuildContext._get_function_providers_in_application_recursively(
-                application_template_dict, application.parameters
-            )
-            for key, provider in providers.items():
-                function_providers[f"{application.name}/{key}"] = provider
-
-        return function_providers
 
     @staticmethod
     def _setup_build_dir(build_dir, clean):
@@ -137,8 +114,8 @@ class BuildContext:
         return self._container_manager
 
     @property
-    def function_providers(self):
-        return self._function_providers
+    def function_provider(self):
+        return self._function_provider
 
     @property
     def layer_provider(self):
@@ -202,14 +179,7 @@ class BuildContext:
             self._collect_single_buildable_layer(self._resource_identifier, result)
 
             if not result.functions and not result.layers:
-                all_resources = list(
-                    itertools.chain.from_iterable(
-                        [
-                            [prefix + f.name for f in function_provider.get_all()]
-                            for prefix, function_provider in self._function_providers.items()
-                        ]
-                    )
-                )
+                all_resources = [f.name for f in self._function_provider.get_all()]
                 all_resources.extend([l.name for l in self._layer_provider.get_all()])
 
                 available_resource_message = (
@@ -218,15 +188,7 @@ class BuildContext:
                 LOG.info(available_resource_message)
                 raise ResourceNotFound(f"Unable to find a function or layer with name '{self._resource_identifier}'")
             return result
-        # single_build_dir uses function's name (ref: build_single_function_definition())
-        # here we replace each function's name
-        functions = itertools.chain.from_iterable(
-            [
-                [f._replace(name=prefix + f.name) for f in function_provider.get_all()]
-                for prefix, function_provider in self._function_providers.items()
-            ]
-        )
-        result.add_functions(functions)
+        result.add_functions(self._function_provider.get_all())
         result.add_layers([l for l in self._layer_provider.get_all() if l.build_method is not None])
         return result
 

--- a/samcli/commands/package/package_context.py
+++ b/samcli/commands/package/package_context.py
@@ -23,11 +23,13 @@ import boto3
 import click
 import docker
 
+from samcli.commands._utils.template import get_template_data
 from samcli.commands.package.exceptions import PackageFailedError
 from samcli.lib.package.artifact_exporter import Template
 from samcli.lib.package.ecr_uploader import ECRUploader
 from samcli.lib.package.code_signer import CodeSigner
 from samcli.lib.package.s3_uploader import S3Uploader
+from samcli.lib.providers.sam_application_provider import SamApplicationProvider
 from samcli.lib.utils.botoconfig import get_boto_config_with_user_agent
 from samcli.yamlhelper import yaml_dump
 

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -196,7 +196,10 @@ class ApplicationBuilder:
 
         for logical_id, resource in template_dict.get("Resources", {}).items():
 
-            if logical_id not in built_artifacts and resource.get("Type") != SamBaseProvider.SERVERLESS_APPLICATION:
+            if logical_id not in built_artifacts and resource.get("Type") not in {
+                SamBaseProvider.SERVERLESS_APPLICATION,
+                SamBaseProvider.CLOUDFORMATION_STACK,
+            }:
                 # this resource was not built. So skip it
                 continue
 
@@ -237,6 +240,8 @@ class ApplicationBuilder:
             # nested application
             if resource_type == SamBaseProvider.SERVERLESS_APPLICATION:
                 properties["Location"] = store_path
+            if resource_type == SamBaseProvider.CLOUDFORMATION_STACK:
+                properties["TemplateURL"] = store_path
 
         return template_dict
 

--- a/samcli/lib/providers/sam_application_provider.py
+++ b/samcli/lib/providers/sam_application_provider.py
@@ -1,0 +1,117 @@
+"""
+Class that provides nested applications from a given SAM template
+"""
+import logging
+from typing import NamedTuple, Optional, Any
+
+from samcli.lib.utils.colors import Colored
+from .sam_base_provider import SamBaseProvider
+
+LOG = logging.getLogger(__name__)
+
+
+class Application(NamedTuple):
+    name: str
+    location: str
+    parameters: Optional[Any]
+
+
+class SamApplicationProvider(SamBaseProvider):
+    """
+    Fetches and returns nested application from a SAM Template. The SAM template passed to this provider is assumed
+    to be valid, normalized and a dictionary.
+
+    It may or may not contain an application.
+    """
+
+    def __init__(self, template_dict, parameter_overrides=None):
+        """
+        Initialize the class with SAM template data. The SAM template passed to this provider is assumed
+        to be valid, normalized and a dictionary. It should be normalized by running all pre-processing
+        before passing to this class. The process of normalization will remove structures like ``Globals``, resolve
+        intrinsic functions etc.
+        This class does not perform any syntactic validation of the template.
+
+        After the class is initialized, any changes to the ``template_dict`` will not be reflected in here.
+        You need to explicitly update the class with new template, if necessary.
+
+        :param dict template_dict: SAM Template as a dictionary
+        :param dict parameter_overrides: Optional dictionary of values for SAM template parameters that might want
+            to get substituted within the template
+        """
+
+        self.template_dict = SamApplicationProvider.get_template(template_dict, parameter_overrides)
+        self.resources = self.template_dict.get("Resources", {})
+
+        LOG.debug("%d resources found in the template", len(self.resources))
+
+        # Store a map of function name to function information for quick reference
+        self.applications = self._extract_applications(self.resources)
+
+        self._colored = Colored()
+
+    def get(self, name):
+        """
+        Returns the application given name or LogicalId of the application. Every SAM resource has a logicalId, but it may
+        also have a application name. This method searches only for LogicalID and returns the application that matches
+        it.
+
+        :param string name: Name of the application
+        :return Function: namedtuple containing the Application information if application is found.
+                          None, if application is not found
+        :raises ValueError If name is not given
+        """
+
+        if not name:
+            raise ValueError("Application name is required")
+
+        for f in self.get_all():
+            if f.name == name:
+                return f
+
+        return None
+
+    def get_all(self):
+        """
+        Yields all the applications available in the SAM Template.
+
+        :yields Application: map containing the application information
+        """
+
+        for _, application in self.applications.items():
+            yield application
+
+    @staticmethod
+    def _extract_applications(resources):
+        """
+        Extracts and returns nested application information from the given dictionary of SAM/CloudFormation resources.
+        This method supports applications defined with AWS::Serverless::Application
+
+        :param dict resources: Dictionary of SAM/CloudFormation resources
+        :return dict(string : application): Dictionary of application LogicalId to the
+            Application object
+        """
+
+        result = {}
+
+        for name, resource in resources.items():
+
+            resource_type = resource.get("Type")
+            resource_properties = resource.get("Properties", {})
+            resource_metadata = resource.get("Metadata", None)
+            # Add extra metadata information to properties under a separate field.
+            if resource_metadata:
+                resource_properties["Metadata"] = resource_metadata
+
+            if resource_type == SamApplicationProvider.SERVERLESS_APPLICATION:
+                result[name] = SamApplicationProvider._convert_sam_application_resource(name, resource_properties)
+
+            # We don't care about other resource types. Just ignore them
+
+        return result
+
+    @staticmethod
+    def _convert_sam_application_resource(name, resource_properties):
+        return Application(
+            name=name, location=resource_properties.get("Location"), parameters=resource_properties.get("Parameters")
+        )

--- a/samcli/lib/providers/sam_base_provider.py
+++ b/samcli/lib/providers/sam_base_provider.py
@@ -21,6 +21,7 @@ class SamBaseProvider:
     LAMBDA_FUNCTION = "AWS::Lambda::Function"
     SERVERLESS_LAYER = "AWS::Serverless::LayerVersion"
     LAMBDA_LAYER = "AWS::Lambda::LayerVersion"
+    SERVERLESS_APPLICATION = "AWS::Serverless::Application"
     DEFAULT_CODEURI = "."
 
     def get(self, name):

--- a/samcli/lib/providers/sam_base_provider.py
+++ b/samcli/lib/providers/sam_base_provider.py
@@ -4,6 +4,7 @@ Base class for SAM Template providers
 
 import logging
 
+from samcli.commands._utils.resources import AWS_CLOUDFORMATION_STACK, AWS_SERVERLESS_APPLICATION
 from samcli.lib.intrinsic_resolver.intrinsic_property_resolver import IntrinsicResolver
 from samcli.lib.intrinsic_resolver.intrinsics_symbol_table import IntrinsicsSymbolTable
 from samcli.lib.samlib.resource_metadata_normalizer import ResourceMetadataNormalizer
@@ -21,7 +22,8 @@ class SamBaseProvider:
     LAMBDA_FUNCTION = "AWS::Lambda::Function"
     SERVERLESS_LAYER = "AWS::Serverless::LayerVersion"
     LAMBDA_LAYER = "AWS::Lambda::LayerVersion"
-    SERVERLESS_APPLICATION = "AWS::Serverless::Application"
+    SERVERLESS_APPLICATION = AWS_SERVERLESS_APPLICATION
+    CLOUDFORMATION_STACK = AWS_CLOUDFORMATION_STACK
     DEFAULT_CODEURI = "."
 
     def get(self, name):


### PR DESCRIPTION
##### TODO

- [x] Put children templates into build dir
- [ ] ~package functions in children templates from build directory.~ surprisingly `sam package` handles it without any changes

##### Template structure:

The templates can be found here: https://github.com/aahung/sam-nested-test

- main template
  - `StockBuyerFunction`
- template with logic ID `Child` of main template
  - `StockCheckerFunction`
- template with logic ID `Child` of `Child` of main template
  - `StockSellerFunction`

##### `sam build` artifacts

```
.aws-sam/build
├── Child
│   ├── Child
│   │   ├── StockSellerFunction
│   │   │   ├── app.js
│   │   │   ├── node_modules
│   │   │   └── package.json
│   │   └── template.yaml
│   ├── StockCheckerFunction
│   │   ├── app.js
│   │   ├── node_modules
│   │   │   └── uuid
│   │   └── package.json
│   ├── build.toml
│   └── template.yaml
├── StockBuyerFunction
│   ├── app.js
│   ├── node_modules
│   │   └── uuid
│   └── package.json
├── build.toml
└── template.yaml
```

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
