### PR TITLE
ci: Fix an integration test failure caused by resource already exists

### DIFF
--- a/tests/integration/package/test_package_command_image.py
+++ b/tests/integration/package/test_package_command_image.py
@@ -138,4 +138,4 @@ class TestPackageImage(PackageIntegBase):
         # when image function is not in main template, erc_repo_name only shows in stderr (pushing progress)
         # here we make sure the image is successfully pushed to the correct repo
         self.assertIn(f"{self.ecr_repo_name}", process_stderr)
-        self.assertIn("Pushed", process_stderr)
+        self.assertIn("Uploading", process_stderr)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

Fix the integration test failure:
```
tests/integration/package/test_package_command_image.py:141: in test_package_template_with_image_function_in_nested_application
    self.assertIn("Pushed", process_stderr)
E   AssertionError: 'Pushed' not found in '\x1b[1A\x1b[G\x1b[0KThe push refers to repository [*****]\n\n\x1b[1A\x1b[G\x1b[0K\rc04d1437198b: Preparing \x1b[0B\x1b[G\x1b[1A\x1b[G\n\x1b[1A\x1b[G\x1b[0K\rc04d1437198b: Layer already exists \x1b[1B\x1b[G\n\x1b[1A\x1b[G\x1b[0Kalpine-7731472c3f2a-latest: digest: sha256:d0710affa17fad5f466a70159cc458227bd25d4afb39514ef662ead3e6c99515 size: 528\n\n\rUploading to b44d7f8e83d3e55edef4a6ad7675ae4e.template  472 / 472.0  (100.00%)'
```

When that integration test runs, the image was already uploaded once. In this test we only need to verify the image function is uploaded. Whether it was uploaded before or not does not matter. `Uploading` is the common word showing up in both scenario.

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
