### PR TITLE
fix: Cannot package Image functions in nested stack

### DIFF
--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -33,7 +33,8 @@ from samcli.commands.deploy.exceptions import (
 )
 from samcli.commands._utils.table_print import pprint_column_names, pprint_columns, newline_per_item, MIN_OFFSET
 from samcli.commands.deploy import exceptions as deploy_exceptions
-from samcli.lib.package.artifact_exporter import mktempfile, parse_s3_url
+from samcli.lib.package.artifact_exporter import mktempfile
+from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.utils.time import utc_to_timestamp
 
 LOG = logging.getLogger(__name__)
@@ -173,7 +174,7 @@ class Deployer:
                 temporary_file.flush()
 
                 # TemplateUrl property requires S3 URL to be in path-style format
-                parts = parse_s3_url(
+                parts = S3Uploader.parse_s3_url(
                     s3_uploader.upload_with_dedup(temporary_file.name, "template"), version_property="Version"
                 )
                 kwargs["TemplateURL"] = s3_uploader.to_path_style_s3_url(parts["Key"], parts.get("Version", None))

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -36,7 +36,7 @@ from samcli.lib.package.packageable_resources import (
 )
 from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.package.uploaders import Uploaders
-from samcli.lib.package.utils import is_local_folder, make_abs_path, is_s3_url, is_local_file, mktempfile, parse_s3_url
+from samcli.lib.package.utils import is_local_folder, make_abs_path, is_s3_url, is_local_file, mktempfile
 from samcli.lib.utils.packagetype import ZIP
 from samcli.yamlhelper import yaml_parse, yaml_dump
 
@@ -88,7 +88,7 @@ class CloudFormationStackResource(ResourceZip):
             url = self.uploader.upload_with_dedup(temporary_file.name, "template")
 
             # TemplateUrl property requires S3 URL to be in path-style format
-            parts = parse_s3_url(url, version_property="Version")
+            parts = S3Uploader.parse_s3_url(url, version_property="Version")
             s3_path_url = self.uploader.to_path_style_s3_url(parts["Key"], parts.get("Version", None))
             set_value_from_jmespath(resource_dict, self.PROPERTY_NAME, s3_path_url)
 

--- a/samcli/lib/package/code_signer.py
+++ b/samcli/lib/package/code_signer.py
@@ -5,7 +5,7 @@ Client for initiate and monitor code signing jobs
 import logging
 
 from samcli.commands.exceptions import UserException
-from samcli.lib.package.artifact_exporter import parse_s3_url
+from samcli.lib.package.s3_uploader import S3Uploader
 
 LOG = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class CodeSigner:
         profile_owner = signing_profile_for_resource["profile_owner"]
 
         # parse given s3 url, and extract bucket and object key
-        parsed_s3_url = parse_s3_url(s3_url)
+        parsed_s3_url = S3Uploader.parse_s3_url(s3_url)
         s3_bucket = parsed_s3_url["Bucket"]
         s3_key = parsed_s3_url["Key"]
         s3_target_prefix = s3_key.rsplit("/", 1)[0] + "/signed_"

--- a/samcli/lib/package/packageable_resources.py
+++ b/samcli/lib/package/packageable_resources.py
@@ -20,7 +20,6 @@ from samcli.lib.package.utils import (
     copy_to_temp_dir,
     upload_local_artifacts,
     upload_local_image_artifacts,
-    parse_s3_url,
     is_s3_url,
     is_path_value_valid,
 )
@@ -260,7 +259,7 @@ class ResourceWithS3UrlDict(ResourceZip):
             resource_id, resource_dict, self.PROPERTY_NAME, parent_dir, self.uploader
         )
 
-        parsed_url = parse_s3_url(
+        parsed_url = S3Uploader.parse_s3_url(
             artifact_s3_url,
             bucket_name_property=self.BUCKET_NAME_PROPERTY,
             object_key_property=self.OBJECT_KEY_PROPERTY,

--- a/samcli/lib/package/uploaders.py
+++ b/samcli/lib/package/uploaders.py
@@ -1,0 +1,42 @@
+"""
+Contains Uploaders, a class to hold a S3Uploader and an ECRUploader
+"""
+
+from enum import Enum
+from typing import Union
+
+from samcli.lib.package.ecr_uploader import ECRUploader
+from samcli.lib.package.s3_uploader import S3Uploader
+
+
+class Destination(Enum):
+    S3 = "s3"  # pylint: disable=invalid-name
+    ECR = "ecr"
+
+
+class Uploaders:
+    """
+    Class to hold a S3Uploader and an ECRUploader
+    """
+
+    _s3_uploader: S3Uploader
+    _ecr_uploader: ECRUploader
+
+    def __init__(self, s3_uploader: S3Uploader, ecr_uploader: ECRUploader):
+        self._s3_uploader = s3_uploader
+        self._ecr_uploader = ecr_uploader
+
+    def get(self, destination: Destination) -> Union[S3Uploader, ECRUploader]:
+        if destination == Destination.S3:
+            return self._s3_uploader
+        if destination == Destination.ECR:
+            return self._ecr_uploader
+        raise ValueError(f"destination has invalid value: {destination}")
+
+    @property
+    def s3(self):
+        return self._s3_uploader
+
+    @property
+    def ecr(self):
+        return self._ecr_uploader

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -10,13 +10,14 @@ import uuid
 import zipfile
 import contextlib
 from contextlib import contextmanager
-from urllib.parse import urlparse, parse_qs
+from typing import Dict, Optional, cast
 
 import jmespath
 
 from samcli.commands.package import exceptions
 from samcli.commands.package.exceptions import ImageNotFoundError
 from samcli.lib.package.ecr_utils import is_ecr_url
+from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.utils.hash import dir_checksum
 
 LOG = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ def make_abs_path(directory, path):
 
 def is_s3_url(url):
     try:
-        parse_s3_url(url)
+        S3Uploader.parse_s3_url(url)
         return True
     except ValueError:
         return False
@@ -50,28 +51,6 @@ def is_local_file(path):
 
 def is_zip_file(path):
     return is_path_value_valid(path) and zipfile.is_zipfile(path)
-
-
-def parse_s3_url(url, bucket_name_property="Bucket", object_key_property="Key", version_property=None):
-
-    if isinstance(url, str) and url.startswith("s3://"):
-
-        parsed = urlparse(url)
-        query = parse_qs(parsed.query)
-
-        if parsed.netloc and parsed.path:
-            result = dict()
-            result[bucket_name_property] = parsed.netloc
-            result[object_key_property] = parsed.path.lstrip("/")
-
-            # If there is a query string that has a single versionId field,
-            # set the object version and return
-            if version_property is not None and "versionId" in query and len(query["versionId"]) == 1:
-                result[version_property] = query["versionId"][0]
-
-            return result
-
-    raise ValueError("URL given to the parse method is not a valid S3 url " "{0}".format(url))
 
 
 def upload_local_image_artifacts(resource_id, resource_dict, property_name, parent_dir, uploader):
@@ -105,7 +84,14 @@ def upload_local_image_artifacts(resource_id, resource_dict, property_name, pare
     return uploader.upload(image_path, resource_id)
 
 
-def upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir, uploader, extension=None):
+def upload_local_artifacts(
+    resource_id: str,
+    resource_dict: Dict,
+    property_name: str,
+    parent_dir: str,
+    uploader: S3Uploader,
+    extension: Optional[str] = None,
+) -> str:
     """
     Upload local artifacts referenced by the property at given resource and
     return S3 URL of the uploaded object. It is the responsibility of callers
@@ -142,7 +128,7 @@ def upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir
         # refer to local artifacts
         # Nothing to do if property value is an S3 URL
         LOG.debug("Property %s of %s is already a S3 URL", property_name, resource_id)
-        return local_path
+        return cast(str, local_path)
 
     local_path = make_abs_path(parent_dir, local_path)
 
@@ -164,7 +150,7 @@ def resource_not_packageable(resource_dict):
     return False
 
 
-def zip_and_upload(local_path, uploader, extension):
+def zip_and_upload(local_path: str, uploader: S3Uploader, extension: Optional[str]) -> str:
     with zip_folder(local_path) as (zip_file, md5_hash):
         return uploader.upload_with_dedup(zip_file, precomputed_md5=md5_hash, extension=extension)
 

--- a/tests/integration/package/test_package_command_image.py
+++ b/tests/integration/package/test_package_command_image.py
@@ -118,3 +118,24 @@ class TestPackageImage(PackageIntegBase):
 
         self.assertEqual(2, process.returncode)
         self.assertIn("Error: Missing option '--image-repository'", process_stderr.decode("utf-8"))
+
+    @parameterized.expand(["aws-serverless-application-image.yaml"])
+    def test_package_template_with_image_function_in_nested_application(self, template_file):
+        template_path = self.test_data_path.joinpath(template_file)
+        command_list = self.get_command_list(
+            image_repository=self.ecr_repo_name, template=template_path, resolve_s3=True
+        )
+
+        process = Popen(command_list, stdout=PIPE, stderr=PIPE)
+        try:
+            _, stderr = process.communicate(timeout=TIMEOUT)
+        except TimeoutExpired:
+            process.kill()
+            raise
+        process_stderr = stderr.strip().decode("utf-8")
+
+        self.assertEqual(0, process.returncode)
+        # when image function is not in main template, erc_repo_name only shows in stderr (pushing progress)
+        # here we make sure the image is successfully pushed to the correct repo
+        self.assertIn(f"{self.ecr_repo_name}", process_stderr)
+        self.assertIn("Pushed", process_stderr)

--- a/tests/integration/testdata/package/aws-serverless-application-image.yaml
+++ b/tests/integration/testdata/package/aws-serverless-application-image.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Simple Serverless Application
+
+Resources:
+  myApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./aws-serverless-function-image.yaml

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -7,7 +7,7 @@ import unittest
 
 from contextlib import contextmanager, closing
 from unittest import mock
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock
 
 from samcli.commands.package.exceptions import ExportFailedError
 from samcli.lib.package.s3_uploader import S3Uploader


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

1. Current `Template`'s `uploader` has three possible types, which is not very easy to comprehend
    - `S3Uploader`
    - `ECRUploader`
    - `Dict[str, Union[S3Uploader, ECRUploader]]`
2. When uploaders are passed along the invocation path, they can be lost:
    1. `Template` (originally `{"s3": self.s3_uploader, "ecr": self.ecr_uploader}`
    2. `Resource` (either has `s3_uploader` or `ecr_uploader`) because of this piece of code
        https://github.com/aws/aws-sam-cli/blob/0e4e99b37d031ba4caca128f3c3b333da519f770/samcli/lib/package/artifact_exporter.py#L228-L234
    3. `Template` (created by `CloudFormationStackResource.do_export`), now `Template` can only has `s3_uploader` or `ecr_uploader`, not both.
         https://github.com/aws/aws-sam-cli/blob/0e4e99b37d031ba4caca128f3c3b333da519f770/samcli/lib/package/artifact_exporter.py#L76
    Imagine this scenario: if a user tries to package an image type function inside a nested CFN stack, sam-cli would crash because the last `Template` does not have `ecr_uploader` any more (`CloudFormationStackResource` has a `S3` export destination, `ecr_export` is dropped at that point). Example template can be found in https://github.com/aws/aws-sam-cli/pull/2532/commits/c8877cdcb7ffed543e90173769e8b6b4f2fdba0c
3. @sriram-mv had something in mind already when ECR was originally implemented:
    https://github.com/aws/aws-sam-cli/blob/0e4e99b37d031ba4caca128f3c3b333da519f770/samcli/commands/package/package_context.py#L116-L117

#### How does it address the issue?

By passing a new object `uploaders` with type `Uploaders` (which packs both `s3_uploader` and `ecr_uploader`), we can handle the use case mentioned above. By doing this, we make types consistent, resulting in better readability.

#### What side effects does this change have?

None

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
