### PR TITLE
ci: Freeze mypy version in dev.txt

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,9 @@ pytest-cov==2.10.1
 pylint~=2.6.0
 
 # type checking and related stubs
-mypy~=0.790
+# mypy adds new rules in new minor versions, which could cause our PR check to fail
+# here we fix its version and upgrade it manually in the future
+mypy==0.790
 boto3-stubs[essential]~=1.14
 
 # Test requirements


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

mypy adds some new rules in 0.800 and it broke current PR check.
I checked the rules and it looks like it requires some effort to fix it or suppress the type error (in the bundled `sam init` template files.) So the current solution is to freeze mypy's version so its future new versions won't break our PR checks.

#### How does it address the issue?

#### What side effects does this change have?

No

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
