### PR TITLE
(Fix) observe the docker images for lambda functions with Image package type

### DIFF
--- a/samcli/lib/utils/file_observer.py
+++ b/samcli/lib/utils/file_observer.py
@@ -5,15 +5,273 @@ import logging
 import threading
 
 from pathlib import Path
+
+import docker
+from docker.errors import ImageNotFound
 from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 
 from samcli.lib.utils.hash import dir_checksum, file_checksum
+from samcli.lib.utils.packagetype import ZIP, IMAGE
 
 LOG = logging.getLogger(__name__)
 
 
-class FileObserverException(Exception):
+class ObserverException(Exception):
+    """
+    Exception raised when unable to observe the input Lambda Function.
+    """
+
+
+class LambdaFunctionObserver:
+    """
+    A class that will observe Lambda Function sources regardless if the source is code or image
+    """
+
+    def __init__(self, on_change):
+        """
+        Initialize the Image observer
+        Parameters
+        ----------
+        on_change:
+            Reference to the function that will be called if there is a change in aby of the observed image
+        """
+        self._observers = {
+            ZIP: FileObserver(self._on_zip_change),
+            IMAGE: ImageObserver(self._on_image_change),
+        }
+
+        self._observed_functions = {
+            ZIP: {},
+            IMAGE: {},
+        }
+
+        def _get_zip_lambda_function_paths(function_config):
+            """
+            Returns a list of ZIP package type lambda function source code paths
+
+            Parameters
+            ----------
+            function_config: dict
+                The lambda function configuration that will be observed
+
+            Returns
+            -------
+            list[str]
+                List of lambda functions' source code paths to be observed
+            """
+            code_paths = [function_config.code_abs_path]
+            if function_config.layers:
+                code_paths += [layer.codeuri for layer in function_config.layers]
+            return code_paths
+
+        def _get_image_lambda_function_image_names(function_config):
+            """
+            Returns a list of Image package type lambda function image names
+
+            Parameters
+            ----------
+            function_config: dict
+                The lambda function configuration that will be observed
+
+            Returns
+            -------
+            list[str]
+                List of lambda functions' image names to be observed
+            """
+            return [function_config.imageuri]
+
+        self.get_resources = {
+            ZIP: _get_zip_lambda_function_paths,
+            IMAGE: _get_image_lambda_function_image_names,
+        }
+
+        self._input_on_change = on_change
+
+    def _on_zip_change(self, paths):
+        """
+        It got executed once there is a change in one of the watched lambda functions' source code.
+
+        Parameters
+        ----------
+        paths: list[str]
+            the changed lambda functions' source code paths
+        """
+        self._on_change(paths, ZIP)
+
+    def _on_image_change(self, images):
+        """
+        It got executed once there is a change in one of the watched lambda functions' images.
+
+        Parameters
+        ----------
+        images: list[str]
+            the changed lambda functions' images names
+        """
+        self._on_change(images, IMAGE)
+
+    def _on_change(self, resources, package_type):
+        """
+        It got executed once there is a change in one of the watched lambda functions' resources.
+
+        Parameters
+        ----------
+        resources: list[str]
+            the changed lambda functions' resources (either source code path pr image names)
+        package_type: str
+            determine if the changed resource is a source code path or an image name
+        """
+        changed_functions = []
+        for resource in resources:
+            if self._observed_functions[package_type].get(resource, None):
+                changed_functions += self._observed_functions[package_type][resource]
+        self._input_on_change(changed_functions)
+
+    def watch(self, function_config):
+        """
+        Start watching the input lambda function.
+
+        Parameters
+        ----------
+        function_config: dict
+            The lambda function configuration that will be observed
+
+        Raises
+        ------
+        ObserverException:
+            if not able to observe the input function source path/image
+        """
+        if self.get_resources.get(function_config.packagetype, None):
+            resources = self.get_resources[function_config.packagetype](function_config)
+            for resource in resources:
+                functions = self._observed_functions[function_config.packagetype].get(resource, [])
+                functions += [function_config]
+                self._observed_functions[function_config.packagetype][resource] = functions
+                self._observers[function_config.packagetype].watch(resource)
+
+    def unwatch(self, function_config):
+        """
+        Remove the input lambda function from the observed functions
+
+        Parameters
+        ----------
+        function_config: dict
+            The lambda function configuration that will be observed
+        """
+        if self.get_resources.get(function_config.packagetype, None):
+            resources = self.get_resources[function_config.packagetype](function_config)
+            for resource in resources:
+                functions = self._observed_functions[function_config.packagetype].get(resource, [])
+                if function_config in functions:
+                    functions.remove(function_config)
+                if not functions:
+                    self._observed_functions[function_config.packagetype].pop(resource, None)
+                    self._observers[function_config.packagetype].unwatch(resource)
+
+    def start(self):
+        """
+        Start Observing.
+        """
+        for _, observer in self._observers.items():
+            observer.start()
+
+    def stop(self):
+        """
+        Stop Observing.
+        """
+        for _, observer in self._observers.items():
+            observer.stop()
+
+
+class ImageObserverException(ObserverException):
+    """
+    Exception raised when unable to observe the input image.
+    """
+
+
+class ImageObserver:
+    """
+    A class that will observe some docker images for any change.
+    """
+
+    def __init__(self, on_change):
+        """
+        Initialize the Image observer
+        Parameters
+        ----------
+        on_change:
+            Reference to the function that will be called if there is a change in aby of the observed image
+        """
+        self._observed_images = {}
+        self._input_on_change = on_change
+        self.docker_client = docker.from_env()
+        self.events = self.docker_client.events(filters={"type": "image"}, decode=True)
+        self._images_observer_thread = None
+        self._lock = threading.Lock()
+
+    def _watch_images_events(self):
+        for event in self.events:
+            if event.get("Action", None) != "tag":
+                continue
+            image_name = event["Actor"]["Attributes"]["name"]
+            if self._observed_images.get(image_name, None):
+                new_image_id = event["id"]
+                if new_image_id != self._observed_images[image_name]:
+                    self._observed_images[image_name] = new_image_id
+                    self._input_on_change([image_name])
+
+    def watch(self, image_name):
+        """
+        Start watching the input image.
+
+        Parameters
+        ----------
+        image_name: str
+            The container image name that will be observed
+
+        Raises
+        ------
+        ImageObserverException:
+            if the input image_name is not exist
+        """
+        try:
+            image = self.docker_client.images.get(image_name)
+            self._observed_images[image_name] = image.id
+        except ImageNotFound as exc:
+            raise ImageObserverException("Can not observe non exist image") from exc
+
+    def unwatch(self, image_name):
+        """
+        Remove the input image form the observed images
+
+        Parameters
+        ----------
+        image_name: str
+            The container image name to be unobserved
+        """
+        self._observed_images.pop(image_name, None)
+
+    def start(self):
+        """
+        Start Observing.
+        """
+        with self._lock:
+            if not self._images_observer_thread:
+                self._images_observer_thread = threading.Thread(target=self._watch_images_events, daemon=True)
+                self._images_observer_thread.start()
+
+    def stop(self):
+        """
+        Stop Observing.
+        """
+        with self._lock:
+            self.events.close()
+            # wait until the images observer thread got stopped
+            while self._images_observer_thread.is_alive():
+                pass
+
+
+class FileObserverException(ObserverException):
     """
     Exception raised when unable to observe the input path.
     """
@@ -36,10 +294,16 @@ class FileObserver:
         self._observed_watches = {}
         self._watch_dog_observed_paths = {}
         self._observer = Observer()
-        self._code_change_handler = PatternMatchingEventHandler(
+        self._code_modification_handler = PatternMatchingEventHandler(
             patterns=["*"], ignore_patterns=[], ignore_directories=False
         )
-        self._code_change_handler.on_modified = self.on_change
+
+        self._code_deletion_handler = PatternMatchingEventHandler(
+            patterns=["*"], ignore_patterns=[], ignore_directories=False
+        )
+
+        self._code_modification_handler.on_modified = self.on_change
+        self._code_deletion_handler.on_deleted = self.on_change
         self._input_on_change = on_change
         self._lock = threading.Lock()
 
@@ -54,13 +318,7 @@ class FileObserver:
         event: watchdog.events.FileSystemEventHandler
             Determines that there is a change happened to some file/dir in the observed paths
         """
-        event_path = event.src_path
-        observed_paths = []
-
-        for watchdog_path, child_observed_paths in self._watch_dog_observed_paths.items():
-            if event_path.startswith(watchdog_path):
-                observed_paths += child_observed_paths
-
+        observed_paths = [path for path in self._observed_paths if event.src_path.startswith(path)]
         if not observed_paths:
             return
 
@@ -102,16 +360,39 @@ class FileObserver:
 
         self._observed_paths[path] = calculate_checksum(path)
 
-        # Watchdog will observe the path's parent path to make sure not missing the event if the path itself got deleted
-        parent_path = str(path_obj.parent)
-        child_paths = self._watch_dog_observed_paths.get(parent_path, [])
+        # recursively watch the input path, and all child path for any modification
+        self._watch_path(path, path, self._code_modification_handler, True)
+
+        # watch only the direct parent path child directories for any deletion
+        # Parent directory watching is needed, as if the input path got deleted,
+        # watchdog will not send an event for it
+        self._watch_path(str(path_obj.parent), path, self._code_deletion_handler, False)
+
+    def _watch_path(self, watch_dog_path, original_path, watcher_handler, recursive):
+        """
+        update the observed paths data structure, and call watch dog observer to observe the input watch dog path
+        if it is not observed before
+
+        Parameters
+        ----------
+        watch_dog_path: str
+            The file/dir path to be observed by watch dog
+        original_path: str
+            The original input file/dir path to be observed
+        watcher_handler: FileSystemEventHandler
+            The watcher event handler
+        recursive: bool
+            determines if we need to watch the path, and all children paths recursively, or just the direct children
+            paths
+        """
+        child_paths = self._watch_dog_observed_paths.get(watch_dog_path, [])
         first_time = not bool(child_paths)
-        if path not in child_paths:
-            child_paths += [path]
-        self._watch_dog_observed_paths[parent_path] = child_paths
+        if original_path not in child_paths:
+            child_paths += [original_path]
+        self._watch_dog_observed_paths[watch_dog_path] = child_paths
         if first_time:
-            self._observed_watches[parent_path] = self._observer.schedule(
-                self._code_change_handler, parent_path, recursive=True
+            self._observed_watches[watch_dog_path] = self._observer.schedule(
+                watcher_handler, watch_dog_path, recursive=recursive
             )
 
     def unwatch(self, path):
@@ -124,18 +405,34 @@ class FileObserver:
             The file/dir path to be unobserved
         """
         path_obj = Path(path)
-        if not path_obj.exists():
-            raise FileObserverException("Can not unwatch non exist path")
-        parent_path = str(path_obj.parent)
-        child_paths = self._watch_dog_observed_paths.get(parent_path, [])
-        if path in child_paths:
-            child_paths.remove(path)
-            self._observed_paths.pop(path, None)
+
+        # unwatch input path
+        self._unwatch_path(path, path)
+
+        # unwatch parent path
+        self._unwatch_path(str(path_obj.parent), path)
+
+    def _unwatch_path(self, watch_dog_path, original_path):
+        """
+        update the observed paths data structure, and call watch dog observer to unobserve the input watch dog path
+        if it is not observed before
+
+        Parameters
+        ----------
+        watch_dog_path: str
+            The file/dir path to be unobserved by watch dog
+        original_path: str
+            The original input file/dir path to be unobserved
+        """
+        child_paths = self._watch_dog_observed_paths.get(watch_dog_path, [])
+        if original_path in child_paths:
+            child_paths.remove(original_path)
+            self._observed_paths.pop(original_path, None)
         if not child_paths:
-            self._watch_dog_observed_paths.pop(parent_path, None)
-            if self._observed_watches[parent_path]:
-                self._observer.unschedule(self._observed_watches[parent_path])
-                self._observed_watches.pop(parent_path, None)
+            self._watch_dog_observed_paths.pop(watch_dog_path, None)
+            if self._observed_watches.get(watch_dog_path, None):
+                self._observer.unschedule(self._observed_watches[watch_dog_path])
+                self._observed_watches.pop(watch_dog_path, None)
 
     def start(self):
         """

--- a/samcli/lib/utils/file_observer.py
+++ b/samcli/lib/utils/file_observer.py
@@ -3,18 +3,66 @@ Wraps watchdog to observe file system for any change.
 """
 import logging
 import threading
+from abc import ABC, abstractmethod
 
 from pathlib import Path
+from threading import Thread, Lock
+from typing import Callable, List, Dict, Optional
 
 import docker
+from docker import DockerClient
 from docker.errors import ImageNotFound
+from docker.types import CancellableStream
 from watchdog.observers import Observer
-from watchdog.events import PatternMatchingEventHandler
+from watchdog.events import PatternMatchingEventHandler, FileSystemEvent, FileSystemEventHandler
+from watchdog.observers.api import ObservedWatch, BaseObserver
 
 from samcli.lib.utils.hash import dir_checksum, file_checksum
 from samcli.lib.utils.packagetype import ZIP, IMAGE
+from samcli.local.lambdafn.config import FunctionConfig
 
 LOG = logging.getLogger(__name__)
+
+
+class ResourceObserver(ABC):
+    @abstractmethod
+    def watch(self, resource: str) -> None:
+        """
+        Start watching the input resource.
+
+        Parameters
+        ----------
+        resource: str
+            The resource that should be observed for modifications
+
+        Raises
+        ------
+        ObserverException:
+            if the input resource is not exist
+        """
+
+    @abstractmethod
+    def unwatch(self, resource: str) -> None:
+        """
+        Remove the input resource form the observed resorces
+
+        Parameters
+        ----------
+        resource: str
+            The resource to be unobserved
+        """
+
+    @abstractmethod
+    def start(self):
+        """
+        Start Observing.
+        """
+
+    @abstractmethod
+    def stop(self):
+        """
+        Stop Observing.
+        """
 
 
 class ObserverException(Exception):
@@ -28,7 +76,7 @@ class LambdaFunctionObserver:
     A class that will observe Lambda Function sources regardless if the source is code or image
     """
 
-    def __init__(self, on_change):
+    def __init__(self, on_change: Callable) -> None:
         """
         Initialize the Image observer
         Parameters
@@ -36,23 +84,23 @@ class LambdaFunctionObserver:
         on_change:
             Reference to the function that will be called if there is a change in aby of the observed image
         """
-        self._observers = {
+        self._observers: Dict[str, ResourceObserver] = {
             ZIP: FileObserver(self._on_zip_change),
             IMAGE: ImageObserver(self._on_image_change),
         }
 
-        self._observed_functions = {
+        self._observed_functions: Dict[str, Dict[str, List[FunctionConfig]]] = {
             ZIP: {},
             IMAGE: {},
         }
 
-        def _get_zip_lambda_function_paths(function_config):
+        def _get_zip_lambda_function_paths(function_config: FunctionConfig) -> List[str]:
             """
             Returns a list of ZIP package type lambda function source code paths
 
             Parameters
             ----------
-            function_config: dict
+            function_config: FunctionConfig
                 The lambda function configuration that will be observed
 
             Returns
@@ -65,13 +113,13 @@ class LambdaFunctionObserver:
                 code_paths += [layer.codeuri for layer in function_config.layers]
             return code_paths
 
-        def _get_image_lambda_function_image_names(function_config):
+        def _get_image_lambda_function_image_names(function_config: FunctionConfig) -> List[str]:
             """
             Returns a list of Image package type lambda function image names
 
             Parameters
             ----------
-            function_config: dict
+            function_config: FunctionConfig
                 The lambda function configuration that will be observed
 
             Returns
@@ -81,14 +129,14 @@ class LambdaFunctionObserver:
             """
             return [function_config.imageuri]
 
-        self.get_resources = {
+        self.get_resources: Dict[str, Callable] = {
             ZIP: _get_zip_lambda_function_paths,
             IMAGE: _get_image_lambda_function_image_names,
         }
 
-        self._input_on_change = on_change
+        self._input_on_change: Callable = on_change
 
-    def _on_zip_change(self, paths):
+    def _on_zip_change(self, paths: List[str]) -> None:
         """
         It got executed once there is a change in one of the watched lambda functions' source code.
 
@@ -99,7 +147,7 @@ class LambdaFunctionObserver:
         """
         self._on_change(paths, ZIP)
 
-    def _on_image_change(self, images):
+    def _on_image_change(self, images: List[str]) -> None:
         """
         It got executed once there is a change in one of the watched lambda functions' images.
 
@@ -110,7 +158,7 @@ class LambdaFunctionObserver:
         """
         self._on_change(images, IMAGE)
 
-    def _on_change(self, resources, package_type):
+    def _on_change(self, resources: List[str], package_type: str) -> None:
         """
         It got executed once there is a change in one of the watched lambda functions' resources.
 
@@ -121,19 +169,19 @@ class LambdaFunctionObserver:
         package_type: str
             determine if the changed resource is a source code path or an image name
         """
-        changed_functions = []
+        changed_functions: List[FunctionConfig] = []
         for resource in resources:
             if self._observed_functions[package_type].get(resource, None):
                 changed_functions += self._observed_functions[package_type][resource]
         self._input_on_change(changed_functions)
 
-    def watch(self, function_config):
+    def watch(self, function_config: FunctionConfig) -> None:
         """
         Start watching the input lambda function.
 
         Parameters
         ----------
-        function_config: dict
+        function_config: FunctionConfig
             The lambda function configuration that will be observed
 
         Raises
@@ -149,13 +197,13 @@ class LambdaFunctionObserver:
                 self._observed_functions[function_config.packagetype][resource] = functions
                 self._observers[function_config.packagetype].watch(resource)
 
-    def unwatch(self, function_config):
+    def unwatch(self, function_config: FunctionConfig) -> None:
         """
         Remove the input lambda function from the observed functions
 
         Parameters
         ----------
-        function_config: dict
+        function_config: FunctionConfig
             The lambda function configuration that will be observed
         """
         if self.get_resources.get(function_config.packagetype, None):
@@ -189,12 +237,12 @@ class ImageObserverException(ObserverException):
     """
 
 
-class ImageObserver:
+class ImageObserver(ResourceObserver):
     """
     A class that will observe some docker images for any change.
     """
 
-    def __init__(self, on_change):
+    def __init__(self, on_change: Callable) -> None:
         """
         Initialize the Image observer
         Parameters
@@ -202,12 +250,12 @@ class ImageObserver:
         on_change:
             Reference to the function that will be called if there is a change in aby of the observed image
         """
-        self._observed_images = {}
-        self._input_on_change = on_change
-        self.docker_client = docker.from_env()
-        self.events = self.docker_client.events(filters={"type": "image"}, decode=True)
-        self._images_observer_thread = None
-        self._lock = threading.Lock()
+        self._observed_images: Dict[str, str] = {}
+        self._input_on_change: Callable = on_change
+        self.docker_client: DockerClient = docker.from_env()
+        self.events: CancellableStream = self.docker_client.events(filters={"type": "image"}, decode=True)
+        self._images_observer_thread: Optional[Thread] = None
+        self._lock: Lock = threading.Lock()
 
     def _watch_images_events(self):
         for event in self.events:
@@ -220,13 +268,13 @@ class ImageObserver:
                     self._observed_images[image_name] = new_image_id
                     self._input_on_change([image_name])
 
-    def watch(self, image_name):
+    def watch(self, resource: str) -> None:
         """
         Start watching the input image.
 
         Parameters
         ----------
-        image_name: str
+        resource: str
             The container image name that will be observed
 
         Raises
@@ -235,21 +283,21 @@ class ImageObserver:
             if the input image_name is not exist
         """
         try:
-            image = self.docker_client.images.get(image_name)
-            self._observed_images[image_name] = image.id
+            image = self.docker_client.images.get(resource)
+            self._observed_images[resource] = image.id
         except ImageNotFound as exc:
             raise ImageObserverException("Can not observe non exist image") from exc
 
-    def unwatch(self, image_name):
+    def unwatch(self, resource: str) -> None:
         """
         Remove the input image form the observed images
 
         Parameters
         ----------
-        image_name: str
+        resource: str
             The container image name to be unobserved
         """
-        self._observed_images.pop(image_name, None)
+        self._observed_images.pop(resource, None)
 
     def start(self):
         """
@@ -277,12 +325,12 @@ class FileObserverException(ObserverException):
     """
 
 
-class FileObserver:
+class FileObserver(ResourceObserver):
     """
     A class that will observe some file system paths for any change.
     """
 
-    def __init__(self, on_change):
+    def __init__(self, on_change: Callable) -> None:
         """
         Initialize the file observer
         Parameters
@@ -290,24 +338,24 @@ class FileObserver:
         on_change:
             Reference to the function that will be called if there is a change in aby of the observed paths
         """
-        self._observed_paths = {}
-        self._observed_watches = {}
-        self._watch_dog_observed_paths = {}
-        self._observer = Observer()
-        self._code_modification_handler = PatternMatchingEventHandler(
+        self._observed_paths: Dict[str, str] = {}
+        self._observed_watches: Dict[str, ObservedWatch] = {}
+        self._watch_dog_observed_paths: Dict[str, List[str]] = {}
+        self._observer: BaseObserver = Observer()
+        self._code_modification_handler: PatternMatchingEventHandler = PatternMatchingEventHandler(
             patterns=["*"], ignore_patterns=[], ignore_directories=False
         )
 
-        self._code_deletion_handler = PatternMatchingEventHandler(
+        self._code_deletion_handler: PatternMatchingEventHandler = PatternMatchingEventHandler(
             patterns=["*"], ignore_patterns=[], ignore_directories=False
         )
 
         self._code_modification_handler.on_modified = self.on_change
         self._code_deletion_handler.on_deleted = self.on_change
-        self._input_on_change = on_change
-        self._lock = threading.Lock()
+        self._input_on_change: Callable = on_change
+        self._lock: Lock = threading.Lock()
 
-    def on_change(self, event):
+    def on_change(self, event: FileSystemEvent) -> None:
         """
         It got executed once there is a change in one of the paths that watchdog is observing.
         This method will check if any of the input paths is really changed, and based on that it will
@@ -315,7 +363,7 @@ class FileObserver:
 
         Parameters
         ----------
-        event: watchdog.events.FileSystemEventHandler
+        event: watchdog.events.FileSystemEvent
             Determines that there is a change happened to some file/dir in the observed paths
         """
         observed_paths = [path for path in self._observed_paths if event.src_path.startswith(path)]
@@ -337,7 +385,7 @@ class FileObserver:
         if changed_paths:
             self._input_on_change(changed_paths)
 
-    def watch(self, path):
+    def watch(self, resource: str) -> None:
         """
         Start watching the input path. File Observer will keep track of the input path with its hash, to check it later
         if it got really changed or not.
@@ -346,7 +394,7 @@ class FileObserver:
 
         Parameters
         ----------
-        path: str
+        resource: str
             The file/dir path to be observed
 
         Raises
@@ -354,21 +402,23 @@ class FileObserver:
         FileObserverException:
             if the input path is not exist
         """
-        path_obj = Path(path)
+        path_obj = Path(resource)
         if not path_obj.exists():
             raise FileObserverException("Can not observe non exist path")
 
-        self._observed_paths[path] = calculate_checksum(path)
+        self._observed_paths[resource] = calculate_checksum(resource)
 
         # recursively watch the input path, and all child path for any modification
-        self._watch_path(path, path, self._code_modification_handler, True)
+        self._watch_path(resource, resource, self._code_modification_handler, True)
 
         # watch only the direct parent path child directories for any deletion
         # Parent directory watching is needed, as if the input path got deleted,
         # watchdog will not send an event for it
-        self._watch_path(str(path_obj.parent), path, self._code_deletion_handler, False)
+        self._watch_path(str(path_obj.parent), resource, self._code_deletion_handler, False)
 
-    def _watch_path(self, watch_dog_path, original_path, watcher_handler, recursive):
+    def _watch_path(
+        self, watch_dog_path: str, original_path: str, watcher_handler: FileSystemEventHandler, recursive: bool
+    ) -> None:
         """
         update the observed paths data structure, and call watch dog observer to observe the input watch dog path
         if it is not observed before
@@ -395,24 +445,24 @@ class FileObserver:
                 watcher_handler, watch_dog_path, recursive=recursive
             )
 
-    def unwatch(self, path):
+    def unwatch(self, resource: str) -> None:
         """
         Remove the input path form the observed paths, and stop watching this path.
 
         Parameters
         ----------
-        path: str
+        resource: str
             The file/dir path to be unobserved
         """
-        path_obj = Path(path)
+        path_obj = Path(resource)
 
         # unwatch input path
-        self._unwatch_path(path, path)
+        self._unwatch_path(resource, resource)
 
         # unwatch parent path
-        self._unwatch_path(str(path_obj.parent), path)
+        self._unwatch_path(str(path_obj.parent), resource)
 
-    def _unwatch_path(self, watch_dog_path, original_path):
+    def _unwatch_path(self, watch_dog_path: str, original_path: str) -> None:
         """
         update the observed paths data structure, and call watch dog observer to unobserve the input watch dog path
         if it is not observed before
@@ -451,7 +501,7 @@ class FileObserver:
                 self._observer.stop()
 
 
-def calculate_checksum(path):
+def calculate_checksum(path: str) -> str:
     path_obj = Path(path)
     if path_obj.is_file():
         checksum = file_checksum(path)

--- a/samcli/lib/utils/hash.py
+++ b/samcli/lib/utils/hash.py
@@ -7,7 +7,7 @@ import hashlib
 BLOCK_SIZE = 4096
 
 
-def file_checksum(file_name):
+def file_checksum(file_name: str) -> str:
     """
 
     Parameters
@@ -37,7 +37,7 @@ def file_checksum(file_name):
         return md5.hexdigest()
 
 
-def dir_checksum(directory, followlinks=True):
+def dir_checksum(directory: str, followlinks: bool = True) -> str:
     """
 
     Parameters

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -10,7 +10,8 @@ import logging
 import threading
 
 from samcli.local.docker.lambda_container import LambdaContainer
-from samcli.lib.utils.file_observer import FileObserver
+from samcli.lib.utils.file_observer import LambdaFunctionObserver
+from samcli.lib.utils.packagetype import ZIP
 from samcli.lib.telemetry.metric import capture_parameter
 from .zip import unzip
 
@@ -285,9 +286,7 @@ class WarmLambdaRuntime(LambdaRuntime):
         """
         self._containers = {}
 
-        # used to observe any code change in case if warm containers is enabled to support the reloading
-        self._observed_paths = {}
-        self._observer = FileObserver(self._on_code_change)
+        self._observer = LambdaFunctionObserver(self._on_code_change)
 
         super().__init__(container_manager, image_builder)
 
@@ -328,7 +327,10 @@ class WarmLambdaRuntime(LambdaRuntime):
 
         container = super().create(function_config, debug_context)
         self._containers[function_config.name] = container
-        self._add_function_to_observer(function_config)
+
+        self._observer.watch(function_config)
+        self._observer.start()
+
         return container
 
     def _on_invoke_done(self, container):
@@ -342,25 +344,6 @@ class WarmLambdaRuntime(LambdaRuntime):
         container: Container
            The current running container
         """
-
-    def _add_function_to_observer(self, function_config):
-        """
-        observe the function code path, so the function container be reload if its code got changed.
-
-        Parameters
-        ----------
-        function_config: FunctionConfig
-            Configuration of the function to create a new Container for it.
-        """
-        code_paths = [function_config.code_abs_path]
-        if function_config.layers:
-            code_paths += [layer.codeuri for layer in function_config.layers]
-        for code_path in code_paths:
-            functions = self._observed_paths.get(code_path, [])
-            functions += [function_config]
-            self._observed_paths[code_path] = functions
-            self._observer.watch(code_path)
-        self._observer.start()
 
     def _configure_interrupt(self, function_name, timeout, container, is_debugging):
         """
@@ -415,51 +398,30 @@ class WarmLambdaRuntime(LambdaRuntime):
         self._clean_decompressed_paths()
         self._observer.stop()
 
-    def _on_code_change(self, paths):
+    def _on_code_change(self, functions):
         """
         Handles the lambda function code change event. it determines if there is a real change in the code
         by comparing the checksum of the code path before and after the event.
 
         Parameters
         ----------
-        paths: list of str
-            the paths of the code that got changed
+        functions: list [FunctionConfig]
+            the lambda functions that their source code or images got changed
         """
-        for path in paths:
-            functions = self._observed_paths.get(path, []).copy()
-            for function_config in functions:
-                function_name = function_config.name
-                LOG.info(
-                    "Lambda Function '%s' code has been changed, terminate its warm container. "
-                    "The new container will be created in lazy mode",
-                    function_name,
-                )
-                container = self._containers.get(function_name, None)
-                if container:
-                    self._container_manager.stop(container)
-                    self._containers.pop(function_name, None)
-                self._remove_observed_lambda_function(function_config)
-
-    def _remove_observed_lambda_function(self, function_config):
-        """
-        remove the lambda function's code paths from the observed paths
-
-        Parameters
-        ----------
-        function_config: FunctionConfig
-            Configuration of the function to invoke
-        """
-        code_paths = [function_config.code_abs_path]
-        if function_config.layers:
-            code_paths += [layer.codeuri for layer in function_config.layers]
-
-        for path in code_paths:
-            functions = self._observed_paths.get(path, [])
-            if function_config in functions:
-                functions.remove(function_config)
-            if not functions:
-                self._observed_paths.pop(path, None)
-                self._observer.unwatch(path)
+        for function_config in functions:
+            function_name = function_config.name
+            resource = "source code" if function_config.packagetype == ZIP else f"{function_config.imageuri} image"
+            LOG.info(
+                "Lambda Function '%s' %s has been changed, terminate its warm container. "
+                "The new container will be created in lazy mode",
+                function_name,
+                resource,
+            )
+            container = self._containers.get(function_name, None)
+            if container:
+                self._container_manager.stop(container)
+                self._containers.pop(function_name, None)
+            self._observer.unwatch(function_config)
 
 
 def _unzip_file(filepath):

--- a/tests/integration/local/start_api/start_api_integ_base.py
+++ b/tests/integration/local/start_api/start_api_integ_base.py
@@ -1,3 +1,5 @@
+import shutil
+import uuid
 from typing import Optional, Dict
 from unittest import TestCase, skipIf
 import threading
@@ -7,7 +9,7 @@ import os
 import random
 from pathlib import Path
 
-from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS
+from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS, run_command
 
 
 @skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
@@ -18,6 +20,9 @@ class StartApiIntegBaseClass(TestCase):
     binary_data_file: Optional[str] = None
     integration_dir = str(Path(__file__).resolve().parents[2])
 
+    build_before_invoke = False
+    build_overrides: Optional[Dict[str, str]] = None
+
     @classmethod
     def setUpClass(cls):
         # This is the directory for tests/integration which will be used to file the testdata
@@ -27,11 +32,28 @@ class StartApiIntegBaseClass(TestCase):
         if cls.binary_data_file:
             cls.binary_data_file = os.path.join(cls.integration_dir, cls.binary_data_file)
 
+        if cls.build_before_invoke:
+            cls.build()
+
         cls.port = str(StartApiIntegBaseClass.random_port())
 
         cls.thread = threading.Thread(target=cls.start_api())
         cls.thread.setDaemon(True)
         cls.thread.start()
+
+    @classmethod
+    def build(cls):
+        command = "sam"
+        if os.getenv("SAM_CLI_DEV"):
+            command = "samdev"
+        command_list = [command, "build"]
+        if cls.build_overrides:
+            overrides_arg = " ".join(
+                ["ParameterKey={},ParameterValue={}".format(key, value) for key, value in cls.build_overrides.items()]
+            )
+            command_list += ["--parameter-overrides", overrides_arg]
+        working_dir = str(Path(cls.template).resolve().parents[0])
+        run_command(command_list, cwd=working_dir)
 
     @classmethod
     def start_api(cls):
@@ -71,3 +93,44 @@ class StartApiIntegBaseClass(TestCase):
 
         with open(filename, "rb") as fp:
             return fp.read()
+
+
+class WatchWarmContainersIntegBaseClass(StartApiIntegBaseClass):
+    temp_path: Optional[str] = None
+    template_path: Optional[str] = None
+    code_path: Optional[str] = None
+    docker_file_path: Optional[str] = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_path = str(uuid.uuid4()).replace("-", "")[:10]
+        working_dir = str(Path(cls.integration_dir).resolve().joinpath(cls.temp_path))
+        if Path(working_dir).resolve().exists():
+            shutil.rmtree(working_dir)
+        os.mkdir(working_dir)
+        cls.template_path = f"/{cls.temp_path}/template.yaml"
+        cls.code_path = f"/{cls.temp_path}/main.py"
+        cls.docker_file_path = f"/{cls.temp_path}/Dockerfile"
+
+        if cls.template_content:
+            cls._write_file_content(cls.template_path, cls.template_content)
+
+        if cls.code_content:
+            cls._write_file_content(cls.code_path, cls.code_content)
+
+        if cls.docker_file_content:
+            cls._write_file_content(cls.docker_file_path, cls.docker_file_content)
+
+        super().setUpClass()
+
+    @classmethod
+    def _write_file_content(cls, path, content):
+        with open(cls.integration_dir + path, "w") as f:
+            f.write(content)
+
+    @classmethod
+    def tearDownClass(cls):
+        working_dir = str(Path(cls.integration_dir).resolve().joinpath(cls.temp_path))
+        if Path(working_dir).resolve().exists():
+            shutil.rmtree(working_dir)
+        super().tearDownClass()

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -1,17 +1,16 @@
-import os
-import threading
 import uuid
+import random
 
 import docker
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from time import time
+from time import time, sleep
 
 import pytest
 
 from samcli.commands.local.cli_common.invoke_context import ContainersInitializationMode
 from samcli.local.apigw.local_apigw_service import Route
-from .start_api_integ_base import StartApiIntegBaseClass
+from .start_api_integ_base import StartApiIntegBaseClass, WatchWarmContainersIntegBaseClass
 
 
 class TestParallelRequests(StartApiIntegBaseClass):
@@ -1751,3 +1750,285 @@ class TestLazyContainersMultipleInvoke(TestWarmContainersBaseClass):
 
         # only one container is initialized
         self.assertEqual(initiated_containers, initiated_containers_before_any_invoke + 1)
+
+
+class TestImagePackageType(StartApiIntegBaseClass):
+    template_path = "/testdata/start_api/image_package_type/template.yaml"
+    build_before_invoke = True
+    tag = f"python-{random.randint(1000,2000)}"
+    build_overrides = {"Tag": tag}
+    parameter_overrides = {"ImageUri": f"helloworldfunction:{tag}"}
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_can_invoke_lambda_function_successfully(self):
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})
+
+
+class TestImagePackageTypeWithEagerWarmContainersMode(StartApiIntegBaseClass):
+    template_path = "/testdata/start_api/image_package_type/template.yaml"
+    container_mode = ContainersInitializationMode.EAGER.value
+    build_before_invoke = True
+    tag = f"python-{random.randint(1000,2000)}"
+    build_overrides = {"Tag": tag}
+    parameter_overrides = {"ImageUri": f"helloworldfunction:{tag}"}
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_can_invoke_lambda_function_successfully(self):
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})
+
+
+class TestImagePackageTypeWithEagerLazyContainersMode(StartApiIntegBaseClass):
+    template_path = "/testdata/start_api/image_package_type/template.yaml"
+    container_mode = ContainersInitializationMode.LAZY.value
+    build_before_invoke = True
+    tag = f"python-{random.randint(1000,2000)}"
+    build_overrides = {"Tag": tag}
+    parameter_overrides = {"ImageUri": f"helloworldfunction:{tag}"}
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_can_invoke_lambda_function_successfully(self):
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})
+
+
+class TestWatchingZipWarmContainers(WatchWarmContainersIntegBaseClass):
+    template_content = """AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31    
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.handler
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+      Events:
+        PathWithPathParams:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /hello
+    """
+    code_content = """import json
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}
+    """
+    code_content_2 = """import json
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world2"})}
+    """
+    docker_file_content = ""
+    container_mode = ContainersInitializationMode.EAGER.value
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_changed_code_got_observed_and_loaded(self):
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})
+
+        self._write_file_content(self.code_path, self.code_content_2)
+        # wait till SAM got notified that the source code got changed
+        sleep(0.5)
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world2"})
+
+
+class TestWatchingImageWarmContainers(WatchWarmContainersIntegBaseClass):
+    template_content = """AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31    
+Parameteres:
+  Tag:
+    Type: String
+  ImageUri:
+    Type: String
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - main.handler
+        Timeout: 600
+      ImageUri: !Ref ImageUri
+      Events:
+        PathWithPathParams:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /hello
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: .
+      Dockerfile: Dockerfile
+        """
+    code_content = """import json
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}"""
+    code_content_2 = """import json
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world2"})}"""
+    docker_file_content = """FROM public.ecr.aws/lambda/python:3.7
+COPY main.py ./"""
+    container_mode = ContainersInitializationMode.EAGER.value
+    build_before_invoke = True
+    tag = f"python-{random.randint(1000, 2000)}"
+    build_overrides = {"Tag": tag}
+    parameter_overrides = {"ImageUri": f"helloworldfunction:{tag}"}
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=6000, method="thread")
+    def test_changed_code_got_observed_and_loaded(self):
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})
+
+        self._write_file_content(self.code_path, self.code_content_2)
+        self.build()
+        # wait till SAM got notified that the image got changed
+        sleep(0.5)
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world2"})
+
+
+class TestWatchingZipLazyContainers(WatchWarmContainersIntegBaseClass):
+    template_content = """AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31    
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.handler
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+      Events:
+        PathWithPathParams:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /hello
+    """
+    code_content = """import json
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}
+    """
+    code_content_2 = """import json
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world2"})}
+    """
+    docker_file_content = ""
+    container_mode = ContainersInitializationMode.LAZY.value
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_changed_code_got_observed_and_loaded(self):
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})
+
+        self._write_file_content(self.code_path, self.code_content_2)
+        # wait till SAM got notified that the source code got changed
+        sleep(0.5)
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world2"})
+
+
+class TestWatchingImageLazyContainers(WatchWarmContainersIntegBaseClass):
+    template_content = """AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31    
+Parameteres:
+  Tag:
+    Type: String
+  ImageUri:
+    Type: String
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - main.handler
+        Timeout: 600
+      ImageUri: !Ref ImageUri
+      Events:
+        PathWithPathParams:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /hello
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: .
+      Dockerfile: Dockerfile
+        """
+    code_content = """import json
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}"""
+    code_content_2 = """import json
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world2"})}"""
+    docker_file_content = """FROM public.ecr.aws/lambda/python:3.7
+COPY main.py ./"""
+    container_mode = ContainersInitializationMode.LAZY.value
+    build_before_invoke = True
+    tag = f"python-{random.randint(1000, 2000)}"
+    build_overrides = {"Tag": tag}
+    parameter_overrides = {"ImageUri": f"helloworldfunction:{tag}"}
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=6000, method="thread")
+    def test_changed_code_got_observed_and_loaded(self):
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})
+
+        self._write_file_content(self.code_path, self.code_content_2)
+        self.build()
+        # wait till SAM got notified that the image got changed
+        sleep(0.5)
+        response = requests.get(self.url + "/hello", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world2"})

--- a/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
+++ b/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
@@ -1,4 +1,6 @@
+import shutil
 import signal
+import uuid
 from typing import Optional, Dict
 from unittest import TestCase, skipIf
 import threading
@@ -6,10 +8,9 @@ from subprocess import Popen
 import time
 import os
 import random
-
 from pathlib import Path
 
-from tests.testing_utils import SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE
+from tests.testing_utils import SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE, run_command
 
 
 @skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
@@ -17,8 +18,11 @@ class StartLambdaIntegBaseClass(TestCase):
     template: Optional[str] = None
     container_mode: Optional[str] = None
     parameter_overrides: Optional[Dict[str, str]] = None
-    binary_data_file = None
+    binary_data_file: Optional[str] = None
     integration_dir = str(Path(__file__).resolve().parents[2])
+
+    build_before_invoke = False
+    build_overrides: Optional[Dict[str, str]] = None
 
     @classmethod
     def setUpClass(cls):
@@ -28,9 +32,26 @@ class StartLambdaIntegBaseClass(TestCase):
         cls.port = str(StartLambdaIntegBaseClass.random_port())
         cls.env_var_path = cls.integration_dir + "/testdata/invoke/vars.json"
 
+        if cls.build_before_invoke:
+            cls.build()
+
         cls.thread = threading.Thread(target=cls.start_lambda())
         cls.thread.setDaemon(True)
         cls.thread.start()
+
+    @classmethod
+    def build(cls):
+        command = "sam"
+        if os.getenv("SAM_CLI_DEV"):
+            command = "samdev"
+        command_list = [command, "build"]
+        if cls.build_overrides:
+            overrides_arg = " ".join(
+                ["ParameterKey={},ParameterValue={}".format(key, value) for key, value in cls.build_overrides.items()]
+            )
+            command_list += ["--parameter-overrides", overrides_arg]
+        working_dir = str(Path(cls.template).resolve().parents[0])
+        run_command(command_list, cwd=working_dir)
 
     @classmethod
     def start_lambda(cls, wait_time=5):
@@ -71,3 +92,44 @@ class StartLambdaIntegBaseClass(TestCase):
     @staticmethod
     def random_port():
         return random.randint(30000, 40000)
+
+
+class WatchWarmContainersIntegBaseClass(StartLambdaIntegBaseClass):
+    temp_path: Optional[str] = None
+    template_path: Optional[str] = None
+    code_path: Optional[str] = None
+    docker_file_path: Optional[str] = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_path = str(uuid.uuid4()).replace("-", "")[:10]
+        working_dir = str(Path(cls.integration_dir).resolve().joinpath(cls.temp_path))
+        if Path(working_dir).resolve().exists():
+            shutil.rmtree(working_dir)
+        os.mkdir(working_dir)
+        cls.template_path = f"/{cls.temp_path}/template.yaml"
+        cls.code_path = f"/{cls.temp_path}/main.py"
+        cls.docker_file_path = f"/{cls.temp_path}/Dockerfile"
+
+        if cls.template_content:
+            cls._write_file_content(cls.template_path, cls.template_content)
+
+        if cls.code_content:
+            cls._write_file_content(cls.code_path, cls.code_content)
+
+        if cls.docker_file_content:
+            cls._write_file_content(cls.docker_file_path, cls.docker_file_content)
+
+        super().setUpClass()
+
+    @classmethod
+    def _write_file_content(cls, path, content):
+        with open(cls.integration_dir + path, "w") as f:
+            f.write(content)
+
+    @classmethod
+    def tearDownClass(cls):
+        working_dir = str(Path(cls.integration_dir).resolve().joinpath(cls.temp_path))
+        if Path(working_dir).resolve().exists():
+            shutil.rmtree(working_dir)
+        super().tearDownClass()

--- a/tests/integration/testdata/start_api/image_package_type/Dockerfile
+++ b/tests/integration/testdata/start_api/image_package_type/Dockerfile
@@ -1,0 +1,3 @@
+FROM public.ecr.aws/lambda/python:3.7
+
+COPY main.py ./

--- a/tests/integration/testdata/start_api/image_package_type/main.py
+++ b/tests/integration/testdata/start_api/image_package_type/main.py
@@ -1,0 +1,111 @@
+import json
+import sys
+import time
+
+
+def handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}
+
+
+def echo_event_handler(event, context):
+    return {"statusCode": 200, "body": json.dumps(event)}
+
+
+def echo_event_handler_2(event, context):
+    event["handler"] = "echo_event_handler_2"
+
+    return {"statusCode": 200, "body": json.dumps(event)}
+
+
+def echo_integer_body(event, context):
+    return {"statusCode": 200, "body": 42}
+
+
+def content_type_setter_handler(event, context):
+    return {"statusCode": 200, "body": "hello", "headers": {"Content-Type": "text/plain"}}
+
+
+def only_set_status_code_handler(event, context):
+    return {"statusCode": 200}
+
+
+def only_set_body_handler(event, context):
+    return {"body": json.dumps({"hello": "world"})}
+
+
+def string_status_code_handler(event, context):
+    return {"statusCode": "200", "body": json.dumps({"hello": "world"})}
+
+
+def sleep_10_sec_handler(event, context):
+    # sleep thread for 10s. This is useful for testing multiple requests
+    time.sleep(10)
+
+    return {"statusCode": 200, "body": json.dumps({"message": "HelloWorld! I just slept and waking up."})}
+
+
+def write_to_stderr(event, context):
+    sys.stderr.write("Docker Lambda is writing to stderr")
+
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}
+
+
+def write_to_stdout(event, context):
+    sys.stdout.write("Docker Lambda is writing to stdout")
+
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}
+
+
+def invalid_response_returned(event, context):
+    return "This is invalid"
+
+def integer_response_returned(event, context):
+    return 2
+
+def invalid_v2_respose_returned(event, context):
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"}), "key": "value"}
+
+def invalid_hash_response(event, context):
+    return {"foo": "bar"}
+
+
+def base64_response(event, context):
+    gifImageBase64 = "R0lGODlhPQBEAPeoAJosM//AwO/AwHVYZ/z595kzAP/s7P+goOXMv8+fhw/v739/f+8PD98fH/8mJl+fn/9ZWb8/PzWlwv///6wWGbImAPgTEMImIN9gUFCEm/gDALULDN8PAD6atYdCTX9gUNKlj8wZAKUsAOzZz+UMAOsJAP/Z2ccMDA8PD/95eX5NWvsJCOVNQPtfX/8zM8+QePLl38MGBr8JCP+zs9myn/8GBqwpAP/GxgwJCPny78lzYLgjAJ8vAP9fX/+MjMUcAN8zM/9wcM8ZGcATEL+QePdZWf/29uc/P9cmJu9MTDImIN+/r7+/vz8/P8VNQGNugV8AAF9fX8swMNgTAFlDOICAgPNSUnNWSMQ5MBAQEJE3QPIGAM9AQMqGcG9vb6MhJsEdGM8vLx8fH98AANIWAMuQeL8fABkTEPPQ0OM5OSYdGFl5jo+Pj/+pqcsTE78wMFNGQLYmID4dGPvd3UBAQJmTkP+8vH9QUK+vr8ZWSHpzcJMmILdwcLOGcHRQUHxwcK9PT9DQ0O/v70w5MLypoG8wKOuwsP/g4P/Q0IcwKEswKMl8aJ9fX2xjdOtGRs/Pz+Dg4GImIP8gIH0sKEAwKKmTiKZ8aB/f39Wsl+LFt8dgUE9PT5x5aHBwcP+AgP+WltdgYMyZfyywz78AAAAAAAD///8AAP9mZv///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAAKgALAAAAAA9AEQAAAj/AFEJHEiwoMGDCBMqXMiwocAbBww4nEhxoYkUpzJGrMixogkfGUNqlNixJEIDB0SqHGmyJSojM1bKZOmyop0gM3Oe2liTISKMOoPy7GnwY9CjIYcSRYm0aVKSLmE6nfq05QycVLPuhDrxBlCtYJUqNAq2bNWEBj6ZXRuyxZyDRtqwnXvkhACDV+euTeJm1Ki7A73qNWtFiF+/gA95Gly2CJLDhwEHMOUAAuOpLYDEgBxZ4GRTlC1fDnpkM+fOqD6DDj1aZpITp0dtGCDhr+fVuCu3zlg49ijaokTZTo27uG7Gjn2P+hI8+PDPERoUB318bWbfAJ5sUNFcuGRTYUqV/3ogfXp1rWlMc6awJjiAAd2fm4ogXjz56aypOoIde4OE5u/F9x199dlXnnGiHZWEYbGpsAEA3QXYnHwEFliKAgswgJ8LPeiUXGwedCAKABACCN+EA1pYIIYaFlcDhytd51sGAJbo3onOpajiihlO92KHGaUXGwWjUBChjSPiWJuOO/LYIm4v1tXfE6J4gCSJEZ7YgRYUNrkji9P55sF/ogxw5ZkSqIDaZBV6aSGYq/lGZplndkckZ98xoICbTcIJGQAZcNmdmUc210hs35nCyJ58fgmIKX5RQGOZowxaZwYA+JaoKQwswGijBV4C6SiTUmpphMspJx9unX4KaimjDv9aaXOEBteBqmuuxgEHoLX6Kqx+yXqqBANsgCtit4FWQAEkrNbpq7HSOmtwag5w57GrmlJBASEU18ADjUYb3ADTinIttsgSB1oJFfA63bduimuqKB1keqwUhoCSK374wbujvOSu4QG6UvxBRydcpKsav++Ca6G8A6Pr1x2kVMyHwsVxUALDq/krnrhPSOzXG1lUTIoffqGR7Goi2MAxbv6O2kEG56I7CSlRsEFKFVyovDJoIRTg7sugNRDGqCJzJgcKE0ywc0ELm6KBCCJo8DIPFeCWNGcyqNFE06ToAfV0HBRgxsvLThHn1oddQMrXj5DyAQgjEHSAJMWZwS3HPxT/QMbabI/iBCliMLEJKX2EEkomBAUCxRi42VDADxyTYDVogV+wSChqmKxEKCDAYFDFj4OmwbY7bDGdBhtrnTQYOigeChUmc1K3QTnAUfEgGFgAWt88hKA6aCRIXhxnQ1yg3BCayK44EWdkUQcBByEQChFXfCB776aQsG0BIlQgQgE8qO26X1h8cEUep8ngRBnOy74E9QgRgEAC8SvOfQkh7FDBDmS43PmGoIiKUUEGkMEC/PJHgxw0xH74yx/3XnaYRJgMB8obxQW6kL9QYEJ0FIFgByfIL7/IQAlvQwEpnAC7DtLNJCKUoO/w45c44GwCXiAFB/OXAATQryUxdN4LfFiwgjCNYg+kYMIEFkCKDs6PKAIJouyGWMS1FSKJOMRB/BoIxYJIUXFUxNwoIkEKPAgCBZSQHQ1A2EWDfDEUVLyADj5AChSIQW6gu10bE/JG2VnCZGfo4R4d0sdQoBAHhPjhIB94v/wRoRKQWGRHgrhGSQJxCS+0pCZbEhAAOw=="  # NOQA
+
+    return {
+        "statusCode": 200,
+        "body": gifImageBase64,
+        "isBase64Encoded": True,
+        "headers": {"Content-Type": "image/gif"},
+    }
+
+
+def echo_base64_event_body(event, context):
+    return {
+        "statusCode": 200,
+        "body": event["body"],
+        "headers": {"Content-Type": event["headers"]["Content-Type"]},
+        "isBase64Encoded": event["isBase64Encoded"],
+    }
+
+
+def multiple_headers(event, context):
+    return {
+        "statusCode": 200,
+        "body": "hello",
+        "headers": {"Content-Type": "text/plain"},
+        "multiValueHeaders": {"MyCustomHeader": ["Value1", "Value2"]},
+    }
+
+
+def multiple_headers_overrides_headers(event, context):
+    return {
+        "statusCode": 200,
+        "body": "hello",
+        "headers": {"Content-Type": "text/plain", "MyCustomHeader": "Custom"},
+        "multiValueHeaders": {"MyCustomHeader": ["Value1", "Value2"]},
+    }
+
+
+def handle_options_cors(event, context):
+    return {"statusCode": 204, "body": json.dumps({"hello": "world"})}

--- a/tests/integration/testdata/start_api/image_package_type/template.yaml
+++ b/tests/integration/testdata/start_api/image_package_type/template.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameteres:
+  Tag:
+    Type: String
+  ImageUri:
+    Type: String
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - main.handler
+        Timeout: 600
+      ImageUri: !Ref ImageUri
+      Events:
+        HelloWorld:
+          Type: Api
+          Properties:
+            Path: /hello
+            Method: get
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: .
+      Dockerfile: Dockerfile

--- a/tests/unit/lib/utils/test_file_observer.py
+++ b/tests/unit/lib/utils/test_file_observer.py
@@ -4,7 +4,17 @@ Unit tests for file observer
 from unittest import TestCase
 from unittest.mock import Mock, patch, call
 
-from samcli.lib.utils.file_observer import FileObserver, FileObserverException, calculate_checksum
+from docker.errors import ImageNotFound
+
+from samcli.lib.utils.file_observer import (
+    FileObserver,
+    FileObserverException,
+    calculate_checksum,
+    ImageObserver,
+    ImageObserverException,
+    LambdaFunctionObserver,
+)
+from samcli.lib.utils.packagetype import ZIP, IMAGE
 
 
 class FileObserver_watch(TestCase):
@@ -31,7 +41,7 @@ class FileObserver_watch(TestCase):
         self._PatternMatchingEventHandlerMock.assert_called_with(
             patterns=["*"], ignore_patterns=[], ignore_directories=False
         )
-        self.assertEqual(self.observer._code_change_handler, self.handler_mock)
+        self.assertEqual(self.observer._code_modification_handler, self.handler_mock)
         self.assertEqual(self.observer._input_on_change, self.on_change)
 
     @patch("samcli.lib.utils.file_observer.Path")
@@ -54,13 +64,22 @@ class FileObserver_watch(TestCase):
         self.assertEqual(self.observer._observed_paths, {path_str: check_sum})
         self.assertEqual(
             self.observer._watch_dog_observed_paths,
-            {parent_path: [path_str]},
+            {parent_path: [path_str], path_str: [path_str]},
         )
         self.assertEqual(
             self.observer._observed_watches,
-            {parent_path: self.watcher_mock},
+            {
+                parent_path: self.watcher_mock,
+                path_str: self.watcher_mock,
+            },
         )
-        self.watchdog_observer_mock.schedule.assert_called_with(self.handler_mock, parent_path, recursive=True)
+        self.assertEqual(
+            self.watchdog_observer_mock.schedule.call_args_list,
+            [
+                call(self.handler_mock, path_str, recursive=True),
+                call(self.handler_mock, parent_path, recursive=False),
+            ],
+        )
 
     @patch("samcli.lib.utils.file_observer.Path")
     @patch("samcli.lib.utils.file_observer.calculate_checksum")
@@ -91,16 +110,22 @@ class FileObserver_watch(TestCase):
 
         self.assertEqual(
             self.observer._watch_dog_observed_paths,
-            {parent_path: [path1_str, path2_str]},
+            {parent_path: [path1_str, path2_str], path1_str: [path1_str], path2_str: [path2_str]},
         )
         self.assertEqual(
             self.observer._observed_watches,
-            {parent_path: self.watcher_mock},
+            {
+                parent_path: self.watcher_mock,
+                path1_str: self.watcher_mock,
+                path2_str: self.watcher_mock,
+            },
         )
         self.assertEqual(
             self.watchdog_observer_mock.schedule.call_args_list,
             [
-                call(self.handler_mock, parent_path, recursive=True),
+                call(self.handler_mock, path1_str, recursive=True),
+                call(self.handler_mock, parent_path, recursive=False),
+                call(self.handler_mock, path2_str, recursive=True),
             ],
         )
 
@@ -218,17 +243,6 @@ class FileObserver_unwatch(TestCase):
         )
         self.watchdog_observer_mock.unschedule.assert_called_with(self._parent2_watcher_mock)
 
-    @patch("samcli.lib.utils.file_observer.Path")
-    def test_raise_FileObserverException_if_unwatched_path_is_not_exist(self, PathMock):
-        path_str = "path"
-
-        path_mock = Mock()
-        PathMock.return_value = path_mock
-        path_mock.exists.return_value = False
-
-        with self.assertRaises(FileObserverException):
-            self.observer.unwatch(path_str)
-
 
 class FileObserver_on_change(TestCase):
     @patch("samcli.lib.utils.file_observer.Observer")
@@ -271,7 +285,7 @@ class FileObserver_on_change(TestCase):
         path_mock = Mock()
         PathMock.return_value = path_mock
 
-        calculate_checksum_mock.side_effect = ["1234", "123456543"]
+        calculate_checksum_mock.side_effect = ["123456543"]
 
         path_mock.exists.return_value = True
 
@@ -280,12 +294,12 @@ class FileObserver_on_change(TestCase):
         self.assertEqual(
             self.observer._observed_paths,
             {
-                "parent_path1/path1": "1234",
-                "parent_path1/path2": "123456543",
+                "parent_path1/path1": "123456543",
+                "parent_path1/path2": "4567",
                 "parent_path2/path3": "7890",
             },
         )
-        self.on_change.assert_called_once_with(["parent_path1/path2"])
+        self.on_change.assert_called_once_with(["parent_path1/path1"])
 
     @patch("samcli.lib.utils.file_observer.Path")
     @patch("samcli.lib.utils.file_observer.calculate_checksum")
@@ -423,6 +437,524 @@ class FileObserver_stop(TestCase):
         self.watchdog_observer_mock.is_alive.return_value = False
         self.observer.stop()
         self.watchdog_observer_mock.stop.assert_not_called()
+
+
+class ImageObserver_init(TestCase):
+    @patch("samcli.lib.utils.file_observer.threading")
+    @patch("samcli.lib.utils.file_observer.docker")
+    def test_image_observer_initiated_successfully(self, docker_mock, threading_mock):
+        on_change = Mock()
+        docker_client_mock = Mock()
+        docker_mock.from_env.return_value = docker_client_mock
+        events_mock = Mock()
+        docker_client_mock.events.return_value = events_mock
+        lock_mock = Mock()
+        threading_mock.Lock.return_value = lock_mock
+        image_observer = ImageObserver(on_change)
+        self.assertEqual(image_observer._observed_images, {})
+        self.assertEqual(image_observer._input_on_change, on_change)
+        self.assertEqual(image_observer.docker_client, docker_client_mock)
+        self.assertEqual(image_observer.events, events_mock)
+        self.assertEqual(image_observer._images_observer_thread, None)
+        self.assertEqual(image_observer._lock, lock_mock)
+
+
+class ImageObserver_watch(TestCase):
+    @patch("samcli.lib.utils.file_observer.docker")
+    def setUp(self, docker_mock):
+        self.on_change = Mock()
+        self.docker_client_mock = Mock()
+        docker_mock.from_env.return_value = self.docker_client_mock
+        self.events_mock = Mock()
+        self.docker_client_mock.events.return_value = self.events_mock
+        self.image_observer = ImageObserver(self.on_change)
+
+    def test_successfully_watch_exist_image(self):
+        image_name = "test_image:test_version"
+        image_mock = Mock()
+        id_mock = Mock()
+        image_mock.id = id_mock
+        self.docker_client_mock.images.get.return_value = image_mock
+        self.image_observer.watch(image_name)
+        self.assertEqual(
+            {
+                image_name: id_mock,
+            },
+            self.image_observer._observed_images,
+        )
+        self.docker_client_mock.images.get.assert_called_with(image_name)
+
+    def test_ImageObserverException_raised_for_not_exist_image(self):
+        image_name = "test_image:test_version"
+        self.docker_client_mock.images.get.side_effect = ImageNotFound("")
+
+        with self.assertRaises(ImageObserverException):
+            self.image_observer.watch(image_name)
+        self.docker_client_mock.images.get.assert_called_with(image_name)
+
+
+class ImageObserver_unwatch(TestCase):
+    @patch("samcli.lib.utils.file_observer.docker")
+    def setUp(self, docker_mock):
+        self.on_change = Mock()
+        self.docker_client_mock = Mock()
+        docker_mock.from_env.return_value = self.docker_client_mock
+        self.events_mock = Mock()
+        self.docker_client_mock.events.return_value = self.events_mock
+        self.image_observer = ImageObserver(self.on_change)
+
+        self.image_name = "test_image:test_version"
+        image_mock = Mock()
+        self.id_mock = Mock()
+        image_mock.id = self.id_mock
+        self.docker_client_mock.images.get.return_value = image_mock
+        self.image_observer.watch(self.image_name)
+
+    def test_successfully_unwatch_observed_image(self):
+        self.image_observer.unwatch(self.image_name)
+        self.assertEqual({}, self.image_observer._observed_images)
+
+    def test_no_exception_unwatch_non_observed_image(self):
+        self.image_observer.unwatch("any_image")
+        self.assertEqual(
+            {
+                self.image_name: self.id_mock,
+            },
+            self.image_observer._observed_images,
+        )
+
+
+class ImageObserver_start(TestCase):
+    @patch("samcli.lib.utils.file_observer.docker")
+    def setUp(self, docker_mock):
+        self.on_change = Mock()
+        self.docker_client_mock = Mock()
+        docker_mock.from_env.return_value = self.docker_client_mock
+        self.events_mock = Mock()
+        self.docker_client_mock.events.return_value = self.events_mock
+        self.image_observer = ImageObserver(self.on_change)
+
+    @patch("samcli.lib.utils.file_observer.threading")
+    def test_successfully_start_observing(self, threading_mock):
+        thread_mock = Mock()
+        threading_mock.Thread.return_value = thread_mock
+        self.image_observer.start()
+        threading_mock.Thread.assert_called_once_with(target=self.image_observer._watch_images_events, daemon=True)
+        thread_mock.start.assert_called_once_with()
+
+    @patch("samcli.lib.utils.file_observer.threading")
+    def test_observing_thread_start_one_time_only(self, threading_mock):
+        thread_mock = Mock()
+        threading_mock.Thread.return_value = thread_mock
+        self.image_observer.start()
+        self.image_observer.start()
+        threading_mock.Thread.assert_called_once_with(target=self.image_observer._watch_images_events, daemon=True)
+        thread_mock.start.assert_called_once_with()
+
+
+class ImageObserver_stop(TestCase):
+    @patch("samcli.lib.utils.file_observer.threading")
+    @patch("samcli.lib.utils.file_observer.docker")
+    def setUp(self, docker_mock, threading_mock):
+        self.on_change = Mock()
+        self.docker_client_mock = Mock()
+        docker_mock.from_env.return_value = self.docker_client_mock
+        self.events_mock = Mock()
+        self.docker_client_mock.events.return_value = self.events_mock
+        self.image_observer = ImageObserver(self.on_change)
+        self.thread_mock = Mock()
+        threading_mock.Thread.return_value = self.thread_mock
+        self.image_observer.start()
+
+    def test_successfully_stop_observing(self):
+        self.thread_mock.is_alive.side_effect = [True, False, False]
+        self.image_observer.stop()
+        self.events_mock.close.assert_called_once_with()
+        self.assertEqual(self.thread_mock.is_alive.call_count, 2)
+
+
+class ImageObserver_watch_images_events(TestCase):
+    @patch("samcli.lib.utils.file_observer.docker")
+    def setUp(self, docker_mock):
+        self.on_change = Mock()
+        self.docker_client_mock = Mock()
+        docker_mock.from_env.return_value = self.docker_client_mock
+        self.mocked_events_list = []
+        self.events_mock = iter(self.mocked_events_list)
+        self.docker_client_mock.events.return_value = self.events_mock
+        self.image_observer = ImageObserver(self.on_change)
+
+        self.image_name = "test_image:test_version"
+        image_mock = Mock()
+        self.id_mock = Mock()
+        image_mock.id = self.id_mock
+        self.docker_client_mock.images.get.return_value = image_mock
+        self.image_observer.watch(self.image_name)
+
+    def test_invoke_input_on_change_handler_if_image_id_changed(self):
+        new_id_mock = Mock()
+        self.mocked_events_list += [
+            {"Action": "tag", "id": new_id_mock, "Actor": {"Attributes": {"name": self.image_name}}}
+        ]
+        self.image_observer._watch_images_events()
+        self.assertEqual({self.image_name: new_id_mock}, self.image_observer._observed_images)
+        self.on_change.assert_called_once_with([self.image_name])
+
+    def test_input_on_change_handler_not_invoked_if_image_id_not_changed(self):
+        self.mocked_events_list += [
+            {"Action": "tag", "id": self.id_mock, "Actor": {"Attributes": {"name": self.image_name}}}
+        ]
+        self.image_observer._watch_images_events()
+        self.assertEqual({self.image_name: self.id_mock}, self.image_observer._observed_images)
+        self.on_change.assert_not_called()
+
+    def test_skip_non_observed_images(self):
+        image_name = "any_image"
+        self.mocked_events_list += [
+            {"Action": "tag", "id": self.id_mock, "Actor": {"Attributes": {"name": image_name}}}
+        ]
+        self.image_observer._watch_images_events()
+        self.assertEqual({self.image_name: self.id_mock}, self.image_observer._observed_images)
+        self.on_change.assert_not_called()
+
+    def test_skip_non_tag_events(self):
+        new_id_mock = Mock()
+        self.mocked_events_list += [
+            {"Action": "Create", "id": new_id_mock, "Actor": {"Attributes": {"name": self.image_name}}}
+        ]
+        self.image_observer._watch_images_events()
+        self.assertEqual({self.image_name: self.id_mock}, self.image_observer._observed_images)
+        self.on_change.assert_not_called()
+
+
+class LambdaFunctionObserver_init(TestCase):
+    @patch("samcli.lib.utils.file_observer.FileObserver")
+    @patch("samcli.lib.utils.file_observer.ImageObserver")
+    def test_image_observer_initiated_successfully(self, ImageObserverMock, FileObserverMock):
+        on_change = Mock()
+        image_observer_mock = Mock()
+        ImageObserverMock.return_value = image_observer_mock
+        file_observer_mock = Mock()
+        FileObserverMock.return_value = file_observer_mock
+
+        lambda_function_observer = LambdaFunctionObserver(on_change)
+
+        self.assertEqual(
+            lambda_function_observer._observers,
+            {
+                ZIP: file_observer_mock,
+                IMAGE: image_observer_mock,
+            },
+        )
+        self.assertEqual(
+            lambda_function_observer._observed_functions,
+            {
+                ZIP: {},
+                IMAGE: {},
+            },
+        )
+        self.assertEqual(lambda_function_observer._input_on_change, on_change)
+
+
+class LambdaFunctionObserver_watch(TestCase):
+    @patch("samcli.lib.utils.file_observer.FileObserver")
+    @patch("samcli.lib.utils.file_observer.ImageObserver")
+    def setUp(self, ImageObserverMock, FileObserverMock):
+        self.on_change = Mock()
+        self.image_observer_mock = Mock()
+        ImageObserverMock.return_value = self.image_observer_mock
+        self.file_observer_mock = Mock()
+        FileObserverMock.return_value = self.file_observer_mock
+        self.lambda_function_observer = LambdaFunctionObserver(self.on_change)
+
+    def test_watch_ZIP_lambda_function(self):
+        lambda_function = Mock()
+        lambda_function.packagetype = ZIP
+        lambda_function.code_abs_path = "path1"
+        lambda_function.layers = []
+        self.lambda_function_observer.watch(lambda_function)
+        self.assertEqual(
+            self.lambda_function_observer._observed_functions,
+            {
+                ZIP: {"path1": [lambda_function]},
+                IMAGE: {},
+            },
+        )
+        self.file_observer_mock.watch.assert_called_with("path1")
+
+    def test_watch_ZIP_lambda_function_with_layers(self):
+        lambda_function = Mock()
+        lambda_function.packagetype = ZIP
+        lambda_function.code_abs_path = "path1"
+        layer1_mock = Mock()
+        layer1_mock.codeuri = "layer1_path"
+        layer2_mock = Mock()
+        layer2_mock.codeuri = "layer2_path"
+
+        lambda_function.layers = [layer1_mock, layer2_mock]
+        self.lambda_function_observer.watch(lambda_function)
+        self.assertEqual(
+            self.lambda_function_observer._observed_functions,
+            {
+                ZIP: {
+                    "path1": [lambda_function],
+                    "layer1_path": [lambda_function],
+                    "layer2_path": [lambda_function],
+                },
+                IMAGE: {},
+            },
+        )
+        self.assertEqual(
+            self.file_observer_mock.watch.call_args_list,
+            [
+                call("path1"),
+                call("layer1_path"),
+                call("layer2_path"),
+            ],
+        )
+
+    def test_watch_IMAGE_lambda_function(self):
+        lambda_function = Mock()
+        lambda_function.packagetype = IMAGE
+        lambda_function.imageuri = "image1"
+        self.lambda_function_observer.watch(lambda_function)
+        self.assertEqual(
+            self.lambda_function_observer._observed_functions,
+            {
+                ZIP: {},
+                IMAGE: {"image1": [lambda_function]},
+            },
+        )
+        self.image_observer_mock.watch.assert_called_with("image1")
+
+
+class LambdaFunctionObserver_unwatch(TestCase):
+    @patch("samcli.lib.utils.file_observer.FileObserver")
+    @patch("samcli.lib.utils.file_observer.ImageObserver")
+    def setUp(self, ImageObserverMock, FileObserverMock):
+        self.on_change = Mock()
+        self.image_observer_mock = Mock()
+        ImageObserverMock.return_value = self.image_observer_mock
+        self.file_observer_mock = Mock()
+        FileObserverMock.return_value = self.file_observer_mock
+        self.lambda_function_observer = LambdaFunctionObserver(self.on_change)
+
+        self.zip_lambda_function1 = Mock()
+        self.zip_lambda_function1.packagetype = ZIP
+        self.zip_lambda_function1.code_abs_path = "path1"
+        self.zip_lambda_function1.layers = []
+        self.lambda_function_observer.watch(self.zip_lambda_function1)
+
+        self.zip_lambda_function2 = Mock()
+        self.zip_lambda_function2.packagetype = ZIP
+        self.zip_lambda_function2.code_abs_path = "path2"
+        layer1_mock = Mock()
+        layer1_mock.codeuri = "layer1_path1"
+        layer2_mock = Mock()
+        layer2_mock.codeuri = "layer1_path2"
+        self.zip_lambda_function2.layers = [layer1_mock, layer2_mock]
+        self.lambda_function_observer.watch(self.zip_lambda_function2)
+
+        self.zip_lambda_function3 = Mock()
+        self.zip_lambda_function3.packagetype = ZIP
+        self.zip_lambda_function3.code_abs_path = "path3"
+        self.zip_lambda_function3.layers = [layer1_mock]
+        self.lambda_function_observer.watch(self.zip_lambda_function3)
+
+        self.image_lambda_function1 = Mock()
+        self.image_lambda_function1.packagetype = IMAGE
+        self.image_lambda_function1.imageuri = "image1"
+        self.lambda_function_observer.watch(self.image_lambda_function1)
+
+        self.image_lambda_function2 = Mock()
+        self.image_lambda_function2.packagetype = IMAGE
+        self.image_lambda_function2.imageuri = "image2"
+        self.lambda_function_observer.watch(self.image_lambda_function2)
+
+        self.image_lambda_function3 = Mock()
+        self.image_lambda_function3.packagetype = IMAGE
+        self.image_lambda_function3.imageuri = "image2"
+        self.lambda_function_observer.watch(self.image_lambda_function3)
+
+    def test_successfully_unwatch_last_zip_lambda_function(self):
+        self.lambda_function_observer.unwatch(self.zip_lambda_function1)
+        self.assertEqual(
+            self.lambda_function_observer._observed_functions,
+            {
+                ZIP: {
+                    "path2": [self.zip_lambda_function2],
+                    "path3": [self.zip_lambda_function3],
+                    "layer1_path1": [self.zip_lambda_function2, self.zip_lambda_function3],
+                    "layer1_path2": [self.zip_lambda_function2],
+                },
+                IMAGE: {
+                    "image1": [self.image_lambda_function1],
+                    "image2": [self.image_lambda_function2, self.image_lambda_function3],
+                },
+            },
+        )
+        self.file_observer_mock.unwatch.assert_called_with("path1")
+
+    def test_successfully_unwatch_zip_lambda_function_with_layers(self):
+        self.lambda_function_observer.unwatch(self.zip_lambda_function2)
+        self.assertEqual(
+            self.lambda_function_observer._observed_functions,
+            {
+                ZIP: {
+                    "path1": [self.zip_lambda_function1],
+                    "path3": [self.zip_lambda_function3],
+                    "layer1_path1": [self.zip_lambda_function3],
+                },
+                IMAGE: {
+                    "image1": [self.image_lambda_function1],
+                    "image2": [self.image_lambda_function2, self.image_lambda_function3],
+                },
+            },
+        )
+        self.assertEqual(
+            self.file_observer_mock.unwatch.call_args_list,
+            [
+                call("path2"),
+                call("layer1_path2"),
+            ],
+        )
+
+    def test_successfully_unwatch_last_image_lambda_function(self):
+        self.lambda_function_observer.unwatch(self.image_lambda_function1)
+        self.assertEqual(
+            self.lambda_function_observer._observed_functions,
+            {
+                ZIP: {
+                    "path1": [self.zip_lambda_function1],
+                    "path2": [self.zip_lambda_function2],
+                    "path3": [self.zip_lambda_function3],
+                    "layer1_path1": [self.zip_lambda_function2, self.zip_lambda_function3],
+                    "layer1_path2": [self.zip_lambda_function2],
+                },
+                IMAGE: {"image2": [self.image_lambda_function2, self.image_lambda_function3]},
+            },
+        )
+        self.image_observer_mock.unwatch.assert_called_with("image1")
+
+    def test_successfully_unwatch_non_last_image_lambda_function(self):
+        self.lambda_function_observer.unwatch(self.image_lambda_function2)
+        self.assertEqual(
+            self.lambda_function_observer._observed_functions,
+            {
+                ZIP: {
+                    "path1": [self.zip_lambda_function1],
+                    "path2": [self.zip_lambda_function2],
+                    "path3": [self.zip_lambda_function3],
+                    "layer1_path1": [self.zip_lambda_function2, self.zip_lambda_function3],
+                    "layer1_path2": [self.zip_lambda_function2],
+                },
+                IMAGE: {"image1": [self.image_lambda_function1], "image2": [self.image_lambda_function3]},
+            },
+        )
+        self.image_observer_mock.unwatch.assert_not_called()
+
+
+class LambdaFunctionObserver_start(TestCase):
+    @patch("samcli.lib.utils.file_observer.FileObserver")
+    @patch("samcli.lib.utils.file_observer.ImageObserver")
+    def setUp(self, ImageObserverMock, FileObserverMock):
+        self.on_change = Mock()
+        self.image_observer_mock = Mock()
+        ImageObserverMock.return_value = self.image_observer_mock
+        self.file_observer_mock = Mock()
+        FileObserverMock.return_value = self.file_observer_mock
+        self.lambda_function_observer = LambdaFunctionObserver(self.on_change)
+
+    def test_successfully_start_observing(self):
+        self.lambda_function_observer.start()
+        self.file_observer_mock.start.assert_called_once_with()
+        self.image_observer_mock.start.assert_called_once_with()
+
+
+class LambdaFunctionObserver_stop(TestCase):
+    @patch("samcli.lib.utils.file_observer.FileObserver")
+    @patch("samcli.lib.utils.file_observer.ImageObserver")
+    def setUp(self, ImageObserverMock, FileObserverMock):
+        self.on_change = Mock()
+        self.image_observer_mock = Mock()
+        ImageObserverMock.return_value = self.image_observer_mock
+        self.file_observer_mock = Mock()
+        FileObserverMock.return_value = self.file_observer_mock
+        self.lambda_function_observer = LambdaFunctionObserver(self.on_change)
+
+    def test_successfully_start_observing(self):
+        self.lambda_function_observer.stop()
+        self.file_observer_mock.stop.assert_called_once_with()
+        self.image_observer_mock.stop.assert_called_once_with()
+
+
+class LambdaFunctionObserver_on_change(TestCase):
+    @patch("samcli.lib.utils.file_observer.FileObserver")
+    @patch("samcli.lib.utils.file_observer.ImageObserver")
+    def setUp(self, ImageObserverMock, FileObserverMock):
+        self.on_change = Mock()
+        self.image_observer_mock = Mock()
+        ImageObserverMock.return_value = self.image_observer_mock
+        self.file_observer_mock = Mock()
+        FileObserverMock.return_value = self.file_observer_mock
+        self.lambda_function_observer = LambdaFunctionObserver(self.on_change)
+
+        self.zip_lambda_function1 = Mock()
+        self.zip_lambda_function1.packagetype = ZIP
+        self.zip_lambda_function1.code_abs_path = "path1"
+        self.zip_lambda_function1.layers = []
+        self.lambda_function_observer.watch(self.zip_lambda_function1)
+
+        self.zip_lambda_function2 = Mock()
+        self.zip_lambda_function2.packagetype = ZIP
+        self.zip_lambda_function2.code_abs_path = "path2"
+        layer1_mock = Mock()
+        layer1_mock.codeuri = "layer1_path1"
+        layer2_mock = Mock()
+        layer2_mock.codeuri = "layer1_path2"
+        self.zip_lambda_function2.layers = [layer1_mock, layer2_mock]
+        self.lambda_function_observer.watch(self.zip_lambda_function2)
+
+        self.zip_lambda_function3 = Mock()
+        self.zip_lambda_function3.packagetype = ZIP
+        self.zip_lambda_function3.code_abs_path = "path3"
+        self.zip_lambda_function3.layers = [layer1_mock]
+        self.lambda_function_observer.watch(self.zip_lambda_function3)
+
+        self.image_lambda_function1 = Mock()
+        self.image_lambda_function1.packagetype = IMAGE
+        self.image_lambda_function1.imageuri = "image1"
+        self.lambda_function_observer.watch(self.image_lambda_function1)
+
+        self.image_lambda_function2 = Mock()
+        self.image_lambda_function2.packagetype = IMAGE
+        self.image_lambda_function2.imageuri = "image2"
+        self.lambda_function_observer.watch(self.image_lambda_function2)
+
+        self.image_lambda_function3 = Mock()
+        self.image_lambda_function3.packagetype = IMAGE
+        self.image_lambda_function3.imageuri = "image2"
+        self.lambda_function_observer.watch(self.image_lambda_function3)
+
+    def test_one_lambda_function_code_path_got_changed(self):
+        self.lambda_function_observer._on_zip_change(["path1"])
+        self.on_change.assert_called_once_with([self.zip_lambda_function1])
+
+    def test_one_lambda_function_layer_code_path_got_changed(self):
+        self.lambda_function_observer._on_zip_change(["layer1_path2"])
+        self.on_change.assert_called_once_with([self.zip_lambda_function2])
+
+    def test_common_layer_code_path_got_changed(self):
+        self.lambda_function_observer._on_zip_change(["layer1_path1"])
+        self.on_change.assert_called_once_with([self.zip_lambda_function2, self.zip_lambda_function3])
+
+    def test_one_lambda_function_image_got_changed(self):
+        self.lambda_function_observer._on_image_change(["image1"])
+        self.on_change.assert_called_once_with([self.image_lambda_function1])
+
+    def test_common_image_got_changed(self):
+        self.lambda_function_observer._on_image_change(["image2"])
+        self.on_change.assert_called_once_with([self.image_lambda_function2, self.image_lambda_function3])
 
 
 class TestCalculateChecksum(TestCase):

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from unittest.mock import Mock, patch, MagicMock, ANY, call
 from parameterized import parameterized
 
-from samcli.lib.utils.packagetype import ZIP
+from samcli.lib.utils.packagetype import ZIP, IMAGE
 from samcli.lib.providers.provider import LayerVersion
 from samcli.local.lambdafn.runtime import LambdaRuntime, _unzip_file, WarmLambdaRuntime
 from samcli.local.lambdafn.config import FunctionConfig
@@ -543,8 +543,11 @@ class TestWarmLambdaRuntime_invoke(TestCase):
         self.env_var_value = {"a": "b"}
         self.env_vars.resolve.return_value = self.env_var_value
 
+    @patch("samcli.local.lambdafn.runtime.LambdaFunctionObserver")
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
-    def test_must_run_container_then_wait_for_result_and_container_not_stopped(self, LambdaContainerMock):
+    def test_must_run_container_then_wait_for_result_and_container_not_stopped(
+        self, LambdaContainerMock, LambdaFunctionObserverMock
+    ):
         event = "event"
         code_dir = "some code dir"
         stdout = "stdout"
@@ -556,7 +559,6 @@ class TestWarmLambdaRuntime_invoke(TestCase):
         lambda_image_mock = Mock()
 
         self.runtime = WarmLambdaRuntime(self.manager_mock, lambda_image_mock)
-        self.runtime._add_function_to_observer = Mock()
 
         # Using MagicMock to mock the context manager
         self.runtime._get_code_dir = MagicMock()
@@ -635,16 +637,19 @@ class TestWarmLambdaRuntime_create(TestCase):
         self.env_var_value = {"a": "b"}
         self.env_vars.resolve.return_value = self.env_var_value
 
+    @patch("samcli.local.lambdafn.runtime.LambdaFunctionObserver")
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
-    def test_must_create_non_cached_container(self, LambdaContainerMock):
+    def test_must_create_non_cached_container(self, LambdaContainerMock, LambdaFunctionObserverMock):
         code_dir = "some code dir"
         container = Mock()
         debug_options = Mock()
         debug_options.debug_function = self.name
         lambda_image_mock = Mock()
 
+        lambda_function_observer_mock = Mock()
+        LambdaFunctionObserverMock.return_value = lambda_function_observer_mock
+
         self.runtime = WarmLambdaRuntime(self.manager_mock, lambda_image_mock)
-        self.runtime._add_function_to_observer = Mock()
 
         # Using MagicMock to mock the context manager
         self.runtime._get_code_dir = MagicMock()
@@ -672,10 +677,12 @@ class TestWarmLambdaRuntime_create(TestCase):
         self.manager_mock.create.assert_called_with(container)
         # validate that the created container got cached
         self.assertEqual(self.runtime._containers[self.name], container)
-        self.runtime._add_function_to_observer.assert_called_with(self.func_config)
+        lambda_function_observer_mock.watch.assert_called_with(self.func_config)
+        lambda_function_observer_mock.start.assert_called_with()
 
+    @patch("samcli.local.lambdafn.runtime.LambdaFunctionObserver")
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
-    def test_must_return_cached_container(self, LambdaContainerMock):
+    def test_must_return_cached_container(self, LambdaContainerMock, LambdaFunctionObserverMock):
         code_dir = "some code dir"
         container = Mock()
         debug_options = Mock()
@@ -683,7 +690,6 @@ class TestWarmLambdaRuntime_create(TestCase):
         lambda_image_mock = Mock()
 
         self.runtime = WarmLambdaRuntime(self.manager_mock, lambda_image_mock)
-        self.runtime._add_function_to_observer = Mock()
 
         # Using MagicMock to mock the context manager
         self.runtime._get_code_dir = MagicMock()
@@ -697,8 +703,11 @@ class TestWarmLambdaRuntime_create(TestCase):
         self.manager_mock.create.assert_called_once_with(container)
         self.assertEqual(result, container)
 
+    @patch("samcli.local.lambdafn.runtime.LambdaFunctionObserver")
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
-    def test_must_ignore_debug_options_if_function_name_is_not_debug_function(self, LambdaContainerMock):
+    def test_must_ignore_debug_options_if_function_name_is_not_debug_function(
+        self, LambdaContainerMock, LambdaFunctionObserverMock
+    ):
         code_dir = "some code dir"
         container = Mock()
         debug_options = Mock()
@@ -706,7 +715,6 @@ class TestWarmLambdaRuntime_create(TestCase):
         lambda_image_mock = Mock()
 
         self.runtime = WarmLambdaRuntime(self.manager_mock, lambda_image_mock)
-        self.runtime._add_function_to_observer = Mock()
 
         # Using MagicMock to mock the context manager
         self.runtime._get_code_dir = MagicMock()
@@ -765,57 +773,6 @@ class TestWarmLambdaRuntime_get_code_dir(TestCase):
         self.assertEqual(res, uncompressed_dir_mock)
 
 
-class TestWarmLambdaRuntime_add_function_to_observer(TestCase):
-    def setUp(self):
-        self.manager_mock = Mock()
-
-        self.name = "name"
-        self.lang = "runtime"
-        self.handler = "handler"
-        self.code_path = "code-path"
-
-        self.layer1_code_path = "layer1-code-path"
-        self.layer1_arn = "layer1-arn"
-        self.layers = [LayerVersion(arn=self.layer1_arn, codeuri=self.layer1_code_path, compatible_runtimes=self.lang)]
-        self.imageuri = None
-        self.packagetype = ZIP
-        self.imageconfig = None
-        self.func_config = FunctionConfig(
-            self.name,
-            self.lang,
-            self.handler,
-            self.imageuri,
-            self.imageconfig,
-            self.packagetype,
-            self.code_path,
-            self.layers,
-        )
-
-    @patch("samcli.local.lambdafn.runtime.FileObserver")
-    def test_must_observe_function_code_path_and_layers_paths(self, FileObserverMock):
-        lambda_image_mock = Mock()
-        observer_mock = Mock()
-        FileObserverMock.return_value = observer_mock
-        self.runtime = WarmLambdaRuntime(self.manager_mock, lambda_image_mock)
-        self.runtime._add_function_to_observer(self.func_config)
-
-        self.assertEqual(
-            self.runtime._observed_paths,
-            {
-                "code-path": [self.func_config],
-                "layer1-code-path": [self.func_config],
-            },
-        )
-        self.assertEqual(
-            observer_mock.watch.call_args_list,
-            [
-                call("code-path"),
-                call("layer1-code-path"),
-            ],
-        )
-        observer_mock.start.assert_called_once_with()
-
-
 class TestWarmLambdaRuntime_clean_warm_containers_related_resources(TestCase):
     def setUp(self):
         self.manager_mock = Mock()
@@ -865,7 +822,6 @@ class TestWarmLambdaRuntime_on_code_change(TestCase):
         self.lang = "runtime"
         self.handler = "handler"
         self.imageuri = None
-        self.packagetype = ZIP
         self.imageconfig = None
 
         self.func1_name = "func1_name"
@@ -886,7 +842,7 @@ class TestWarmLambdaRuntime_on_code_change(TestCase):
             self.handler,
             self.imageuri,
             self.imageconfig,
-            self.packagetype,
+            ZIP,
             self.func1_code_path,
             self.common_layers,
         )
@@ -896,16 +852,10 @@ class TestWarmLambdaRuntime_on_code_change(TestCase):
             self.handler,
             self.imageuri,
             self.imageconfig,
-            self.packagetype,
+            IMAGE,
             self.func2_code_path,
             self.common_layers,
         )
-
-        self.runtime._observed_paths = {
-            self.func1_code_path: [self.func_config1],
-            self.func2_code_path: [self.func_config2],
-            self.common_layer_code_path: [self.func_config1, self.func_config2],
-        }
 
         self.func1_container_mock = Mock()
         self.func2_container_mock = Mock()
@@ -915,20 +865,9 @@ class TestWarmLambdaRuntime_on_code_change(TestCase):
         }
 
     def test_only_one_container_get_stopped_when_its_code_dir_got_changed(self):
-        changed_paths = [self.func1_code_path]
-
-        self.runtime._on_code_change(changed_paths)
+        self.runtime._on_code_change([self.func_config1])
 
         self.manager_mock.stop.assert_called_with(self.func1_container_mock)
-
-        self.assertEqual(
-            self.runtime._observed_paths,
-            {
-                self.func2_code_path: [self.func_config2],
-                self.common_layer_code_path: [self.func_config2],
-            },
-        )
-
         self.assertEqual(
             self.runtime._containers,
             {
@@ -936,12 +875,10 @@ class TestWarmLambdaRuntime_on_code_change(TestCase):
             },
         )
 
-        self.observer_mock.unwatch.assert_called_with(self.func1_code_path)
+        self.observer_mock.unwatch.assert_called_with(self.func_config1)
 
-    def test_both_containers_get_stopped_when_their_code_dir_got_changed(self):
-        changed_paths = [self.func1_code_path, self.func2_code_path]
-
-        self.runtime._on_code_change(changed_paths)
+    def test_both_containers_get_stopped_when_both_functions_got_updated(self):
+        self.runtime._on_code_change([self.func_config1, self.func_config2])
 
         self.assertEqual(
             self.manager_mock.stop.call_args_list,
@@ -950,43 +887,13 @@ class TestWarmLambdaRuntime_on_code_change(TestCase):
                 call(self.func2_container_mock),
             ],
         )
-
-        self.assertEqual(self.runtime._observed_paths, {})
-
         self.assertEqual(self.runtime._containers, {})
 
         self.assertEqual(
             self.observer_mock.unwatch.call_args_list,
             [
-                call(self.func1_code_path),
-                call(self.func2_code_path),
-                call(self.common_layer_code_path),
-            ],
-        )
-
-    def test_both_containers_get_stopped_when_common_layer_code_dir_got_changed(self):
-        changed_paths = [self.common_layer_code_path]
-
-        self.runtime._on_code_change(changed_paths)
-
-        self.assertEqual(
-            self.manager_mock.stop.call_args_list,
-            [
-                call(self.func1_container_mock),
-                call(self.func2_container_mock),
-            ],
-        )
-
-        self.assertEqual(self.runtime._observed_paths, {})
-
-        self.assertEqual(self.runtime._containers, {})
-
-        self.assertEqual(
-            self.observer_mock.unwatch.call_args_list,
-            [
-                call(self.func1_code_path),
-                call(self.func2_code_path),
-                call(self.common_layer_code_path),
+                call(self.func_config1),
+                call(self.func_config2),
             ],
         )
 


### PR DESCRIPTION
#### Which issue(s) does this change fix? 
https://github.com/aws/aws-sam-cli/issues/2507

#### Why is this change necessary?
 to make sam cli able to reload the image package type lambda functions if it got changed.

#### How does it address the issue?
SAM will listen the docker events to observe if there is any change to the lambda function image.

#### What side effects does this change have?
N/A

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
