### PR TITLE
fix: Go 1.16 set GOFLAGS to allow change of go.mod and go.sum

### DIFF
--- a/appveyor-windows-build-go.yml
+++ b/appveyor-windows-build-go.yml
@@ -41,6 +41,11 @@ install:
     - "refreshenv"
     - "go version"
     - "go env"
+    # Set Go to allow modify go.mod and go.sum
+    # Breaking change introduced by https://golang.org/doc/go1.16
+    - "go env -w GOFLAGS=-mod=mod"
+    # Check that GOFLAGS have been set.
+    - "go env"
 
     # Make sure the temp directory exists for Python to use.
     - ps: "mkdir -Force D:\\tmp"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
* Go integration tests

#### Why is this change necessary?
* Go 1.16 introduced a breaking change with go build no longer being allowed to change/create go.mod and go.sum files by default.
* Initial Assessment was that setting go env will not fix this, but that been set incorrectly without an "=" sign.

#### How does it address the issue?
* Set a go env variable to allow for changes.
#### What side effects does this change have?
* None, allows for build tests to start passing again.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
