### PR TITLE
Update Makefile: change pip to python3 -m pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SAM_CLI_TELEMETRY ?= 0
 
 init:
-	SAM_CLI_DEV=1 pip install -e '.[dev]'
+	SAM_CLI_DEV=1 python3 -m pip install -e '.[dev]'
 
 test:
 	# Run unit tests


### PR DESCRIPTION
This will help those users who have pip available as pip3.

#### Why is this change necessary?
It avoid pip command not found error, on running make

#### What side effects does this change have?
It requires python3 now, which would be available in most the cases as python2 is deprecated.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
