### PR TITLE
fix: No Default Compress Type for Windows

### DIFF
--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -216,7 +216,9 @@ def make_zip(file_name, source_root):
                             info.external_attr = 0o100755 << 16
                             # Set host OS to Unix
                             info.create_system = 3
-                            zf.writestr(info, file_bytes, compress_type=compression_type, compresslevel=compression_level)
+                            zf.writestr(
+                                info, file_bytes, compress_type=compression_type, compresslevel=compression_level
+                            )
                     else:
                         zf.write(full_path, relative_path)
 

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -193,9 +193,8 @@ def make_zip(file_name, source_root):
     zipfile_name = "{0}.zip".format(file_name)
     source_root = os.path.abspath(source_root)
     compression_type = zipfile.ZIP_DEFLATED
-    compression_level = 9
     with open(zipfile_name, "wb") as f:
-        zip_file = zipfile.ZipFile(f, "w", compression_type, compresslevel=compression_level)
+        zip_file = zipfile.ZipFile(f, "w", compression_type)
         with contextlib.closing(zip_file) as zf:
             for root, _, files in os.walk(source_root, followlinks=True):
                 for filename in files:
@@ -216,9 +215,7 @@ def make_zip(file_name, source_root):
                             info.external_attr = 0o100755 << 16
                             # Set host OS to Unix
                             info.create_system = 3
-                            zf.writestr(
-                                info, file_bytes, compress_type=compression_type, compresslevel=compression_level
-                            )
+                            zf.writestr(info, file_bytes, compress_type=compression_type)
                     else:
                         zf.write(full_path, relative_path)
 

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -192,8 +192,10 @@ def zip_folder(folder_path):
 def make_zip(file_name, source_root):
     zipfile_name = "{0}.zip".format(file_name)
     source_root = os.path.abspath(source_root)
+    compression_type = zipfile.ZIP_DEFLATED
+    compression_level = 9
     with open(zipfile_name, "wb") as f:
-        zip_file = zipfile.ZipFile(f, "w", zipfile.ZIP_DEFLATED)
+        zip_file = zipfile.ZipFile(f, "w", compression_type, compresslevel=compression_level)
         with contextlib.closing(zip_file) as zf:
             for root, _, files in os.walk(source_root, followlinks=True):
                 for filename in files:
@@ -214,7 +216,7 @@ def make_zip(file_name, source_root):
                             info.external_attr = 0o100755 << 16
                             # Set host OS to Unix
                             info.create_system = 3
-                            zf.writestr(info, file_bytes)
+                            zf.writestr(info, file_bytes, compress_type=compression_type, compresslevel=compression_level)
                     else:
                         zf.write(full_path, relative_path)
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/2511

#### Why is this change necessary?
Artifact ZIP file has 0% compression.

#### How does it address the issue?
Specifies the compression level and type.
`zf.writestr` does not use the compression type given in the ZipFile constructor.

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
