### PR TITLE
fix: Added pre-dev.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include THIRD-PARTY-LICENSES
 include requirements/base.txt
+include requirements/pre-dev.txt
 include requirements/dev.txt
 include samcli/local/rapid/aws-lambda-rie
 recursive-include samcli/lib/init/templates *


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
https://github.com/aws/aws-sam-cli/issues/2660
#### Why is this change necessary?
pre-dev.txt requirement file was missing from the MANIFEST.in which causes PyPi tarball source to fail installation.
#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
