### PR TITLE
chore: Provide future support for nested stack in local invoke/start-api/start-lambda

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -59,6 +59,6 @@ ignore_missing_imports=True
 ignore_missing_imports=True
 
 # progressive add typechecks and these modules already complete the process, let's keep them clean
-[mypy-samcli.commands.build,samcli.lib.build.*,samcli.commands.local.cli_common.invoke_context]
+[mypy-samcli.commands.build,samcli.lib.build.*,samcli.commands.local.cli_common.invoke_context,samcli.commands.local.lib.local_lambda]
 disallow_untyped_defs=True
 disallow_incomplete_defs=True

--- a/mypy.ini
+++ b/mypy.ini
@@ -59,6 +59,6 @@ ignore_missing_imports=True
 ignore_missing_imports=True
 
 # progressive add typechecks and these modules already complete the process, let's keep them clean
-[mypy-samcli.commands.build,samcli.lib.build.*]
+[mypy-samcli.commands.build,samcli.lib.build.*,samcli.commands.local.cli_common.invoke_context]
 disallow_untyped_defs=True
 disallow_incomplete_defs=True

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -5,7 +5,7 @@ Context object used by build command
 import logging
 import os
 import shutil
-from typing import Optional, Dict, List
+from typing import Optional, List
 import pathlib
 
 from samcli.lib.providers.provider import ResourcesToBuildCollector, Stack
@@ -60,7 +60,6 @@ class BuildContext:
 
         self._function_provider: Optional[SamFunctionProvider] = None
         self._layer_provider: Optional[SamLayerProvider] = None
-        self._template_dict: Optional[Dict] = None
         self._container_manager: Optional[ContainerManager] = None
         self._stacks: List[Stack] = []
 
@@ -69,7 +68,6 @@ class BuildContext:
         self._stacks = SamLocalStackProvider.get_stacks(
             self._template_file, parameter_overrides=self._parameter_overrides
         )
-        self._template_dict = SamLocalStackProvider.find_root_stack(self.stacks).template_dict
 
         self._function_provider = SamFunctionProvider(self.stacks)
         self._layer_provider = SamLayerProvider(self.stacks)
@@ -133,11 +131,6 @@ class BuildContext:
     def layer_provider(self) -> SamLayerProvider:
         # same as function_provider()
         return self._layer_provider  # type: ignore
-
-    @property
-    def template_dict(self) -> Dict:
-        # same as function_provider()
-        return self._template_dict  # type: ignore
 
     @property
     def build_dir(self) -> str:

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -134,10 +134,11 @@ class InvokeContext:
         self._debugger_path = debugger_path
         self._container_env_vars_file = container_env_vars_file
 
-        self.parameter_overrides = parameter_overrides or {}
+        self._parameter_overrides = parameter_overrides
         # Override certain CloudFormation pseudo-parameters based on values provided by customer
+        self._pseudo_parameter_overrides: Optional[Dict] = None
         if aws_region:
-            self.parameter_overrides["AWS::Region"] = aws_region
+            self._pseudo_parameter_overrides = {"AWS::Region": aws_region}
 
         self._layer_cache_basedir = layer_cache_basedir
         self._force_image_build = force_image_build
@@ -397,7 +398,11 @@ class InvokeContext:
 
     def _get_stacks(self) -> List[Stack]:
         try:
-            return SamLocalStackProvider.get_stacks(self._template_file, parameter_overrides=self.parameter_overrides)
+            return SamLocalStackProvider.get_stacks(
+                self._template_file,
+                parameter_overrides=self._parameter_overrides,
+                pseudo_parameter_overrides=self._pseudo_parameter_overrides,
+            )
         except (TemplateNotFoundException, TemplateFailedParsingException) as ex:
             raise InvokeContextException(str(ex)) from ex
 

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import posixpath
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, IO, cast, Tuple, Any
@@ -288,12 +289,12 @@ class InvokeContext:
             return all_functions[0].name
 
         # Get all the available function names to print helpful exception message
-        all_function_names = [f.name for f in all_functions]
+        all_function_full_paths = [posixpath.join(f.stack_path, f.name) for f in all_functions]
 
         # There are more functions in the template, and function identifier is not provided, hence raise.
         raise InvokeContextException(
-            "You must provide a function identifier (function's Logical ID in the template). "
-            "Possible options in your template: {}".format(all_function_names)
+            "You must provide a function logical ID when there are more than one functions in your template. "
+            "Possible options in your template: {}".format(all_function_full_paths)
         )
 
     @property

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -154,12 +154,13 @@ class InvokeContext:
 
         self._debug_function = debug_function
 
-        # Note(xinhol): despite self._template_dict and self._function_provider are initialized as None
+        # Note(xinhol): despite self._template_dict, self._function_provider and self._stacks are initialized as None
         # they will be assigned with a non-None value in __enter__() and
         # it is only used in the context (after __enter__ is called)
         # so we can assume they are not Optional here
         self._template_dict: Dict = None  # type: ignore
         self._function_provider: SamFunctionProvider = None  # type: ignore
+        self._stacks: List[Stack] = None  # type: ignore
         self._env_vars_value: Optional[Dict] = None
         self._container_env_vars_value: Optional[Dict] = None
         self._log_file_handle: Optional[IO] = None
@@ -177,9 +178,9 @@ class InvokeContext:
         :returns InvokeContext: Returns this object
         """
 
-        stacks = self._get_stacks()
-        self._template_dict = SamLocalStackProvider.find_root_stack(stacks).template_dict
-        self._function_provider = SamFunctionProvider(stacks)
+        self._stacks = self._get_stacks()
+        self._template_dict = SamLocalStackProvider.find_root_stack(self._stacks).template_dict
+        self._function_provider = SamFunctionProvider(self._stacks)
 
         self._env_vars_value = self._get_env_vars_value(self._env_vars_file)
         self._container_env_vars_value = self._get_env_vars_value(self._container_env_vars_file)
@@ -364,6 +365,15 @@ class InvokeContext:
         :return dict: Template data
         """
         return self._template_dict
+
+    @property
+    def stacks(self) -> List[Stack]:
+        """
+        Returns the list of stacks (including the root stack and all children stacks)
+
+        :return list: list of stacks
+        """
+        return self._stacks
 
     def get_cwd(self) -> str:
         """

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -136,9 +136,9 @@ class InvokeContext:
 
         self._parameter_overrides = parameter_overrides
         # Override certain CloudFormation pseudo-parameters based on values provided by customer
-        self._pseudo_parameter_overrides: Optional[Dict] = None
+        self._global_parameter_overrides: Optional[Dict] = None
         if aws_region:
-            self._pseudo_parameter_overrides = {"AWS::Region": aws_region}
+            self._global_parameter_overrides = {"AWS::Region": aws_region}
 
         self._layer_cache_basedir = layer_cache_basedir
         self._force_image_build = force_image_build
@@ -390,7 +390,7 @@ class InvokeContext:
             return SamLocalStackProvider.get_stacks(
                 self._template_file,
                 parameter_overrides=self._parameter_overrides,
-                pseudo_parameter_overrides=self._pseudo_parameter_overrides,
+                global_parameter_overrides=self._global_parameter_overrides,
             )
         except (TemplateNotFoundException, TemplateFailedParsingException) as ex:
             raise InvokeContextException(str(ex)) from ex

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -301,7 +301,7 @@ class InvokeContext:
     @property
     def lambda_runtime(self) -> LambdaRuntime:
         if not self._lambda_runtimes:
-            layer_downloader = LayerDownloader(self._layer_cache_basedir, self.get_cwd())
+            layer_downloader = LayerDownloader(self._layer_cache_basedir, self.get_cwd(), self._stacks)
             image_builder = LambdaImage(layer_downloader, self._skip_pull_image, self._force_image_build)
             self._lambda_runtimes = {
                 ContainersMode.WARM: WarmLambdaRuntime(self._container_manager, image_builder),

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -5,7 +5,6 @@ import errno
 import json
 import logging
 import os
-import posixpath
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, IO, cast, Tuple, Any
@@ -289,7 +288,7 @@ class InvokeContext:
             return all_functions[0].name
 
         # Get all the available function names to print helpful exception message
-        all_function_full_paths = [posixpath.join(f.stack_path, f.name) for f in all_functions]
+        all_function_full_paths = [f.full_path for f in all_functions]
 
         # There are more functions in the template, and function identifier is not provided, hence raise.
         raise InvokeContextException(

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -155,11 +155,10 @@ class InvokeContext:
 
         self._debug_function = debug_function
 
-        # Note(xinhol): despite self._template_dict, self._function_provider and self._stacks are initialized as None
+        # Note(xinhol): despite self._function_provider and self._stacks are initialized as None
         # they will be assigned with a non-None value in __enter__() and
         # it is only used in the context (after __enter__ is called)
         # so we can assume they are not Optional here
-        self._template_dict: Dict = None  # type: ignore
         self._function_provider: SamFunctionProvider = None  # type: ignore
         self._stacks: List[Stack] = None  # type: ignore
         self._env_vars_value: Optional[Dict] = None
@@ -180,7 +179,6 @@ class InvokeContext:
         """
 
         self._stacks = self._get_stacks()
-        self._template_dict = SamLocalStackProvider.find_root_stack(self._stacks).template_dict
         self._function_provider = SamFunctionProvider(self._stacks)
 
         self._env_vars_value = self._get_env_vars_value(self._env_vars_file)
@@ -357,15 +355,6 @@ class InvokeContext:
         """
         stream = self._log_file_handle if self._log_file_handle else osutils.stderr()
         return StreamWriter(stream, self._is_debugging)
-
-    @property
-    def template(self) -> Dict:
-        """
-        Returns the template data as dictionary
-
-        :return dict: Template data
-        """
-        return self._template_dict
 
     @property
     def stacks(self) -> List[Stack]:

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -269,10 +269,10 @@ class InvokeContext:
         cast(WarmLambdaRuntime, self.lambda_runtime).clean_running_containers_and_related_resources()
 
     @property
-    def function_name(self) -> str:
+    def function_identifier(self) -> str:
         """
-        Returns name of the function to invoke. If no function identifier is provided, this method will return name of
-        the only function from the template
+        Returns identifier of the function to invoke. If no function identifier is provided, this method will return
+        logicalID of the only function from the template
 
         :return string: Name of the function
         :raises InvokeContextException: If function identifier is not provided
@@ -285,10 +285,10 @@ class InvokeContext:
 
         all_functions = list(self._function_provider.get_all())
         if len(all_functions) == 1:
-            return all_functions[0].functionname
+            return all_functions[0].name
 
         # Get all the available function names to print helpful exception message
-        all_function_names = [f.functionname for f in all_functions]
+        all_function_names = [f.name for f in all_functions]
 
         # There are more functions in the template, and function identifier is not provided, hence raise.
         raise InvokeContextException(

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -162,7 +162,7 @@ def do_cli(  # pylint: disable=R0914
 
             # Invoke the function
             context.local_lambda_runner.invoke(
-                context.function_name, event=event_data, stdout=context.stdout, stderr=context.stderr
+                context.function_identifier, event=event_data, stdout=context.stdout, stderr=context.stderr
             )
 
     except FunctionNotFound as ex:

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -34,9 +34,7 @@ class LocalApiService:
         self.static_dir = static_dir
 
         self.cwd = lambda_invoke_context.get_cwd()
-        self.api_provider = ApiProvider(
-            lambda_invoke_context.template, parameter_overrides=lambda_invoke_context.parameter_overrides, cwd=self.cwd
-        )
+        self.api_provider = ApiProvider(lambda_invoke_context.stacks, cwd=self.cwd)
         self.lambda_runner = lambda_invoke_context.local_lambda_runner
         self.stderr_stream = lambda_invoke_context.stderr
 

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -162,10 +162,11 @@ class LocalLambdaRunner:
         if function.packagetype == ZIP:
             # the template file containing the function might not be in the same directory as root template file
             # therefore we need to join the path of template directory and codeuri in case codeuri is a relative path.
-            stacks = [stack for stack in self.provider.stacks if stack.stack_path == function.stack_path]
-            if not stacks:
+            try:
+                stack = next(stack for stack in self.provider.stacks if stack.stack_path == function.stack_path)
+            except StopIteration:
                 raise RuntimeError(f"Cannot find stack that matches function's stack_path {function.stack_path}")
-            stack = stacks[0]
+
             # Note(xinhol) function.codeuri might be None here, we should check first.
             codeuri = (
                 function.codeuri

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -4,7 +4,6 @@ Implementation of Local Lambda runner
 
 import os
 import logging
-import posixpath
 from typing import Any, Dict, Optional, cast
 import boto3
 
@@ -102,7 +101,7 @@ class LocalLambdaRunner:
         function = self.provider.get(function_identifier)
 
         if not function:
-            all_function_full_paths = [posixpath.join(f.stack_path, f.name) for f in self.provider.get_all()]
+            all_function_full_paths = [f.full_path for f in self.provider.get_all()]
             available_function_message = "{} not found. Possible options in your template: {}".format(
                 function_identifier, all_function_full_paths
             )

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -4,6 +4,7 @@ Implementation of Local Lambda runner
 
 import os
 import logging
+import posixpath
 from typing import Any, Dict, Optional, cast
 import boto3
 
@@ -101,9 +102,9 @@ class LocalLambdaRunner:
         function = self.provider.get(function_identifier)
 
         if not function:
-            all_functions = [f.name for f in self.provider.get_all()]
+            all_function_full_paths = [posixpath.join(f.stack_path, f.name) for f in self.provider.get_all()]
             available_function_message = "{} not found. Possible options in your template: {}".format(
-                function_identifier, all_functions
+                function_identifier, all_function_full_paths
             )
             LOG.info(available_function_message)
             raise FunctionNotFound("Unable to find a Function with name '{}'".format(function_identifier))

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -169,7 +169,7 @@ class LocalLambdaRunner:
                     f"Cannot find stack that matches function's stack_path {function.stack_path}"
                 ) from ex
 
-            # Note(xinhol) function.codeuri might be None here, we should check first.
+            # Note(xinhol): function.codeuri might be None here, we might want to add some check here.
             codeuri = (
                 function.codeuri
                 if os.path.isabs(function.codeuri)  # type: ignore

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -4,17 +4,24 @@ Implementation of Local Lambda runner
 
 import os
 import logging
+from typing import Any, Dict, Optional, cast
 import boto3
 
+from botocore.credentials import Credentials
+
+from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.lib.providers.sam_function_provider import SamFunctionProvider
 from samcli.lib.utils.codeuri import resolve_code_path
 from samcli.lib.utils.packagetype import ZIP, IMAGE
+from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.docker.container import ContainerResponseException
 from samcli.local.lambdafn.env_vars import EnvironmentVariables
 from samcli.local.lambdafn.config import FunctionConfig
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.local.lib.exceptions import InvalidIntermediateImageError
 from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError, NoPrivilegeException
+from samcli.lib.providers.provider import Function
+from samcli.local.lambdafn.runtime import LambdaRuntime
 
 LOG = logging.getLogger(__name__)
 
@@ -29,14 +36,14 @@ class LocalLambdaRunner:
 
     def __init__(
         self,
-        local_runtime,
+        local_runtime: LambdaRuntime,
         function_provider: SamFunctionProvider,
-        cwd,
-        aws_profile=None,
-        aws_region=None,
-        env_vars_values=None,
-        debug_context=None,
-    ):
+        cwd: str,
+        aws_profile: Optional[str] = None,
+        aws_region: Optional[str] = None,
+        env_vars_values: Optional[Dict[Any, Any]] = None,
+        debug_context: Optional[DebugContext] = None,
+    ) -> None:
         """
         Initializes the class
 
@@ -57,10 +64,16 @@ class LocalLambdaRunner:
         self.aws_region = aws_region
         self.env_vars_values = env_vars_values or {}
         self.debug_context = debug_context
-        self._boto3_session_creds = None
-        self._boto3_region = None
+        self._boto3_session_creds: Optional[Dict[str, str]] = None
+        self._boto3_region: Optional[str] = None
 
-    def invoke(self, function_name, event, stdout=None, stderr=None):
+    def invoke(
+        self,
+        function_name: str,
+        event: str,
+        stdout: Optional[StreamWriter] = None,
+        stderr: Optional[StreamWriter] = None,
+    ) -> None:
         """
         Find the Lambda function with given name and invoke it. Pass the given event to the function and return
         response through the given streams.
@@ -114,7 +127,7 @@ class LocalLambdaRunner:
             LOG.info("No response from invoke container for %s", function.name)
         except OSError as os_error:
             # pylint: disable=no-member
-            if hasattr(os_error, "winerror") and os_error.winerror == 1314:
+            if hasattr(os_error, "winerror") and os_error.winerror == 1314:  # type: ignore
                 raise NoPrivilegeException(
                     "Administrator, Windows Developer Mode, "
                     "or SeCreateSymbolicLinkPrivilege is required to create symbolic link for files: {}, {}".format(
@@ -124,7 +137,7 @@ class LocalLambdaRunner:
 
             raise
 
-    def is_debugging(self):
+    def is_debugging(self) -> bool:
         """
         Are we debugging the invoke?
 
@@ -136,7 +149,7 @@ class LocalLambdaRunner:
         """
         return bool(self.debug_context)
 
-    def get_invoke_config(self, function):
+    def get_invoke_config(self, function: Function) -> FunctionConfig:
         """
         Returns invoke configuration to pass to Lambda Runtime to invoke the given function
 
@@ -153,10 +166,11 @@ class LocalLambdaRunner:
             if not stacks:
                 raise RuntimeError(f"Cannot find stack that matches function's stack_path {function.stack_path}")
             stack = stacks[0]
+            # Note(xinhol) function.codeuri might be None here, we should check first.
             codeuri = (
                 function.codeuri
-                if os.path.isabs(function.codeuri)
-                else os.path.join(os.path.dirname(stack.location), function.codeuri)
+                if os.path.isabs(function.codeuri)  # type: ignore
+                else os.path.join(os.path.dirname(stack.location), function.codeuri)  # type: ignore
             )
             code_abs_path = resolve_code_path(self.cwd, codeuri)
             LOG.debug("Resolved absolute path to code is %s", code_abs_path)
@@ -183,7 +197,7 @@ class LocalLambdaRunner:
             env_vars=env_vars,
         )
 
-    def _make_env_vars(self, function):
+    def _make_env_vars(self, function: Function) -> EnvironmentVariables:
         """Returns the environment variables configuration for this function
 
         Parameters
@@ -206,7 +220,7 @@ class LocalLambdaRunner:
         name = function.name
 
         variables = None
-        if function.environment and isinstance(function.environment, dict) and "Variables" in function.environment:
+        if isinstance(function.environment, dict) and "Variables" in function.environment:
             variables = function.environment["Variables"]
         else:
             LOG.debug("No environment variables found for function '%s'", name)
@@ -246,13 +260,18 @@ class LocalLambdaRunner:
             shell_env_values=shell_env,
             override_values=overrides,
             aws_creds=aws_creds,
-        )
+        )  # EnvironmentVariables is not yet annotated with type hints, disable mypy check for now. type: ignore
 
-    def _get_session_creds(self):
+    def _get_session_creds(self) -> Credentials:
         if self._boto3_session_creds is None:
             # to pass command line arguments for region & profile to setup boto3 default session
             LOG.debug("Loading AWS credentials from session with profile '%s'", self.aws_profile)
-            session = boto3.session.Session(profile_name=self.aws_profile, region_name=self.aws_region)
+            # The signature of boto3.session.Session defines the default values of profile_name and region_name
+            # so they should be Optional. But mypy follows its docstring which does not have "Optional."
+            # Here we trick mypy thinking they are both str rather than Optional[str].
+            session = boto3.session.Session(
+                profile_name=cast(str, self.aws_profile), region_name=cast(str, self.aws_region)
+            )
 
             # check for region_name in session and cache
             if hasattr(session, "region_name") and session.region_name:
@@ -264,7 +283,7 @@ class LocalLambdaRunner:
 
         return self._boto3_session_creds
 
-    def get_aws_creds(self):
+    def get_aws_creds(self) -> Dict[str, str]:
         """
         Returns AWS credentials obtained from the shell environment or given profile
 
@@ -272,7 +291,7 @@ class LocalLambdaRunner:
              {"region": "", "key": "", "secret": "", "sessiontoken": ""}. If credentials could not be resolved,
              this returns None
         """
-        result = {}
+        result: Dict[str, str] = {}
 
         # Load the credentials from profile/environment
         creds = self._get_session_creds()

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -164,8 +164,10 @@ class LocalLambdaRunner:
             # therefore we need to join the path of template directory and codeuri in case codeuri is a relative path.
             try:
                 stack = next(stack for stack in self.provider.stacks if stack.stack_path == function.stack_path)
-            except StopIteration:
-                raise RuntimeError(f"Cannot find stack that matches function's stack_path {function.stack_path}")
+            except StopIteration as ex:
+                raise RuntimeError(
+                    f"Cannot find stack that matches function's stack_path {function.stack_path}"
+                ) from ex
 
             # Note(xinhol) function.codeuri might be None here, we should check first.
             codeuri = (

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -69,7 +69,7 @@ class LocalLambdaRunner:
 
     def invoke(
         self,
-        function_name: str,
+        function_identifier: str,
         event: str,
         stdout: Optional[StreamWriter] = None,
         stderr: Optional[StreamWriter] = None,
@@ -82,8 +82,8 @@ class LocalLambdaRunner:
 
         Parameters
         ----------
-        function_name str
-            Name of the Lambda function to invoke
+        function_identifier str
+            Identifier of the Lambda function to invoke, it can be logicalID, function name or full path
         event str
             Event data passed to the function. Must be a valid JSON String.
         stdout samcli.lib.utils.stream_writer.StreamWriter
@@ -98,23 +98,23 @@ class LocalLambdaRunner:
         """
 
         # Generate the correct configuration based on given inputs
-        function = self.provider.get(function_name)
+        function = self.provider.get(function_identifier)
 
         if not function:
             all_functions = [f.name for f in self.provider.get_all()]
             available_function_message = "{} not found. Possible options in your template: {}".format(
-                function_name, all_functions
+                function_identifier, all_functions
             )
             LOG.info(available_function_message)
-            raise FunctionNotFound("Unable to find a Function with name '{}'".format(function_name))
+            raise FunctionNotFound("Unable to find a Function with name '{}'".format(function_identifier))
 
-        LOG.debug("Found one Lambda function with name '%s'", function_name)
+        LOG.debug("Found one Lambda function with name '%s'", function_identifier)
         if function.packagetype == ZIP:
             LOG.info("Invoking %s (%s)", function.handler, function.runtime)
         elif function.packagetype == IMAGE:
             if not function.imageuri:
                 raise InvalidIntermediateImageError(
-                    f"ImageUri not provided for Function: {function_name} of PackageType: {function.packagetype}"
+                    f"ImageUri not provided for Function: {function_identifier} of PackageType: {function.packagetype}"
                 )
             LOG.info("Invoking Container created from %s", function.imageuri)
         config = self.get_invoke_config(function)

--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -14,13 +14,15 @@ class SwaggerParser:
     _BINARY_MEDIA_TYPES_EXTENSION_KEY = "x-amazon-apigateway-binary-media-types"  # pylint: disable=C0103
     _ANY_METHOD = "ANY"
 
-    def __init__(self, swagger):
+    def __init__(self, stack_path: str, swagger):
         """
         Constructs an Swagger Parser object
 
+        :param str stack_path: Path of the stack the resource is located
         :param dict swagger: Dictionary representation of a Swagger document
         """
         self.swagger = swagger or {}
+        self.stack_path = stack_path
 
     def get_binary_media_types(self):
         """
@@ -91,6 +93,7 @@ class SwaggerParser:
                     methods=[method],
                     event_type=event_type,
                     payload_format_version=payload_format_version,
+                    stack_path=self.stack_path,
                 )
                 result.append(route)
         return result

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -5,6 +5,7 @@ routes in a standardized format
 
 import logging
 from collections import defaultdict
+from typing import Optional, List
 
 from samcli.local.apigw.local_apigw_service import Route
 from samcli.lib.providers.provider import Api
@@ -145,12 +146,12 @@ class ApiCollector:
 
         Return
         -------
-        A list of routes without duplicate routes with the same function_name and method
+        A list of routes without duplicate routes with the same stack_path, function_name and method
         """
         grouped_routes = {}
 
         for route in routes:
-            key = "{}-{}".format(route.function_name, route.path)
+            key = "{}-{}-{}".format(route.stack_path, route.function_name, route.path)
             config = grouped_routes.get(key, None)
             methods = route.methods
             if config:
@@ -162,10 +163,11 @@ class ApiCollector:
                 methods=sorted_methods,
                 event_type=route.event_type,
                 payload_format_version=route.payload_format_version,
+                stack_path=route.stack_path,
             )
         return list(grouped_routes.values())
 
-    def add_binary_media_types(self, logical_id, binary_media_types):
+    def add_binary_media_types(self, logical_id: str, binary_media_types: Optional[List[str]]) -> None:
         """
         Stores the binary media type configuration for the API with given logical ID
         Parameters

--- a/samcli/lib/providers/api_provider.py
+++ b/samcli/lib/providers/api_provider.py
@@ -1,19 +1,19 @@
 """Class that provides the Api with a list of routes from a Template"""
 
 import logging
+from typing import List
 
 from samcli.lib.providers.api_collector import ApiCollector
 from samcli.lib.providers.cfn_api_provider import CfnApiProvider
 from samcli.lib.providers.cfn_base_api_provider import CfnBaseApiProvider
-from samcli.lib.providers.provider import AbstractApiProvider
+from samcli.lib.providers.provider import AbstractApiProvider, Stack
 from samcli.lib.providers.sam_api_provider import SamApiProvider
-from samcli.lib.providers.sam_base_provider import SamBaseProvider
 
 LOG = logging.getLogger(__name__)
 
 
 class ApiProvider(AbstractApiProvider):
-    def __init__(self, template_dict, parameter_overrides=None, cwd=None):
+    def __init__(self, stacks: List[Stack], cwd=None):
         """
         Initialize the class with template data. The template_dict is assumed
         to be valid, normalized and a dictionary. template_dict should be normalized by running any and all
@@ -25,20 +25,17 @@ class ApiProvider(AbstractApiProvider):
 
         Parameters
         ----------
-        template_dict : dict
-            Template as a dictionary
+        stacks : dict
+            List of stacks apis are extracted from
 
         cwd : str
             Optional working directory with respect to which we will resolve relative path to Swagger file
         """
-        self.template_dict = SamBaseProvider.get_template(template_dict, parameter_overrides)
-        self.resources = self.template_dict.get("Resources", {})
-
-        LOG.debug("%d resources found in the template", len(self.resources))
+        self.stacks = stacks
 
         # Store a set of apis
         self.cwd = cwd
-        self.api = self._extract_api(self.resources)
+        self.api = self._extract_api()
         self.routes = self.api.routes
         LOG.debug("%d APIs found in the template", len(self.routes))
 
@@ -51,44 +48,43 @@ class ApiProvider(AbstractApiProvider):
 
         yield self.api
 
-    def _extract_api(self, resources):
+    def _extract_api(self):
         """
         Extracts all the routes by running through the one providers. The provider that has the first type matched
         will be run across all the resources
 
         Parameters
         ----------
-        resources: dict
-            The dictionary containing the different resources within the template
         Returns
         ---------
         An Api from the parsed template
         """
 
         collector = ApiCollector()
-        provider = self.find_api_provider(resources)
-        provider.extract_resources(resources, collector, cwd=self.cwd)
+        provider = self.find_api_provider(self.stacks)
+        provider.extract_resources(self.stacks, collector, cwd=self.cwd)
         return collector.get_api()
 
     @staticmethod
-    def find_api_provider(resources):
+    def find_api_provider(stacks: List[Stack]):
         """
         Finds the ApiProvider given the first api type of the resource
 
         Parameters
         -----------
-        resources: dict
-            The dictionary containing the different resources within the template
+        stacks: List[Stack]
+            List of stacks apis are extracted from
 
         Return
         ----------
         Instance of the ApiProvider that will be run on the template with a default of SamApiProvider
         """
-        for _, resource in resources.items():
-            if resource.get(CfnBaseApiProvider.RESOURCE_TYPE) in SamApiProvider.TYPES:
-                return SamApiProvider()
+        for stack in stacks:
+            for _, resource in stack.resources.items():
+                if resource.get(CfnBaseApiProvider.RESOURCE_TYPE) in SamApiProvider.TYPES:
+                    return SamApiProvider()
 
-            if resource.get(CfnBaseApiProvider.RESOURCE_TYPE) in CfnApiProvider.TYPES:
-                return CfnApiProvider()
+                if resource.get(CfnBaseApiProvider.RESOURCE_TYPE) in CfnApiProvider.TYPES:
+                    return CfnApiProvider()
 
         return SamApiProvider()

--- a/samcli/lib/providers/cfn_api_provider.py
+++ b/samcli/lib/providers/cfn_api_provider.py
@@ -1,7 +1,9 @@
 """Parses SAM given a template"""
 import logging
+from typing import List
 
 from samcli.commands.local.lib.swagger.integration_uri import LambdaUri
+from samcli.lib.providers.provider import Stack
 from samcli.local.apigw.local_apigw_service import Route
 from samcli.commands.local.cli_common.user_exceptions import InvalidSamTemplateException
 from samcli.lib.providers.cfn_base_api_provider import CfnBaseApiProvider
@@ -31,14 +33,14 @@ class CfnApiProvider(CfnBaseApiProvider):
         APIGATEWAY_V2_STAGE,
     ]
 
-    def extract_resources(self, resources, collector, cwd=None):
+    def extract_resources(self, stacks: List[Stack], collector, cwd=None):
         """
         Extract the Route Object from a given resource and adds it to the RouteCollector.
 
         Parameters
         ----------
-        resources: dict
-            The dictionary containing the different resources within the template
+        stacks: List[Stack]
+            List of stacks apis are extracted from
 
         collector: samcli.lib.providers.api_collector.ApiCollector
             Instance of the API collector that where we will save the API information
@@ -51,38 +53,43 @@ class CfnApiProvider(CfnBaseApiProvider):
         Returns a list of routes
         """
 
-        for logical_id, resource in resources.items():
-            resource_type = resource.get(CfnBaseApiProvider.RESOURCE_TYPE)
-            if resource_type == CfnApiProvider.APIGATEWAY_RESTAPI:
-                self._extract_cloud_formation_route(logical_id, resource, collector, cwd=cwd)
+        for stack in stacks:
+            resources = stack.resources
+            for logical_id, resource in resources.items():
+                resource_type = resource.get(CfnBaseApiProvider.RESOURCE_TYPE)
+                if resource_type == CfnApiProvider.APIGATEWAY_RESTAPI:
+                    self._extract_cloud_formation_route(stack.stack_path, logical_id, resource, collector, cwd=cwd)
 
-            if resource_type == CfnApiProvider.APIGATEWAY_STAGE:
-                self._extract_cloud_formation_stage(resources, resource, collector)
+                if resource_type == CfnApiProvider.APIGATEWAY_STAGE:
+                    self._extract_cloud_formation_stage(resources, resource, collector)
 
-            if resource_type == CfnApiProvider.APIGATEWAY_METHOD:
-                self._extract_cloud_formation_method(resources, logical_id, resource, collector)
+                if resource_type == CfnApiProvider.APIGATEWAY_METHOD:
+                    self._extract_cloud_formation_method(stack.stack_path, resources, logical_id, resource, collector)
 
-            if resource_type == CfnApiProvider.APIGATEWAY_V2_API:
-                self._extract_cfn_gateway_v2_api(logical_id, resource, collector, cwd=cwd)
+                if resource_type == CfnApiProvider.APIGATEWAY_V2_API:
+                    self._extract_cfn_gateway_v2_api(stack.stack_path, logical_id, resource, collector, cwd=cwd)
 
-            if resource_type == CfnApiProvider.APIGATEWAY_V2_ROUTE:
-                self._extract_cfn_gateway_v2_route(resources, logical_id, resource, collector)
+                if resource_type == CfnApiProvider.APIGATEWAY_V2_ROUTE:
+                    self._extract_cfn_gateway_v2_route(stack.stack_path, resources, logical_id, resource, collector)
 
-            if resource_type == CfnApiProvider.APIGATEWAY_V2_STAGE:
-                self._extract_cfn_gateway_v2_stage(resources, resource, collector)
+                if resource_type == CfnApiProvider.APIGATEWAY_V2_STAGE:
+                    self._extract_cfn_gateway_v2_stage(resources, resource, collector)
 
         all_apis = []
         for _, apis in collector:
             all_apis.extend(apis)
         return all_apis
 
-    def _extract_cloud_formation_route(self, logical_id, api_resource, collector, cwd=None):
+    def _extract_cloud_formation_route(self, stack_path: str, logical_id, api_resource, collector, cwd=None):
         """
         Extract APIs from AWS::ApiGateway::RestApi resource by reading and parsing Swagger documents. The result is
         added to the collector.
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         logical_id : str
             Logical ID of the resource
 
@@ -101,7 +108,7 @@ class CfnApiProvider(CfnBaseApiProvider):
             # Swagger is not found anywhere.
             LOG.debug("Skipping resource '%s'. Swagger document not found in Body and BodyS3Location", logical_id)
             return
-        self.extract_swagger_route(logical_id, body, body_s3_location, binary_media, collector, cwd)
+        self.extract_swagger_route(stack_path, logical_id, body, body_s3_location, binary_media, collector, cwd)
 
     @staticmethod
     def _extract_cloud_formation_stage(resources, stage_resource, collector):
@@ -136,12 +143,15 @@ class CfnApiProvider(CfnBaseApiProvider):
         collector.stage_name = stage_name
         collector.stage_variables = stage_variables
 
-    def _extract_cloud_formation_method(self, resources, logical_id, method_resource, collector):
+    def _extract_cloud_formation_method(self, stack_path: str, resources, logical_id, method_resource, collector):
         """
         Extract APIs from AWS::ApiGateway::Method and work backwards up the tree to resolve and find the true path.
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         resources: dict
             All Resource definition, including its properties
 
@@ -179,11 +189,14 @@ class CfnApiProvider(CfnBaseApiProvider):
             collector.add_binary_media_types(logical_id, [content_type])
 
         routes = Route(
-            methods=[method], function_name=self._get_integration_function_name(integration), path=resource_path
+            methods=[method],
+            function_name=self._get_integration_function_name(integration),
+            path=resource_path,
+            stack_path=stack_path,
         )
         collector.add_routes(rest_api_id, [routes])
 
-    def _extract_cfn_gateway_v2_api(self, logical_id, api_resource, collector, cwd=None):
+    def _extract_cfn_gateway_v2_api(self, stack_path: str, logical_id, api_resource, collector, cwd=None):
         """
         Extract APIs from AWS::ApiGatewayV2::Api resource by reading and parsing Swagger documents. The result is
         added to the collector. If the Swagger documents is not available, it can add a catch-all route based on
@@ -191,6 +204,9 @@ class CfnApiProvider(CfnBaseApiProvider):
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         logical_id : str
             Logical ID of the resource
 
@@ -219,19 +235,23 @@ class CfnApiProvider(CfnBaseApiProvider):
                     path=path,
                     function_name=LambdaUri.get_function_name(target),
                     event_type=Route.HTTP,
+                    stack_path=stack_path,
                 )
                 collector.add_routes(logical_id, [routes])
             return
 
-        self.extract_swagger_route(logical_id, body, body_s3_location, None, collector, cwd, Route.HTTP)
+        self.extract_swagger_route(stack_path, logical_id, body, body_s3_location, None, collector, cwd, Route.HTTP)
 
-    def _extract_cfn_gateway_v2_route(self, resources, logical_id, route_resource, collector):
+    def _extract_cfn_gateway_v2_route(self, stack_path: str, resources, logical_id, route_resource, collector):
         """
         Extract APIs from AWS::ApiGatewayV2::Route, and link it with the integration resource to get the lambda
         function.
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         resources: dict
             All Resource definition, including its properties
 
@@ -274,6 +294,7 @@ class CfnApiProvider(CfnBaseApiProvider):
             function_name=function_name,
             event_type=Route.HTTP,
             payload_format_version=payload_format_version,
+            stack_path=stack_path,
         )
         collector.add_routes(api_id, [routes])
 

--- a/samcli/lib/providers/cfn_base_api_provider.py
+++ b/samcli/lib/providers/cfn_base_api_provider.py
@@ -6,7 +6,7 @@ from samcli.commands.local.lib.swagger.parser import SwaggerParser
 from samcli.commands.local.lib.swagger.reader import SwaggerReader
 from samcli.lib.providers.api_collector import ApiCollector
 
-from samcli.lib.providers.provider import Cors
+from samcli.lib.providers.provider import Cors, Stack
 from samcli.local.apigw.local_apigw_service import Route
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 
@@ -16,14 +16,14 @@ LOG = logging.getLogger(__name__)
 class CfnBaseApiProvider:
     RESOURCE_TYPE = "Type"
 
-    def extract_resources(self, resources, collector, cwd=None):
+    def extract_resources(self, stacks: List[Stack], collector, cwd=None):
         """
         Extract the Route Object from a given resource and adds it to the RouteCollector.
 
         Parameters
         ----------
-        resources: dict
-            The dictionary containing the different resources within the template
+        stacks: List[Stack]
+            List of stacks apis are extracted from
 
         collector: samcli.lib.providers.api_collector.ApiCollector
             Instance of the API collector that where we will save the API information
@@ -39,10 +39,11 @@ class CfnBaseApiProvider:
 
     @staticmethod
     def extract_swagger_route(
+        stack_path: str,
         logical_id: str,
         body: Dict,
         uri: Union[str, Dict],
-        binary_media: List,
+        binary_media: Optional[List],
         collector: ApiCollector,
         cwd: Optional[str] = None,
         event_type=Route.API,
@@ -52,6 +53,9 @@ class CfnBaseApiProvider:
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         logical_id : str
             Logical ID of the resource
 
@@ -72,7 +76,7 @@ class CfnBaseApiProvider:
         """
         reader = SwaggerReader(definition_body=body, definition_uri=uri, working_dir=cwd)
         swagger = reader.read()
-        parser = SwaggerParser(swagger)
+        parser = SwaggerParser(stack_path, swagger)
         routes = parser.get_routes(event_type)
         LOG.debug("Found '%s' APIs in resource '%s'", len(routes), logical_id)
 

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -38,7 +38,7 @@ class Function(NamedTuple):
     codeuri: Optional[str]
     # Environment variables. This is a dictionary with one key called Variables inside it.
     # This contains the definition of environment variables
-    environment: Optional[str]
+    environment: Optional[Dict]
     # Lambda Execution IAM Role ARN. In the future, this can be used by Local Lambda runtime to assume the IAM role
     # to get credentials to run the container with. This gives a much higher fidelity simulation of cloud Lambda.
     rolearn: Optional[str]

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -374,7 +374,8 @@ class Stack(NamedTuple):
     name: str
     # The file location of the stack template.
     location: str
-    # The parameter overrides for the stack
+    # The parameter overrides for the stack, if there is global_parameter_overrides,
+    # it is also merged into this variable.
     parameters: Optional[Dict]
     # the raw template dict
     template_dict: Dict

--- a/samcli/lib/providers/sam_api_provider.py
+++ b/samcli/lib/providers/sam_api_provider.py
@@ -1,9 +1,11 @@
 """Parses SAM given the template"""
 
 import logging
+from typing import List
 
 from samcli.lib.providers.cfn_base_api_provider import CfnBaseApiProvider
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+from samcli.lib.providers.provider import Stack
 from samcli.local.apigw.local_apigw_service import Route
 
 LOG = logging.getLogger(__name__)
@@ -23,14 +25,14 @@ class SamApiProvider(CfnBaseApiProvider):
     IMPLICIT_API_RESOURCE_ID = "ServerlessRestApi"
     IMPLICIT_HTTP_API_RESOURCE_ID = "ServerlessHttpApi"
 
-    def extract_resources(self, resources, collector, cwd=None):
+    def extract_resources(self, stacks: List[Stack], collector, cwd=None):
         """
         Extract the Route Object from a given resource and adds it to the RouteCollector.
 
         Parameters
         ----------
-        resources: dict
-            The dictionary containing the different resources within the template
+        stacks: List[Stack]
+            List of stacks apis are extracted from
 
         collector: samcli.commands.local.lib.route_collector.ApiCollector
             Instance of the API collector that where we will save the API information
@@ -43,24 +45,28 @@ class SamApiProvider(CfnBaseApiProvider):
         # the template we are creating the implicit apis due to plugins that translate it in the SAM repo,
         # which we later merge with the explicit ones in SamApiProvider.merge_apis. This requires the code to be
         # parsed here and in InvokeContext.
-        for logical_id, resource in resources.items():
-            resource_type = resource.get(CfnBaseApiProvider.RESOURCE_TYPE)
-            if resource_type == SamApiProvider.SERVERLESS_FUNCTION:
-                self._extract_routes_from_function(logical_id, resource, collector)
-            if resource_type == SamApiProvider.SERVERLESS_API:
-                self._extract_from_serverless_api(logical_id, resource, collector, cwd=cwd)
-            if resource_type == SamApiProvider.SERVERLESS_HTTP_API:
-                self._extract_from_serverless_http(logical_id, resource, collector, cwd=cwd)
+        for stack in stacks:
+            for logical_id, resource in stack.resources.items():
+                resource_type = resource.get(CfnBaseApiProvider.RESOURCE_TYPE)
+                if resource_type == SamApiProvider.SERVERLESS_FUNCTION:
+                    self._extract_routes_from_function(stack.stack_path, logical_id, resource, collector)
+                if resource_type == SamApiProvider.SERVERLESS_API:
+                    self._extract_from_serverless_api(stack.stack_path, logical_id, resource, collector, cwd=cwd)
+                if resource_type == SamApiProvider.SERVERLESS_HTTP_API:
+                    self._extract_from_serverless_http(stack.stack_path, logical_id, resource, collector, cwd=cwd)
 
         collector.routes = self.merge_routes(collector)
 
-    def _extract_from_serverless_api(self, logical_id, api_resource, collector, cwd=None):
+    def _extract_from_serverless_api(self, stack_path: str, logical_id, api_resource, collector, cwd=None):
         """
         Extract APIs from AWS::Serverless::Api resource by reading and parsing Swagger documents. The result is added
         to the collector.
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         logical_id : str
             Logical ID of the resource
 
@@ -88,18 +94,21 @@ class SamApiProvider(CfnBaseApiProvider):
                 "Skipping resource '%s'. Swagger document not found in DefinitionBody and DefinitionUri", logical_id
             )
             return
-        self.extract_swagger_route(logical_id, body, uri, binary_media, collector, cwd=cwd)
+        self.extract_swagger_route(stack_path, logical_id, body, uri, binary_media, collector, cwd=cwd)
         collector.stage_name = stage_name
         collector.stage_variables = stage_variables
         collector.cors = cors
 
-    def _extract_from_serverless_http(self, logical_id, api_resource, collector, cwd=None):
+    def _extract_from_serverless_http(self, stack_path: str, logical_id, api_resource, collector, cwd=None):
         """
         Extract APIs from AWS::Serverless::HttpApi resource by reading and parsing Swagger documents.
         The result is added to the collector.
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         logical_id : str
             Logical ID of the resource
 
@@ -126,17 +135,20 @@ class SamApiProvider(CfnBaseApiProvider):
                 "Skipping resource '%s'. Swagger document not found in DefinitionBody and DefinitionUri", logical_id
             )
             return
-        self.extract_swagger_route(logical_id, body, uri, None, collector, cwd=cwd, event_type=Route.HTTP)
+        self.extract_swagger_route(stack_path, logical_id, body, uri, None, collector, cwd=cwd, event_type=Route.HTTP)
         collector.stage_name = stage_name
         collector.stage_variables = stage_variables
         collector.cors = cors
 
-    def _extract_routes_from_function(self, logical_id, function_resource, collector):
+    def _extract_routes_from_function(self, stack_path: str, logical_id, function_resource, collector):
         """
         Fetches a list of routes configured for this SAM Function resource.
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         logical_id : str
             Logical ID of the resourc
 
@@ -149,15 +161,18 @@ class SamApiProvider(CfnBaseApiProvider):
 
         resource_properties = function_resource.get("Properties", {})
         serverless_function_events = resource_properties.get(self._FUNCTION_EVENT, {})
-        self.extract_routes_from_events(logical_id, serverless_function_events, collector)
+        self.extract_routes_from_events(stack_path, logical_id, serverless_function_events, collector)
 
-    def extract_routes_from_events(self, function_logical_id, serverless_function_events, collector):
+    def extract_routes_from_events(self, stack_path: str, function_logical_id, serverless_function_events, collector):
         """
         Given an AWS::Serverless::Function Event Dictionary, extract out all 'route' events and store  within the
         collector
 
         Parameters
         ----------
+        stack_path : str
+            Path of the stack the resource is located
+
         function_logical_id : str
             LogicalId of the AWS::Serverless::Function
 
@@ -172,7 +187,7 @@ class SamApiProvider(CfnBaseApiProvider):
             event_type = event.get(self._EVENT_TYPE)
             if event_type in [self._EVENT_TYPE_API, self._EVENT_TYPE_HTTP_API]:
                 route_resource_id, route = self._convert_event_route(
-                    function_logical_id, event.get("Properties"), event.get(SamApiProvider._EVENT_TYPE)
+                    stack_path, function_logical_id, event.get("Properties"), event.get(SamApiProvider._EVENT_TYPE)
                 )
                 collector.add_routes(route_resource_id, [route])
                 count += 1
@@ -180,10 +195,11 @@ class SamApiProvider(CfnBaseApiProvider):
         LOG.debug("Found '%d' API Events in Serverless function with name '%s'", count, function_logical_id)
 
     @staticmethod
-    def _convert_event_route(lambda_logical_id, event_properties, event_type):
+    def _convert_event_route(stack_path: str, lambda_logical_id, event_properties, event_type):
         """
         Converts a AWS::Serverless::Function's Event Property to an Route configuration usable by the provider.
 
+        :param str stack_path: Path of the stack the resource is located
         :param str lambda_logical_id: Logical Id of the AWS::Serverless::Function
         :param dict event_properties: Dictionary of the Event's Property
         :return tuple: tuple of route resource name and route
@@ -223,6 +239,7 @@ class SamApiProvider(CfnBaseApiProvider):
                 function_name=lambda_logical_id,
                 event_type=event_type,
                 payload_format_version=payload_format_version,
+                stack_path=stack_path,
             ),
         )
 
@@ -233,6 +250,7 @@ class SamApiProvider(CfnBaseApiProvider):
         definition wins because that conveys clear intent that the API is backed by a function. This method will
         merge two such list of routes with the right order of precedence. If a Path+Method combination is defined
         in both the places, only one wins.
+        In a multi-stack situation, the API defined in the top level wins.
 
         Parameters
         ----------
@@ -261,8 +279,12 @@ class SamApiProvider(CfnBaseApiProvider):
         all_routes = {}
 
         # By adding implicit APIs to the end of the list, they will be iterated last. If a configuration was already
-        # written by explicit API, it will be overriden by implicit API, just by virtue of order of iteration.
-        all_configs = explicit_routes + implicit_routes
+        # written by explicit API, it will be overridden by implicit API, just by virtue of order of iteration.
+        # Within the explicit/implicit APIs, one defined in top level stack has the higher precedence. Here we
+        # use length of stack_path to order APIs (desc) due to top level stacks always have shorter stack_path.
+        all_configs = sorted(explicit_routes, key=lambda route: -len(route.stack_path)) + sorted(
+            implicit_routes, key=lambda route: -len(route.stack_path)
+        )
 
         for config in all_configs:
             # Normalize the methods before de-duping to allow an ANY method in implicit API to override a regular HTTP

--- a/samcli/lib/providers/sam_api_provider.py
+++ b/samcli/lib/providers/sam_api_provider.py
@@ -1,7 +1,6 @@
 """Parses SAM given the template"""
 
 import logging
-import re
 from typing import List
 
 from samcli.lib.providers.cfn_base_api_provider import CfnBaseApiProvider
@@ -282,9 +281,9 @@ class SamApiProvider(CfnBaseApiProvider):
         # By adding implicit APIs to the end of the list, they will be iterated last. If a configuration was already
         # written by explicit API, it will be overridden by implicit API, just by virtue of order of iteration.
         # Within the explicit/implicit APIs, one defined in top level stack has the higher precedence. Here we
-        # use negative depth of stack_path to sort APIs.
-        all_configs = sorted(explicit_routes, key=SamApiProvider._sort_key_stack_depth_desc) + sorted(
-            implicit_routes, key=SamApiProvider._sort_key_stack_depth_desc
+        # use depth of stack_path to sort APIs (desc).
+        all_configs = sorted(explicit_routes, key=SamApiProvider._get_route_stack_depth, reverse=True) + sorted(
+            implicit_routes, key=SamApiProvider._get_route_stack_depth, reverse=True
         )
 
         for config in all_configs:
@@ -310,15 +309,15 @@ class SamApiProvider(CfnBaseApiProvider):
         return list(result)
 
     @staticmethod
-    def _sort_key_stack_depth_desc(route: Route):
+    def _get_route_stack_depth(route: Route):
         """
-        Returns negative stack depth, used for sorted(routes, _sort_key_stack_depth_desc).
+        Returns stack depth, used for sorted(routes, _get_route_stack_depth).
         Examples:
-            "" (root stack), -depth = 0
-            "A" (1-level nested stack), -depth = -1
-            "A/B/C" (3-level nested stack), -depth = -3
+            "" (root stack), depth = 0
+            "A" (1-level nested stack), depth = 1
+            "A/B/C" (3-level nested stack), depth = 3
         """
 
         if not route.stack_path:
             return 0
-        return -(len(re.findall(r"/", route.stack_path)) + 1)
+        return route.stack_path.count("/") + 1

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -276,7 +276,25 @@ class SamLocalStackProvider(SamBaseProvider):
     def merge_parameter_overrides(
         parameter_overrides: Optional[Dict], global_parameter_overrides: Optional[Dict]
     ) -> Dict:
+        """
+        Combine global parameters and stack-specific parameters.
+        Right now the only global parameter override available is AWS::Region (via --region in "sam local"),
+        and AWS::Region won't appear in normal stack-specific parameter_overrides, so we don't
+        specify which type of parameters have high precedence.
+
+        Parameters
+        ----------
+        parameter_overrides: Optional[Dict]
+            stack-specific parameters
+        global_parameter_overrides: Optional[Dict]
+            global parameters
+
+        Returns
+        -------
+        Dict
+            merged dict containing both global and stack-specific parameters
+        """
         merged_parameter_overrides = {}
-        merged_parameter_overrides.update(parameter_overrides or {})
         merged_parameter_overrides.update(global_parameter_overrides or {})
+        merged_parameter_overrides.update(parameter_overrides or {})
         return merged_parameter_overrides

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -24,7 +24,12 @@ class SamLocalStackProvider(SamBaseProvider):
     ENV_SAM_CLI_ENABLE_NESTED_STACK = "SAM_CLI_ENABLE_NESTED_STACK"
 
     def __init__(
-        self, template_file: str, stack_path: str, template_dict: Dict, parameter_overrides: Optional[Dict] = None
+        self,
+        template_file: str,
+        stack_path: str,
+        template_dict: Dict,
+        parameter_overrides: Optional[Dict] = None,
+        pseudo_parameter_overrides: Optional[Dict] = None,
     ):
         """
         Initialize the class with SAM template data. The SAM template passed to this provider is assumed
@@ -39,12 +44,17 @@ class SamLocalStackProvider(SamBaseProvider):
         :param dict template_dict: SAM Template as a dictionary
         :param dict parameter_overrides: Optional dictionary of values for SAM template parameters that might want
             to get substituted within the template
+        :param dict pseudo_parameter_overrides: Optional dictionary of values for SAM template pseudo parameters
+            that might want to get substituted within the template and its child templates
         """
 
         self._template_directory = os.path.dirname(template_file)
         self._stack_path = stack_path
-        self._template_dict = self.get_template(template_dict, parameter_overrides)
+        self._template_dict = self.get_template(
+            template_dict, self.merge_parameter_overrides(parameter_overrides, pseudo_parameter_overrides)
+        )
         self._resources = self._template_dict.get("Resources", {})
+        self._pseudo_parameter_overrides = pseudo_parameter_overrides
 
         LOG.debug("%d stacks found in the template", len(self._resources))
 
@@ -115,7 +125,11 @@ class SamLocalStackProvider(SamBaseProvider):
 
     @staticmethod
     def _convert_sam_application_resource(
-        template_directory: str, stack_path: str, name: str, resource_properties: Dict
+        template_directory: str,
+        stack_path: str,
+        name: str,
+        resource_properties: Dict,
+        pseudo_parameter_overrides: Optional[Dict] = None,
     ) -> Optional[Stack]:
         location = resource_properties.get("Location")
 
@@ -145,13 +159,19 @@ class SamLocalStackProvider(SamBaseProvider):
             parent_stack_path=stack_path,
             name=name,
             location=location,
-            parameters=resource_properties.get("Parameters"),
+            parameters=SamLocalStackProvider.merge_parameter_overrides(
+                resource_properties.get("Parameters", {}), pseudo_parameter_overrides
+            ),
             template_dict=get_template_data(location),
         )
 
     @staticmethod
     def _convert_cfn_stack_resource(
-        template_directory: str, stack_path: str, name: str, resource_properties: Dict
+        template_directory: str,
+        stack_path: str,
+        name: str,
+        resource_properties: Dict,
+        pseudo_parameter_overrides: Optional[Dict] = None,
     ) -> Optional[Stack]:
         template_url = resource_properties.get("TemplateURL", "")
 
@@ -171,7 +191,9 @@ class SamLocalStackProvider(SamBaseProvider):
             parent_stack_path=stack_path,
             name=name,
             location=template_url,
-            parameters=resource_properties.get("Parameters"),
+            parameters=SamLocalStackProvider.merge_parameter_overrides(
+                resource_properties.get("Parameters", {}), pseudo_parameter_overrides
+            ),
             template_dict=get_template_data(template_url),
         )
 
@@ -181,9 +203,41 @@ class SamLocalStackProvider(SamBaseProvider):
         stack_path: str = "",
         name: str = "",
         parameter_overrides: Optional[Dict] = None,
+        pseudo_parameter_overrides: Optional[Dict] = None,
     ) -> List[Stack]:
+        """
+        Recursively extract stacks from a template file.
+
+        Parameters
+        ----------
+        template_file: str
+            the file path of the template to extract stacks from
+        stack_path: str
+            the stack path of the parent stack, for root stack, it is ""
+        name: str
+            the name of the stack associated with the template_file, for root stack, it is ""
+        parameter_overrides: Optional[Dict]
+            Optional dictionary of values for SAM template parameters that might want
+            to get substituted within the template
+        pseudo_parameter_overrides: Optional[Dict]
+            Optional dictionary of values for SAM template pseudo parameters
+            that might want to get substituted within the template and its child templates
+
+        Returns
+        -------
+        stacks: List[Stack]
+            The list of stacks extracted from template_file
+        """
         template_dict = get_template_data(template_file)
-        stacks = [Stack(stack_path, name, template_file, parameter_overrides, template_dict)]
+        stacks = [
+            Stack(
+                stack_path,
+                name,
+                template_file,
+                SamLocalStackProvider.merge_parameter_overrides(parameter_overrides, pseudo_parameter_overrides),
+                template_dict,
+            )
+        ]
 
         # Note(xinhol): recursive get_stacks is only enabled in tests by env var SAM_CLI_ENABLE_NESTED_STACK.
         # We will remove this env var and make this method recursive by default
@@ -191,7 +245,9 @@ class SamLocalStackProvider(SamBaseProvider):
         if not os.environ.get(SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK, False):
             return stacks
 
-        current = SamLocalStackProvider(template_file, stack_path, template_dict, parameter_overrides)
+        current = SamLocalStackProvider(
+            template_file, stack_path, template_dict, parameter_overrides, pseudo_parameter_overrides
+        )
         for child_stack in current.get_all():
             stacks.extend(
                 SamLocalStackProvider.get_stacks(
@@ -199,6 +255,7 @@ class SamLocalStackProvider(SamBaseProvider):
                     os.path.join(stack_path, name),
                     child_stack.name,
                     child_stack.parameters,
+                    pseudo_parameter_overrides,
                 )
             )
         return stacks
@@ -214,3 +271,12 @@ class SamLocalStackProvider(SamBaseProvider):
             stacks_str = ", ".join([stack.stack_path for stack in stacks])
             raise ValueError(f"{stacks_str} does not contain a root stack")
         return candidates[0]
+
+    @staticmethod
+    def merge_parameter_overrides(
+        parameter_overrides: Optional[Dict], pseudo_parameter_overrides: Optional[Dict]
+    ) -> Dict:
+        merged_parameter_overrides = {}
+        merged_parameter_overrides.update(parameter_overrides or {})
+        merged_parameter_overrides.update(pseudo_parameter_overrides or {})
+        return merged_parameter_overrides

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import base64
+from typing import List, Optional
 
 from flask import Flask, request
 from werkzeug.datastructures import Headers
@@ -38,7 +39,14 @@ class Route:
     ANY_HTTP_METHODS = ["GET", "DELETE", "PUT", "POST", "HEAD", "OPTIONS", "PATCH"]
 
     def __init__(
-        self, function_name, path, methods, event_type=API, payload_format_version=None, is_default_route=False
+        self,
+        function_name: str,
+        path: str,
+        methods: List[str],
+        event_type: str = API,
+        payload_format_version: Optional[str] = None,
+        is_default_route: bool = False,
+        stack_path: str = "",
     ):
         """
         Creates an ApiGatewayRoute
@@ -49,6 +57,7 @@ class Route:
         :param str event_type: Type of the event. "Api" or "HttpApi"
         :param str payload_format_version: version of payload format
         :param bool is_default_route: determines if the default route or not
+        :param str stack_path: path of the stack the route is located
         """
         self.methods = self.normalize_method(methods)
         self.function_name = function_name
@@ -56,6 +65,7 @@ class Route:
         self.event_type = event_type
         self.payload_format_version = payload_format_version
         self.is_default_route = is_default_route
+        self.stack_path = stack_path
 
     def __eq__(self, other):
         return (
@@ -63,10 +73,12 @@ class Route:
             and sorted(self.methods) == sorted(other.methods)
             and self.function_name == other.function_name
             and self.path == other.path
+            and self.stack_path == other.stack_path
         )
 
     def __hash__(self):
-        route_hash = hash(self.function_name) * hash(self.path)
+        # stack_path could be empty string, and hash('') = 0. To avoid that, we add a prefix to stack_path
+        route_hash = hash(self.function_name) * hash(self.path) * hash(f"stack_path:{self.stack_path}")
         for method in sorted(self.methods):
             route_hash *= hash(method)
         return route_hash
@@ -202,6 +214,7 @@ class LocalApigwService(BaseLocalService):
                 event_type=Route.HTTP,
                 payload_format_version=route.payload_format_version,
                 is_default_route=True,
+                stack_path=route.stack_path,
             )
 
     def _generate_route_keys(self, methods, path):

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -77,8 +77,7 @@ class Route:
         )
 
     def __hash__(self):
-        # stack_path could be empty string, and hash('') = 0. To avoid that, we add a prefix to stack_path
-        route_hash = hash(self.function_name) * hash(self.path) * hash(f"stack_path:{self.stack_path}")
+        route_hash = hash(f"{self.stack_path}-{self.function_name}-{self.path}")
         for method in sorted(self.methods):
             route_hash *= hash(method)
         return route_hash

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -8,12 +8,14 @@ import tempfile
 import signal
 import logging
 import threading
+from typing import Optional
 
 from samcli.local.docker.lambda_container import LambdaContainer
 from samcli.lib.utils.file_observer import LambdaFunctionObserver
 from samcli.lib.utils.packagetype import ZIP
 from samcli.lib.telemetry.metric import capture_parameter
 from .zip import unzip
+from ...lib.utils.stream_writer import StreamWriter
 
 LOG = logging.getLogger(__name__)
 
@@ -123,7 +125,14 @@ class LambdaRuntime:
             raise
 
     @capture_parameter("runtimeMetric", "runtimes", 1, parameter_nested_identifier="runtime", as_list=True)
-    def invoke(self, function_config, event, debug_context=None, stdout=None, stderr=None):
+    def invoke(
+        self,
+        function_config,
+        event,
+        debug_context=None,
+        stdout: Optional[StreamWriter] = None,
+        stderr: Optional[StreamWriter] = None,
+    ):
         """
         Invoke the given Lambda function locally.
 
@@ -137,8 +146,10 @@ class LambdaRuntime:
         :param FunctionConfig function_config: Configuration of the function to invoke
         :param event: String input event passed to Lambda function
         :param DebugContext debug_context: Debugging context for the function (includes port, args, and path)
-        :param io.IOBase stdout: Optional. IO Stream to that receives stdout text from container.
-        :param io.IOBase stderr: Optional. IO Stream that receives stderr text from container
+        :param samcli.lib.utils.stream_writer.StreamWriter stdout: Optional.
+            StreamWriter that receives stdout text from container.
+        :param samcli.lib.utils.stream_writer.StreamWriter stderr: Optional.
+            StreamWriter that receives stderr text from container.
         :raises Keyboard
         """
         timer = None

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -101,8 +101,8 @@ class LayerDownloader:
             # therefore we need to join the path of template directory and codeuri in case codeuri is a relative path.
             try:
                 stack = next(stack for stack in self._stacks if stack.stack_path == layer.stack_path)
-            except StopIteration:
-                raise RuntimeError(f"Cannot find stack that matches layer's stack_path {layer.stack_path}")
+            except StopIteration as ex:
+                raise RuntimeError(f"Cannot find stack that matches layer's stack_path {layer.stack_path}") from ex
 
             codeuri = (
                 layer.codeuri

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -99,10 +99,11 @@ class LayerDownloader:
             LOG.info("%s is a local Layer in the template", layer.name)
             # the template file containing the layer might not be in the same directory as root template file
             # therefore we need to join the path of template directory and codeuri in case codeuri is a relative path.
-            stacks = [stack for stack in self._stacks if stack.stack_path == layer.stack_path]
-            if not stacks:
+            try:
+                stack = next(stack for stack in self._stacks if stack.stack_path == layer.stack_path)
+            except StopIteration:
                 raise RuntimeError(f"Cannot find stack that matches layer's stack_path {layer.stack_path}")
-            stack = stacks[0]
+
             codeuri = (
                 layer.codeuri
                 if os.path.isabs(layer.codeuri)

--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -12,6 +12,7 @@ TIMEOUT = 300
 @skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
 class InvokeIntegBase(TestCase):
     template: Optional[Path] = None
+    nested_stack_enabled = False
 
     @classmethod
     def setUpClass(cls):
@@ -21,6 +22,12 @@ class InvokeIntegBase(TestCase):
         cls.event_path = str(cls.test_data_path.joinpath("invoke", "event.json"))
         cls.event_utf8_path = str(cls.test_data_path.joinpath("invoke", "event_utf8.json"))
         cls.env_var_path = str(cls.test_data_path.joinpath("invoke", "vars.json"))
+
+        cls.env = None
+        if cls.nested_stack_enabled:
+            newenv = os.environ.copy()
+            newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
+            cls.env = newenv
 
     @staticmethod
     def get_integ_dir():

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -1011,6 +1011,7 @@ class TestInvokeWithFunctionFullPathToAvoidAmbiguity(InvokeIntegBase):
         [
             ("FunctionA", {"key1": "value1", "key2": "value2", "key3": "value3"}),
             ("FunctionB", "wrote to stderr"),
+            ("FunctionSomeLogicalID", "wrote to stdout"),
             ("FunctionNameC", "wrote to stdout"),
         ]
     )

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -5,7 +5,7 @@ import copy
 import tempfile
 from unittest import skipIf
 
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 from subprocess import Popen, PIPE, TimeoutExpired
 from timeit import default_timer as timer
 import pytest
@@ -24,16 +24,24 @@ from pathlib import Path
 TIMEOUT = 300
 
 
+@parameterized_class(
+    ("template", "nested_stack_enabled"),
+    [
+        (Path("template.yml"), False),
+        (
+            Path("nested-templates", "template-parent.yaml"),
+            "nested_stack_enabled",
+        ),
+    ],
+)
 class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
-    template = Path("template.yml")
-
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returncode_is_zero(self):
         command_list = self.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -49,7 +57,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_utf8_path
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -62,7 +70,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
     def test_function_with_metadata(self):
         command_list = self.get_command_list("FunctionWithMetadata", template_path=self.template_path, no_event=True)
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -86,7 +94,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             function_name, template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -102,7 +110,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -118,7 +126,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "func-name-override", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -138,7 +146,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         )
 
         start = timer()
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -171,7 +179,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             env_var_path=self.env_var_path,
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -187,7 +195,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -202,7 +210,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "WriteToStdoutFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, stderr=PIPE)
+        process = Popen(command_list, stdout=PIPE, stderr=PIPE, env=self.env)
         try:
             stdout, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -221,7 +229,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "WriteToStderrFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stderr=PIPE)
+        process = Popen(command_list, stderr=PIPE, env=self.env)
         try:
             _, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -235,7 +243,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_expected_result_when_no_event_given(self):
         command_list = self.get_command_list("EchoEventFunction", template_path=self.template_path)
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -256,7 +264,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             parameter_overrides={"MyRuntimeVersion": "v0", "DefaultTimeout": "100"},
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -288,7 +296,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path, region=custom_region
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -317,6 +325,8 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         env["AWS_ACCESS_KEY_ID"] = key
         env["AWS_SECRET_ACCESS_KEY"] = secret
         env["AWS_SESSION_TOKEN"] = session
+        if self.nested_stack_enabled:
+            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stdout=PIPE, env=env)
         try:
@@ -343,7 +353,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             docker_network="host",
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -361,6 +371,8 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         env = os.environ.copy()
         env["SAM_DOCKER_NETWORK"] = "non-existing-network"
+        if self.nested_stack_enabled:
+            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stderr=PIPE, env=env)
         try:
@@ -380,6 +392,8 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.test_data_path.joinpath("invoke", "sam-template.yaml")
         env = os.environ.copy()
         env["SAM_TEMPLATE_FILE"] = str(self.test_data_path.joinpath("invoke", "sam-template.yaml"))
+        if self.nested_stack_enabled:
+            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stdout=PIPE, env=env)
         try:
@@ -403,6 +417,8 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         env = os.environ.copy()
         env["SAM_SKIP_PULL_IMAGE"] = "True"
+        if self.nested_stack_enabled:
+            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stderr=PIPE, env=env)
         try:
@@ -422,7 +438,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "GitLayerFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -443,7 +459,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             parameter_overrides={"LayerVersion": "5"},
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -659,9 +675,18 @@ class TestUsingConfigFiles(InvokeIntegBase):
         return custom_cred
 
 
+@parameterized_class(
+    ("template", "nested_stack_enabled"),
+    [
+        (Path("layers", "layer-template.yml"), False),
+        (
+            Path("nested-templates", "layer-template-parent.yaml"),
+            "nested_stack_enabled",
+        ),
+    ],
+)
 @skipIf(SKIP_LAYERS_TESTS, "Skip layers tests in Appveyor only")
 class TestLayerVersion(InvokeIntegBase):
-    template = Path("layers", "layer-template.yml")
     region = "us-west-2"
     layer_utils = LayerUtils(region=region)
 
@@ -715,7 +740,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -739,7 +764,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -765,7 +790,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -790,7 +815,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate()
         except TimeoutExpired:
@@ -815,7 +840,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -840,7 +865,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, env=self.env)
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -861,6 +886,8 @@ class TestLayerVersion(InvokeIntegBase):
 
         env = os.environ.copy()
         env["SAM_LAYER_CACHE_BASEDIR"] = str(self.layer_cache)
+        if self.nested_stack_enabled:
+            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stdout=PIPE, env=env)
         try:
@@ -901,7 +928,7 @@ class TestLayerVersionThatDoNotCreateCache(InvokeIntegBase):
             parameter_overrides={"NonExistentLayerArn": non_existent_layer_arn},
         )
 
-        process = Popen(command_list, stderr=PIPE)
+        process = Popen(command_list, stderr=PIPE, env=self.env)
         try:
             _, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -924,7 +951,7 @@ class TestLayerVersionThatDoNotCreateCache(InvokeIntegBase):
             region=self.region,
         )
 
-        process = Popen(command_list, stderr=PIPE)
+        process = Popen(command_list, stderr=PIPE, env=self.env)
         try:
             _, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -683,6 +683,10 @@ class TestUsingConfigFiles(InvokeIntegBase):
             Path("nested-templates", "layer-template-parent.yaml"),
             "nested_stack_enabled",
         ),
+        (
+            Path("layers", "some-dir", "layer-template-parent.yaml"),
+            "nested_stack_enabled",
+        ),
     ],
 )
 @skipIf(SKIP_LAYERS_TESTS, "Skip layers tests in Appveyor only")

--- a/tests/integration/local/start_api/start_api_integ_base.py
+++ b/tests/integration/local/start_api/start_api_integ_base.py
@@ -23,6 +23,8 @@ class StartApiIntegBaseClass(TestCase):
     build_before_invoke = False
     build_overrides: Optional[Dict[str, str]] = None
 
+    nested_stack_enabled = False
+
     @classmethod
     def setUpClass(cls):
         # This is the directory for tests/integration which will be used to file the testdata
@@ -69,7 +71,11 @@ class StartApiIntegBaseClass(TestCase):
         if cls.parameter_overrides:
             command_list += ["--parameter-overrides", cls._make_parameter_override_arg(cls.parameter_overrides)]
 
-        cls.start_api_process = Popen(command_list)
+        newenv = None
+        if cls.nested_stack_enabled:
+            newenv = os.environ.copy()
+            newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
+        cls.start_api_process = Popen(command_list, env=newenv)
         # we need to wait some time for start-api to start, hence the sleep
         time.sleep(5)
 

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import time, sleep
 
 import pytest
+from parameterized import parameterized_class
 
 from samcli.commands.local.cli_common.invoke_context import ContainersInitializationMode
 from samcli.local.apigw.local_apigw_service import Route
@@ -120,12 +121,17 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
         pass
 
 
+@parameterized_class(
+    ("template_path", "nested_stack_enabled"),
+    [
+        ("/testdata/start_api/template.yaml", False),
+        ("/testdata/start_api/nested-templates/template-parent.yaml", "nested_stack_enabled"),
+    ],
+)
 class TestService(StartApiIntegBaseClass):
     """
     Testing general requirements around the Service that powers `sam local start-api`
     """
-
-    template_path = "/testdata/start_api/template.yaml"
 
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
@@ -229,12 +235,17 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("body"), data)
 
 
+@parameterized_class(
+    ("template_path", "nested_stack_enabled"),
+    [
+        ("/testdata/start_api/template-http-api.yaml", False),
+        ("/testdata/start_api/nested-templates/template-http-api-parent.yaml", "nested_stack_enabled"),
+    ],
+)
 class TestServiceWithHttpApi(StartApiIntegBaseClass):
     """
     Testing general requirements around the Service that powers `sam local start-api`
     """
-
-    template_path = "/testdata/start_api/template-http-api.yaml"
 
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
@@ -1534,9 +1545,17 @@ class TestCFNTemplateQuickCreatedHttpApiWithDefaultRoute(StartApiIntegBaseClass)
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), "600")
 
 
+@parameterized_class(
+    ("template_path", "nested_stack_enabled"),
+    [
+        ("/testdata/start_api/cfn-http-api-with-normal-and-default-routes.yaml", False),
+        (
+            "/testdata/start_api/nested-templates/cfn-http-api-with-normal-and-default-routes-parent.yaml",
+            "nested_stack_enabled",
+        ),
+    ],
+)
 class TestCFNTemplateHttpApiWithNormalAndDefaultRoutes(StartApiIntegBaseClass):
-    template_path = "/testdata/start_api/cfn-http-api-with-normal-and-default-routes.yaml"
-
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
@@ -1611,6 +1630,16 @@ class TestServerlessTemplateWithRestApiAndHttpApiGateways(StartApiIntegBaseClass
         self.assertEqual(response.json(), {"hello": "world"})
 
 
+@parameterized_class(
+    ("template_path", "nested_stack_enabled"),
+    [
+        ("/testdata/start_api/cfn-http-api-and-rest-api-gateways.yaml", False),
+        (
+            "/testdata/start_api/nested-templates/cfn-http-api-and-rest-api-gateways-parent.yaml",
+            "nested_stack_enabled",
+        ),
+    ],
+)
 class TestCFNTemplateWithRestApiAndHttpApiGateways(StartApiIntegBaseClass):
     template_path = "/testdata/start_api/cfn-http-api-and-rest-api-gateways.yaml"
 

--- a/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
+++ b/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
@@ -24,6 +24,8 @@ class StartLambdaIntegBaseClass(TestCase):
     build_before_invoke = False
     build_overrides: Optional[Dict[str, str]] = None
 
+    nested_stack_enabled = False
+
     @classmethod
     def setUpClass(cls):
         # This is the directory for tests/integration which will be used to file the testdata
@@ -76,7 +78,11 @@ class StartLambdaIntegBaseClass(TestCase):
         if cls.parameter_overrides:
             command_list += ["--parameter-overrides", cls._make_parameter_override_arg(cls.parameter_overrides)]
 
-        cls.start_lambda_process = Popen(command_list)
+        newenv = None
+        if cls.nested_stack_enabled:
+            newenv = os.environ.copy()
+            newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
+        cls.start_lambda_process = Popen(command_list, env=newenv)
         # we need to wait some time for start-lambda to start, hence the sleep
         time.sleep(wait_time)
 

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import time, sleep
 import json
 import docker
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 
 import pytest
 import random
@@ -111,9 +111,17 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
         self.assertEqual(str(error.exception), expected_error_message)
 
 
+@parameterized_class(
+    ("template_path", "nested_stack_enabled"),
+    [
+        ("/testdata/invoke/template.yml", False),
+        (
+            "/testdata/invoke/nested-templates/template-parent.yaml",
+            "nested_stack_enabled",
+        ),
+    ],
+)
 class TestLambdaService(StartLambdaIntegBaseClass):
-    template_path = "/testdata/invoke/template.yml"
-
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
         self.lambda_client = boto3.client(

--- a/tests/integration/testdata/invoke/layers/some-dir/layer-template-parent.yaml
+++ b/tests/integration/testdata/invoke/layers/some-dir/layer-template-parent.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Parameters:
+  LayerOneArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:layer:1
+    Type: String
+
+  LayerTwoArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:layer2:1
+    Type: String
+
+  ChangedLayerArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:changed_layer:1
+    Type: String
+
+  NonExistentLayerArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:non_existent_layer:1
+    Type: String
+
+Resources:
+  SubApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../layer-template.yml
+      Parameters:
+        LayerOneArn: !Ref LayerOneArn
+        LayerTwoArn: !Ref LayerTwoArn
+        ChangedLayerArn: !Ref ChangedLayerArn
+        NonExistentLayerArn: !Ref NonExistentLayerArn

--- a/tests/integration/testdata/invoke/nested-templates/layer-template-parent.yaml
+++ b/tests/integration/testdata/invoke/nested-templates/layer-template-parent.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Parameters:
+  LayerOneArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:layer:1
+    Type: String
+
+  LayerTwoArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:layer2:1
+    Type: String
+
+  ChangedLayerArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:changed_layer:1
+    Type: String
+
+  NonExistentLayerArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:non_existent_layer:1
+    Type: String
+
+Resources:
+  SubApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../layers/layer-template.yml
+      Parameters:
+        LayerOneArn: !Ref LayerOneArn
+        LayerTwoArn: !Ref LayerTwoArn
+        ChangedLayerArn: !Ref ChangedLayerArn
+        NonExistentLayerArn: !Ref NonExistentLayerArn

--- a/tests/integration/testdata/invoke/nested-templates/template-parent.yaml
+++ b/tests/integration/testdata/invoke/nested-templates/template-parent.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  DefaultTimeout:
+    Default: 5
+    Type: Number
+
+  MyRuntimeVersion:
+    Type: String
+
+  StringValueTimeout:
+      Default: "5"
+      Type: Number
+
+  EmptyDefaultParameter:
+    Type: String
+    Default: ""
+
+  FunctionNameParam:
+    Type: String
+    Default: "MyReallyCoolFunction"
+
+  LayerVersion:
+    Type: String
+    Default: "2"
+
+Resources:
+  SubApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../template.yml
+      Parameters:
+        DefaultTimeout: !Ref DefaultTimeout
+        MyRuntimeVersion: !Ref MyRuntimeVersion
+        StringValueTimeout: !Ref StringValueTimeout
+        EmptyDefaultParameter: !Ref EmptyDefaultParameter
+        FunctionNameParam: !Ref FunctionNameParam
+        LayerVersion: !Ref LayerVersion

--- a/tests/integration/testdata/invoke/template-deep-child.yaml
+++ b/tests/integration/testdata/invoke/template-deep-child.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  SubSubApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./template-deep-grandchild.yaml
+
+  FunctionA:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.echo_event
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600

--- a/tests/integration/testdata/invoke/template-deep-grandchild.yaml
+++ b/tests/integration/testdata/invoke/template-deep-grandchild.yaml
@@ -9,3 +9,20 @@ Resources:
       Runtime: python3.6
       CodeUri: .
       Timeout: 600
+
+  FunctionB:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.write_to_stderr
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+
+  FunctionSomeLogicalID:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: FunctionNameC
+      Handler: main.write_to_stdout
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600

--- a/tests/integration/testdata/invoke/template-deep-grandchild.yaml
+++ b/tests/integration/testdata/invoke/template-deep-grandchild.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  FunctionA:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.handler
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600

--- a/tests/integration/testdata/invoke/template-deep-root.yaml
+++ b/tests/integration/testdata/invoke/template-deep-root.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  SubApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./template-deep-child.yaml

--- a/tests/integration/testdata/start_api/nested-templates/cfn-http-api-and-rest-api-gateways-parent.yaml
+++ b/tests/integration/testdata/start_api/nested-templates/cfn-http-api-and-rest-api-gateways-parent.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  SubApp:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: ../cfn-http-api-and-rest-api-gateways.yaml

--- a/tests/integration/testdata/start_api/nested-templates/cfn-http-api-with-normal-and-default-routes-parent.yaml
+++ b/tests/integration/testdata/start_api/nested-templates/cfn-http-api-with-normal-and-default-routes-parent.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  SubApp:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: ../cfn-http-api-with-normal-and-default-routes.yaml

--- a/tests/integration/testdata/start_api/nested-templates/template-http-api-parent.yaml
+++ b/tests/integration/testdata/start_api/nested-templates/template-http-api-parent.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  SubApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../template-http-api.yaml

--- a/tests/integration/testdata/start_api/nested-templates/template-parent.yaml
+++ b/tests/integration/testdata/start_api/nested-templates/template-parent.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  SubApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ../template.yaml

--- a/tests/integration/testdata/start_api/nested-templates/template-precedence-child.yaml
+++ b/tests/integration/testdata/start_api/nested-templates/template-precedence-child.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  EchoIntegerBodyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.echo_integer_body
+      Runtime: python3.6
+      CodeUri: ..
+      Timeout: 600
+      Events:
+        EchoEventBodyPath:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /path1
+        EchoEventBodyPath2:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /path1
+
+  EchoEventFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.echo_event_handler
+      Runtime: python3.6
+      CodeUri: ..
+      Timeout: 600
+      Events:
+        EchoEventBodyPath:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /path2

--- a/tests/integration/testdata/start_api/nested-templates/template-precedence-root.yaml
+++ b/tests/integration/testdata/start_api/nested-templates/template-precedence-root.yaml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Api:
+    BinaryMediaTypes:
+      # These are equivalent to image/gif and image/png when deployed
+      - image~1gif
+      - image~1png
+    Variables:
+      VarName: varValue
+    Cors: "'*''"
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.handler
+      Runtime: python3.6
+      FunctionName: customname
+      CodeUri: ..
+      Timeout: 600
+      Events:
+        IdBasePath:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /path1
+
+  ChildStack:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./template-precedence-child.yaml

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -63,7 +63,6 @@ class TestBuildContext__enter__(TestCase):
         result = context.__enter__()
 
         self.assertEqual(result, context)  # __enter__ must return self
-        self.assertEqual(context.template_dict, template_dict)
         self.assertEqual(context.function_provider, funcprovider)
         self.assertEqual(context.layer_provider, layerprovider)
         self.assertEqual(context.base_dir, base_dir)
@@ -357,7 +356,6 @@ class TestBuildContext__enter__(TestCase):
         result = context.__enter__()
 
         self.assertEqual(result, context)  # __enter__ must return self
-        self.assertEqual(context.template_dict, template_dict)
         self.assertEqual(context.function_provider, funcprovider)
         self.assertEqual(context.layer_provider, layerprovider)
         self.assertEqual(context.base_dir, base_dir)

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -44,7 +44,7 @@ class TestInvokeContext__enter__(TestCase):
         )
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, Mock(), template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -79,7 +79,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._pseudo_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -127,7 +127,7 @@ class TestInvokeContext__enter__(TestCase):
         invoke_context._initialize_all_functions_containers = _initialize_all_functions_containers_mock
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, Mock(), template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -162,7 +162,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._pseudo_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -212,7 +212,7 @@ class TestInvokeContext__enter__(TestCase):
         invoke_context._initialize_all_functions_containers = _initialize_all_functions_containers_mock
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, Mock(), template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -246,7 +246,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._pseudo_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(
             invoke_context._get_env_vars_value.call_args_list, [call("env_vars_file"), call("container_env_vars_file")]
@@ -293,7 +293,7 @@ class TestInvokeContext__enter__(TestCase):
         )
 
         template_dict = "template_dict"
-        stacks = [Stack("", "", template_file, invoke_context.parameter_overrides, template_dict)]
+        stacks = [Stack("", "", template_file, Mock(), template_dict)]
         invoke_context._get_stacks = Mock()
         invoke_context._get_stacks.return_value = stacks
 
@@ -328,7 +328,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context.parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._pseudo_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -1066,4 +1066,6 @@ class TestInvokeContext_get_stacks(TestCase):
     def test_must_pass_custom_region(self, get_stacks_mock):
         invoke_context = InvokeContext("template_file", aws_region="my-custom-region")
         invoke_context._get_stacks()
-        get_stacks_mock.assert_called_with("template_file", parameter_overrides={"AWS::Region": "my-custom-region"})
+        get_stacks_mock.assert_called_with(
+            "template_file", parameter_overrides=None, pseudo_parameter_overrides={"AWS::Region": "my-custom-region"}
+        )

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -68,7 +68,6 @@ class TestInvokeContext__enter__(TestCase):
         result = invoke_context.__enter__()
         self.assertTrue(result is invoke_context, "__enter__() must return self")
 
-        self.assertEqual(invoke_context._template_dict, template_dict)
         self.assertEqual(invoke_context._function_provider, function_provider)
         self.assertEqual(invoke_context._env_vars_value, env_vars_value)
         self.assertEqual(invoke_context._log_file_handle, log_file_handle)
@@ -151,7 +150,6 @@ class TestInvokeContext__enter__(TestCase):
         result = invoke_context.__enter__()
         self.assertTrue(result is invoke_context, "__enter__() must return self")
 
-        self.assertEqual(invoke_context._template_dict, template_dict)
         self.assertEqual(invoke_context._function_provider, function_provider)
         self.assertEqual(invoke_context._env_vars_value, env_vars_value)
         self.assertEqual(invoke_context._log_file_handle, log_file_handle)
@@ -234,7 +232,6 @@ class TestInvokeContext__enter__(TestCase):
         result = invoke_context.__enter__()
         self.assertTrue(result is invoke_context, "__enter__() must return self")
 
-        self.assertEqual(invoke_context._template_dict, template_dict)
         self.assertEqual(invoke_context._function_provider, function_provider)
         self.assertEqual(invoke_context._env_vars_value, "Env var value")
         self.assertEqual(invoke_context._container_env_vars_value, "Debug env var value")
@@ -317,7 +314,6 @@ class TestInvokeContext__enter__(TestCase):
         result = invoke_context.__enter__()
         self.assertTrue(result is invoke_context, "__enter__() must return self")
 
-        self.assertEqual(invoke_context._template_dict, template_dict)
         self.assertEqual(invoke_context._function_provider, function_provider)
         self.assertEqual(invoke_context._env_vars_value, env_vars_value)
         self.assertEqual(invoke_context._log_file_handle, log_file_handle)
@@ -838,14 +834,6 @@ class TestInvokeContext_stderr_property(TestCase):
 
                 StreamWriterMock.assert_called_once_with(log_file_handle_mock, ANY)
                 self.assertEqual(stream_writer_mock, stderr)
-
-
-class TestInvokeContext_template_property(TestCase):
-    def test_must_return_tempalte_dict(self):
-        context = InvokeContext(template_file="file")
-        context._template_dict = "My template"
-
-        self.assertEqual("My template", context.template)
 
 
 class TestInvokeContextget_cwd(TestCase):

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -460,17 +460,17 @@ class TestInvokeContext_function_name_property(TestCase):
         id = "id"
         context = InvokeContext(template_file="template_file", function_identifier=id)
 
-        self.assertEqual(id, context.function_name)
+        self.assertEqual(id, context.function_identifier)
 
     def test_must_return_one_function_from_template(self):
         context = InvokeContext(template_file="template_file")
 
         function = Mock()
-        function.functionname = "myname"
+        function.name = "myname"
         context._function_provider = Mock()
         context._function_provider.get_all.return_value = [function]  # Provider returns only one function
 
-        self.assertEqual("myname", context.function_name)
+        self.assertEqual("myname", context.function_identifier)
 
     def test_must_raise_if_more_than_one_function(self):
         context = InvokeContext(template_file="template_file")
@@ -479,7 +479,7 @@ class TestInvokeContext_function_name_property(TestCase):
         context._function_provider.get_all.return_value = [Mock(), Mock(), Mock()]  # Provider returns three functions
 
         with self.assertRaises(InvokeContextException):
-            context.function_name
+            context.function_identifier
 
 
 class TestInvokeContext_local_lambda_runner(TestCase):

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -78,7 +78,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context._pseudo_parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._global_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -160,7 +160,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context._pseudo_parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._global_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -243,7 +243,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context._pseudo_parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._global_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(
             invoke_context._get_env_vars_value.call_args_list, [call("env_vars_file"), call("container_env_vars_file")]
@@ -324,7 +324,7 @@ class TestInvokeContext__enter__(TestCase):
 
         invoke_context._get_stacks.assert_called_once()
         SamFunctionProviderMock.assert_called_with(stacks)
-        self.assertEqual(invoke_context._pseudo_parameter_overrides, {"AWS::Region": "region"})
+        self.assertEqual(invoke_context._global_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
         invoke_context._setup_log_file.assert_called_with(log_file)
@@ -1055,5 +1055,5 @@ class TestInvokeContext_get_stacks(TestCase):
         invoke_context = InvokeContext("template_file", aws_region="my-custom-region")
         invoke_context._get_stacks()
         get_stacks_mock.assert_called_with(
-            "template_file", parameter_overrides=None, pseudo_parameter_overrides={"AWS::Region": "my-custom-region"}
+            "template_file", parameter_overrides=None, global_parameter_overrides={"AWS::Region": "my-custom-region"}
         )

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -98,7 +98,7 @@ class TestCli(TestCase):
         )
 
         context_mock.local_lambda_runner.invoke.assert_called_with(
-            context_mock.function_name, event=event_data, stdout=context_mock.stdout, stderr=context_mock.stderr
+            context_mock.function_identifier, event=event_data, stdout=context_mock.stdout, stderr=context_mock.stderr
         )
         get_event_mock.assert_called_with(self.eventfile)
 
@@ -157,7 +157,7 @@ class TestCli(TestCase):
 
         get_event_mock.assert_not_called()
         context_mock.local_lambda_runner.invoke.assert_called_with(
-            context_mock.function_name, event="{}", stdout=context_mock.stdout, stderr=context_mock.stderr
+            context_mock.function_identifier, event="{}", stdout=context_mock.stdout, stderr=context_mock.stderr
         )
 
     @parameterized.expand(

--- a/tests/unit/commands/local/lib/test_api_provider.py
+++ b/tests/unit/commands/local/lib/test_api_provider.py
@@ -203,10 +203,10 @@ class TestApiProviderSelection(TestCase):
 
 
 class TestApiProvider_merge_routes(TestCase):
-    @parameterized.expand([("", 0), ("A", -1), ("A/B/C", -3)])
-    def test_sort_key_stack_depth_desc(self, stack_path, negative_depth):
+    @parameterized.expand([("", 0), ("A", 1), ("A/B/C", 3)])
+    def test_get_route_stack_depth(self, stack_path, expected_depth):
         route = Mock(stack_path=stack_path)
-        self.assertEqual(SamApiProvider._sort_key_stack_depth_desc(route), negative_depth)
+        self.assertEqual(SamApiProvider._get_route_stack_depth(route), expected_depth)
 
     def test_explicit_apis_overridden_by_implicit(self):
         explicit1 = Mock(stack_path="", methods=["GET"], path="/")

--- a/tests/unit/commands/local/lib/test_local_api_service.py
+++ b/tests/unit/commands/local/lib/test_local_api_service.py
@@ -54,7 +54,8 @@ class TestLocalApiService_start(TestCase):
 
         # Make sure the right methods are called
         SamApiProviderMock.assert_called_with(
-            self.template, cwd=self.cwd, parameter_overrides=self.lambda_invoke_context_mock.parameter_overrides
+            self.lambda_invoke_context_mock.stacks,
+            cwd=self.cwd,
         )
 
         log_routes_mock.assert_called_with(routing_list, self.host, self.port)

--- a/tests/unit/commands/local/lib/test_sam_api_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_api_provider.py
@@ -3,20 +3,25 @@ import tempfile
 from collections import OrderedDict
 from unittest import TestCase
 
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from parameterized import parameterized
 
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.lib.providers.api_provider import ApiProvider
-from samcli.lib.providers.provider import Cors
+from samcli.lib.providers.provider import Cors, Stack
 from samcli.local.apigw.local_apigw_service import Route
+
+
+def make_mock_stacks_from_template(template):
+    stack_mock = Stack("", "", Mock(), parameters=None, template_dict=template)
+    return [stack_mock]
 
 
 class TestSamApiProviderWithImplicitApis(TestCase):
     def test_provider_with_no_resource_properties(self):
         template = {"Resources": {"SamFunc1": {"Type": "AWS::Lambda::Function"}}}
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         self.assertEqual(provider.routes, [])
 
@@ -36,7 +41,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         self.assertEqual(len(provider.routes), 1)
         self.assertEqual(list(provider.routes)[0], Route(path="/path", methods=["GET"], function_name="SamFunc1"))
@@ -59,7 +64,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         api = Route(path="/path", methods=["GET", "POST"], function_name="SamFunc1")
 
@@ -90,7 +95,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         api1 = Route(path="/path", methods=["GET"], function_name="SamFunc1")
         api2 = Route(path="/path", methods=["POST"], function_name="SamFunc2")
@@ -113,7 +118,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         self.assertEqual(provider.routes, [])
 
@@ -131,7 +136,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             }
         }
 
-        provider1 = ApiProvider(template1)
+        provider1 = ApiProvider(make_mock_stacks_from_template(template))
 
         self.assertEqual(provider1.routes, [])
 
@@ -145,7 +150,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         self.assertEqual(provider.routes, [])
 
@@ -173,7 +178,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         result = [f for f in provider.get_all()]
         routes = result[0].routes
@@ -186,7 +191,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
     def test_provider_get_all_with_no_routes(self):
         template = {}
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         result = [f for f in provider.get_all()]
         routes = result[0].routes
@@ -209,7 +214,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         api1 = Route(
             path="/path", methods=["GET", "DELETE", "PUT", "POST", "HEAD", "OPTIONS", "PATCH"], function_name="SamFunc1"
@@ -236,7 +241,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             },
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         self.assertEqual(len(provider.routes), 1)
         self.assertEqual(list(provider.routes)[0], Route(path="/path", methods=["GET"], function_name="SamFunc1"))
@@ -270,7 +275,7 @@ class TestSamApiProviderWithImplicitApis(TestCase):
             )
         ]
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         self.assertCountEqual(provider.routes, expected_routes)
         self.assertCountEqual(provider.api.binary_media_types, binary)
@@ -289,7 +294,7 @@ class TestSamApiProviderWithExplicitApis(TestCase):
     def test_with_no_routes(self):
         template = {"Resources": {"Api1": {"Type": "AWS::Serverless::Api", "Properties": {"StageName": "Prod"}}}}
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         self.assertEqual(provider.routes, [])
 
@@ -303,7 +308,7 @@ class TestSamApiProviderWithExplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
         self.assertCountEqual(self.input_routes, provider.routes)
 
     def test_with_swagger_as_local_file(self):
@@ -323,7 +328,7 @@ class TestSamApiProviderWithExplicitApis(TestCase):
                 }
             }
 
-            provider = ApiProvider(template)
+            provider = ApiProvider(make_mock_stacks_from_template(template))
             self.assertCountEqual(self.input_routes, provider.routes)
 
     @patch("samcli.lib.providers.cfn_base_api_provider.SwaggerReader")
@@ -343,7 +348,7 @@ class TestSamApiProviderWithExplicitApis(TestCase):
         SwaggerReaderMock.return_value.read.return_value = make_swagger(self.input_routes)
 
         cwd = "foo"
-        provider = ApiProvider(template, cwd=cwd)
+        provider = ApiProvider(make_mock_stacks_from_template(template), cwd=cwd)
         self.assertCountEqual(self.input_routes, provider.routes)
         SwaggerReaderMock.assert_called_with(definition_body=body, definition_uri=filename, working_dir=cwd)
 
@@ -367,7 +372,7 @@ class TestSamApiProviderWithExplicitApis(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
         self.assertCountEqual(expected_routes, provider.routes)
 
     def test_with_binary_media_types(self):
@@ -390,7 +395,7 @@ class TestSamApiProviderWithExplicitApis(TestCase):
             Route(path="/path3", methods=["DELETE"], function_name="SamFunc1"),
         ]
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
         self.assertCountEqual(expected_routes, provider.routes)
         self.assertCountEqual(provider.api.binary_media_types, expected_binary_types)
 
@@ -414,7 +419,7 @@ class TestSamApiProviderWithExplicitApis(TestCase):
         expected_binary_types = sorted(self.binary_types + extra_binary_types)
         expected_routes = [Route(path="/path", methods=["OPTIONS"], function_name="SamFunc1")]
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
         self.assertCountEqual(expected_routes, provider.routes)
         self.assertCountEqual(provider.api.binary_media_types, expected_binary_types)
 
@@ -461,7 +466,7 @@ class TestSamApiProviderWithExplicitAndImplicitApis(TestCase):
             Route(path="/path3", methods=["POST"], function_name="ImplicitFunc"),
         ]
 
-        provider = ApiProvider(self.template)
+        provider = ApiProvider(make_mock_stacks_from_template(self.template))
         self.assertCountEqual(expected_routes, provider.routes)
 
     def test_must_prefer_implicit_api_over_explicit(self):
@@ -489,7 +494,7 @@ class TestSamApiProviderWithExplicitAndImplicitApis(TestCase):
             Route(path="/path3", methods=["GET"], function_name="explicitfunction"),
         ]
 
-        provider = ApiProvider(self.template)
+        provider = ApiProvider(make_mock_stacks_from_template(self.template))
         self.assertCountEqual(expected_routes, provider.routes)
 
     def test_must_prefer_implicit_with_any_method(self):
@@ -521,7 +526,7 @@ class TestSamApiProviderWithExplicitAndImplicitApis(TestCase):
             )
         ]
 
-        provider = ApiProvider(self.template)
+        provider = ApiProvider(make_mock_stacks_from_template(self.template))
         self.assertCountEqual(expected_routes, provider.routes)
 
     def test_with_any_method_on_both(self):
@@ -563,7 +568,7 @@ class TestSamApiProviderWithExplicitAndImplicitApis(TestCase):
             Route(path="/path2", methods=["POST"], function_name="explicitfunction"),
         ]
 
-        provider = ApiProvider(self.template)
+        provider = ApiProvider(make_mock_stacks_from_template(self.template))
         self.assertCountEqual(expected_routes, provider.routes)
 
     def test_must_add_explicit_api_when_ref_with_rest_api_id(self):
@@ -599,7 +604,7 @@ class TestSamApiProviderWithExplicitAndImplicitApis(TestCase):
             Route(path="/newpath2", methods=["POST"], function_name="ImplicitFunc"),
         ]
 
-        provider = ApiProvider(self.template)
+        provider = ApiProvider(make_mock_stacks_from_template(self.template))
         self.assertCountEqual(expected_routes, provider.routes)
 
     def test_both_routes_must_get_binary_media_types(self):
@@ -629,7 +634,7 @@ class TestSamApiProviderWithExplicitAndImplicitApis(TestCase):
             Route(path="/newpath2", methods=["POST"], function_name="ImplicitFunc"),
         ]
 
-        provider = ApiProvider(self.template)
+        provider = ApiProvider(make_mock_stacks_from_template(self.template))
         self.assertCountEqual(expected_routes, provider.routes)
         self.assertCountEqual(provider.api.binary_media_types, expected_explicit_binary_types)
 
@@ -666,7 +671,7 @@ class TestSamApiProviderWithExplicitAndImplicitApis(TestCase):
             Route(path="/true-implicit-path", methods=["POST"], function_name="ImplicitFunc"),
         ]
 
-        provider = ApiProvider(self.template)
+        provider = ApiProvider(make_mock_stacks_from_template(self.template))
         self.assertCountEqual(expected_routes, provider.routes)
         self.assertCountEqual(provider.api.binary_media_types, expected_explicit_binary_types)
 
@@ -700,7 +705,7 @@ class TestSamStageValues(TestCase):
                 }
             }
         }
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
         route1 = Route(path="/path", methods=["GET"], function_name="NoApiEventFunction")
 
         self.assertIn(route1, provider.routes)
@@ -736,7 +741,7 @@ class TestSamStageValues(TestCase):
                 }
             }
         }
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
         route1 = Route(path="/path", methods=["GET"], function_name="NoApiEventFunction")
 
         self.assertIn(route1, provider.routes)
@@ -808,7 +813,7 @@ class TestSamStageValues(TestCase):
             },
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         result = [f for f in provider.get_all()]
         routes = result[0].routes
@@ -867,7 +872,7 @@ class TestSamCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -923,7 +928,7 @@ class TestSamCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -984,7 +989,7 @@ class TestSamCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -1047,7 +1052,7 @@ class TestSamCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -1112,7 +1117,7 @@ class TestSamCors(TestCase):
         with self.assertRaises(
             InvalidSamDocumentException, msg="ApiProvider should fail for Invalid Cors AllowMethods not single quoted"
         ):
-            ApiProvider(template)
+            ApiProvider(make_mock_stacks_from_template(template))
 
     def test_raises_error_when_cors_value_not_single_quoted(self):
         template = {
@@ -1157,7 +1162,7 @@ class TestSamCors(TestCase):
         with self.assertRaises(
             InvalidSamDocumentException, msg="ApiProvider should fail for Invalid Cors value not single quoted"
         ):
-            ApiProvider(template)
+            ApiProvider(make_mock_stacks_from_template(template))
 
     def test_invalid_cors_dict_allow_methods(self):
         template = {
@@ -1207,7 +1212,7 @@ class TestSamCors(TestCase):
         with self.assertRaises(
             InvalidSamDocumentException, msg="ApiProvider should fail for Invalid Cors Allow method"
         ):
-            ApiProvider(template)
+            ApiProvider(make_mock_stacks_from_template(template))
 
     def test_default_cors_dict_prop(self):
         template = {
@@ -1239,7 +1244,7 @@ class TestSamCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(allow_origin="www.domain.com", allow_methods=",".join(sorted(Route.ANY_HTTP_METHODS)))
@@ -1298,7 +1303,7 @@ class TestSamCors(TestCase):
             },
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -1358,7 +1363,7 @@ class TestSamHttpApiCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -1414,7 +1419,7 @@ class TestSamHttpApiCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -1470,7 +1475,7 @@ class TestSamHttpApiCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = None
@@ -1528,7 +1533,7 @@ class TestSamHttpApiCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -1591,7 +1596,7 @@ class TestSamHttpApiCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(
@@ -1656,7 +1661,7 @@ class TestSamHttpApiCors(TestCase):
         with self.assertRaises(
             InvalidSamDocumentException, msg="ApiProvider should fail for Invalid Cors Allow method"
         ):
-            ApiProvider(template)
+            ApiProvider(make_mock_stacks_from_template(template))
 
     def test_default_cors_dict_prop(self):
         template = {
@@ -1688,7 +1693,7 @@ class TestSamHttpApiCors(TestCase):
             }
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(allow_origin="www.domain.com", allow_methods=",".join(sorted(Route.ANY_HTTP_METHODS)))
@@ -1747,7 +1752,7 @@ class TestSamHttpApiCors(TestCase):
             },
         }
 
-        provider = ApiProvider(template)
+        provider = ApiProvider(make_mock_stacks_from_template(template))
 
         routes = provider.routes
         cors = Cors(

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -60,8 +60,8 @@ class TestSamBuildableStackProvider(TestCase):
         self.assertListEqual(
             stacks,
             [
-                Stack("", "", self.template_file, None, template),
-                Stack("", "ChildStack", child_location_path, None, LEAF_TEMPLATE),
+                Stack("", "", self.template_file, {}, template),
+                Stack("", "ChildStack", child_location_path, {}, LEAF_TEMPLATE),
             ],
         )
 
@@ -98,7 +98,7 @@ class TestSamBuildableStackProvider(TestCase):
         self.assertListEqual(
             stacks,
             [
-                Stack("", "", self.template_file, None, template),
+                Stack("", "", self.template_file, {}, template),
             ],
         )
 
@@ -136,9 +136,9 @@ class TestSamBuildableStackProvider(TestCase):
         self.assertListEqual(
             stacks,
             [
-                Stack("", "", self.template_file, None, template),
-                Stack("", "ChildStack", child_template_file, None, child_template),
-                Stack("ChildStack", "GrandChildStack", grand_child_template_file, None, LEAF_TEMPLATE),
+                Stack("", "", self.template_file, {}, template),
+                Stack("", "ChildStack", child_template_file, {}, child_template),
+                Stack("ChildStack", "GrandChildStack", grand_child_template_file, {}, LEAF_TEMPLATE),
             ],
         )
 
@@ -165,7 +165,7 @@ class TestSamBuildableStackProvider(TestCase):
         self.assertListEqual(
             stacks,
             [
-                Stack("", "", self.template_file, None, template),
+                Stack("", "", self.template_file, {}, template),
             ],
         )
 
@@ -205,7 +205,48 @@ class TestSamBuildableStackProvider(TestCase):
         self.assertListEqual(
             stacks,
             [
-                Stack("", "", template_file, None, template),
-                Stack("", "ChildStack", child_location_path, None, LEAF_TEMPLATE),
+                Stack("", "", template_file, {}, template),
+                Stack("", "ChildStack", child_location_path, {}, LEAF_TEMPLATE),
+            ],
+        )
+
+    @parameterized.expand(
+        [
+            (AWS_SERVERLESS_APPLICATION, "Location", "./child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_SERVERLESS_APPLICATION, "Location", "child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "./child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_SERVERLESS_APPLICATION, "Location", "file:///child.yaml", "/child.yaml"),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "file:///child.yaml", "/child.yaml"),
+        ]
+    )
+    def test_pseudo_parameter_overrides_can_be_passed_to_child_stacks(
+        self, resource_type, location_property_name, child_location, child_location_path
+    ):
+        template_file = "somedir/template.yaml"
+        template = {
+            "Resources": {
+                "ChildStack": {
+                    "Type": resource_type,
+                    "Properties": {location_property_name: child_location},
+                }
+            }
+        }
+        self.get_template_data_mock.side_effect = lambda t: {
+            template_file: template,
+            child_location_path: LEAF_TEMPLATE,
+        }.get(t)
+
+        pseudo_parameter_overrides = {"AWS::Region": "custom_region"}
+
+        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
+            stacks = SamLocalStackProvider.get_stacks(
+                template_file, "", "", parameter_overrides=None, pseudo_parameter_overrides=pseudo_parameter_overrides
+            )
+        self.assertListEqual(
+            stacks,
+            [
+                Stack("", "", template_file, pseudo_parameter_overrides, template),
+                Stack("", "ChildStack", child_location_path, pseudo_parameter_overrides, LEAF_TEMPLATE),
             ],
         )

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -220,7 +220,7 @@ class TestSamBuildableStackProvider(TestCase):
             (AWS_CLOUDFORMATION_STACK, "TemplateURL", "file:///child.yaml", "/child.yaml"),
         ]
     )
-    def test_pseudo_parameter_overrides_can_be_passed_to_child_stacks(
+    def test_global_parameter_overrides_can_be_passed_to_child_stacks(
         self, resource_type, location_property_name, child_location, child_location_path
     ):
         template_file = "somedir/template.yaml"
@@ -237,16 +237,16 @@ class TestSamBuildableStackProvider(TestCase):
             child_location_path: LEAF_TEMPLATE,
         }.get(t)
 
-        pseudo_parameter_overrides = {"AWS::Region": "custom_region"}
+        global_parameter_overrides = {"AWS::Region": "custom_region"}
 
         with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
             stacks = SamLocalStackProvider.get_stacks(
-                template_file, "", "", parameter_overrides=None, pseudo_parameter_overrides=pseudo_parameter_overrides
+                template_file, "", "", parameter_overrides=None, global_parameter_overrides=global_parameter_overrides
             )
         self.assertListEqual(
             stacks,
             [
-                Stack("", "", template_file, pseudo_parameter_overrides, template),
-                Stack("", "ChildStack", child_location_path, pseudo_parameter_overrides, LEAF_TEMPLATE),
+                Stack("", "", template_file, global_parameter_overrides, template),
+                Stack("", "ChildStack", child_location_path, global_parameter_overrides, LEAF_TEMPLATE),
             ],
         )

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -1299,3 +1299,8 @@ class TestRouteEqualsHash(TestCase):
         route1 = Route(function_name="test", path="/test", methods=["POST", "GET"])
         route2 = Route(function_name="test", path="/test", methods=["GET", "POST"])
         self.assertEqual(route1.__hash__(), route2.__hash__())
+
+    def test_route_different_stack_path_hash(self):
+        route1 = Route(function_name="test", path="/test1", methods=["GET", "POST"], stack_path="2")
+        route2 = Route(function_name="test", path="/test1", methods=["GET", "POST"], stack_path="1")
+        self.assertNotEqual(route1.__hash__(), route2.__hash__())


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

In #2594, #2609, #2618 and #2623, `sam build`, `sam local invoke` and `sam local start-lambda` supports functions in nested stacks when `SAM_CLI_ENABLE_NESTED_STACK=1`.

How PR is a followup to do these things:
- add type hint to make following changes easier
- make start-api work with nested stacks.
  - add "stack_path" to `Route`. In previous PRs, we already added `stack_path` to `Function` and `LayerVersion`.
  - ApiProvider now goes through all nested stacks to find routes.
- add unit/integration tests to verify `local invoke` `local start-lambda` and `local start-api`. 
- fix a bug causing `AWS::Region` is not passed to child stacks when users invoke with `--region` arg (bug discovered during writing integration tests, therefore I put this fix in this PR).

#### What's left for nested stack?

- Remove the env var `SAM_CLI_ENABLE_NESTED_STACK` and make nested stack enabled by default.
- Add integration tests for `sam package` and `sam deploy`.

#### How does it address the issue?

#### What side effects does this change have?

This PR has no customer impact.

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
