### PR TITLE
ci: Check template content when test nested image function package

### DIFF
--- a/tests/integration/package/test_package_command_image.py
+++ b/tests/integration/package/test_package_command_image.py
@@ -1,10 +1,15 @@
+import tempfile
 from subprocess import Popen, PIPE, TimeoutExpired
 
 from unittest import skipIf
+from urllib.parse import urlparse
+
+import boto3
 from parameterized import parameterized
 
 import docker
 
+from samcli.commands._utils.template import get_template_data
 from .package_integ_base import PackageIntegBase
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
 
@@ -122,20 +127,38 @@ class TestPackageImage(PackageIntegBase):
     @parameterized.expand(["aws-serverless-application-image.yaml"])
     def test_package_template_with_image_function_in_nested_application(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
-            image_repository=self.ecr_repo_name, template=template_path, resolve_s3=True
-        )
 
-        process = Popen(command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            _, stderr = process.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            process.kill()
-            raise
-        process_stderr = stderr.strip().decode("utf-8")
+        # when image function is not in main template, erc_repo_name does not show up in stdout
+        # here we download the nested application template file and verify its content
+        with tempfile.NamedTemporaryFile() as packaged_file, tempfile.TemporaryFile() as packaged_nested_file:
+            command_list = self.get_command_list(
+                image_repository=self.ecr_repo_name,
+                template=template_path,
+                resolve_s3=True,
+                output_template_file=packaged_file.name,
+            )
 
-        self.assertEqual(0, process.returncode)
-        # when image function is not in main template, erc_repo_name only shows in stderr (pushing progress)
-        # here we make sure the image is successfully pushed to the correct repo
-        self.assertIn(f"{self.ecr_repo_name}", process_stderr)
-        self.assertIn("Uploading", process_stderr)
+            process = Popen(command_list, stdout=PIPE, stderr=PIPE)
+            try:
+                process.communicate(timeout=TIMEOUT)
+            except TimeoutExpired:
+                process.kill()
+                raise
+
+            self.assertEqual(0, process.returncode)
+
+            # download the root template and locate nested template url
+            template_dict = get_template_data(packaged_file.name)
+            nested_app_template_uri = (
+                template_dict.get("Resources", {}).get("myApp", {}).get("Properties").get("Location")
+            )
+
+            # extract bucket name and object key from the url
+            parsed = urlparse(nested_app_template_uri)
+            bucket_name, key = parsed.path.lstrip("/").split("/")
+
+            # download and verify it contains ecr_repo_name
+            s3 = boto3.resource("s3")
+            s3.Object(bucket_name, key).download_fileobj(packaged_nested_file)
+            packaged_nested_file.seek(0)
+            self.assertIn(f"{self.ecr_repo_name}", packaged_nested_file.read().decode())


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

A followup to #2542. Turned out the `stderr` is not reliable and it replies on docker client outputting the expected message. Here I changed the assertion to verify uploaded template file instead.

This behavior is decided by our sam-cli only, we don't need to worry about docker client version or docker client changing behavior in the future breaking our tests.

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
