### PR TITLE
Fix python command for installing pip and requirements in Makefile-co…

### DIFF
--- a/tests/integration/testdata/buildcmd/Provided/Makefile-container
+++ b/tests/integration/testdata/buildcmd/Provided/Makefile-container
@@ -2,6 +2,6 @@ build-Function:
 	cp *.py $(ARTIFACTS_DIR)
 	cp requirements.txt $(ARTIFACTS_DIR)
 	curl https://bootstrap.pypa.io/get-pip.py > /tmp/get-pip.py
-	python /tmp/get-pip.py
-	python -m pip install -r requirements.txt -t $(ARTIFACTS_DIR)
+	python3 /tmp/get-pip.py
+	python3 -m pip install -r requirements.txt -t $(ARTIFACTS_DIR)
 	rm -rf $(ARTIFACTS_DIR)/bin


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
It fixes failing integration test `TestBuildCommand_ProvidedFunctions` for the container builds.
In `Makefile-container`, it was using `python` command, which is Python2, to install pip. As [pip has dropped support for Python2.7](https://pip.pypa.io/en/stable/news/#id1), the installation doesn't work anymore.

#### How does it address the issue?
change `python` to `python3`

#### What side effects does this change have?
Not that I'm aware of

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
