### PR TITLE
ci: Remove type stubs import from dev.txt

### DIFF
--- a/samcli/lib/package/s3_uploader.py
+++ b/samcli/lib/package/s3_uploader.py
@@ -20,14 +20,13 @@ import threading
 import os
 import sys
 from collections import abc
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, cast
 from urllib.parse import urlparse, parse_qs
 
 import botocore
 import botocore.exceptions
 
 from boto3.s3 import transfer
-from mypy_boto3_s3.client import S3Client
 
 from samcli.commands.package.exceptions import NoSuchBucketError, BucketNotSpecifiedError
 from samcli.lib.utils.hash import file_checksum
@@ -56,7 +55,7 @@ class S3Uploader:
 
     def __init__(
         self,
-        s3_client: S3Client,
+        s3_client: Any,
         bucket_name: str,
         prefix: Optional[str] = None,
         kms_key_id: Optional[str] = None,
@@ -191,7 +190,7 @@ class S3Uploader:
         s3_object_tagging = self.s3.get_object_tagging(Bucket=s3_bucket, Key=s3_key)
         LOG.debug("S3 Object (%s) tagging information %s", s3_url, s3_object_tagging)
         s3_object_version_id = s3_object_tagging["VersionId"]
-        return s3_object_version_id
+        return cast(str, s3_object_version_id)
 
     @staticmethod
     def parse_s3_url(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

`mypy_boto3_s3` is in `dev.txt`, we should not import this.

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
