### PR TITLE
fix: allow sam validate to look built template

### DIFF
--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -8,7 +8,7 @@ from botocore.exceptions import NoCredentialsError
 import click
 
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
-from samcli.commands._utils.options import template_option_without_build
+from samcli.commands._utils.options import template_click_option
 from samcli.lib.telemetry.metric import track_command
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
 from samcli.lib.utils.version_checker import check_newer_version
@@ -16,7 +16,7 @@ from samcli.lib.utils.version_checker import check_newer_version
 
 @click.command("validate", short_help="Validate an AWS SAM template.")
 @configuration_option(provider=TomlProvider(section="parameters"))
-@template_option_without_build
+@template_click_option(include_build=True)
 @aws_creds_options
 @cli_framework_options
 @pass_context


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/2613

#### Why is this change necessary?
* `sam validate` only looks for current template.yaml which maybe out of date, if a build has been run.

#### How does it address the issue?

* Directly check for a built template.yaml if present, `sam build` generates this template.

#### What side effects does this change have?

* None
#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
