### PR TITLE
fix: Custom region is not passed properly in local invoke

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -132,7 +132,12 @@ class InvokeContext:
         self._debug_args = debug_args
         self._debugger_path = debugger_path
         self._container_env_vars_file = container_env_vars_file
+
         self._parameter_overrides = parameter_overrides or {}
+        # Override certain CloudFormation pseudo-parameters based on values provided by customer
+        if aws_region:
+            self._parameter_overrides["AWS::Region"] = aws_region
+
         self._layer_cache_basedir = layer_cache_basedir
         self._force_image_build = force_image_build
         self._aws_region = aws_region
@@ -372,10 +377,6 @@ class InvokeContext:
 
     @property
     def parameter_overrides(self):
-        # Override certain CloudFormation pseudo-parameters based on values provided by customer
-        if self._aws_region:
-            self._parameter_overrides["AWS::Region"] = self._aws_region
-
         return self._parameter_overrides
 
     @property

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -133,10 +133,10 @@ class InvokeContext:
         self._debugger_path = debugger_path
         self._container_env_vars_file = container_env_vars_file
 
-        self._parameter_overrides = parameter_overrides or {}
+        self.parameter_overrides = parameter_overrides or {}
         # Override certain CloudFormation pseudo-parameters based on values provided by customer
         if aws_region:
-            self._parameter_overrides["AWS::Region"] = aws_region
+            self.parameter_overrides["AWS::Region"] = aws_region
 
         self._layer_cache_basedir = layer_cache_basedir
         self._force_image_build = force_image_build
@@ -376,16 +376,12 @@ class InvokeContext:
         return cwd
 
     @property
-    def parameter_overrides(self):
-        return self._parameter_overrides
-
-    @property
     def _is_debugging(self):
         return bool(self._debug_context)
 
     def _get_stacks(self):
         try:
-            return SamLocalStackProvider.get_stacks(self._template_file, parameter_overrides=self._parameter_overrides)
+            return SamLocalStackProvider.get_stacks(self._template_file, parameter_overrides=self.parameter_overrides)
         except (TemplateNotFoundException, TemplateFailedParsingException) as ex:
             raise InvokeContextException(str(ex)) from ex
 

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -44,7 +44,7 @@ class TestInvokeContext__enter__(TestCase):
         )
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context._parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -79,7 +79,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context._parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -127,7 +127,7 @@ class TestInvokeContext__enter__(TestCase):
         invoke_context._initialize_all_functions_containers = _initialize_all_functions_containers_mock
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context._parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -162,7 +162,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context._parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -212,7 +212,7 @@ class TestInvokeContext__enter__(TestCase):
         invoke_context._initialize_all_functions_containers = _initialize_all_functions_containers_mock
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context._parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -246,7 +246,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context._parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(
             invoke_context._get_env_vars_value.call_args_list, [call("env_vars_file"), call("container_env_vars_file")]
@@ -293,7 +293,7 @@ class TestInvokeContext__enter__(TestCase):
         )
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context._parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -328,7 +328,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context._parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -44,7 +44,7 @@ class TestInvokeContext__enter__(TestCase):
         )
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, invoke_context._parameter_overrides, template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -79,7 +79,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -127,7 +127,7 @@ class TestInvokeContext__enter__(TestCase):
         invoke_context._initialize_all_functions_containers = _initialize_all_functions_containers_mock
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, invoke_context._parameter_overrides, template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -162,7 +162,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -212,7 +212,7 @@ class TestInvokeContext__enter__(TestCase):
         invoke_context._initialize_all_functions_containers = _initialize_all_functions_containers_mock
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, invoke_context._parameter_overrides, template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -246,7 +246,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(
             invoke_context._get_env_vars_value.call_args_list, [call("env_vars_file"), call("container_env_vars_file")]
@@ -293,7 +293,7 @@ class TestInvokeContext__enter__(TestCase):
         )
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, invoke_context._parameter_overrides, template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -328,7 +328,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -1059,3 +1059,11 @@ class TestInvokeContext_get_debug_context(TestCase):
         resolve_path_mock.is_dir.assert_called_once()
         pathlib_path_mock.resolve.assert_called_once_with(strict=True)
         pathlib_mock.assert_called_once_with("./path")
+
+
+class TestInvokeContext_get_stacks(TestCase):
+    @patch("samcli.commands.local.cli_common.invoke_context.SamLocalStackProvider.get_stacks")
+    def test_must_pass_custom_region(self, get_stacks_mock):
+        invoke_context = InvokeContext("template_file", aws_region="my-custom-region")
+        invoke_context._get_stacks()
+        get_stacks_mock.assert_called_with("template_file", parameter_overrides={"AWS::Region": "my-custom-region"})


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

Fix local invoke with custom region. Somehow it was not caught in the canary run yesterday https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux/builds/37696048/job/5vth4t3503scpn9a

#### How does it address the issue?

Caused by a typo in #2594, `_parameter_overrides` should be `parameter_overrides`.
This also further refactors how property `parameter_overrides` works. Doing mutation in property getter is not a good practice. When I looked at the code I did not realize `parameter_overrides` could mutate `_parameter_overrides` and is different from `_parameter_overrides`. The mutation has been moved to the constructor.

#### What side effects does this change have?

N/A

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
