### PR TITLE
feat: Enable nested stack support for sam build and sam local

### DIFF
--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -155,14 +155,14 @@ $ sam build MyFunction
 @docker_common_options
 @cli_framework_options
 @aws_creds_options
-@click.argument("function_identifier", required=False)
+@click.argument("resource_logical_id", required=False)
 @pass_context
 @track_command
 @check_newer_version
 def cli(
     ctx: Context,
     # please keep the type below consistent with @click.options
-    function_identifier: Optional[str],
+    resource_logical_id: Optional[str],
     template_file: str,
     base_dir: Optional[str],
     build_dir: str,
@@ -184,7 +184,7 @@ def cli(
     mode = _get_mode_value_from_envvar("SAM_BUILD_MODE", choices=["debug"])
 
     do_cli(
-        function_identifier,
+        resource_logical_id,
         template_file,
         base_dir,
         build_dir,

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -46,13 +46,13 @@ STDIN_FILE_NAME = "-"
 @local_common_options
 @cli_framework_options
 @aws_creds_options
-@click.argument("function_identifier", required=False)
+@click.argument("function_logical_id", required=False)
 @pass_context
 @track_command  # pylint: disable=R0914
 @check_newer_version
 def cli(
     ctx,
-    function_identifier,
+    function_logical_id,
     template_file,
     event,
     no_event,
@@ -77,7 +77,7 @@ def cli(
 
     do_cli(
         ctx,
-        function_identifier,
+        function_logical_id,
         template_file,
         event,
         no_event,

--- a/samcli/lib/providers/api_provider.py
+++ b/samcli/lib/providers/api_provider.py
@@ -61,7 +61,7 @@ class ApiProvider(AbstractApiProvider):
         """
 
         collector = ApiCollector()
-        provider = self.find_api_provider(self.stacks)
+        provider = ApiProvider.find_api_provider(self.stacks)
         provider.extract_resources(self.stacks, collector, cwd=self.cwd)
         return collector.get_api()
 

--- a/samcli/lib/providers/cfn_api_provider.py
+++ b/samcli/lib/providers/cfn_api_provider.py
@@ -80,7 +80,8 @@ class CfnApiProvider(CfnBaseApiProvider):
             all_apis.extend(apis)
         return all_apis
 
-    def _extract_cloud_formation_route(self, stack_path: str, logical_id, api_resource, collector, cwd=None):
+    @staticmethod
+    def _extract_cloud_formation_route(stack_path: str, logical_id, api_resource, collector, cwd=None):
         """
         Extract APIs from AWS::ApiGateway::RestApi resource by reading and parsing Swagger documents. The result is
         added to the collector.
@@ -108,7 +109,9 @@ class CfnApiProvider(CfnBaseApiProvider):
             # Swagger is not found anywhere.
             LOG.debug("Skipping resource '%s'. Swagger document not found in Body and BodyS3Location", logical_id)
             return
-        self.extract_swagger_route(stack_path, logical_id, body, body_s3_location, binary_media, collector, cwd)
+        CfnBaseApiProvider.extract_swagger_route(
+            stack_path, logical_id, body, body_s3_location, binary_media, collector, cwd
+        )
 
     @staticmethod
     def _extract_cloud_formation_stage(resources, stage_resource, collector):
@@ -240,7 +243,9 @@ class CfnApiProvider(CfnBaseApiProvider):
                 collector.add_routes(logical_id, [routes])
             return
 
-        self.extract_swagger_route(stack_path, logical_id, body, body_s3_location, None, collector, cwd, Route.HTTP)
+        CfnBaseApiProvider.extract_swagger_route(
+            stack_path, logical_id, body, body_s3_location, None, collector, cwd, Route.HTTP
+        )
 
     def _extract_cfn_gateway_v2_route(self, stack_path: str, resources, logical_id, route_resource, collector):
         """

--- a/samcli/lib/providers/cfn_base_api_provider.py
+++ b/samcli/lib/providers/cfn_base_api_provider.py
@@ -99,7 +99,7 @@ class CfnBaseApiProvider:
         if cors_prop and isinstance(cors_prop, dict):
             allow_methods = self._get_cors_prop(cors_prop, "AllowMethods")
             if allow_methods:
-                allow_methods = self.normalize_cors_allow_methods(allow_methods)
+                allow_methods = CfnBaseApiProvider.normalize_cors_allow_methods(allow_methods)
             else:
                 allow_methods = ",".join(sorted(Route.ANY_HTTP_METHODS))
 
@@ -184,7 +184,7 @@ class CfnBaseApiProvider:
         if cors_prop and isinstance(cors_prop, dict):
             allow_methods = self._get_cors_prop_http(cors_prop, "AllowMethods", list)
             if isinstance(allow_methods, list):
-                allow_methods = self.normalize_cors_allow_methods(allow_methods)
+                allow_methods = CfnBaseApiProvider.normalize_cors_allow_methods(allow_methods)
             else:
                 allow_methods = ",".join(sorted(Route.ANY_HTTP_METHODS))
 

--- a/samcli/lib/providers/sam_api_provider.py
+++ b/samcli/lib/providers/sam_api_provider.py
@@ -94,7 +94,7 @@ class SamApiProvider(CfnBaseApiProvider):
                 "Skipping resource '%s'. Swagger document not found in DefinitionBody and DefinitionUri", logical_id
             )
             return
-        self.extract_swagger_route(stack_path, logical_id, body, uri, binary_media, collector, cwd=cwd)
+        CfnBaseApiProvider.extract_swagger_route(stack_path, logical_id, body, uri, binary_media, collector, cwd=cwd)
         collector.stage_name = stage_name
         collector.stage_variables = stage_variables
         collector.cors = cors
@@ -135,7 +135,9 @@ class SamApiProvider(CfnBaseApiProvider):
                 "Skipping resource '%s'. Swagger document not found in DefinitionBody and DefinitionUri", logical_id
             )
             return
-        self.extract_swagger_route(stack_path, logical_id, body, uri, None, collector, cwd=cwd, event_type=Route.HTTP)
+        CfnBaseApiProvider.extract_swagger_route(
+            stack_path, logical_id, body, uri, None, collector, cwd=cwd, event_type=Route.HTTP
+        )
         collector.stage_name = stage_name
         collector.stage_variables = stage_variables
         collector.cors = cors

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -43,7 +43,7 @@ class SamFunctionProvider(SamBaseProvider):
             LOG.debug("%d resources found in the stack %s", len(stack.resources), stack.stack_path)
 
         # Store a map of function full_path to function information for quick reference
-        self.functions = self._extract_functions(self.stacks, ignore_code_extraction_warnings)
+        self.functions = SamFunctionProvider._extract_functions(self.stacks, ignore_code_extraction_warnings)
 
         self._deprecated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
         self._colored = Colored()

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -48,7 +48,8 @@ class SamLocalStackProvider(SamBaseProvider):
         self._template_directory = os.path.dirname(template_file)
         self._stack_path = stack_path
         self._template_dict = self.get_template(
-            template_dict, self.merge_parameter_overrides(parameter_overrides, global_parameter_overrides)
+            template_dict,
+            SamLocalStackProvider.merge_parameter_overrides(parameter_overrides, global_parameter_overrides),
         )
         self._resources = self._template_dict.get("Resources", {})
         self._global_parameter_overrides = global_parameter_overrides

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -20,9 +20,6 @@ class SamLocalStackProvider(SamBaseProvider):
     It may or may not contain a stack.
     """
 
-    # see get_stacks() for info about this env var
-    ENV_SAM_CLI_ENABLE_NESTED_STACK = "SAM_CLI_ENABLE_NESTED_STACK"
-
     def __init__(
         self,
         template_file: str,
@@ -238,12 +235,6 @@ class SamLocalStackProvider(SamBaseProvider):
                 template_dict,
             )
         ]
-
-        # Note(xinhol): recursive get_stacks is only enabled in tests by env var SAM_CLI_ENABLE_NESTED_STACK.
-        # We will remove this env var and make this method recursive by default
-        # for nested stack support in the future.
-        if not os.environ.get(SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK, False):
-            return stacks
 
         current = SamLocalStackProvider(
             template_file, stack_path, template_dict, parameter_overrides, global_parameter_overrides

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -301,36 +301,6 @@ class NestedBuildIntegBase(BuildIntegBase):
                 f"Building codeuri: .* runtime: .* metadata: .* functions: \\[.*'{function_full_path}'.*\\]",
             )
 
-    def _verify_invoke_built_function(self, template_path, function_logical_id, overrides, expected_result):
-        """
-        Note(Xinhol) this _verify_invoke_built_function() is identical to the superclass' one
-        except it add SAM_CLI_ENABLE_NESTED_STACK=1 environment variable to it.
-        Once the nested stack support is completed and SAM_CLI_ENABLE_NESTED_STACK is removed,
-        we can remove this overriding method _verify_invoke_built_function.
-        """
-        LOG.info("Invoking built function '{}'".format(function_logical_id))
-
-        cmdlist = [
-            self.cmd,
-            "local",
-            "invoke",
-            function_logical_id,
-            "-t",
-            str(template_path),
-            "--no-event",
-            "--parameter-overrides",
-            overrides,
-            "--debug",
-        ]
-
-        newenv = os.environ.copy()
-        newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
-        process_execute = run_command(cmdlist, env=newenv)
-        process_execute.process.wait()
-
-        process_stdout = process_execute.stdout.decode("utf-8")
-        self.assertEqual(json.loads(process_stdout), expected_result)
-
     def _verify_invoke_built_functions(self, template_path, overrides, function_and_expected):
         for function_identifier, expected in function_and_expected:
             self._verify_invoke_built_function(template_path, function_identifier, overrides, expected)

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1554,6 +1554,9 @@ class TestBuildWithNestedStacks(NestedBuildIntegBase):
 
         command_result = run_command(cmdlist, cwd=self.working_dir)
 
+        # make sure functions are deduplicated properly, in stderr they will show up in the same line.
+        self.assertRegex(command_result.stderr.decode("utf-8"), r"Building .+'Function2',.+LocalNestedStack/Function2")
+
         function_full_paths = ["Function", "Function2", "LocalNestedStack/Function1", "LocalNestedStack/Function2"]
         stack_paths = ["", "LocalNestedStack"]
         if not SKIP_DOCKER_TESTS:

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1517,9 +1517,7 @@ class TestBuildWithNestedStacks(NestedBuildIntegBase):
         LOG.info("Running Command: %s", cmdlist)
         LOG.info(self.working_dir)
 
-        newenv = os.environ.copy()
-        newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
-        command_result = run_command(cmdlist, cwd=self.working_dir, env=newenv)
+        command_result = run_command(cmdlist, cwd=self.working_dir)
 
         function_full_paths = ["Function", "Function2", "LocalNestedStack/Function1", "LocalNestedStack/Function2"]
         stack_paths = ["", "LocalNestedStack"]
@@ -1599,9 +1597,7 @@ class TestBuildWithNestedStacksImage(NestedBuildIntegBase):
         LOG.info("Running Command: %s", cmdlist)
         LOG.info(self.working_dir)
 
-        newenv = os.environ.copy()
-        newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
-        command_result = run_command(cmdlist, cwd=self.working_dir, env=newenv)
+        command_result = run_command(cmdlist, cwd=self.working_dir)
 
         stack_paths = ["", "LocalNestedStack"]
         if not SKIP_DOCKER_TESTS:

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -6,7 +6,7 @@ import logging
 import random
 from unittest import skipIf
 from pathlib import Path
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 
 import pytest
 
@@ -910,6 +910,13 @@ class TestBuildCommand_LayerBuilds(BuildIntegBase):
         return "python{}.{}".format(sys.version_info.major, sys.version_info.minor)
 
 
+@parameterized_class(
+    ("template", "is_nested_parent"),
+    [
+        ("template-parent.yaml", "is_nested_parent"),
+        ("template.yaml", False),
+    ],
+)
 class TestBuildCommand_ProvidedFunctions(BuildIntegBase):
     # Test Suite for runtime: provided and where selection of the build workflow is implicitly makefile builder
     # if the makefile is present.
@@ -944,9 +951,14 @@ class TestBuildCommand_ProvidedFunctions(BuildIntegBase):
         # Built using Makefile for a python project.
         run_command(cmdlist, cwd=self.working_dir)
 
-        self._verify_built_artifact(
-            self.default_build_dir, self.FUNCTION_LOGICAL_ID, self.EXPECTED_FILES_PROJECT_MANIFEST
-        )
+        if self.is_nested_parent:
+            self._verify_built_artifact_in_subapp(
+                self.default_build_dir, "SubApp", self.FUNCTION_LOGICAL_ID, self.EXPECTED_FILES_PROJECT_MANIFEST
+            )
+        else:
+            self._verify_built_artifact(
+                self.default_build_dir, self.FUNCTION_LOGICAL_ID, self.EXPECTED_FILES_PROJECT_MANIFEST
+            )
 
         expected = "2.23.0"
         # Building was done with a makefile, but invoke should be checked with corresponding python image.
@@ -967,6 +979,29 @@ class TestBuildCommand_ProvidedFunctions(BuildIntegBase):
 
         template_path = build_dir.joinpath("template.yaml")
         resource_artifact_dir = build_dir.joinpath(function_logical_id)
+
+        # Make sure the template has correct CodeUri for resource
+        self._verify_resource_property(str(template_path), function_logical_id, "CodeUri", function_logical_id)
+
+        all_artifacts = set(os.listdir(str(resource_artifact_dir)))
+        actual_files = all_artifacts.intersection(expected_files)
+        self.assertEqual(actual_files, expected_files)
+
+    def _verify_built_artifact_in_subapp(self, build_dir, subapp_path, function_logical_id, expected_files):
+
+        self.assertTrue(build_dir.exists(), "Build directory should be created")
+        subapp_build_dir = Path(build_dir, subapp_path)
+        self.assertTrue(subapp_build_dir.exists(), f"Build directory for sub app {subapp_path} should be created")
+
+        build_dir_files = os.listdir(str(build_dir))
+        self.assertIn("template.yaml", build_dir_files)
+
+        subapp_build_dir_files = os.listdir(str(subapp_build_dir))
+        self.assertIn("template.yaml", subapp_build_dir_files)
+        self.assertIn(function_logical_id, subapp_build_dir_files)
+
+        template_path = subapp_build_dir.joinpath("template.yaml")
+        resource_artifact_dir = subapp_build_dir.joinpath(function_logical_id)
 
         # Make sure the template has correct CodeUri for resource
         self._verify_resource_property(str(template_path), function_logical_id, "CodeUri", function_logical_id)

--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -12,7 +12,6 @@ TIMEOUT = 300
 @skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
 class InvokeIntegBase(TestCase):
     template: Optional[Path] = None
-    nested_stack_enabled = False
 
     @classmethod
     def setUpClass(cls):
@@ -22,12 +21,6 @@ class InvokeIntegBase(TestCase):
         cls.event_path = str(cls.test_data_path.joinpath("invoke", "event.json"))
         cls.event_utf8_path = str(cls.test_data_path.joinpath("invoke", "event_utf8.json"))
         cls.env_var_path = str(cls.test_data_path.joinpath("invoke", "vars.json"))
-
-        cls.env = None
-        if cls.nested_stack_enabled:
-            newenv = os.environ.copy()
-            newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
-            cls.env = newenv
 
     @staticmethod
     def get_integ_dir():

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -25,13 +25,10 @@ TIMEOUT = 300
 
 
 @parameterized_class(
-    ("template", "nested_stack_enabled"),
+    ("template",),
     [
-        (Path("template.yml"), False),
-        (
-            Path("nested-templates", "template-parent.yaml"),
-            "nested_stack_enabled",
-        ),
+        (Path("template.yml"),),
+        (Path("nested-templates/template-parent.yaml"),),
     ],
 )
 class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
@@ -41,7 +38,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -57,7 +54,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_utf8_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -70,7 +67,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
     def test_function_with_metadata(self):
         command_list = self.get_command_list("FunctionWithMetadata", template_path=self.template_path, no_event=True)
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -94,7 +91,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             function_name, template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -110,7 +107,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -126,7 +123,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "func-name-override", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -146,7 +143,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         )
 
         start = timer()
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -179,7 +176,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             env_var_path=self.env_var_path,
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -195,7 +192,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -210,7 +207,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "WriteToStdoutFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, stderr=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE, stderr=PIPE)
         try:
             stdout, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -229,7 +226,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "WriteToStderrFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stderr=PIPE, env=self.env)
+        process = Popen(command_list, stderr=PIPE)
         try:
             _, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -243,7 +240,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_expected_result_when_no_event_given(self):
         command_list = self.get_command_list("EchoEventFunction", template_path=self.template_path)
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -264,7 +261,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             parameter_overrides={"MyRuntimeVersion": "v0", "DefaultTimeout": "100"},
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -296,7 +293,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path, region=custom_region
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -325,8 +322,6 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         env["AWS_ACCESS_KEY_ID"] = key
         env["AWS_SECRET_ACCESS_KEY"] = secret
         env["AWS_SESSION_TOKEN"] = session
-        if self.nested_stack_enabled:
-            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stdout=PIPE, env=env)
         try:
@@ -353,7 +348,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             docker_network="host",
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -371,8 +366,6 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         env = os.environ.copy()
         env["SAM_DOCKER_NETWORK"] = "non-existing-network"
-        if self.nested_stack_enabled:
-            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stderr=PIPE, env=env)
         try:
@@ -392,8 +385,6 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.test_data_path.joinpath("invoke", "sam-template.yaml")
         env = os.environ.copy()
         env["SAM_TEMPLATE_FILE"] = str(self.test_data_path.joinpath("invoke", "sam-template.yaml"))
-        if self.nested_stack_enabled:
-            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stdout=PIPE, env=env)
         try:
@@ -417,8 +408,6 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         env = os.environ.copy()
         env["SAM_SKIP_PULL_IMAGE"] = "True"
-        if self.nested_stack_enabled:
-            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stderr=PIPE, env=env)
         try:
@@ -438,7 +427,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             "GitLayerFunction", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -459,7 +448,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             parameter_overrides={"LayerVersion": "5"},
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -676,17 +665,11 @@ class TestUsingConfigFiles(InvokeIntegBase):
 
 
 @parameterized_class(
-    ("template", "nested_stack_enabled"),
+    ("template",),
     [
-        (Path("layers", "layer-template.yml"), False),
-        (
-            Path("nested-templates", "layer-template-parent.yaml"),
-            "nested_stack_enabled",
-        ),
-        (
-            Path("layers", "some-dir", "layer-template-parent.yaml"),
-            "nested_stack_enabled",
-        ),
+        (Path("layers", "layer-template.yml"),),
+        (Path("nested-templates", "layer-template-parent.yaml"),),
+        (Path("layers", "some-dir", "layer-template-parent.yaml"),),
     ],
 )
 @skipIf(SKIP_LAYERS_TESTS, "Skip layers tests in Appveyor only")
@@ -744,7 +727,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -768,7 +751,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -794,7 +777,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -819,7 +802,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate()
         except TimeoutExpired:
@@ -844,7 +827,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -869,7 +852,7 @@ class TestLayerVersion(InvokeIntegBase):
             parameter_overrides=self.layer_utils.parameters_overrides,
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -890,8 +873,6 @@ class TestLayerVersion(InvokeIntegBase):
 
         env = os.environ.copy()
         env["SAM_LAYER_CACHE_BASEDIR"] = str(self.layer_cache)
-        if self.nested_stack_enabled:
-            env["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
 
         process = Popen(command_list, stdout=PIPE, env=env)
         try:
@@ -932,7 +913,7 @@ class TestLayerVersionThatDoNotCreateCache(InvokeIntegBase):
             parameter_overrides={"NonExistentLayerArn": non_existent_layer_arn},
         )
 
-        process = Popen(command_list, stderr=PIPE, env=self.env)
+        process = Popen(command_list, stderr=PIPE)
         try:
             _, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -955,7 +936,7 @@ class TestLayerVersionThatDoNotCreateCache(InvokeIntegBase):
             region=self.region,
         )
 
-        process = Popen(command_list, stderr=PIPE, env=self.env)
+        process = Popen(command_list, stderr=PIPE)
         try:
             _, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -1005,7 +986,6 @@ class TestBadLayerVersion(InvokeIntegBase):
 
 class TestInvokeWithFunctionFullPathToAvoidAmbiguity(InvokeIntegBase):
     template = Path("template-deep-root.yaml")
-    nested_stack_enabled = True
 
     @parameterized.expand(
         [
@@ -1021,7 +1001,7 @@ class TestInvokeWithFunctionFullPathToAvoidAmbiguity(InvokeIntegBase):
             function_identifier, template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
@@ -1039,7 +1019,7 @@ class TestInvokeWithFunctionFullPathToAvoidAmbiguity(InvokeIntegBase):
             "SubApp/SubSubApp/FunctionA", template_path=self.template_path, event_path=self.event_path
         )
 
-        process = Popen(command_list, stdout=PIPE, env=self.env)
+        process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:

--- a/tests/integration/local/start_api/start_api_integ_base.py
+++ b/tests/integration/local/start_api/start_api_integ_base.py
@@ -23,8 +23,6 @@ class StartApiIntegBaseClass(TestCase):
     build_before_invoke = False
     build_overrides: Optional[Dict[str, str]] = None
 
-    nested_stack_enabled = False
-
     @classmethod
     def setUpClass(cls):
         # This is the directory for tests/integration which will be used to file the testdata
@@ -71,11 +69,7 @@ class StartApiIntegBaseClass(TestCase):
         if cls.parameter_overrides:
             command_list += ["--parameter-overrides", cls._make_parameter_override_arg(cls.parameter_overrides)]
 
-        newenv = None
-        if cls.nested_stack_enabled:
-            newenv = os.environ.copy()
-            newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
-        cls.start_api_process = Popen(command_list, env=newenv)
+        cls.start_api_process = Popen(command_list)
         # we need to wait some time for start-api to start, hence the sleep
         time.sleep(5)
 

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -122,10 +122,10 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
 
 
 @parameterized_class(
-    ("template_path", "nested_stack_enabled"),
+    ("template_path",),
     [
-        ("/testdata/start_api/template.yaml", False),
-        ("/testdata/start_api/nested-templates/template-parent.yaml", "nested_stack_enabled"),
+        ("/testdata/start_api/template.yaml",),
+        ("/testdata/start_api/nested-templates/template-parent.yaml",),
     ],
 )
 class TestService(StartApiIntegBaseClass):
@@ -236,10 +236,10 @@ class TestService(StartApiIntegBaseClass):
 
 
 @parameterized_class(
-    ("template_path", "nested_stack_enabled"),
+    ("template_path",),
     [
-        ("/testdata/start_api/template-http-api.yaml", False),
-        ("/testdata/start_api/nested-templates/template-http-api-parent.yaml", "nested_stack_enabled"),
+        ("/testdata/start_api/template-http-api.yaml",),
+        ("/testdata/start_api/nested-templates/template-http-api-parent.yaml",),
     ],
 )
 class TestServiceWithHttpApi(StartApiIntegBaseClass):
@@ -1546,13 +1546,10 @@ class TestCFNTemplateQuickCreatedHttpApiWithDefaultRoute(StartApiIntegBaseClass)
 
 
 @parameterized_class(
-    ("template_path", "nested_stack_enabled"),
+    ("template_path",),
     [
-        ("/testdata/start_api/cfn-http-api-with-normal-and-default-routes.yaml", False),
-        (
-            "/testdata/start_api/nested-templates/cfn-http-api-with-normal-and-default-routes-parent.yaml",
-            "nested_stack_enabled",
-        ),
+        ("/testdata/start_api/cfn-http-api-with-normal-and-default-routes.yaml",),
+        ("/testdata/start_api/nested-templates/cfn-http-api-with-normal-and-default-routes-parent.yaml",),
     ],
 )
 class TestCFNTemplateHttpApiWithNormalAndDefaultRoutes(StartApiIntegBaseClass):
@@ -1631,13 +1628,10 @@ class TestServerlessTemplateWithRestApiAndHttpApiGateways(StartApiIntegBaseClass
 
 
 @parameterized_class(
-    ("template_path", "nested_stack_enabled"),
+    ("template_path",),
     [
-        ("/testdata/start_api/cfn-http-api-and-rest-api-gateways.yaml", False),
-        (
-            "/testdata/start_api/nested-templates/cfn-http-api-and-rest-api-gateways-parent.yaml",
-            "nested_stack_enabled",
-        ),
+        ("/testdata/start_api/cfn-http-api-and-rest-api-gateways.yaml",),
+        ("/testdata/start_api/nested-templates/cfn-http-api-and-rest-api-gateways-parent.yaml",),
     ],
 )
 class TestCFNTemplateWithRestApiAndHttpApiGateways(StartApiIntegBaseClass):
@@ -2076,7 +2070,6 @@ class TestApiPrecedenceInNestedStacks(StartApiIntegBaseClass):
     """
 
     template_path = "/testdata/start_api/nested-templates/template-precedence-root.yaml"
-    nested_stack_enabled = True
 
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -2099,3 +2099,19 @@ class TestApiPrecedenceInNestedStacks(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         self.assertEqual(response_data.get("body"), data)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_should_not_call_non_existent_path(self):
+        data = "some data"
+        response = requests.post(self.url + "/path404", data=data, timeout=300)
+
+        self.assertEqual(response.status_code, 403)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_should_not_call_non_mounting_method(self):
+        data = "some data"
+        response = requests.put(self.url + "/path2", data=data, timeout=300)
+
+        self.assertEqual(response.status_code, 403)

--- a/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
+++ b/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
@@ -24,8 +24,6 @@ class StartLambdaIntegBaseClass(TestCase):
     build_before_invoke = False
     build_overrides: Optional[Dict[str, str]] = None
 
-    nested_stack_enabled = False
-
     @classmethod
     def setUpClass(cls):
         # This is the directory for tests/integration which will be used to file the testdata
@@ -78,11 +76,7 @@ class StartLambdaIntegBaseClass(TestCase):
         if cls.parameter_overrides:
             command_list += ["--parameter-overrides", cls._make_parameter_override_arg(cls.parameter_overrides)]
 
-        newenv = None
-        if cls.nested_stack_enabled:
-            newenv = os.environ.copy()
-            newenv["SAM_CLI_ENABLE_NESTED_STACK"] = "1"
-        cls.start_lambda_process = Popen(command_list, env=newenv)
+        cls.start_lambda_process = Popen(command_list)
         # we need to wait some time for start-lambda to start, hence the sleep
         time.sleep(wait_time)
 

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -112,13 +112,10 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
 
 
 @parameterized_class(
-    ("template_path", "nested_stack_enabled"),
+    ("template_path",),
     [
-        ("/testdata/invoke/template.yml", False),
-        (
-            "/testdata/invoke/nested-templates/template-parent.yaml",
-            "nested_stack_enabled",
-        ),
+        ("/testdata/invoke/template.yml",),
+        ("/testdata/invoke/nested-templates/template-parent.yaml",),
     ],
 )
 class TestLambdaService(StartLambdaIntegBaseClass):

--- a/tests/integration/package/test_package_command_image.py
+++ b/tests/integration/package/test_package_command_image.py
@@ -1,3 +1,5 @@
+import os
+import re
 import tempfile
 from subprocess import Popen, PIPE, TimeoutExpired
 
@@ -24,7 +26,13 @@ class TestPackageImage(PackageIntegBase):
     @classmethod
     def setUpClass(cls):
         cls.docker_client = docker.from_env()
-        cls.local_images = [("alpine", "latest")]
+        cls.local_images = [
+            ("alpine", "latest"),
+            # below 3 images are for test_package_with_deep_nested_template_image()
+            ("python", "3.9-slim"),
+            ("python", "3.8-slim"),
+            ("python", "3.7-slim"),
+        ]
         # setup some images locally by pulling them.
         for repo, tag in cls.local_images:
             cls.docker_client.api.pull(repository=repo, tag=tag)
@@ -166,3 +174,44 @@ class TestPackageImage(PackageIntegBase):
             s3.Object(bucket_name, key).download_fileobj(packaged_nested_file)
             packaged_nested_file.seek(0)
             self.assertIn(f"{self.ecr_repo_name}", packaged_nested_file.read().decode())
+
+    def test_package_with_deep_nested_template_image(self):
+        """
+        this template contains two nested stacks:
+        - root
+          - FunctionA
+          - ChildStackX
+            - FunctionB
+            - ChildStackY
+              - FunctionA
+        """
+        template_file = os.path.join("deep-nested-image", "template.yaml")
+
+        template_path = self.test_data_path.joinpath(template_file)
+        command_list = self.get_command_list(
+            image_repository=self.ecr_repo_name, resolve_s3=True, template=template_path, force_upload=True
+        )
+
+        process = Popen(command_list, stdout=PIPE, stderr=PIPE)
+        try:
+            _, stderr = process.communicate(timeout=TIMEOUT)
+        except TimeoutExpired:
+            process.kill()
+            raise
+        process_stderr = stderr.strip().decode("utf-8")
+
+        # there are in total 3 function images and 2 child template file to upload
+        # verify both child templates are uploaded
+        uploads = re.findall(r"\.template", process_stderr)
+        self.assertEqual(len(uploads), 2)
+
+        # verify all function images are pushed
+        images = [
+            ("python", "3.9-slim"),
+            ("python", "3.8-slim"),
+            ("python", "3.7-slim"),
+        ]
+        for image, tag in images:
+            # check string like this:
+            # ...python-ce689abb4f0d-3.9-slim: digest:...
+            self.assertRegex(process_stderr, fr"{image}-.+-{tag}: digest:")

--- a/tests/integration/package/test_package_command_zip.py
+++ b/tests/integration/package/test_package_command_zip.py
@@ -1,9 +1,13 @@
+import os
+import pathlib
+import re
 from subprocess import Popen, PIPE, TimeoutExpired
 import tempfile
 
 from unittest import skipIf
 from parameterized import parameterized, param
 
+from samcli.lib.utils.hash import dir_checksum, file_checksum
 from samcli.lib.warnings.sam_cli_warning import CodeDeployWarning
 from .package_integ_base import PackageIntegBase
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
@@ -497,3 +501,49 @@ class TestPackageZip(PackageIntegBase):
         # Not comparing with full warning message because of line ending mismatch on
         # windows and non-windows
         self.assertIn(warning_keyword, process_stdout)
+
+    def test_package_with_deep_nested_template(self):
+        """
+        this template contains two nested stacks:
+        - root
+          - FunctionA
+          - ChildStackX
+            - FunctionB
+            - ChildStackY
+              - FunctionA
+              - MyLayerVersion
+        """
+        template_file = os.path.join("deep-nested", "template.yaml")
+
+        template_path = self.test_data_path.joinpath(template_file)
+        command_list = self.get_command_list(s3_bucket=self.s3_bucket.name, template=template_path, force_upload=True)
+
+        process = Popen(command_list, stdout=PIPE, stderr=PIPE)
+        try:
+            _, stderr = process.communicate(timeout=TIMEOUT)
+        except TimeoutExpired:
+            process.kill()
+            raise
+        process_stderr = stderr.strip().decode("utf-8")
+
+        # there are in total 3 function dir, 1 layer dir and 2 child templates to upload
+        uploads = re.findall(r"Uploading to.+", process_stderr)
+        self.assertEqual(len(uploads), 6)
+
+        # make sure uploads' checksum match the dirs and child templates
+        build_dir = pathlib.Path(os.path.dirname(__file__)).parent.joinpath("testdata", "package", "deep-nested")
+        dirs = [
+            build_dir.joinpath("FunctionA"),
+            build_dir.joinpath("ChildStackX", "FunctionB"),
+            build_dir.joinpath("ChildStackX", "ChildStackY", "FunctionA"),
+            build_dir.joinpath("ChildStackX", "ChildStackY", "MyLayerVersion"),
+        ]
+        # here we only verify function/layer code dirs' hash
+        # because templates go through some pre-process before being uploaded and the hash can not be determined
+        for dir in dirs:
+            checksum = dir_checksum(dir.absolute())
+            self.assertIn(checksum, process_stderr)
+
+        # verify both child templates are uploaded
+        uploads = re.findall(r"\.template", process_stderr)
+        self.assertEqual(len(uploads), 2)

--- a/tests/integration/testdata/buildcmd/template-parent.yaml
+++ b/tests/integration/testdata/buildcmd/template-parent.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameteres:
+  Runtime:
+    Type: String
+  CodeUri:
+    Type: String
+  Handler:
+    Type: String
+
+Resources:
+  SubApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./template.yaml
+      Parameters:
+        Runtime: !Ref Runtime
+        CodeUri: !Ref CodeUri
+        Handler: !Ref Handler

--- a/tests/integration/testdata/package/deep-nested-image/ChildStackX/ChildStackY/template.yaml
+++ b/tests/integration/testdata/package/deep-nested-image/ChildStackX/ChildStackY/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Resources:
+  FunctionA:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageUri: python:3.9-slim

--- a/tests/integration/testdata/package/deep-nested-image/ChildStackX/template.yaml
+++ b/tests/integration/testdata/package/deep-nested-image/ChildStackX/template.yaml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Resources:
+  FunctionB:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageUri: python:3.7-slim
+
+  ChildStackY:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ChildStackY/template.yaml

--- a/tests/integration/testdata/package/deep-nested-image/template.yaml
+++ b/tests/integration/testdata/package/deep-nested-image/template.yaml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Resources:
+  FunctionA:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Image
+      ImageUri: python:3.8-slim
+
+  ChildStackX:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ChildStackX/template.yaml

--- a/tests/integration/testdata/package/deep-nested/ChildStackX/ChildStackY/FunctionA/main_a_2.py
+++ b/tests/integration/testdata/package/deep-nested/ChildStackX/ChildStackY/FunctionA/main_a_2.py
@@ -1,0 +1,8 @@
+import json
+
+
+def handler(event, context):
+    """
+    FunctionA in leaf template
+    """
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}

--- a/tests/integration/testdata/package/deep-nested/ChildStackX/ChildStackY/MyLayerVersion/my_layer/simple_python.py
+++ b/tests/integration/testdata/package/deep-nested/ChildStackX/ChildStackY/MyLayerVersion/my_layer/simple_python.py
@@ -1,0 +1,2 @@
+def layer_ping():
+    return "This is a Layer Ping from simple_python"

--- a/tests/integration/testdata/package/deep-nested/ChildStackX/ChildStackY/template.yaml
+++ b/tests/integration/testdata/package/deep-nested/ChildStackX/ChildStackY/template.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Resources:
+  FunctionA:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main_a_2.handler
+      Runtime: python3.7
+      CodeUri: FunctionA
+      Timeout: 600
+
+  MyLayerVersion:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: MyLayer
+      Description: Layer description
+      ContentUri: MyLayerVersion
+      CompatibleRuntimes:
+        - python3.7

--- a/tests/integration/testdata/package/deep-nested/ChildStackX/FunctionB/main_b.py
+++ b/tests/integration/testdata/package/deep-nested/ChildStackX/FunctionB/main_b.py
@@ -1,0 +1,8 @@
+import json
+
+
+def handler(event, context):
+    """
+    FunctionB in child template
+    """
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}

--- a/tests/integration/testdata/package/deep-nested/ChildStackX/template.yaml
+++ b/tests/integration/testdata/package/deep-nested/ChildStackX/template.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Resources:
+  FunctionB:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main_b.handler
+      Runtime: python3.7
+      CodeUri: FunctionB
+      Timeout: 600
+
+  ChildStackY:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ChildStackY/template.yaml

--- a/tests/integration/testdata/package/deep-nested/FunctionA/main_a.py
+++ b/tests/integration/testdata/package/deep-nested/FunctionA/main_a.py
@@ -1,0 +1,8 @@
+import json
+
+
+def handler(event, context):
+    """
+    FunctionA in root template
+    """
+    return {"statusCode": 200, "body": json.dumps({"hello": "world"})}

--- a/tests/integration/testdata/package/deep-nested/template.yaml
+++ b/tests/integration/testdata/package/deep-nested/template.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Resources:
+  FunctionA:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main_a.handler
+      Runtime: python3.7
+      CodeUri: FunctionA
+      Timeout: 600
+
+  ChildStackX:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ChildStackX/template.yaml

--- a/tests/integration/testdata/package/samconfig-deep-nested.toml
+++ b/tests/integration/testdata/package/samconfig-deep-nested.toml
@@ -1,0 +1,5 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+capabilities = "CAPABILITY_IAM CAPABILITY_AUTO_EXPAND"

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -50,55 +50,17 @@ class TestSamBuildableStackProvider(TestCase):
             self.template_file: template,
             child_location_path: LEAF_TEMPLATE,
         }.get(t)
-        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
-            stacks = SamLocalStackProvider.get_stacks(
-                self.template_file,
-                "",
-                "",
-                parameter_overrides=None,
-            )
+        stacks = SamLocalStackProvider.get_stacks(
+            self.template_file,
+            "",
+            "",
+            parameter_overrides=None,
+        )
         self.assertListEqual(
             stacks,
             [
                 Stack("", "", self.template_file, {}, template),
                 Stack("", "ChildStack", child_location_path, {}, LEAF_TEMPLATE),
-            ],
-        )
-
-    @parameterized.expand(
-        [
-            (AWS_SERVERLESS_APPLICATION, "Location", "./child.yaml", "./child.yaml"),
-            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "./child.yaml", "./child.yaml"),
-            (AWS_SERVERLESS_APPLICATION, "Location", "file:///child.yaml", "/child.yaml"),
-            (AWS_CLOUDFORMATION_STACK, "TemplateURL", "file:///child.yaml", "/child.yaml"),
-        ]
-    )
-    def test_sam_nested_stack_should_not_be_extracted_when_recursive_is_disabled(
-        self, resource_type, location_property_name, child_location, child_location_path
-    ):
-        template = {
-            "Resources": {
-                "ChildStack": {
-                    "Type": resource_type,
-                    "Properties": {location_property_name: child_location},
-                }
-            }
-        }
-        self.get_template_data_mock.side_effect = lambda t: {
-            self.template_file: template,
-            child_location_path: LEAF_TEMPLATE,
-        }.get(t)
-        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: ""}):
-            stacks = SamLocalStackProvider.get_stacks(
-                self.template_file,
-                "",
-                "",
-                parameter_overrides=None,
-            )
-        self.assertListEqual(
-            stacks,
-            [
-                Stack("", "", self.template_file, {}, template),
             ],
         )
 
@@ -126,13 +88,12 @@ class TestSamBuildableStackProvider(TestCase):
             child_template_file: child_template,
             grand_child_template_file: LEAF_TEMPLATE,
         }.get(t)
-        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
-            stacks = SamLocalStackProvider.get_stacks(
-                self.template_file,
-                "",
-                "",
-                parameter_overrides=None,
-            )
+        stacks = SamLocalStackProvider.get_stacks(
+            self.template_file,
+            "",
+            "",
+            parameter_overrides=None,
+        )
         self.assertListEqual(
             stacks,
             [
@@ -155,13 +116,12 @@ class TestSamBuildableStackProvider(TestCase):
         self.get_template_data_mock.side_effect = lambda t: {
             self.template_file: template,
         }.get(t)
-        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
-            stacks = SamLocalStackProvider.get_stacks(
-                self.template_file,
-                "",
-                "",
-                parameter_overrides=None,
-            )
+        stacks = SamLocalStackProvider.get_stacks(
+            self.template_file,
+            "",
+            "",
+            parameter_overrides=None,
+        )
         self.assertListEqual(
             stacks,
             [
@@ -195,13 +155,12 @@ class TestSamBuildableStackProvider(TestCase):
             template_file: template,
             child_location_path: LEAF_TEMPLATE,
         }.get(t)
-        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
-            stacks = SamLocalStackProvider.get_stacks(
-                template_file,
-                "",
-                "",
-                parameter_overrides=None,
-            )
+        stacks = SamLocalStackProvider.get_stacks(
+            template_file,
+            "",
+            "",
+            parameter_overrides=None,
+        )
         self.assertListEqual(
             stacks,
             [
@@ -239,10 +198,9 @@ class TestSamBuildableStackProvider(TestCase):
 
         global_parameter_overrides = {"AWS::Region": "custom_region"}
 
-        with patch.dict(os.environ, {SamLocalStackProvider.ENV_SAM_CLI_ENABLE_NESTED_STACK: "1"}):
-            stacks = SamLocalStackProvider.get_stacks(
-                template_file, "", "", parameter_overrides=None, global_parameter_overrides=global_parameter_overrides
-            )
+        stacks = SamLocalStackProvider.get_stacks(
+            template_file, "", "", parameter_overrides=None, global_parameter_overrides=global_parameter_overrides
+        )
         self.assertListEqual(
             stacks,
             [

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -103,7 +103,7 @@ class TestSamConfigForAllCommands(TestCase):
     @patch("samcli.commands.build.command.do_cli")
     def test_build(self, do_cli_mock):
         config_values = {
-            "function_identifier": "foo",
+            "resource_logical_id": "foo",
             "template_file": "mytemplate.yaml",
             "base_dir": "basedir",
             "build_dir": "builddir",
@@ -152,7 +152,7 @@ class TestSamConfigForAllCommands(TestCase):
     @patch("samcli.commands.build.command.do_cli")
     def test_build_with_container_env_vars(self, do_cli_mock):
         config_values = {
-            "function_identifier": "foo",
+            "resource_logical_id": "foo",
             "template_file": "mytemplate.yaml",
             "base_dir": "basedir",
             "build_dir": "builddir",
@@ -203,7 +203,7 @@ class TestSamConfigForAllCommands(TestCase):
     @patch("samcli.commands.local.invoke.cli.do_cli")
     def test_local_invoke(self, do_cli_mock):
         config_values = {
-            "function_identifier": "foo",
+            "function_logical_id": "foo",
             "template_file": "mytemplate.yaml",
             "event": "event",
             "no_event": False,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

**#2631 is not merged, this PR is based on #2631, please only review the last 5 commits.**

**#2631 is not merged, this PR is based on #2631, please only review the last 5 commits.**

**#2631 is not merged, this PR is based on #2631, please only review the last 5 commits.**

- Remove flag SAM_CLI_ENABLE_NESTED_STACK and enable nested stack by de…
- Add 2 integration tests to test sam package with deep nested stack
- Add 2 integration tests to test sam deploy with deep nested stack 
- Make cli options consistent with doc
- Add two failing test cases for start-api and invoke

In #2594, #2609, #2618, #2623 and #2631, this PR removes the feature flag "SAM_CLI_ENABLE_NESTED_STACK" and turn on nested stack support by default.
Also integration tests to test `sam deploy` and `sam package` are added to test:
- zip functions in 3-level nested stacks
- layers in 3-level nested stacks
- image functions in 3-level nested stacks

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
