### PR TITLE
fix: aws-lambda-mock has outdated rapid/init file path

### DIFF
--- a/samcli/local/go-bootstrap/aws-lambda-mock.go
+++ b/samcli/local/go-bootstrap/aws-lambda-mock.go
@@ -93,7 +93,7 @@ func main() {
 	var err error
 	var errored bool
 
-	var mockServerCmd = exec.Command("/var/rapid/init") // <-- This is our mount point for RAPID server.
+	var mockServerCmd = exec.Command("/var/rapid/aws-lambda-rie") // <-- This is our mount point for RAPID server.
 	mockServerCmd.Env = append(os.Environ(),
 		"DOCKER_LAMBDA_NO_BOOTSTRAP=1",
 		"DOCKER_LAMBDA_USE_STDIN=1",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#2462 
/var/rapid/init: no such file or directory

#### Why is this change necessary?

In https://github.com/aws/aws-sam-cli/pull/2425, the file `/local/rapid/init` was changed to `/local/rapid/aws-lambda-rie`, while in “samcli/local/go-bootstrap/aws-lambda-mock.go:96” `rapid/init` is still used.

#### How does it address the issue?

Correct executable path in “samcli/local/go-bootstrap/aws-lambda-mock.go:96” and recompile the `aws-lambda-go`

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
