### PR TITLE
fix: SamFunctionProvider could miss functions with same name but in different stacks

### DIFF
--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -57,9 +57,13 @@ class Function(NamedTuple):
     @property
     def full_path(self) -> str:
         """
-        Return the unique path-like identifier in a multi-stack situation.
+        Return the path-like identifier of this Function. If it is in root stack, full_path = name.
+        This path is guaranteed to be unique in a multi-stack situation.
+        Example:
+            "HelloWorldFunction"
+            "ChildStackA/GrandChildStackB/AFunctionInNestedStack"
         """
-        return _get_full_path(self)
+        return get_full_path(self.stack_path, self.name)
 
 
 class ResourcesToBuildCollector:
@@ -250,9 +254,13 @@ class LayerVersion:
     @property
     def full_path(self) -> str:
         """
-        Return the unique path-like identifier in a multi-stack situation.
+        Return the path-like identifier of this Layer. If it is in root stack, full_path = name.
+        This path is guaranteed to be unique in a multi-stack situation.
+        Example:
+            "HelloWorldLayer"
+            "ChildStackA/GrandChildStackB/ALayerInNestedStack"
         """
-        return _get_full_path(self)
+        return get_full_path(self.stack_path, self.name)
 
     def __eq__(self, other):
         if isinstance(other, type(self)):
@@ -387,9 +395,9 @@ class Stack(NamedTuple):
         return resources
 
 
-def _get_full_path(resource: Union[Function, LayerVersion]) -> str:
+def get_full_path(stack_path: str, logical_id: str) -> str:
     """
     Return the unique posix path-like identifier
-    while will used for identify a function/layers from resources in a multi-stack situation
+    while will used for identify a resource from resources in a multi-stack situation
     """
-    return posixpath.join(resource.stack_path, resource.name)
+    return posixpath.join(stack_path, logical_id)

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -6,7 +6,7 @@ import hashlib
 import logging
 import posixpath
 from collections import namedtuple
-from typing import NamedTuple, Optional, List, Dict, Union
+from typing import NamedTuple, Optional, List, Dict
 
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn, UnsupportedIntrinsic
 from samcli.lib.providers.sam_base_provider import SamBaseProvider

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -2,7 +2,6 @@
 Class that provides functions from a given SAM template
 """
 import logging
-import posixpath
 from typing import Dict, List, Optional, cast, Iterator
 
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
@@ -43,7 +42,7 @@ class SamFunctionProvider(SamBaseProvider):
         for stack in stacks:
             LOG.debug("%d resources found in the stack %s", len(stack.resources), stack.stack_path)
 
-        # Store a map of function name to function information for quick reference
+        # Store a map of function full_path to function information for quick reference
         self.functions = self._extract_functions(self.stacks, ignore_code_extraction_warnings)
 
         self._deprecated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
@@ -53,8 +52,9 @@ class SamFunctionProvider(SamBaseProvider):
         """
         Returns the function given name or LogicalId of the function. Every SAM resource has a logicalId, but it may
         also have a function name. This method searches only for LogicalID and returns the function that matches.
-        If it is in a nested stack, "name" can be prefixed with stack path to avoid ambiguity
-        it.
+        If it is in a nested stack, "name" can be prefixed with stack path to avoid ambiguity.
+        For example, if a function with name "FunctionA" is located in StackN, which is a nested stack in root stack,
+          either "StackN/FunctionA" or "FunctionA" can be used.
 
         :param string name: Name of the function
         :return Function: namedtuple containing the Function information if function is found.
@@ -65,12 +65,12 @@ class SamFunctionProvider(SamBaseProvider):
         if not name:
             raise ValueError("Function name is required")
 
-        for f in self.get_all():
-            if posixpath.join(f.stack_path, f.name) == name or f.name == name:
-                self._deprecate_notification(f.runtime)
-                return f
+        # support lookup by full_path
+        if name in self.functions:
+            return self.functions.get(name)
 
-            if posixpath.join(f.stack_path, f.functionname) == name or f.functionname == name:
+        for f in self.get_all():
+            if name in (f.name, f.functionname):
                 self._deprecate_notification(f.runtime)
                 return f
 
@@ -108,7 +108,7 @@ class SamFunctionProvider(SamBaseProvider):
             Function configuration object
         """
 
-        result = {}
+        result = {}  # dict: full_path -> Function
         for stack in stacks:
             for name, resource in stack.resources.items():
 
@@ -126,13 +126,14 @@ class SamFunctionProvider(SamBaseProvider):
                         stack.resources,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
-                    result[name] = SamFunctionProvider._convert_sam_function_resource(
+                    f = SamFunctionProvider._convert_sam_function_resource(
                         stack.stack_path,
                         name,
                         resource_properties,
                         layers,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
+                    result[f.full_path] = f
 
                 elif resource_type == SamFunctionProvider.LAMBDA_FUNCTION:
                     layers = SamFunctionProvider._parse_layer_info(
@@ -141,9 +142,10 @@ class SamFunctionProvider(SamBaseProvider):
                         stack.resources,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
-                    result[name] = SamFunctionProvider._convert_lambda_function_resource(
+                    f = SamFunctionProvider._convert_lambda_function_resource(
                         stack.stack_path, name, resource_properties, layers
                     )
+                    result[f.full_path] = f
 
                 # We don't care about other resource types. Just ignore them
 

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -102,13 +102,13 @@ class SamFunctionProvider(SamBaseProvider):
         Extracts and returns function information from the given dictionary of SAM/CloudFormation resources. This
         method supports functions defined with AWS::Serverless::Function and AWS::Lambda::Function
 
-        :param dict resources_by_stack: Dictionary of SAM/CloudFormation resources by stack
+        :param stacks: List of SAM/CloudFormation stacks to extract functions from
         :param bool ignore_code_extraction_warnings: suppress log statements on code extraction from resources.
-        :return dict(string : samcli.commands.local.lib.provider.Function): Dictionary of function LogicalId to the
+        :return dict(string : samcli.commands.local.lib.provider.Function): Dictionary of function full_path to the
             Function configuration object
         """
 
-        result = {}  # dict: full_path -> Function
+        result: Dict[str, Function] = {}  # a dict with full_path as key and extracted function as value
         for stack in stacks:
             for name, resource in stack.resources.items():
 
@@ -126,14 +126,14 @@ class SamFunctionProvider(SamBaseProvider):
                         stack.resources,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
-                    f = SamFunctionProvider._convert_sam_function_resource(
+                    function = SamFunctionProvider._convert_sam_function_resource(
                         stack.stack_path,
                         name,
                         resource_properties,
                         layers,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
-                    result[f.full_path] = f
+                    result[function.full_path] = function
 
                 elif resource_type == SamFunctionProvider.LAMBDA_FUNCTION:
                     layers = SamFunctionProvider._parse_layer_info(
@@ -142,10 +142,10 @@ class SamFunctionProvider(SamBaseProvider):
                         stack.resources,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
-                    f = SamFunctionProvider._convert_lambda_function_resource(
+                    function = SamFunctionProvider._convert_lambda_function_resource(
                         stack.stack_path, name, resource_properties, layers
                     )
-                    result[f.full_path] = f
+                    result[function.full_path] = function
 
                 # We don't care about other resource types. Just ignore them
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

This is a follow up of #2594, 2nd PR to support nested stack.
*These two commits are taken out from https://github.com/aahung/aws-sam-cli/tree/nested-stack-2

#### Why is this change necessary?

two functions with the same name can appear in two different nested stacks, which causing one overriding the other. 

#### How does it address the issue?

Before the dict's key is function name, which is not unique in a multi-stack setting. Now the key is a unique key "full_path" consisting of stack_path and function name.

#### What side effects does this change have?

N/A, nested stack support is not available and this PR has no customer impact.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
