### PR TITLE
chore: Fix mismatch docstrings and enable lint check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -20,6 +20,7 @@ load-plugins=
     pylint.extensions.check_elif, # Else If Used checker
     pylint.extensions.emptystring, # compare to empty string
     pylint.extensions.comparetozero, # compare to 0
+    pylint.extensions.docparams, # Parameter documentation checker
 
 # Use multiple processes to speed up Pylint.
 jobs=4
@@ -72,7 +73,24 @@ disable=
     R0904, # Too many public methods (%s/%s)
     R0914, # Too many local variables (%s/%s)
     R0915, # Too many statements
-    C0415  # Import outside toplevel (%s) Used when an import statement is used anywhere other than the module toplevel. Move this import to the top of the file.
+    C0415, # Import outside toplevel (%s) Used when an import statement is used anywhere other than the module toplevel. Move this import to the top of the file.
+    # below are docstring lint rules, in order to incrementally improve our docstring while
+    # without introduce too much effort at a time, we exclude most of the docstring lint rules.
+    # We will remove them one by one.
+    # W9005, # "%s" has constructor parameters documented in class and __init__
+    W9006, # "%s" not documented as being raised
+    W9008, # Redundant returns documentation
+    # W9010, # Redundant yields documentation
+    W9011, # Missing return documentation
+    W9012, # Missing return type documentation
+    W9013, # Missing yield documentation
+    W9014, # Missing yield type documentation
+    # W9015, # "%s" missing in parameter documentation
+    W9016, # "%s" missing in parameter type documentation
+    # W9017, # "%s" differing in parameter documentation
+    # W9018, # "%s" differing in parameter type documentation
+    # W9019, # "%s" useless ignored parameter documentation
+    # W9020, # "%s" useless ignored parameter type documentation
 
 
 [REPORTS]

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -25,11 +25,13 @@ LOG = logging.getLogger(__name__)
 class TomlProvider:
     """
     A parser for toml configuration files
-    :param cmd: sam command name as defined by click
-    :param section: section defined in the configuration file nested within `cmd`
     """
 
     def __init__(self, section=None):
+        """
+        The constructor for TomlProvider class
+        :param section: section defined in the configuration file nested within `cmd`
+        """
         self.section = section
 
     def __call__(self, config_path, config_env, cmd_names):
@@ -40,7 +42,7 @@ class TomlProvider:
 
         :param config_path: The path of configuration file.
         :param config_env: The name of the sectional config_env within configuration file.
-        :param cmd_names list(str): sam command name as defined by click
+        :param list cmd_names: sam command name as defined by click
         :returns dictionary containing the configuration parameters under specified config_env
         """
 
@@ -158,6 +160,8 @@ def get_ctx_defaults(cmd_name, provider, ctx, config_env_name, config_file=None)
 
 
 def configuration_option(*param_decls, **attrs):
+    # pylint does not understand the docstring with the presence of **attrs
+    # pylint: disable=missing-param-doc,differing-param-doc
     """
     Adds configuration file support to a click application.
 

--- a/samcli/cli/global_config.py
+++ b/samcli/cli/global_config.py
@@ -35,6 +35,7 @@ class GlobalConfig:
 
         :param config_dir: Optional, overrides the default config directory path.
         :param installation_id: Optional, will use this installation id rather than checking config values.
+        :param telemetry_enabled: Optional, set whether telemetry is enabled or not.
         :param last_version_check: Optional, will be used to check if there is a newer version of SAM CLI available
         """
         self._config_dir = config_dir

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -29,6 +29,7 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     :param ctx: Click Context
     :param param: Param name
     :param provided_value: Value provided by Click. It could either be the default value or provided by user.
+    :param include_build: A boolean to set whether to search build template or not.
     :return: Actual value to be used in the CLI
     """
 

--- a/samcli/commands/local/generate_event/event_generation.py
+++ b/samcli/commands/local/generate_event/event_generation.py
@@ -190,18 +190,19 @@ class EventTypeSubCommand(click.MultiCommand):
 
         Parameters
         ----------
-        events_lib
-        top_level_cmd_name: string
+        events_lib : events.Events
+            the Events library for generating events
+        top_level_cmd_name : string
             the name of the service
-        subcmd_name: string
+        subcmd_name : string
             the name of the event under the service
-        args: tuple
+        args : tuple
             any arguments passed in before kwargs
-        kwargs: dict
+        kwargs : dict
             the keys and values for substitution in the json
         Returns
         -------
-        event: string
+        event : string
             returns the customized event json as a string
         """
         event = events_lib.generate_event(top_level_cmd_name, subcmd_name, kwargs)

--- a/samcli/commands/logs/logs_context.py
+++ b/samcli/commands/logs/logs_context.py
@@ -229,7 +229,7 @@ class LogsCommandContext:
 
         Parameters
         ----------
-        cfn_client
+        cfn_client : boto3.session.Session.client
             CloudFormation client provided by AWS SDK
 
         stack_name : str

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -75,32 +75,34 @@ class ApplicationBuilder:
         ----------
         resources_to_build: Iterator
             Iterator that can vend out resources available in the SAM template
-
         build_dir : str
             Path to the directory where we will be storing built artifacts
-
         base_dir : str
             Path to a folder. Use this folder as the root to resolve relative source code paths against
-
         cache_dir : str
             Path to a the directory where we will be caching built artifacts
-
         cached:
             Optional. Set to True to build each function with cache to improve performance
-
         is_building_specific_resource : boolean
             Whether customer requested to build a specific resource alone in isolation,
             by specifying function_identifier to the build command.
             Ex: sam build MyServerlessFunction
-
+        manifest_path_override : Optional[str]
+            Optional path to manifest file to replace the default one
         container_manager : samcli.local.docker.manager.ContainerManager
             Optional. If provided, we will attempt to build inside a Docker Container
-
         parallel : bool
             Optional. Set to True to build each function in parallel to improve performance
-
         mode : str
             Optional, name of the build mode to use ex: 'debug'
+        stream_writer : Optional[StreamWriter]
+            An optional stream writer to accept stderr output
+        docker_client : Optional[docker.DockerClient]
+            An optional Docker client object to replace the default one loaded from env
+        container_env_var : Optional[Dict]
+            An optional dictionary of environment variables to pass to the container
+        container_env_var_file : Optional[str]
+            An optional path to file that contains environment variables to pass to the container
         """
         self._resources_to_build = resources_to_build
         self._build_dir = build_dir
@@ -213,6 +215,7 @@ class ApplicationBuilder:
         Parameters
         ----------
         stack: Stack
+            The stack object representing the template
         built_artifacts : dict
             Map of LogicalId of a resource to the path where the the built artifacts for this resource lives
         stack_output_template_path_by_stack_path: Dict[str, str]
@@ -402,9 +405,12 @@ class ApplicationBuilder:
         compatible_runtimes : List[str]
             List of runtimes the layer build is compatible with
 
-        artifact_dir: str
+        artifact_dir : str
             Path to where layer will be build into.
             A subfolder will be created in this directory depending on the specified workflow.
+
+        container_env_vars : Optional[Dict]
+            An optional dictionary of environment variables to pass to the container.
 
         Returns
         -------
@@ -470,18 +476,20 @@ class ApplicationBuilder:
         ----------
         function_name : str
             Name or LogicalId of the function
-
         codeuri : str
             Path to where the code lives
-
+        packagetype : str
+            The package type, 'Zip' or 'Image', see samcli/lib/utils/packagetype.py
         runtime : str
             AWS Lambda function runtime
-
+        handler : Optional[str]
+            An optional string to specify which function the handler should be
         artifact_dir: str
             Path to where function will be build into
-
         metadata : dict
             AWS Lambda function metadata
+        container_env_vars : Optional[Dict]
+            An optional dictionary of environment variables to pass to the container.
 
         Returns
         -------
@@ -727,6 +735,11 @@ class ApplicationBuilder:
         ----------
         function : samcli.lib.providers.provider.Function
             Lambda function to generate the configuration for
+        file_env_vars : Dict
+            The dictionary of environment variables loaded from the file
+        inline_env_vars : Optional[Dict]
+            The optional dictionary of environment variables defined inline
+
 
         Returns
         -------

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -34,7 +34,6 @@ class SamConfig:
         ----------
         config_dir : string
             Directory where the configuration file needs to be stored
-
         filename : string
             Optional. Name of the configuration file. It is recommended to stick with default so in the future we
             could automatically support auto-resolving multiple config files within same directory.
@@ -49,10 +48,8 @@ class SamConfig:
         ----------
         cmd_names : list(str)
             List of representing the entire command. Ex: ["local", "generate-event", "s3", "put"]
-
         section : str
             Specific section within the command to look into Ex: `parameters`
-
         env : str
             Optional, Name of the environment
 
@@ -85,16 +82,12 @@ class SamConfig:
         ----------
         cmd_names : list(str)
             List of representing the entire command. Ex: ["local", "generate-event", "s3", "put"]
-
         section : str
             Specific section within the command to look into Ex: `parameters`
-
         key : str
             Key to write the data under
-
-        value
+        value : Any
             Value to write. Could be any of the supported TOML types.
-
         env : str
             Optional, Name of the environment
 

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -135,6 +135,9 @@ class Deployer:
         :param cfn_template: CloudFormation template string
         :param parameter_values: Template parameters object
         :param capabilities: Array of capabilities passed to CloudFormation
+        :param role_arn: the Arn of the role to create changeset
+        :param notification_arns: Arns for sending notifications
+        :param s3_uploader: S3Uploader object to upload files to S3 buckets
         :param tags: Array of tags passed to CloudFormation
         :return:
         """
@@ -213,6 +216,7 @@ class Deployer:
 
         :param change_set_id: ID of the changeset
         :param stack_name: Name of the CloudFormation stack
+        :param kwargs: Other arguments to pass to pprint_columns()
         :return: dictionary of changes described in the changeset.
         """
         paginator = self._client.get_paginator("describe_change_set")
@@ -338,6 +342,7 @@ class Deployer:
         Calls CloudFormation to get current stack events
         :param stack_name: Name or ID of the stack
         :param time_stamp_marker: last event time on the stack to start streaming events from.
+        :param kwargs: Other arguments to pass to pprint_columns()
         :return:
         """
 

--- a/samcli/lib/init/__init__.py
+++ b/samcli/lib/init/__init__.py
@@ -38,6 +38,8 @@ def generate_project(
     location: Path, optional
         Git, HTTP, Local path or Zip containing cookiecutter template
         (the default is None, which means no custom template)
+    package_type : Optional[str]
+        Optional string representing the package type, 'Zip' or 'Image', see samcli/lib/utils/packagetype.py
     runtime: str
         Lambda Runtime
     dependency_manager: str, optional
@@ -50,6 +52,8 @@ def generate_project(
     no_input : bool, optional
         Whether to prompt for input or to accept default values
         (the default is False, which prompts the user for values it doesn't know for baking)
+    extra_context : Optional[Dict]
+        An optional dictionary, the extra cookiecutter context
 
     Raises
     ------

--- a/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
+++ b/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
@@ -181,9 +181,11 @@ class IntrinsicResolver:
 
         Parameters
         ----------
-        intrinsic: dict, str, list, bool, int
+        intrinsic : dict, str, list, bool, int
             This is an intrinsic property or an intermediate step
-        parent_function: str
+        ignore_errors : bool
+            Whether to ignore errors
+        parent_function : str
             In case there is a missing property, this is used to figure out where the property resolved is missing.
         Return
         ---------

--- a/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
+++ b/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
@@ -94,7 +94,9 @@ class IntrinsicsSymbolTable:
         it will generate a default one and save it in the logical_id_translator as a cache for future computation.
         Parameters
         ------------
-        logical_id_translator: dict
+        template : Optional[Dict]
+            An optional dictionary representing the template
+        logical_id_translator : dict
             This will act as the default symbol table resolver. The resolver will first check if the attribute is
             explicitly defined in this dictionary and do the relevant translation.
 
@@ -109,7 +111,7 @@ class IntrinsicsSymbolTable:
                 }
                 "AWS::Region": "us-east-1"
             }
-        default_type_resolver: dict
+        default_type_resolver : dict
             This can be used provide common attributes that are true across all objects of a certain type.
             This can be in the format of
             {
@@ -123,7 +125,7 @@ class IntrinsicsSymbolTable:
                     "RootResourceId": (lambda l, a, p, r: p.get("ResourceId"))
                 }
             }
-        common_attribute_resolver: dict
+        common_attribute_resolver : dict
             This is a clean way of specifying common attributes across all types.
             The value can either be a function of the form string or (logical_id) => string
             {

--- a/samcli/lib/logs/event.py
+++ b/samcli/lib/logs/event.py
@@ -25,6 +25,8 @@ class LogEvent:
 
         Parameters
         ----------
+        log_group_name : str
+            The log group name
         event_dict : dict
             Dict of log event data returned by CloudWatch Logs API.
             https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilteredLogEvent.html

--- a/samcli/lib/logs/fetcher.py
+++ b/samcli/lib/logs/fetcher.py
@@ -38,13 +38,10 @@ class LogsFetcher:
         ----------
         log_group_name : string
             Name of CloudWatch Logs Group to query.
-
         start : datetime.datetime
             Optional start time for logs.
-
         end : datetime.datetime
             Optional end time for logs.
-
         filter_pattern : str
             Expression to filter the logs by. This is passed directly to CloudWatch, so any expression supported by
             CloudWatch Logs API is supported here.
@@ -96,18 +93,14 @@ class LogsFetcher:
         ----------
         log_group_name : str
             Name of CloudWatch Logs Group to query.
-
         start : datetime.datetime
             Optional start time for logs. Defaults to '5m ago'
-
         filter_pattern : str
             Expression to filter the logs by. This is passed directly to CloudWatch, so any expression supported by
             CloudWatch Logs API is supported here.
-
         max_retries : int
             When logs are not available, this value determines the number of times to retry fetching logs before giving
             up. This counter is reset every time new logs are available.
-
         poll_interval : float
             Number of fractional seconds wait before polling again. Defaults to 300milliseconds.
             If no new logs available, this method will stop polling after ``max_retries * poll_interval`` seconds

--- a/samcli/lib/logs/formatter.py
+++ b/samcli/lib/logs/formatter.py
@@ -12,6 +12,9 @@ class LogsFormatter:
     """
 
     def __init__(self, colored, formatter_chain=None):
+        # the docstring contains an example function which contains another docstring,
+        # pylint is confused so disable it for this method.
+        # pylint: disable=missing-param-doc,differing-param-doc,differing-type-doc
         """
 
         ``formatter_chain`` is a list of methods that can format an event. Each method must take an
@@ -61,8 +64,8 @@ class LogsFormatter:
             Terminal. To turn off coloring, set the appropriate property when instantiating the
             ``samcli.lib.utils.colors.Colored`` class.
 
-        formatter_chain : list of formatter methods
-
+        formatter_chain : List[str]
+            list of formatter methods
         """
 
         self.colored = colored

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -174,9 +174,6 @@ class ApiCollector:
         logical_id : str
             LogicalId of the AWS::Serverless::Api resource
 
-        api: samcli.commands.local.lib.provider.Api
-            Instance of the Api which will save all the api configurations
-
         binary_media_types : list of str
             List of binary media types supported by this resource
         """

--- a/samcli/lib/providers/api_provider.py
+++ b/samcli/lib/providers/api_provider.py
@@ -27,7 +27,8 @@ class ApiProvider(AbstractApiProvider):
         ----------
         template_dict : dict
             Template as a dictionary
-
+        parameter_overrides : Optional[Dict]
+            An optional dictionary containing parameters to override the default parameter values
         cwd : str
             Optional working directory with respect to which we will resolve relative path to Swagger file
         """

--- a/samcli/lib/providers/cfn_api_provider.py
+++ b/samcli/lib/providers/cfn_api_provider.py
@@ -85,12 +85,12 @@ class CfnApiProvider(CfnBaseApiProvider):
         ----------
         logical_id : str
             Logical ID of the resource
-
         api_resource : dict
             Resource definition, including its properties
-
         collector : ApiCollector
             Instance of the API collector that where we will save the API information
+        cwd : Optional[str]
+            An optional string to override the current working directory
         """
         properties = api_resource.get("Properties", {})
         body = properties.get("Body")
@@ -193,12 +193,12 @@ class CfnApiProvider(CfnBaseApiProvider):
         ----------
         logical_id : str
             Logical ID of the resource
-
         api_resource : dict
             Resource definition, including its properties
-
         collector : ApiCollector
             Instance of the API collector that where we will save the API information
+        cwd : Optional[str]
+            An optional string to override the current working directory
         """
         properties = api_resource.get("Properties", {})
         body = properties.get("Body")
@@ -345,8 +345,8 @@ class CfnApiProvider(CfnBaseApiProvider):
 
         Parameters
         ----------
-        method_config : str
-            the API gateway route key
+        integration : Dict
+            the integration defined in the method configuration
 
         Returns
         -------

--- a/samcli/lib/providers/cfn_base_api_provider.py
+++ b/samcli/lib/providers/cfn_base_api_provider.py
@@ -24,10 +24,8 @@ class CfnBaseApiProvider:
         ----------
         resources: dict
             The dictionary containing the different resources within the template
-
         collector: samcli.lib.providers.api_collector.ApiCollector
             Instance of the API collector that where we will save the API information
-
         cwd : str
             Optional working directory with respect to which we will resolve relative path to Swagger file
 
@@ -54,21 +52,18 @@ class CfnBaseApiProvider:
         ----------
         logical_id : str
             Logical ID of the resource
-
         body : dict
             The body of the RestApi
-
         uri : str or dict
             The url to location of the RestApi
-
-        binary_media: list
+        binary_media : list
             The link to the binary media
-
-        collector: samcli.lib.providers.api_collector.ApiCollector
+        collector : samcli.lib.providers.api_collector.ApiCollector
             Instance of the Route collector that where we will save the route information
-
         cwd : str
             Optional working directory with respect to which we will resolve relative path to Swagger file
+        event_type : str
+            The event type, 'Api' or 'HttpApi', see samcli/local/apigw/local_apigw_service.py:35
         """
         reader = SwaggerReader(definition_body=body, definition_uri=uri, working_dir=cwd)
         swagger = reader.read()

--- a/samcli/lib/providers/sam_api_provider.py
+++ b/samcli/lib/providers/sam_api_provider.py
@@ -186,6 +186,7 @@ class SamApiProvider(CfnBaseApiProvider):
 
         :param str lambda_logical_id: Logical Id of the AWS::Serverless::Function
         :param dict event_properties: Dictionary of the Event's Property
+        :param event_type: The event type, 'Api' or 'HttpApi', see samcli/local/apigw/local_apigw_service.py:35
         :return tuple: tuple of route resource name and route
         """
         path = event_properties.get(SamApiProvider._EVENT_PATH)

--- a/samcli/lib/schemas/schemas_code_manager.py
+++ b/samcli/lib/schemas/schemas_code_manager.py
@@ -16,8 +16,8 @@ def do_download_source_code_binding(runtime, schema_template_details, schemas_ap
     generating the code bindings if they haven't been generated first
     :param runtime: Lambda runtime
     :param schema_template_details: e.g: registry_name, schema_name, schema_version
-    :param schemas_api_caller:
-    :param download_dir:
+    :param schemas_api_caller: the schemas api caller object
+    :param download_location: the download location
     :return: directory location where code is downloaded
     """
     registry_name = schema_template_details["registry_name"]

--- a/samcli/lib/utils/version_checker.py
+++ b/samcli/lib/utils/version_checker.py
@@ -58,7 +58,7 @@ def _inform_newer_version(force_check=False) -> None:
 
     Parameters
     ----------
-    check_all_always: bool
+    force_check: bool
         When it is True, it will trigger checking new version of SAM CLI. Default value is False
 
     """

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -59,15 +59,18 @@ class Container:
         """
         Initializes the class with given configuration. This does not automatically create or run the container.
 
-        :param string image: Name of the Docker image to create container with
-        :param string working_dir: Working directory for the container
-        :param string host_dir: Directory in the host operating system that should be mounted to the ``working_dir`` on
+        :param str image: Name of the Docker image to create container with
+        :param str cmd: Command to pass to container
+        :param str working_dir: Working directory for the container
+        :param str host_dir: Directory in the host operating system that should be mounted to the ``working_dir`` on
             container
-        :param list cmd: Command to pass to container
         :param int memory_limit_mb: Optional. Max limit of memory in MegaBytes this Lambda function can use.
         :param dict exposed_ports: Optional. Dict of ports to expose
-        :param list entrypoint: Optional. Entry point process for the container. Defaults to the value in Dockerfile
+        :param dict entrypoint: Optional. Entry point process for the container. Defaults to the value in Dockerfile
         :param dict env_vars: Optional. Dict of environment variables to setup in the container
+        :param docker_client: Optional, a docker client to replace the default one loaded from env
+        :param container_opts: Optional, a dictionary containing the container options
+        :param additional_volumes: Optional list of additional volumes
         """
 
         self._image = image

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -146,10 +146,11 @@ class LambdaContainer(Container):
         return ports_map
 
     @staticmethod
-    def _get_additional_options(runtime, debug_options):
+    def _get_additional_options(runtime: str, debug_options):
         """
         Return additional Docker container options. Used by container debug mode to enable certain container
         security options.
+        :param runtime: The runtime string
         :param DebugContext debug_options: DebugContext for the runtime of the container.
         :return dict: Dictionary containing additional arguments to be passed to container creation.
         """
@@ -171,6 +172,7 @@ class LambdaContainer(Container):
         """
         Return additional volumes to be mounted in the Docker container. Used by container debug for mapping
         debugger executable into the container.
+        :param runtime: the runtime string
         :param DebugContext debug_options: DebugContext for the runtime of the container.
         :return dict: Dictionary containing volume map passed to container creation.
         """

--- a/samcli/local/events/api_event.py
+++ b/samcli/local/events/api_event.py
@@ -96,6 +96,10 @@ class RequestContext:
         :param ContextIdentity identity: Identity for the Request
         :param str extended_request_id:
         :param str path:
+        :param str protocol: Optional, the protocal to make the request
+        :param str domain_name: Optional, the name of the domain
+        :param int request_time_epoch: Optional, an epoch timestamp to override the request time
+        :param datetime request_time: Optional, a datetime object to override the request time
         """
 
         self.resource_id = resource_id

--- a/samcli/local/lambdafn/env_vars.py
+++ b/samcli/local/lambdafn/env_vars.py
@@ -49,6 +49,7 @@ class EnvironmentVariables:
             a) (Required) Function information
             b) (Optional) Environment variable configured on the function
 
+        :param str function_name: The name of the function
         :param integer function_memory: Memory size of the function in megabytes
         :param integer function_timeout: Function's timeout in seconds
         :param string function_handler: Handler of the function

--- a/samcli/local/lambdafn/zip.py
+++ b/samcli/local/lambdafn/zip.py
@@ -45,10 +45,8 @@ def _extract(file_info, output_dir, zip_ref):
     ----------
     file_info : zipfile.ZipInfo
         The ZipInfo for a ZipFile
-
     output_dir : str
         Path to the directory where the it should be unzipped to
-
     zip_ref : zipfile.ZipFile
         The ZipFile we are working with.
 
@@ -88,12 +86,10 @@ def unzip(zip_file_path, output_dir, permission=None):
     ----------
     zip_file_path : str
         Path to the zip file
-
     output_dir : str
         Path to the directory where the it should be unzipped to
-
-    permission : octal int
-        Permission to set
+    permission : int
+        Permission to set in an octal int form
     """
 
     with zipfile.ZipFile(zip_file_path, "r") as zip_ref:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

Some docstrings are outdated and confusing. For example, the arguments of a function do not appear in the docstring, or have the incorrect types.

#### How does it address the issue?

This PR fixes them all and enable lint check so it won't happen next time.

#### What side effects does this change have?

No side effects.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
