### PR TITLE
Feat: Added new cli command to invoke remote funtions

### DIFF
--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -16,6 +16,7 @@ _SAM_CLI_COMMAND_PACKAGES = [
     "samcli.commands.init",
     "samcli.commands.validate.validate",
     "samcli.commands.build",
+    "samcli.commands.invoke",
     "samcli.commands.local.local",
     "samcli.commands.package",
     "samcli.commands.deploy",

--- a/samcli/commands/invoke/__init__.py
+++ b/samcli/commands/invoke/__init__.py
@@ -1,0 +1,6 @@
+"""
+`sam Invoke` command
+"""
+
+# Expose the cli object here
+from .command import cli  # noqa

--- a/samcli/commands/invoke/command.py
+++ b/samcli/commands/invoke/command.py
@@ -1,0 +1,91 @@
+"""
+CLI command for "invoke" command
+"""
+
+import logging
+
+import click
+
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
+from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
+from samcli.lib.telemetry.metric import track_command
+from samcli.lib.utils.events import get_event
+from samcli.lib.utils.version_checker import check_newer_version
+
+LOG = logging.getLogger(__name__)
+
+HELP_TEXT = """
+You can use this command to remotly execute your function in AWS.
+You can pass in an event body using the -e (--event) parameter.
+Logs from the Lambda function will be written to stdout.\n
+\b
+Invoking a Lambda function without an input event
+$ sam invoke "HelloWorldFunction --stack-name mystack"\n
+\b
+Invoking a specific Lambda version
+$ sam invoke "HelloWorldFunction --stack-name mystack --qualifier 7"\n
+\b
+Invoking a Lambda function using an event file
+$ sam invoke "HelloWorldFunction" --stack-name mystack -e event.json\n
+\b
+Invoking a Lambda function using input from stdin
+$ echo '{"message": "Hey, are you there?" }' | sam invoke "HelloWorldFunction" --stack-name mystack --event -
+\b
+You can also invoke using the function's name.
+$ sam invoke mystack-HelloWorldFunction-1FJ8PD36GML2Q \n
+"""
+
+
+@click.command("invoke", help=HELP_TEXT, short_help="Invokes a remote lambda from aws")
+@configuration_option(provider=TomlProvider(section="parameters"))
+@click.option("--qualifier", default=None, help="Version of the Lambda Function.")
+@click.option("--stack-name", default=None, help="Name of the AWS CloudFormation stack that the function is a part of.")
+@click.option(
+    "--event",
+    "-e",
+    type=click.Path(),
+    help="JSON file containing event data passed to the Lambda function during invoke. If this option "
+         "is not specified, no event is assumed. Pass in the value '-' to input JSON via stdin",
+)
+@cli_framework_options
+@aws_creds_options
+@click.argument("function_name", required=False)
+@pass_context
+@track_command
+@check_newer_version
+def cli(
+        ctx,
+        function_name,
+        event,
+        stack_name,
+        qualifier,
+        config_file,
+        config_env,
+):  # pylint: disable=redefined-builtin
+    # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
+
+    do_cli(function_name, stack_name, event, qualifier)  # pragma: no cover
+
+
+def do_cli(function_name, stack_name, event, qualifier):
+    """
+    Implementation of the ``cli`` method
+    """
+    from .invoke_context import InvokeCommandContext
+
+    LOG.debug("'invoke' command is called")
+
+    if event:
+        event_data = get_event(event)
+    else:
+        event_data = "{}"
+
+    with InvokeCommandContext(
+            function_name,
+            stack_name=stack_name
+    ) as context:
+
+        context.lambda_runner.invoke(
+            context.function_physical_id, event=event_data, qualifier=qualifier,
+            stdout=click.get_binary_stream('stdout'), stderr=click.get_binary_stream('stderr')
+        )

--- a/samcli/commands/invoke/invoke_context.py
+++ b/samcli/commands/invoke/invoke_context.py
@@ -1,0 +1,207 @@
+"""
+Read and parse CLI args for the Invoke Command and setup the context for running the command
+"""
+
+import logging
+
+import boto3
+import botocore
+
+from samcli.commands.exceptions import UserException
+from samcli.lib.invoke.runner import InvokeRunner
+from samcli.lib.utils import osutils
+from samcli.lib.utils.stream_writer import StreamWriter
+
+LOG = logging.getLogger(__name__)
+
+
+class InvalidTimestampError(UserException):
+    pass
+
+
+class InvokeCommandContext:
+    """
+    Sets up a context to run the Invoke command by parsing the CLI arguments and creating necessary objects to be able
+    to invoke the remote lambda
+
+    This class **must** be used inside a ``with`` statement as follows:
+
+        with InvokeCommandContext(**kwargs) as context:
+            context.lambda_runner.invoke(...)
+    """
+
+    def __init__(
+        self, function_name, stack_name, output_file=None
+    ):
+        """
+        Initializes the context
+
+        Parameters
+        ----------
+        function_name : str
+            Name of the function to invoke
+
+        stack_name : str
+            Name of the stack where the function is available
+
+        output_file : str
+            Write function output to this file instead of Terminal
+        """
+
+        self._function_name = function_name
+        self._stack_name = stack_name
+        self._output_file = output_file
+        self._output_file_handle = None
+
+        self._lambda_client = boto3.client("lambda")
+        self._cfn_client = boto3.client("cloudformation")
+
+    def __enter__(self):
+        """
+        Performs some basic checks and returns itself when everything is ready to invoke a Lambda function.
+
+        Returns
+        -------
+        InvokeCommandContext
+            Returns this object
+        """
+
+        self._output_file_handle = self._setup_output_file(self._output_file)
+
+        return self
+
+    def __exit__(self, *args):
+        """
+        Cleanup any necessary opened files
+        """
+
+        if self._output_file_handle:
+            self._output_file_handle.close()
+            self._output_file_handle = None
+
+    @property
+    def lambda_runner(self):
+        return InvokeRunner(self._lambda_client)
+
+    @property
+    def stdout(self):
+        """
+        Returns stream writer for stdout to output Lambda function logs to
+
+        Returns
+        -------
+        samcli.lib.utils.stream_writer.StreamWriter
+            Stream writer for stdout
+        """
+        stream = self._output_file_handle if self._output_file_handle else osutils.stdout()
+        return StreamWriter(stream)
+
+    @property
+    def stderr(self):
+        """
+        Returns stream writer for stderr to output Lambda function errors to
+
+        Returns
+        -------
+        samcli.lib.utils.stream_writer.StreamWriter
+            Stream writer for stderr
+        """
+        stream = self._output_file_handle if self._output_file_handle else osutils.stderr()
+        return StreamWriter(stream)
+
+    @property
+    def function_physical_id(self):
+        """
+        Physical ID of the AWS Lambda that we will be executing. It generates the name based on the
+        Lambda Function name and stack name provided.
+
+        Returns
+        -------
+        str
+            Lambda Physical ID
+        """
+
+        function_id = self._get_resource_id_from_stack(self._cfn_client, self._stack_name, self._function_name)
+        LOG.debug(
+            "Function with LogicalId '%s' in stack '%s' resolves to actual physical ID '%s'",
+            self._function_name,
+            self._stack_name,
+            function_id,
+        )
+
+        return function_id
+
+    @property
+    def output_file_handle(self):
+        return self._output_file_handle
+
+    @staticmethod
+    def _setup_output_file(output_file):
+        """
+        Open a log file if necessary and return the file handle. This will create a file if it does not exist
+
+        Parameters
+        ----------
+        output_file : str
+            Path to a file where the logs should be written to
+
+        Returns
+        -------
+        Handle to the opened log file, if necessary. None otherwise
+        """
+        if not output_file:
+            return None
+
+        return open(output_file, "wb")
+
+    @staticmethod
+    def _get_resource_id_from_stack(cfn_client, stack_name, logical_id):
+        """
+        Given the LogicalID of a resource, call AWS CloudFormation to get physical ID of the resource within
+        the specified stack.
+
+        Parameters
+        ----------
+        cfn_client
+            CloudFormation client provided by AWS SDK
+
+        stack_name : str
+            Name of the stack to query
+
+        logical_id : str
+            LogicalId of the resource
+
+        Returns
+        -------
+        str
+            Physical ID of the resource
+
+        Raises
+        ------
+        samcli.commands.exceptions.UserException
+            If the stack or resource does not exist
+        """
+
+        LOG.debug(
+            "Getting resource's PhysicalId from AWS CloudFormation stack. StackName=%s, LogicalId=%s",
+            stack_name,
+            logical_id,
+        )
+
+        try:
+            response = cfn_client.describe_stack_resource(StackName=stack_name, LogicalResourceId=logical_id)
+
+            LOG.debug("Response from AWS CloudFormation %s", response)
+            return response["StackResourceDetail"]["PhysicalResourceId"]
+
+        except botocore.exceptions.ClientError as ex:
+            LOG.debug(
+                "Unable to fetch resource name from CloudFormation Stack: "
+                "StackName=%s, ResourceLogicalId=%s, Response=%s",
+                stack_name,
+                logical_id,
+                ex.response,
+            )
+
+            # The exception message already has a well formatted error message that we can surface to user
+            raise UserException(str(ex), wrapped_from=ex.response["Error"]["Code"]) from ex

--- a/samcli/lib/invoke/runner.py
+++ b/samcli/lib/invoke/runner.py
@@ -1,0 +1,70 @@
+"""
+Invokes remote Lambda
+"""
+import json
+import logging
+from json.decoder import JSONDecodeError
+
+LOG = logging.getLogger(__name__)
+
+
+class InvokeRunner:
+    """
+    Invokes a remote lambda with a given event payload
+    """
+
+    def __init__(self, lambda_client=None):
+        """
+        Initialize the runner
+
+        Parameters
+        ----------
+        lambda_client
+            Lambda Client from AWS SDK
+        """
+        self.lambda_client = lambda_client
+
+    def invoke(self, lambda_id, event, qualifier=None, stdout=None, stderr=None):
+        """
+        Invokes a lambda under a given event and writes its output to the terminal or a given file.
+
+        Parameters
+        ----------
+        lambda_id : string
+            Lambda Physical ID.
+
+        event : dict
+            Event payload
+
+        qualifier : string
+            Optional Function version to execute
+
+        stdout : StreamWriter
+            Optional Stream writer to write the output of the Lambda function to.
+
+        stderr : StreamWriter
+            Optional Stream writer to write the Lambda runtime logs to.
+        """
+
+        kwargs = {
+            "FunctionName": lambda_id,
+            "InvocationType": "RequestResponse",
+            # "LogType": "Tail",
+            "Payload": event,
+        }
+
+        if qualifier:
+            kwargs.update({
+                "Qualifier": qualifier
+            })
+
+        result = self.lambda_client.invoke(**kwargs)
+
+        payload = result['Payload'].read()
+        try:
+            formatted_payload = json.dumps(json.loads(payload), indent=4, sort_keys=True)
+            stdout.write(bytes(formatted_payload, encoding="utf-8") + b"\n")
+
+        except JSONDecodeError as ex:
+            # The response probably isn't in json format, print the raw payload instead
+            stdout.write(payload + b"\n")

--- a/samcli/lib/utils/events.py
+++ b/samcli/lib/utils/events.py
@@ -1,0 +1,28 @@
+"""
+Utility function to handle events from STDIN and paths
+"""
+
+import logging
+
+import click
+
+STDIN_FILE_NAME = "-"
+LOG = logging.getLogger(__name__)
+
+
+def get_event(event_file_name):
+    """
+    Read the event JSON data from the given file. If no file is provided, read the event from stdin.
+
+    :param string event_file_name: Path to event file, or '-' for stdin
+    :return string: Contents of the event file or stdin
+    """
+
+    if event_file_name == STDIN_FILE_NAME:
+        # If event is empty, listen to stdin for event data until EOF
+        LOG.info("Reading invoke payload from stdin (you can also pass it from file with --event)")
+
+    # click.open_file knows to open stdin when filename is '-'. This is safer than manually opening streams, and
+    # accidentally closing a standard stream
+    with click.open_file(event_file_name, "r", encoding="utf-8") as fp:
+        return fp.read()

--- a/tests/unit/lib/utils/test_events.py
+++ b/tests/unit/lib/utils/test_events.py
@@ -1,0 +1,31 @@
+"""
+Tests Utils events
+"""
+
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from parameterized import parameterized, param
+
+from samcli.lib.utils.events import get_event
+
+STDIN_FILE_NAME = "-"
+
+
+class TestGetEvent(TestCase):
+    @parameterized.expand([param(STDIN_FILE_NAME), param("somefile")])
+    @patch("samcli.lib.utils.events.click")
+    def test_must_work_with_stdin(self, filename, click_mock):
+        event_data = "some data"
+
+        # Mock file pointer
+        fp_mock = Mock()
+
+        # Mock the context manager
+        click_mock.open_file.return_value.__enter__.return_value = fp_mock
+        fp_mock.read.return_value = event_data
+
+        result = get_event(filename)
+
+        self.assertEqual(result, event_data)
+        fp_mock.read.assert_called_with()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#2550

#### Why is this change necessary?
Be able to invoke deployed functions from the local environment

#### How does it address the issue?
This pr adds a new command with the following command schema
`sam invoke "HelloWorldFunction --stack-name mystack --qualifier 7 -e event.json`

#### What side effects does this change have?
The function `samcli.commands.local.invoke.cli._get_event` was moved to `samcli.lib.utils.events.get_event`
In order to be reutilized in the new command.


#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
