### PR TITLE
Making pytest stop running tests after 10 failures.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 log_cli = 1
 log_cli_level = INFO
+addopts = --maxfail=10 -rf
 #filterwarnings =
 #    error


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
Our tests when run on AppVeyor take too long to fail. This change will make it fail fast so that we do not have to wait long time to see the failure. Change is take from pytest documentation here: https://docs.pytest.org/en/2.1.0/customize.html

#### How does it address the issue?
This change will wait for 10 failures and then fail the full test run and report the failures.

#### What side effects does this change have?
NA

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
