### PR TITLE
Revert "Revert nested stack changes before 1.18.2 release (#2641)"

### DIFF
--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -127,12 +127,18 @@ class DefaultBuildStrategy(BuildStrategy):
         # copy results to other functions
         if build_definition.packagetype == ZIP:
             for function in build_definition.functions:
-                if function.name is not single_function_name:
+                if function.name != single_function_name:
+                    # for zip function we need to copy over the artifacts
                     # artifacts directory will be created by the builder
                     artifacts_dir = str(pathlib.Path(self._build_dir, function.name))
                     LOG.debug("Copying artifacts from %s to %s", single_build_dir, artifacts_dir)
                     osutils.copytree(single_build_dir, artifacts_dir)
                     function_build_results[function.name] = artifacts_dir
+        elif build_definition.packagetype == IMAGE:
+            for function in build_definition.functions:
+                if function.name != single_function_name:
+                    # for image function, we just need to copy the image tag
+                    function_build_results[function.name] = result
 
         return function_build_results
 

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -54,6 +54,17 @@ class Function(NamedTuple):
     # The path of the stack relative to the root stack, it is empty for functions in root stack
     stack_path: str = ""
 
+    @property
+    def full_path(self) -> str:
+        """
+        Return the path-like identifier of this Function. If it is in root stack, full_path = name.
+        This path is guaranteed to be unique in a multi-stack situation.
+        Example:
+            "HelloWorldFunction"
+            "ChildStackA/GrandChildStackB/AFunctionInNestedStack"
+        """
+        return get_full_path(self.stack_path, self.name)
+
 
 class ResourcesToBuildCollector:
     def __init__(self):
@@ -240,6 +251,17 @@ class LayerVersion:
     def compatible_runtimes(self):
         return self._compatible_runtimes
 
+    @property
+    def full_path(self) -> str:
+        """
+        Return the path-like identifier of this Layer. If it is in root stack, full_path = name.
+        This path is guaranteed to be unique in a multi-stack situation.
+        Example:
+            "HelloWorldLayer"
+            "ChildStackA/GrandChildStackB/ALayerInNestedStack"
+        """
+        return get_full_path(self.stack_path, self.name)
+
     def __eq__(self, other):
         if isinstance(other, type(self)):
             return self.__dict__ == other.__dict__
@@ -371,3 +393,11 @@ class Stack(NamedTuple):
         processed_template_dict: Dict = SamBaseProvider.get_template(self.template_dict, self.parameters)
         resources: Dict = processed_template_dict.get("Resources", {})
         return resources
+
+
+def get_full_path(stack_path: str, logical_id: str) -> str:
+    """
+    Return the unique posix path-like identifier
+    while will used for identify a resource from resources in a multi-stack situation
+    """
+    return posixpath.join(stack_path, logical_id)

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -2,7 +2,6 @@
 Class that provides functions from a given SAM template
 """
 import logging
-import posixpath
 from typing import Dict, List, Optional, cast, Iterator
 
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
@@ -43,7 +42,7 @@ class SamFunctionProvider(SamBaseProvider):
         for stack in stacks:
             LOG.debug("%d resources found in the stack %s", len(stack.resources), stack.stack_path)
 
-        # Store a map of function name to function information for quick reference
+        # Store a map of function full_path to function information for quick reference
         self.functions = self._extract_functions(self.stacks, ignore_code_extraction_warnings)
 
         self._deprecated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
@@ -53,8 +52,9 @@ class SamFunctionProvider(SamBaseProvider):
         """
         Returns the function given name or LogicalId of the function. Every SAM resource has a logicalId, but it may
         also have a function name. This method searches only for LogicalID and returns the function that matches.
-        If it is in a nested stack, "name" can be prefixed with stack path to avoid ambiguity
-        it.
+        If it is in a nested stack, "name" can be prefixed with stack path to avoid ambiguity.
+        For example, if a function with name "FunctionA" is located in StackN, which is a nested stack in root stack,
+          either "StackN/FunctionA" or "FunctionA" can be used.
 
         :param string name: Name of the function
         :return Function: namedtuple containing the Function information if function is found.
@@ -65,12 +65,12 @@ class SamFunctionProvider(SamBaseProvider):
         if not name:
             raise ValueError("Function name is required")
 
-        for f in self.get_all():
-            if posixpath.join(f.stack_path, f.name) == name or f.name == name:
-                self._deprecate_notification(f.runtime)
-                return f
+        # support lookup by full_path
+        if name in self.functions:
+            return self.functions.get(name)
 
-            if posixpath.join(f.stack_path, f.functionname) == name or f.functionname == name:
+        for f in self.get_all():
+            if name in (f.name, f.functionname):
                 self._deprecate_notification(f.runtime)
                 return f
 
@@ -102,13 +102,13 @@ class SamFunctionProvider(SamBaseProvider):
         Extracts and returns function information from the given dictionary of SAM/CloudFormation resources. This
         method supports functions defined with AWS::Serverless::Function and AWS::Lambda::Function
 
-        :param dict resources_by_stack: Dictionary of SAM/CloudFormation resources by stack
+        :param stacks: List of SAM/CloudFormation stacks to extract functions from
         :param bool ignore_code_extraction_warnings: suppress log statements on code extraction from resources.
-        :return dict(string : samcli.commands.local.lib.provider.Function): Dictionary of function LogicalId to the
+        :return dict(string : samcli.commands.local.lib.provider.Function): Dictionary of function full_path to the
             Function configuration object
         """
 
-        result = {}
+        result: Dict[str, Function] = {}  # a dict with full_path as key and extracted function as value
         for stack in stacks:
             for name, resource in stack.resources.items():
 
@@ -126,13 +126,14 @@ class SamFunctionProvider(SamBaseProvider):
                         stack.resources,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
-                    result[name] = SamFunctionProvider._convert_sam_function_resource(
+                    function = SamFunctionProvider._convert_sam_function_resource(
                         stack.stack_path,
                         name,
                         resource_properties,
                         layers,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
+                    result[function.full_path] = function
 
                 elif resource_type == SamFunctionProvider.LAMBDA_FUNCTION:
                     layers = SamFunctionProvider._parse_layer_info(
@@ -141,9 +142,10 @@ class SamFunctionProvider(SamBaseProvider):
                         stack.resources,
                         ignore_code_extraction_warnings=ignore_code_extraction_warnings,
                     )
-                    result[name] = SamFunctionProvider._convert_lambda_function_resource(
+                    function = SamFunctionProvider._convert_lambda_function_resource(
                         stack.stack_path, name, resource_properties, layers
                     )
+                    result[function.full_path] = function
 
                 # We don't care about other resource types. Just ignore them
 

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -23,7 +23,9 @@ class SamLocalStackProvider(SamBaseProvider):
     # see get_stacks() for info about this env var
     ENV_SAM_CLI_ENABLE_NESTED_STACK = "SAM_CLI_ENABLE_NESTED_STACK"
 
-    def __init__(self, stack_path: str, template_dict: Dict, parameter_overrides: Optional[Dict] = None):
+    def __init__(
+        self, template_file: str, stack_path: str, template_dict: Dict, parameter_overrides: Optional[Dict] = None
+    ):
         """
         Initialize the class with SAM template data. The SAM template passed to this provider is assumed
         to be valid, normalized and a dictionary. It should be normalized by running all pre-processing
@@ -32,11 +34,14 @@ class SamLocalStackProvider(SamBaseProvider):
         This class does not perform any syntactic validation of the template.
         After the class is initialized, any changes to the ``template_dict`` will not be reflected in here.
         You need to explicitly update the class with new template, if necessary.
+        :param str template_file: SAM Stack Template file path
+        :param str stack_path: SAM Stack stack_path (See samcli.lib.providers.provider.Stack.stack_path)
         :param dict template_dict: SAM Template as a dictionary
         :param dict parameter_overrides: Optional dictionary of values for SAM template parameters that might want
             to get substituted within the template
         """
 
+        self._template_directory = os.path.dirname(template_file)
         self._stack_path = stack_path
         self._template_dict = self.get_template(template_dict, parameter_overrides)
         self._resources = self._template_dict.get("Resources", {})
@@ -94,10 +99,12 @@ class SamLocalStackProvider(SamBaseProvider):
             stack: Optional[Stack] = None
             if resource_type == SamLocalStackProvider.SERVERLESS_APPLICATION:
                 stack = SamLocalStackProvider._convert_sam_application_resource(
-                    self._stack_path, name, resource_properties
+                    self._template_directory, self._stack_path, name, resource_properties
                 )
             if resource_type == SamLocalStackProvider.CLOUDFORMATION_STACK:
-                stack = SamLocalStackProvider._convert_cfn_stack_resource(self._stack_path, name, resource_properties)
+                stack = SamLocalStackProvider._convert_cfn_stack_resource(
+                    self._template_directory, self._stack_path, name, resource_properties
+                )
 
             if stack:
                 result[name] = stack
@@ -107,7 +114,9 @@ class SamLocalStackProvider(SamBaseProvider):
         return result
 
     @staticmethod
-    def _convert_sam_application_resource(stack_path: str, name: str, resource_properties: Dict) -> Optional[Stack]:
+    def _convert_sam_application_resource(
+        template_directory: str, stack_path: str, name: str, resource_properties: Dict
+    ) -> Optional[Stack]:
         location = resource_properties.get("Location")
 
         if isinstance(location, dict):
@@ -129,6 +138,8 @@ class SamLocalStackProvider(SamBaseProvider):
             return None
         if location.startswith("file://"):
             location = unquote(urlparse(location).path)
+        elif not os.path.isabs(location):
+            location = os.path.join(template_directory, os.path.relpath(location))
 
         return Stack(
             parent_stack_path=stack_path,
@@ -139,7 +150,9 @@ class SamLocalStackProvider(SamBaseProvider):
         )
 
     @staticmethod
-    def _convert_cfn_stack_resource(stack_path: str, name: str, resource_properties: Dict) -> Optional[Stack]:
+    def _convert_cfn_stack_resource(
+        template_directory: str, stack_path: str, name: str, resource_properties: Dict
+    ) -> Optional[Stack]:
         template_url = resource_properties.get("TemplateURL", "")
 
         if SamLocalStackProvider.is_remote_url(template_url):
@@ -151,6 +164,8 @@ class SamLocalStackProvider(SamBaseProvider):
             return None
         if template_url.startswith("file://"):
             template_url = unquote(urlparse(template_url).path)
+        elif not os.path.isabs(template_url):
+            template_url = os.path.join(template_directory, os.path.relpath(template_url))
 
         return Stack(
             parent_stack_path=stack_path,
@@ -176,7 +191,7 @@ class SamLocalStackProvider(SamBaseProvider):
         if not os.environ.get(SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK, False):
             return stacks
 
-        current = SamLocalStackProvider(stack_path, template_dict, parameter_overrides)
+        current = SamLocalStackProvider(template_file, stack_path, template_dict, parameter_overrides)
         for child_stack in current.get_all():
             stacks.extend(
                 SamLocalStackProvider.get_stacks(

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1157,6 +1157,43 @@ class TestBuildWithDedupBuilds(DedupBuildIntegBase):
     ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
     "Skip build tests on windows when running in CI unless overridden",
 )
+class TestBuildWithDedupImageBuilds(DedupBuildIntegBase):
+    template = "dedup-functions-image-template.yaml"
+
+    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.flaky(reruns=3)
+    def test_dedup_build(self, use_container):
+        if use_container and SKIP_DOCKER_TESTS:
+            self.skipTest(SKIP_DOCKER_MESSAGE)
+
+        """
+        Build template above and verify that each function call returns as expected
+        """
+        overrides = {
+            "Function1Handler": "main.first_function_handler",
+            "Function2Handler": "main.second_function_handler",
+            "FunctionRuntime": "3.7",
+            "DockerFile": "Dockerfile",
+            "Tag": f"{random.randint(1,100)}",
+        }
+        cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
+
+        LOG.info("Running Command: {}".format(cmdlist))
+        run_command(cmdlist, cwd=self.working_dir)
+
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template, "HelloWorldFunction", self._make_parameter_override_arg(overrides), "Hello World"
+            )
+            self._verify_invoke_built_function(
+                self.built_template, "HelloMarsFunction", self._make_parameter_override_arg(overrides), "Hello Mars"
+            )
+
+
+@skipIf(
+    ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
 class TestBuildWithDedupBuildsMakefile(DedupBuildIntegBase):
     template = "dedup-functions-makefile-template.yaml"
 

--- a/tests/integration/testdata/buildcmd/PythonImage/main.py
+++ b/tests/integration/testdata/buildcmd/PythonImage/main.py
@@ -9,3 +9,11 @@ def handler(event, context):
     # print(Fernet.generate_key())
 
     return {"pi": "{0:.2f}".format(numpy.pi)}
+
+
+def first_function_handler(event, context):
+    return "Hello World"
+
+
+def second_function_handler(event, context):
+    return "Hello Mars"

--- a/tests/integration/testdata/buildcmd/dedup-functions-image-template.yaml
+++ b/tests/integration/testdata/buildcmd/dedup-functions-image-template.yaml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 20
+    MemorySize: 512
+
+Parameteres:
+  Function1Handler:
+    Type: String
+  Function2Handler:
+    Type: String
+  FunctionRuntime:
+    Type: String
+  DockerFile:
+    Type: String
+  Tag:
+    Type: String
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - !Ref Function1Handler
+      Timeout: 600
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: ./PythonImage
+      Dockerfile: !Ref DockerFile
+      DockerBuildArgs:
+        BASE_RUNTIME: !Ref FunctionRuntime
+
+  HelloMarsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageConfig:
+        Command:
+          - !Ref Function2Handler
+      Timeout: 600
+    Metadata:
+      DockerTag: !Ref Tag
+      DockerContext: ./PythonImage
+      Dockerfile: !Ref DockerFile
+      DockerBuildArgs:
+        BASE_RUNTIME: !Ref FunctionRuntime

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -29,8 +29,8 @@ class TestSamBuildableStackProvider(TestCase):
 
     @parameterized.expand(
         [
-            (AWS_SERVERLESS_APPLICATION, "Location", "./child.yaml", "./child.yaml"),
-            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "./child.yaml", "./child.yaml"),
+            (AWS_SERVERLESS_APPLICATION, "Location", "./child.yaml", "child.yaml"),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "./child.yaml", "child.yaml"),
             (AWS_SERVERLESS_APPLICATION, "Location", "file:///child.yaml", "/child.yaml"),
             (AWS_CLOUDFORMATION_STACK, "TemplateURL", "file:///child.yaml", "/child.yaml"),
         ]
@@ -103,8 +103,8 @@ class TestSamBuildableStackProvider(TestCase):
         )
 
     def test_sam_deep_nested_stack(self):
-        child_template_file = "./child.yaml"
-        grand_child_template_file = "./grand-child.yaml"
+        child_template_file = "child.yaml"
+        grand_child_template_file = "grand-child.yaml"
         template = {
             "Resources": {
                 "ChildStack": {
@@ -166,5 +166,46 @@ class TestSamBuildableStackProvider(TestCase):
             stacks,
             [
                 Stack("", "", self.template_file, None, template),
+            ],
+        )
+
+    @parameterized.expand(
+        [
+            (AWS_SERVERLESS_APPLICATION, "Location", "./child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_SERVERLESS_APPLICATION, "Location", "child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "./child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "child.yaml", os.path.join("somedir", "child.yaml")),
+            (AWS_SERVERLESS_APPLICATION, "Location", "file:///child.yaml", "/child.yaml"),
+            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "file:///child.yaml", "/child.yaml"),
+        ]
+    )
+    def test_sam_nested_stack_template_path_can_be_resolved_if_root_template_is_not_in_working_dir(
+        self, resource_type, location_property_name, child_location, child_location_path
+    ):
+        template_file = "somedir/template.yaml"
+        template = {
+            "Resources": {
+                "ChildStack": {
+                    "Type": resource_type,
+                    "Properties": {location_property_name: child_location},
+                }
+            }
+        }
+        self.get_template_data_mock.side_effect = lambda t: {
+            template_file: template,
+            child_location_path: LEAF_TEMPLATE,
+        }.get(t)
+        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
+            stacks = SamLocalStackProvider.get_stacks(
+                template_file,
+                "",
+                "",
+                parameter_overrides=None,
+            )
+        self.assertListEqual(
+            stacks,
+            [
+                Stack("", "", template_file, None, template),
+                Stack("", "ChildStack", child_location_path, None, LEAF_TEMPLATE),
             ],
         )

--- a/tests/unit/lib/build_module/test_build_strategy.py
+++ b/tests/unit/lib/build_module/test_build_strategy.py
@@ -12,7 +12,7 @@ from samcli.lib.build.build_strategy import (
 from samcli.lib.utils import osutils
 from pathlib import Path
 
-from samcli.lib.utils.packagetype import ZIP
+from samcli.lib.utils.packagetype import ZIP, IMAGE
 
 
 @patch("samcli.lib.build.build_graph.BuildGraph._write")
@@ -192,6 +192,31 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
             str(mock_path(given_build_dir, self.function_build_definition1.get_function_name())),
             str(mock_path(given_build_dir, self.function1_2.name)),
         )
+
+    def test_build_single_function_definition_image_functions_with_same_metadata(self, mock_copy_tree, mock_path):
+        given_build_function = Mock()
+        built_image = Mock()
+        given_build_function.return_value = built_image
+        given_build_layer = Mock()
+        given_build_dir = "build_dir"
+        default_build_strategy = DefaultBuildStrategy(
+            self.build_graph, given_build_dir, given_build_function, given_build_layer
+        )
+
+        function1 = Mock()
+        function1.name = "Function"
+        function1.full_path = "Function"
+        function1.packagetype = IMAGE
+        function2 = Mock()
+        function2.name = "Function2"
+        function2.packagetype = IMAGE
+        build_definition = FunctionBuildDefinition("3.7", "codeuri", IMAGE, {})
+        # since they have the same metadata, they are put into the same build_definition.
+        build_definition.functions = [function1, function2]
+
+        result = default_build_strategy.build_single_function_definition(build_definition)
+        # both of the function name should show up in results
+        self.assertEqual(result, {"Function": built_image, "Function2": built_image})
 
 
 class CachedBuildStrategyTest(BuildStrategyBaseTest):


### PR DESCRIPTION
This reverts commit 60eb2f880e03f0f77d71bbe9ccdc7b14d4f31507.

#### Which issue(s) does this change fix?
Return back nested stack changes that we reverted before releasing V. 1.18.2

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
