### PR TITLE
fix: If image functions have same metadata, only 1st one is in the result

### DIFF
--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -125,16 +125,18 @@ class DefaultBuildStrategy(BuildStrategy):
         function_build_results[single_function_name] = result
 
         # copy results to other functions
-        for function in build_definition.functions:
-            if function.name != single_function_name:
-                if build_definition.packagetype == ZIP:
+        if build_definition.packagetype == ZIP:
+            for function in build_definition.functions:
+                if function.name != single_function_name:
                     # for zip function we need to copy over the artifacts
                     # artifacts directory will be created by the builder
                     artifacts_dir = str(pathlib.Path(self._build_dir, function.name))
                     LOG.debug("Copying artifacts from %s to %s", single_build_dir, artifacts_dir)
                     osutils.copytree(single_build_dir, artifacts_dir)
                     function_build_results[function.name] = artifacts_dir
-                elif build_definition.packagetype == IMAGE:
+        elif build_definition.packagetype == IMAGE:
+            for function in build_definition.functions:
+                if function.name != single_function_name:
                     # for image function, we just need to copy the image tag
                     function_build_results[function.name] = result
 

--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -125,14 +125,18 @@ class DefaultBuildStrategy(BuildStrategy):
         function_build_results[single_function_name] = result
 
         # copy results to other functions
-        if build_definition.packagetype == ZIP:
-            for function in build_definition.functions:
-                if function.name is not single_function_name:
+        for function in build_definition.functions:
+            if function.name != single_function_name:
+                if build_definition.packagetype == ZIP:
+                    # for zip function we need to copy over the artifacts
                     # artifacts directory will be created by the builder
                     artifacts_dir = str(pathlib.Path(self._build_dir, function.name))
                     LOG.debug("Copying artifacts from %s to %s", single_build_dir, artifacts_dir)
                     osutils.copytree(single_build_dir, artifacts_dir)
                     function_build_results[function.name] = artifacts_dir
+                elif build_definition.packagetype == IMAGE:
+                    # for image function, we just need to copy the image tag
+                    function_build_results[function.name] = result
 
         return function_build_results
 

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1157,6 +1157,43 @@ class TestBuildWithDedupBuilds(DedupBuildIntegBase):
     ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
     "Skip build tests on windows when running in CI unless overridden",
 )
+class TestBuildWithDedupImageBuilds(DedupBuildIntegBase):
+    template = "dedup-functions-image-template.yaml"
+
+    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.flaky(reruns=3)
+    def test_dedup_build(self, use_container):
+        if use_container and SKIP_DOCKER_TESTS:
+            self.skipTest(SKIP_DOCKER_MESSAGE)
+
+        """
+        Build template above and verify that each function call returns as expected
+        """
+        overrides = {
+            "Function1Handler": "main.first_function_handler",
+            "Function2Handler": "main.second_function_handler",
+            "FunctionRuntime": "3.7",
+            "DockerFile": "Dockerfile",
+            "Tag": f"{random.randint(1,100)}",
+        }
+        cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
+
+        LOG.info("Running Command: {}".format(cmdlist))
+        run_command(cmdlist, cwd=self.working_dir)
+
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, "HelloWorldFunction", self._make_parameter_override_arg(overrides), "Hello World"
+            )
+            self._verify_invoke_built_function(
+                self.built_template, "HelloMarsFunction", self._make_parameter_override_arg(overrides), "Hello Mars"
+            )
+
+
+@skipIf(
+    ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
 class TestBuildWithDedupBuildsMakefile(DedupBuildIntegBase):
     template = "dedup-functions-makefile-template.yaml"
 

--- a/tests/integration/testdata/buildcmd/PythonImage/main.py
+++ b/tests/integration/testdata/buildcmd/PythonImage/main.py
@@ -9,3 +9,11 @@ def handler(event, context):
     # print(Fernet.generate_key())
 
     return {"pi": "{0:.2f}".format(numpy.pi)}
+
+
+def first_function_handler(event, context):
+    return "Hello World"
+
+
+def second_function_handler(event, context):
+    return "Hello Mars"

--- a/tests/integration/testdata/buildcmd/dedup-functions-image-template.yaml
+++ b/tests/integration/testdata/buildcmd/dedup-functions-image-template.yaml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 20
+    MemorySize: 512
+
+Parameteres:
+  Function1Handler:
+    Type: String
+  Function2Handler:
+    Type: String
+  FunctionRuntime:
+    Type: String
+  DockerFile:
+    Type: String
+  Tag:
+    Type: String
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - !Ref Function1Handler
+      Timeout: 600
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: ./PythonImage
+      Dockerfile: !Ref DockerFile
+      DockerBuildArgs:
+        BASE_RUNTIME: !Ref FunctionRuntime
+
+  HelloMarsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - !Ref Function2Handler
+      Timeout: 600
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: ./PythonImage
+      Dockerfile: !Ref DockerFile
+      DockerBuildArgs:
+        BASE_RUNTIME: !Ref FunctionRuntime

--- a/tests/unit/lib/build_module/test_build_strategy.py
+++ b/tests/unit/lib/build_module/test_build_strategy.py
@@ -12,7 +12,7 @@ from samcli.lib.build.build_strategy import (
 from samcli.lib.utils import osutils
 from pathlib import Path
 
-from samcli.lib.utils.packagetype import ZIP
+from samcli.lib.utils.packagetype import ZIP, IMAGE
 
 
 @patch("samcli.lib.build.build_graph.BuildGraph._write")
@@ -192,6 +192,31 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
             str(mock_path(given_build_dir, self.function_build_definition1.get_function_name())),
             str(mock_path(given_build_dir, self.function1_2.name)),
         )
+
+    def test_build_single_function_definition_image_functions_with_same_metadata(self, mock_copy_tree, mock_path):
+        given_build_function = Mock()
+        built_image = Mock()
+        given_build_function.return_value = built_image
+        given_build_layer = Mock()
+        given_build_dir = "build_dir"
+        default_build_strategy = DefaultBuildStrategy(
+            self.build_graph, given_build_dir, given_build_function, given_build_layer
+        )
+
+        function1 = Mock()
+        function1.name = "Function"
+        function1.full_path = "Function"
+        function1.packagetype = IMAGE
+        function2 = Mock()
+        function2.name = "Function2"
+        function2.packagetype = IMAGE
+        build_definition = FunctionBuildDefinition("3.7", "codeuri", IMAGE, {})
+        # since they have the same metadata, they are put into the same build_definition.
+        build_definition.functions = [function1, function2]
+
+        result = default_build_strategy.build_single_function_definition(build_definition)
+        # both of the function name should show up in results
+        self.assertEqual(result, {"Function": built_image, "Function2": built_image})
 
 
 class CachedBuildStrategyTest(BuildStrategyBaseTest):


### PR DESCRIPTION
…s built

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
