### PR TITLE
fix: Nested stack cannot be extracted if root template is not in working dir

### DIFF
--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -23,7 +23,9 @@ class SamLocalStackProvider(SamBaseProvider):
     # see get_stacks() for info about this env var
     ENV_SAM_CLI_ENABLE_NESTED_STACK = "SAM_CLI_ENABLE_NESTED_STACK"
 
-    def __init__(self, stack_path: str, template_dict: Dict, parameter_overrides: Optional[Dict] = None):
+    def __init__(
+        self, template_file: str, stack_path: str, template_dict: Dict, parameter_overrides: Optional[Dict] = None
+    ):
         """
         Initialize the class with SAM template data. The SAM template passed to this provider is assumed
         to be valid, normalized and a dictionary. It should be normalized by running all pre-processing
@@ -32,11 +34,14 @@ class SamLocalStackProvider(SamBaseProvider):
         This class does not perform any syntactic validation of the template.
         After the class is initialized, any changes to the ``template_dict`` will not be reflected in here.
         You need to explicitly update the class with new template, if necessary.
+        :param str template_file: SAM Stack Template file path
+        :param str stack_path: SAM Stack stack_path (See samcli.lib.providers.provider.Stack.stack_path)
         :param dict template_dict: SAM Template as a dictionary
         :param dict parameter_overrides: Optional dictionary of values for SAM template parameters that might want
             to get substituted within the template
         """
 
+        self._template_directory = os.path.dirname(template_file)
         self._stack_path = stack_path
         self._template_dict = self.get_template(template_dict, parameter_overrides)
         self._resources = self._template_dict.get("Resources", {})
@@ -94,10 +99,12 @@ class SamLocalStackProvider(SamBaseProvider):
             stack: Optional[Stack] = None
             if resource_type == SamLocalStackProvider.SERVERLESS_APPLICATION:
                 stack = SamLocalStackProvider._convert_sam_application_resource(
-                    self._stack_path, name, resource_properties
+                    self._template_directory, self._stack_path, name, resource_properties
                 )
             if resource_type == SamLocalStackProvider.CLOUDFORMATION_STACK:
-                stack = SamLocalStackProvider._convert_cfn_stack_resource(self._stack_path, name, resource_properties)
+                stack = SamLocalStackProvider._convert_cfn_stack_resource(
+                    self._template_directory, self._stack_path, name, resource_properties
+                )
 
             if stack:
                 result[name] = stack
@@ -107,7 +114,9 @@ class SamLocalStackProvider(SamBaseProvider):
         return result
 
     @staticmethod
-    def _convert_sam_application_resource(stack_path: str, name: str, resource_properties: Dict) -> Optional[Stack]:
+    def _convert_sam_application_resource(
+        template_directory: str, stack_path: str, name: str, resource_properties: Dict
+    ) -> Optional[Stack]:
         location = resource_properties.get("Location")
 
         if isinstance(location, dict):
@@ -129,6 +138,8 @@ class SamLocalStackProvider(SamBaseProvider):
             return None
         if location.startswith("file://"):
             location = unquote(urlparse(location).path)
+        elif not os.path.isabs(location):
+            location = os.path.join(template_directory, os.path.relpath(location))
 
         return Stack(
             parent_stack_path=stack_path,
@@ -139,7 +150,9 @@ class SamLocalStackProvider(SamBaseProvider):
         )
 
     @staticmethod
-    def _convert_cfn_stack_resource(stack_path: str, name: str, resource_properties: Dict) -> Optional[Stack]:
+    def _convert_cfn_stack_resource(
+        template_directory: str, stack_path: str, name: str, resource_properties: Dict
+    ) -> Optional[Stack]:
         template_url = resource_properties.get("TemplateURL", "")
 
         if SamLocalStackProvider.is_remote_url(template_url):
@@ -151,6 +164,8 @@ class SamLocalStackProvider(SamBaseProvider):
             return None
         if template_url.startswith("file://"):
             template_url = unquote(urlparse(template_url).path)
+        elif not os.path.isabs(template_url):
+            template_url = os.path.join(template_directory, os.path.relpath(template_url))
 
         return Stack(
             parent_stack_path=stack_path,
@@ -176,7 +191,7 @@ class SamLocalStackProvider(SamBaseProvider):
         if not os.environ.get(SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK, False):
             return stacks
 
-        current = SamLocalStackProvider(stack_path, template_dict, parameter_overrides)
+        current = SamLocalStackProvider(template_file, stack_path, template_dict, parameter_overrides)
         for child_stack in current.get_all():
             stacks.extend(
                 SamLocalStackProvider.get_stacks(

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -29,8 +29,8 @@ class TestSamBuildableStackProvider(TestCase):
 
     @parameterized.expand(
         [
-            (AWS_SERVERLESS_APPLICATION, "Location", "./child.yaml", "./child.yaml"),
-            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "./child.yaml", "./child.yaml"),
+            (AWS_SERVERLESS_APPLICATION, "Location", "./child.yaml", "child.yaml"),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "./child.yaml", "child.yaml"),
             (AWS_SERVERLESS_APPLICATION, "Location", "file:///child.yaml", "/child.yaml"),
             (AWS_CLOUDFORMATION_STACK, "TemplateURL", "file:///child.yaml", "/child.yaml"),
         ]
@@ -103,8 +103,8 @@ class TestSamBuildableStackProvider(TestCase):
         )
 
     def test_sam_deep_nested_stack(self):
-        child_template_file = "./child.yaml"
-        grand_child_template_file = "./grand-child.yaml"
+        child_template_file = "child.yaml"
+        grand_child_template_file = "grand-child.yaml"
         template = {
             "Resources": {
                 "ChildStack": {
@@ -166,5 +166,46 @@ class TestSamBuildableStackProvider(TestCase):
             stacks,
             [
                 Stack("", "", self.template_file, None, template),
+            ],
+        )
+
+    @parameterized.expand(
+        [
+            (AWS_SERVERLESS_APPLICATION, "Location", "./child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_SERVERLESS_APPLICATION, "Location", "child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "./child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_SERVERLESS_APPLICATION, "Location", "file:///child.yaml", "/child.yaml"),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "file:///child.yaml", "/child.yaml"),
+        ]
+    )
+    def test_sam_nested_stack_template_path_can_be_resolved_if_root_template_is_not_in_working_dir(
+        self, resource_type, location_property_name, child_location, child_location_path
+    ):
+        template_file = "somedir/template.yaml"
+        template = {
+            "Resources": {
+                "ChildStack": {
+                    "Type": resource_type,
+                    "Properties": {location_property_name: child_location},
+                }
+            }
+        }
+        self.get_template_data_mock.side_effect = lambda t: {
+            template_file: template,
+            child_location_path: LEAF_TEMPLATE,
+        }.get(t)
+        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
+            stacks = SamLocalStackProvider.get_stacks(
+                template_file,
+                "",
+                "",
+                parameter_overrides=None,
+            )
+        self.assertListEqual(
+            stacks,
+            [
+                Stack("", "", template_file, None, template),
+                Stack("", "ChildStack", child_location_path, None, LEAF_TEMPLATE),
             ],
         )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

This is a follow up of #2594, to support nested stack.

#### Why is this change necessary?

If root template is not `./template.yaml` or in current working directory, local nested templates cannot be resolved properly.

#### How does it address the issue?

Does a path derivation depending on whether nested template location is absolute path or not. If it is not, it is joined with parent's template directory.

#### What side effects does this change have?

N/A, nested stack support is not available and this PR has no customer impact.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
