### PR TITLE
chore: Add docstring to all functions with 30+ LOC

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -80,7 +80,7 @@ disable=
     # We will remove them one by one.
     # W9005, # "%s" has constructor parameters documented in class and __init__
     W9006, # "%s" not documented as being raised
-    W9008, # Redundant returns documentation
+    # W9008, # Redundant returns documentation
     # W9010, # Redundant yields documentation
     W9011, # Missing return documentation
     W9012, # Missing return type documentation

--- a/.pylintrc
+++ b/.pylintrc
@@ -84,8 +84,8 @@ disable=
     # W9010, # Redundant yields documentation
     W9011, # Missing return documentation
     W9012, # Missing return type documentation
-    W9013, # Missing yield documentation
-    W9014, # Missing yield type documentation
+    # W9013, # Missing yield documentation
+    # W9014, # Missing yield type documentation
     # W9015, # "%s" missing in parameter documentation
     W9016, # "%s" missing in parameter type documentation
     # W9017, # "%s" differing in parameter documentation

--- a/.pylintrc
+++ b/.pylintrc
@@ -74,6 +74,7 @@ disable=
     R0914, # Too many local variables (%s/%s)
     R0915, # Too many statements
     C0415, # Import outside toplevel (%s) Used when an import statement is used anywhere other than the module toplevel. Move this import to the top of the file.
+    C0115, # missing-class-docstring
     # below are docstring lint rules, in order to incrementally improve our docstring while
     # without introduce too much effort at a time, we exclude most of the docstring lint rules.
     # We will remove them one by one.
@@ -200,11 +201,13 @@ method-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=.*
+no-docstring-rgx=^_
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
-docstring-min-length=-1
+# To improve our docstring without spending too much effort at a time,
+# here set it to 30 and decrease it gradually in the future.
+docstring-min-length=30
 
 
 [FORMAT]

--- a/samcli/commands/_utils/resources.py
+++ b/samcli/commands/_utils/resources.py
@@ -52,7 +52,13 @@ RESOURCES_WITH_IMAGE_COMPONENT = {
 def resources_generator():
     """
     Generator to yield set of resources and their locations that are supported for package operations
-    :return:
+
+    Yields
+    ------
+    resource : Dict
+        The resource dictionary
+    location : str
+        The location of the resource
     """
     _resource_property_dict = defaultdict(list)
     for _dict in (METADATA_WITH_LOCAL_PATHS, RESOURCES_WITH_LOCAL_PATHS, RESOURCES_WITH_IMAGE_COMPONENT):

--- a/samcli/commands/_utils/table_print.py
+++ b/samcli/commands/_utils/table_print.py
@@ -106,7 +106,6 @@ def pprint_columns(columns, width, margin, format_string, format_args, columns_d
     :param columns_dict: arguments dictionary that have dummy values per column
     :param color: color supplied for rows within the table.
     :param textwrap_kwargs: keyword arguments that are passed to textwrap.wrap
-    :return:
     """
     for columns_text in zip_longest(*wrapped_text_generator(columns, width, margin, **textwrap_kwargs), fillvalue=""):
         counter = count()

--- a/samcli/commands/_utils/table_print.py
+++ b/samcli/commands/_utils/table_print.py
@@ -88,6 +88,7 @@ def wrapped_text_generator(texts, width, margin, **textwrap_kwargs):
     :param margin: margin to be reduced from width for cleaner UX
     :param textwrap_kwargs: keyword arguments that are passed to textwrap.wrap
     :return: generator of wrapped text
+    :rtype: Iterator[str]
     """
     for text in texts:
         yield textwrap.wrap(text, width=width - margin, **textwrap_kwargs)

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -219,11 +219,6 @@ class BuildContext:
         Parameters
         ----------
         resource_collector: Collector that will be populated with resources.
-
-        Returns
-        -------
-        ResourcesToBuildCollector
-
         """
         function = self.function_provider.get(resource_identifier)
         if not function:

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -179,6 +179,9 @@ def cli(
     config_file: str,
     config_env: str,
 ) -> None:
+    """
+    `sam build` command entry point
+    """
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
     mode = _get_mode_value_from_envvar("SAM_BUILD_MODE", choices=["debug"])

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -196,7 +196,9 @@ def cli(
     config_file,
     config_env,
 ):
-
+    """
+    `sam deploy` command entry point
+    """
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
     do_cli(
         template_file,
@@ -256,6 +258,9 @@ def do_cli(
     config_file,
     config_env,
 ):
+    """
+    Implementation of the ``cli`` method
+    """
     from samcli.commands.package.package_context import PackageContext
     from samcli.commands.deploy.deploy_context import DeployContext
     from samcli.commands.deploy.guided_context import GuidedContext

--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -100,6 +100,9 @@ class DeployContext:
         pass
 
     def run(self):
+        """
+        Execute deployment based on the argument provided by customers and samconfig.toml.
+        """
 
         # Parse parameters
         with open(self.template_file, "r") as handle:
@@ -174,6 +177,42 @@ class DeployContext:
         fail_on_empty_changeset=True,
         confirm_changeset=False,
     ):
+        """
+        Deploy the stack to cloudformation.
+        - if changeset needs confirmation, it will prompt for customers to confirm.
+        - if no_execute_changeset is True, the changeset won't be executed.
+
+        Parameters
+        ----------
+        stack_name : str
+            name of the stack
+        template_str : str
+            the string content of the template
+        parameters : List[Dict]
+            List of parameters
+        capabilities : List[str]
+            List of capabilities
+        no_execute_changeset : bool
+            A bool indicating whether to execute changeset
+        role_arn : str
+            the Arn of the role to create changeset
+        notification_arns : List[str]
+            Arns for sending notifications
+        s3_uploader : S3Uploader
+            S3Uploader object to upload files to S3 buckets
+        tags : List[str]
+            List of tags passed to CloudFormation
+        region : str
+            AWS region to deploy the stack to
+        fail_on_empty_changeset : bool
+            Should fail when changeset is empty
+        confirm_changeset : bool
+            Should wait for customer's confirm before executing the changeset
+
+        Returns
+        -------
+        None
+        """
         stacks = SamLocalStackProvider.get_stacks(
             self.template_file, parameter_overrides=sanitize_parameter_overrides(self.parameter_overrides)
         )

--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -208,10 +208,6 @@ class DeployContext:
             Should fail when changeset is empty
         confirm_changeset : bool
             Should wait for customer's confirm before executing the changeset
-
-        Returns
-        -------
-        None
         """
         stacks = SamLocalStackProvider.get_stacks(
             self.template_file, parameter_overrides=sanitize_parameter_overrides(self.parameter_overrides)

--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -100,6 +100,17 @@ class GuidedContext:
 
     # pylint: disable=too-many-statements
     def guided_prompts(self, parameter_override_keys):
+        """
+        Start an interactive cli prompt to collection information for deployment
+
+        Parameters
+        ----------
+        parameter_override_keys
+            The keys of parameters to override, for each key, customers will be asked to provide a value
+        Returns
+        -------
+        None
+        """
         default_stack_name = self.stack_name or "sam-app"
         default_region = self.region or get_session().get_config_variable("region") or "us-east-1"
         default_capabilities = self.capabilities[0] or ("CAPABILITY_IAM",)
@@ -193,6 +204,19 @@ class GuidedContext:
                     raise GuidedDeployFailedError(msg="Security Constraints Not Satisfied!")
 
     def prompt_code_signing_settings(self, stacks: List[Stack]):
+        """
+        Prompt code signing settings to ask whether customers want to code sign their code and
+        display signing details.
+
+        Parameters
+        ----------
+        stacks : List[Stack]
+            List of stacks to search functions and layers
+
+        Returns
+        -------
+        None
+        """
         (functions_with_code_sign, layers_with_code_sign) = signer_config_per_function(stacks)
 
         # if no function or layer definition found with code signing, skip it
@@ -269,6 +293,20 @@ class GuidedContext:
         return _prompted_param_overrides
 
     def prompt_image_repository(self, stacks: List[Stack]):
+        """
+        Prompt for the image repository to push the images.
+        For each image function found in build artifacts, it will prompt for an image repository.
+
+        Parameters
+        ----------
+        stacks : List[Stack]
+            List of stacks to look for image functions.
+
+        Returns
+        -------
+        Dict
+            A dictionary contains image function logical ID as key, image repository as value.
+        """
         image_repositories = {}
         artifacts_format = get_template_artifacts_format(template_file=self.template_file)
         if IMAGE in artifacts_format:

--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -107,9 +107,6 @@ class GuidedContext:
         ----------
         parameter_override_keys
             The keys of parameters to override, for each key, customers will be asked to provide a value
-        Returns
-        -------
-        None
         """
         default_stack_name = self.stack_name or "sam-app"
         default_region = self.region or get_session().get_config_variable("region") or "us-east-1"
@@ -212,10 +209,6 @@ class GuidedContext:
         ----------
         stacks : List[Stack]
             List of stacks to search functions and layers
-
-        Returns
-        -------
-        None
         """
         (functions_with_code_sign, layers_with_code_sign) = signer_config_per_function(stacks)
 

--- a/samcli/commands/deploy/utils.py
+++ b/samcli/commands/deploy/utils.py
@@ -43,7 +43,6 @@ def print_deploy_args(
     :param parameter_overrides: Cloudformation parameter overrides to be supplied based on the stack's template
     :param confirm_changeset: Prompt for changeset to be confirmed before going ahead with the deploy.
     :param signing_profiles: Signing profile details which will be used to sign functions/layers
-    :return:
     """
     _parameters = parameter_overrides.copy()
 

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -220,6 +220,9 @@ def cli(
     config_file,
     config_env,
 ):
+    """
+    `sam init` command entry point
+    """
     do_cli(
         ctx,
         no_interactive,
@@ -254,6 +257,9 @@ def do_cli(
     extra_context,
     auto_clone=True,
 ):
+    """
+    Implementation of the ``cli`` method
+    """
 
     from samcli.commands.init.init_generator import do_generate
     from samcli.commands.init.interactive_init_flow import do_interactive

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -40,6 +40,27 @@ class InitTemplates:
         self._auto_clone = auto_clone
 
     def prompt_for_location(self, package_type, runtime, base_image, dependency_manager):
+        """
+        Prompt for template location based on other information provided in previous steps.
+
+        Parameters
+        ----------
+        package_type : str
+            the package type, 'Zip' or 'Image', see samcli/lib/utils/packagetype.py
+        runtime : str
+            the runtime string
+        base_image : str
+            the base image string
+        dependency_manager : str
+            the dependency manager string
+
+        Returns
+        -------
+        location : str
+            The location of the template
+        app_template : str
+            The name of the template
+        """
         options = self.init_options(package_type, runtime, base_image, dependency_manager)
 
         if len(options) == 1:

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -35,6 +35,10 @@ def do_interactive(
     app_template,
     no_input,
 ):
+    """
+    Implementation of the ``cli`` method when --interactive is provided.
+    It will ask customers a few questions to init a template.
+    """
     if app_template:
         location_opt_choice = "1"
     else:

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -59,6 +59,19 @@ def local_common_options(f):
 
 
 def service_common_options(port):
+    """
+    Construct common CLI Options that are shared for service related commands ('start-api' and 'start_lambda')
+
+    Parameters
+    ----------
+    port
+        The port number to listen to
+
+    Returns
+    -------
+    None
+    """
+
     def construct_options(f):
         """
         Common CLI Options that are shared for service related commands ('start-api' and 'start_lambda')

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -66,10 +66,6 @@ def service_common_options(port):
     ----------
     port
         The port number to listen to
-
-    Returns
-    -------
-    None
     """
 
     def construct_options(f):

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -72,7 +72,9 @@ def cli(
     config_file,
     config_env,
 ):
-
+    """
+    `sam local invoke` command entry point
+    """
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
     do_cli(

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -81,6 +81,9 @@ def cli(
     shutdown,
     debug_function,
 ):
+    """
+    `sam local start-api` command entry point
+    """
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
     do_cli(

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -92,6 +92,9 @@ def cli(
     shutdown,
     debug_function,
 ):
+    """
+    `sam local start-lambda` command entry point
+    """
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
     do_cli(

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -88,6 +88,9 @@ def cli(
     config_file,
     config_env,
 ):  # pylint: disable=redefined-builtin
+    """
+    `sam logs` command entry point
+    """
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
     do_cli(name, stack_name, filter, tail, start_time, end_time)  # pragma: no cover

--- a/samcli/commands/package/command.py
+++ b/samcli/commands/package/command.py
@@ -152,7 +152,9 @@ def cli(
     config_file,
     config_env,
 ):
-
+    """
+    `sam package` command entry point
+    """
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
     do_cli(
@@ -191,6 +193,10 @@ def do_cli(
     profile,
     resolve_s3,
 ):
+    """
+    Implementation of the ``cli`` method
+    """
+
     from samcli.commands.package.package_context import PackageContext
 
     if resolve_s3:

--- a/samcli/commands/package/package_context.py
+++ b/samcli/commands/package/package_context.py
@@ -93,6 +93,9 @@ class PackageContext:
         pass
 
     def run(self):
+        """
+        Execute packaging based on the argument provided by customers and samconfig.toml.
+        """
         region_name = self.region if self.region else None
 
         s3_client = boto3.client(

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -361,10 +361,6 @@ class ApplicationBuilder:
             A generator for the build output.
         function_name str
             Name of the function that is being built
-
-        Returns
-        -------
-        None
         """
         for log in build_logs:
             if log:

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -406,6 +406,20 @@ class Deployer:
         return "COMPLETE" in status and "CLEANUP" not in status
 
     def wait_for_execute(self, stack_name, changeset_type):
+        """
+        Wait for changeset to execute and return when execution completes.
+        If the stack has "Outputs," they will be printed.
+
+        Parameters
+        ----------
+        stack_name : str
+            The name of the stack
+        changeset_type : str
+            The type of the changeset, 'CREATE' or 'UPDATE'
+        Returns
+        -------
+        None
+        """
         sys.stdout.write(
             "\n{} - Waiting for stack create/update "
             "to complete\n".format(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -278,7 +278,6 @@ class Deployer:
 
         :param changeset_id: ID or name of the changeset
         :param stack_name:   Stack name
-        :return: Latest status of the create-change-set operation
         """
         sys.stdout.write("\nWaiting for changeset to be created..\n")
         sys.stdout.flush()
@@ -343,7 +342,6 @@ class Deployer:
         :param stack_name: Name or ID of the stack
         :param time_stamp_marker: last event time on the stack to start streaming events from.
         :param kwargs: Other arguments to pass to pprint_columns()
-        :return:
         """
 
         stack_change_in_progress = True
@@ -416,9 +414,6 @@ class Deployer:
             The name of the stack
         changeset_type : str
             The type of the changeset, 'CREATE' or 'UPDATE'
-        Returns
-        -------
-        None
         """
         sys.stdout.write(
             "\n{} - Waiting for stack create/update "

--- a/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
+++ b/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
@@ -430,10 +430,5 @@ class IntrinsicsSymbolTable:
     def handle_pseudo_no_value():
         """
         This resolves AWS::NoValue so that it returns the python None
-
-        Returns
-        --------
-        None
-        :return:
         """
         return None

--- a/samcli/lib/logs/formatter.py
+++ b/samcli/lib/logs/formatter.py
@@ -14,7 +14,7 @@ class LogsFormatter:
     def __init__(self, colored, formatter_chain=None):
         # the docstring contains an example function which contains another docstring,
         # pylint is confused so disable it for this method.
-        # pylint: disable=missing-param-doc,differing-param-doc,differing-type-doc
+        # pylint: disable=missing-param-doc,differing-param-doc,differing-type-doc,redundant-returns-doc
         """
 
         ``formatter_chain`` is a list of methods that can format an event. Each method must take an

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -169,9 +169,6 @@ class Template:
         """
         Exports the local artifacts referenced by the metadata section in
         the given template to an export destination.
-
-        :return: The template with references to artifacts that have been
-        exported to export destination.
         """
         if "Metadata" not in self.template_dict:
             return

--- a/samcli/lib/package/ecr_uploader.py
+++ b/samcli/lib/package/ecr_uploader.py
@@ -88,7 +88,6 @@ class ECRUploader:
         """
         Stream progress from docker push logs and move the cursor based on the log id.
         :param logs: generator from docker_clent.api.push
-        :return:
         """
         ids = dict()
         for log in logs:

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -161,8 +161,17 @@ def zip_folder(folder_path):
     Zip the entire folder and return a file to the zip. Use this inside
     a "with" statement to cleanup the zipfile after it is used.
 
-    :param folder_path:
-    :return: Name of the zipfile
+    Parameters
+    ----------
+    folder_path : str
+        The path of the folder to zip
+
+    Yields
+    ------
+    zipfile_name : str
+        Name of the zipfile
+    md5hash : str
+        The md5 hash of the directory
     """
     md5hash = dir_checksum(folder_path, followlinks=True)
     filename = os.path.join(tempfile.gettempdir(), "data-" + md5hash)

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -176,6 +176,20 @@ def zip_folder(folder_path):
 
 
 def make_zip(file_name, source_root):
+    """
+    Create a zip file from the source directory
+
+    Parameters
+    ----------
+    file_name : str
+        The basename of the zip file, without .zip
+    source_root : str
+        The path to the source directory
+    Returns
+    -------
+    str
+        The name of the zip file, including .zip extension
+    """
     zipfile_name = "{0}.zip".format(file_name)
     source_root = os.path.abspath(source_root)
     compression_type = zipfile.ZIP_DEFLATED

--- a/samcli/lib/schemas/schemas_code_manager.py
+++ b/samcli/lib/schemas/schemas_code_manager.py
@@ -53,7 +53,6 @@ def do_extract_and_merge_schemas_code(download_location, output_dir, project_nam
     :param output_dir:
     :param project_name:
     :param template_location:
-    :return:
     """
     click.echo("Merging code bindings...")
     cookiecutter_json_path = os.path.join(template_location, "cookiecutter.json")

--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -27,7 +27,7 @@ def mkdir_temp(mode=0o755, ignore_errors=False):
         If true, we will log a debug statement on failure to clean up the temp directory, rather than failing.
         Defaults to False
 
-    Returns
+    Yields
     -------
     str
         Path to the directory
@@ -56,7 +56,6 @@ def rmtree_callback(function, path, excinfo):
     :param function: platform and implementation dependent function.
     :param path: argument to the function that caused it to fail.
     :param excinfo: tuple returned by sys.exc_info()
-    :return:
     """
     try:
         os.chmod(path=path, mode=stat.S_IWRITE)

--- a/samcli/lib/utils/sam_logging.py
+++ b/samcli/lib/utils/sam_logging.py
@@ -24,10 +24,6 @@ class SamCliLogger:
             Logger to configure
         formatter logging.formatter
             Formatter for the logger
-
-        Returns
-        -------
-        None
         """
         handlers = logger.handlers
         if handlers:
@@ -54,10 +50,6 @@ class SamCliLogger:
         ----------
         logger logging.getLogger
             Logger to configure
-
-        Returns
-        -------
-        None
         """
         logger.propagate = False
         logger.addHandler(logging.NullHandler())

--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -19,6 +19,7 @@ def create_tarball(tar_paths, tar_filter=None):
 
     Yields
     ------
+    IO
         The tarball file
     """
     tarballfile = TemporaryFile()

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -221,9 +221,17 @@ class LocalApigwService(BaseLocalService):
         Generates the key to the _dict_of_routes based on the list of methods
         and path supplied
 
-        :param list(str) methods: List of HTTP Methods
-        :param str path: Path off the base url
-        :return: str of Path:Method
+        Parameters
+        ----------
+        methods : List[str]
+            List of HTTP Methods
+        path : str
+            Path off the base url
+
+        Yields
+        ------
+        route_key : str
+            the route key in the form of "Path:Method"
         """
         for method in methods:
             yield self._route_key(method, path)

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -194,10 +194,6 @@ class LambdaImage:
         layers list(samcli.commands.local.lib.provider.Layer)
             List of Layers to be use to mount in the image
 
-        Returns
-        -------
-        None
-
         Raises
         ------
         samcli.commands.local.cli_common.user_exceptions.ImageBuildException

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -201,10 +201,5 @@ class LayerDownloader:
         ----------
         layer_cache
             Directory to where the layers should be cached
-
-        Returns
-        -------
-        None
-
         """
         Path(layer_cache).mkdir(mode=0o700, parents=True, exist_ok=True)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

We often forgot to write docstring for a new function/method, which is very helpful for other people to understand the code.

#### How does it address the issue?

This PR re-enables pylint rule to check functions/methods with 30+ LOC and enforce them to have a docstring. I set it to 30 because there are too many short functions/methods lacking docstring and I couldn't add them all. So let's start with 30. 

#### What side effects does this change have?

No code change. 

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
