### PR TITLE
fix: --s3-bucket or --image-repository requirement

### DIFF
--- a/samcli/commands/_utils/resources.py
+++ b/samcli/commands/_utils/resources.py
@@ -53,7 +53,7 @@ def get_packageable_resource_paths():
     """
     Resource Types with respective Locations that are package-able.
 
-    Yields
+    Returns
     ------
     _resource_property_dict : Dict
         Resource Dictionary containing packageable resource types and their locations as a list.

--- a/samcli/commands/_utils/resources.py
+++ b/samcli/commands/_utils/resources.py
@@ -49,6 +49,26 @@ RESOURCES_WITH_IMAGE_COMPONENT = {
 }
 
 
+def get_packageable_resource_paths():
+    """
+    Resource Types with respective Locations that are package-able.
+
+    Yields
+    ------
+    _resource_property_dict : Dict
+        Resource Dictionary containing packageable resource types and their locations as a list.
+    """
+    _resource_property_dict = defaultdict(list)
+    for _dict in (METADATA_WITH_LOCAL_PATHS, RESOURCES_WITH_LOCAL_PATHS, RESOURCES_WITH_IMAGE_COMPONENT):
+        for key, value in _dict.items():
+            # Only add values to the list if they are different, same property name could be used with the resource
+            # to package to different locations.
+            if value not in _resource_property_dict.get(key, []):
+                _resource_property_dict[key].append(value)
+
+    return _resource_property_dict
+
+
 def resources_generator():
     """
     Generator to yield set of resources and their locations that are supported for package operations
@@ -60,15 +80,7 @@ def resources_generator():
     location : str
         The location of the resource
     """
-    _resource_property_dict = defaultdict(list)
-    for _dict in (METADATA_WITH_LOCAL_PATHS, RESOURCES_WITH_LOCAL_PATHS, RESOURCES_WITH_IMAGE_COMPONENT):
-        for key, value in _dict.items():
-            # Only add values to the list if they are different, same property name could be used with the resource
-            # to package to different locations.
-            if value not in _resource_property_dict.get(key, []):
-                _resource_property_dict[key].append(value)
-
-    for resource, location_list in _resource_property_dict.items():
+    for resource, location_list in get_packageable_resource_paths().items():
         for locations in location_list:
             for location in locations:
                 yield resource, location

--- a/tests/integration/package/test_package_command_image.py
+++ b/tests/integration/package/test_package_command_image.py
@@ -60,12 +60,16 @@ class TestPackageImage(PackageIntegBase):
         self.assertIn("Error: Missing option '--image-repository'", process_stderr.decode("utf-8"))
         self.assertEqual(2, process.returncode)
 
-    @parameterized.expand(["aws-serverless-function-image.yaml", "aws-lambda-function-image.yaml"])
+    @parameterized.expand(
+        [
+            "aws-serverless-function-image.yaml",
+            "aws-lambda-function-image.yaml",
+            "aws-lambda-function-image-and-api.yaml",
+        ]
+    )
     def test_package_template_with_image_repository(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
-            image_repository=self.ecr_repo_name, template=template_path, resolve_s3=True
-        )
+        command_list = self.get_command_list(image_repository=self.ecr_repo_name, template=template_path)
 
         process = Popen(command_list, stdout=PIPE)
         try:

--- a/tests/integration/testdata/package/aws-lambda-function-image-and-api.yaml
+++ b/tests/integration/testdata/package/aws-lambda-function-image-and-api.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Simple AWS Lambda Function based on image PackageType and API
+
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      PackageType: Image
+      Code: alpine:latest
+      Role:
+        Fn::GetAtt:
+          - "LambdaExecutionRole"
+          - "Arn"
+      Timeout: 25
+
+  # Below resource is not a package-able resource, nor does it have a PackageType.
+  MyHttpApi:
+      Type: AWS::Serverless::HttpApi
+      Properties:
+        StageName: INTEG


### PR DESCRIPTION

#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/2450

#### Why is this change necessary?
* only make `--s3-bucket` or `--image-repository` mandatory if there are
resources present in the template that have locations that need to be
packaged to different AWS destinations such as S3 or ECR.

#### How does it address the issue?
* look for specific packageable resource locations based on their types to determine if `--s3-bucket` or `--image-repository` is required.
#### What side effects does this change have?
* for templates that have zero dependence on S3 or ECR, sam package will no longer require either `--s3-bucket` or `--image-repository`

```
template.yaml

AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31
Description: >
  python3.8

  Sample SAM Template for image

# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
Globals:
  Function:
    Timeout: 3

Resources:
  RailsHttpApi:
    Type: AWS::Serverless::HttpApi
    Properties:
      StageName: PROD

 ~/..../ sam package                                                                                                                                                 
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31
Description: 'python3.8

  Sample SAM Template for image

  '
Globals:
  Function:
    Timeout: 3
Resources:
  RailsHttpApi:
    Type: AWS::Serverless::HttpApi
    Properties:
      StageName: PROD
```

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
