### PR TITLE
[Draft] Use-case driven init flow

### DIFF
--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Dict
 
 import click
+import requests
 
 from samcli.cli.main import global_cfg
 from samcli.commands.exceptions import UserException, AppTemplateUpdateException
@@ -32,6 +33,7 @@ class InvalidInitTemplateError(UserException):
 class InitTemplates:
     def __init__(self, no_interactive=False, auto_clone=True):
         self._repo_url = "https://github.com/sapessi/aws-sam-cli-app-templates"
+        self._manifest_url = "https://raw.githubusercontent.com/sapessi/aws-sam-cli-app-templates/master/manifest.json"
         self._repo_name = "aws-sam-cli-app-templates"
         self._temp_repo_name = "TEMP-aws-sam-cli-app-templates"
         self.repo_path = None
@@ -59,38 +61,40 @@ class InitTemplates:
         return bool(entry["appTemplate"] == app_template)
 
     def use_case_init_options(self, package_type, runtime, base_image, dependency_manager):
+        manifest_resp = requests.get(self._manifest_url)
+
+        if not manifest_resp:
+            raise InvalidInitTemplateError("Can't retrieve templates manifest from {url}".format(url=self._manifest_url))
+
+        use_case_options = {}
+        manifest_body = manifest_resp.json()
+
+        for template_runtime in manifest_body:
+            # filter by runtime and base image if they are specified
+            if runtime and runtime != template_runtime:
+                continue
+            if base_image and base_image != template_runtime:
+                continue
+
+            for template in manifest_body[template_runtime]:
+                # abort, we are using an older version of the manifest
+                if "useCaseName" not in template:
+                    raise InvalidInitTemplateError(
+                        "Template {name} missing use case descriptor".format(name=template["displayName"]))
+
+                use_case_name = template["useCaseName"]
+                if use_case_name not in use_case_options:
+                    use_case_options[use_case_name] = {}
+                if template_runtime not in use_case_options[use_case_name]:
+                    use_case_options[use_case_name][template_runtime] = []
+
+                use_case_options[use_case_name][template_runtime].append(template)
+
+        return use_case_options
+
+    def clone_templates_repo(self):
         if not self.clone_attempted:
             self._clone_repo()
-        if self.repo_path is None:
-            return self._init_options_from_bundle(package_type, runtime, dependency_manager)
-
-        manifest_path = os.path.join(self.repo_path, "manifest.json")
-        with open(str(manifest_path)) as fp:
-            use_case_options = {}
-            body = fp.read()
-            manifest_body = json.loads(body)
-
-            for template_runtime in manifest_body:
-                # filter by runtime and base image if they are specified
-                if runtime and runtime != template_runtime:
-                    continue
-                if base_image and base_image != template_runtime:
-                    continue
-
-                for template in manifest_body[template_runtime]:
-                    # abort, we are using an older version of the manifest
-                    if "useCaseName" not in template:
-                        return self._init_options_from_manifest(package_type, runtime, base_image, dependency_manager)
-
-                    use_case_name = template["useCaseName"]
-                    if use_case_name not in use_case_options:
-                        use_case_options[use_case_name] = {}
-                    if template_runtime not in use_case_options[use_case_name]:
-                        use_case_options[use_case_name][template_runtime] = []
-
-                    use_case_options[use_case_name][template_runtime].append(template)
-
-            return use_case_options
 
     def init_options(self, package_type, runtime, base_image, dependency_manager):
         if not self.clone_attempted:

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -64,7 +64,8 @@ class InitTemplates:
         manifest_resp = requests.get(self._manifest_url)
 
         if not manifest_resp:
-            raise InvalidInitTemplateError("Can't retrieve templates manifest from {url}".format(url=self._manifest_url))
+            raise InvalidInitTemplateError("Can't retrieve templates manifest from {url}".
+                                           format(url=self._manifest_url))
 
         use_case_options = {}
         manifest_body = manifest_resp.json()

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -31,45 +31,13 @@ class InvalidInitTemplateError(UserException):
 
 class InitTemplates:
     def __init__(self, no_interactive=False, auto_clone=True):
-        self._repo_url = "https://github.com/aws/aws-sam-cli-app-templates"
+        self._repo_url = "https://github.com/sapessi/aws-sam-cli-app-templates"
         self._repo_name = "aws-sam-cli-app-templates"
         self._temp_repo_name = "TEMP-aws-sam-cli-app-templates"
         self.repo_path = None
         self.clone_attempted = False
         self._no_interactive = no_interactive
         self._auto_clone = auto_clone
-
-    def prompt_for_location(self, package_type, runtime, base_image, dependency_manager):
-        options = self.init_options(package_type, runtime, base_image, dependency_manager)
-
-        if len(options) == 1:
-            template_md = options[0]
-        else:
-            choices = list(map(str, range(1, len(options) + 1)))
-            choice_num = 1
-            click.echo("\nAWS quick start application templates:")
-            for o in options:
-                if o.get("displayName") is not None:
-                    msg = "\t" + str(choice_num) + " - " + o.get("displayName")
-                    click.echo(msg)
-                else:
-                    msg = (
-                        "\t"
-                        + str(choice_num)
-                        + " - Default Template for runtime "
-                        + runtime
-                        + " with dependency manager "
-                        + dependency_manager
-                    )
-                    click.echo(msg)
-                choice_num = choice_num + 1
-            choice = click.prompt("Template selection", type=click.Choice(choices), show_choices=False)
-            template_md = options[int(choice) - 1]  # zero index
-        if template_md.get("init_location") is not None:
-            return (template_md["init_location"], template_md["appTemplate"])
-        if template_md.get("directory") is not None:
-            return (os.path.join(self.repo_path, template_md["directory"]), template_md["appTemplate"])
-        raise InvalidInitTemplateError("Invalid template. This should not be possible, please raise an issue.")
 
     def location_from_app_template(self, package_type, runtime, base_image, dependency_manager, app_template):
         options = self.init_options(package_type, runtime, base_image, dependency_manager)
@@ -89,6 +57,40 @@ class InitTemplates:
         # we need to cast it to bool because entry["appTemplate"] can be Any, and Any's __eq__ can return Any
         # detail: https://github.com/python/mypy/issues/5697
         return bool(entry["appTemplate"] == app_template)
+
+    def use_case_init_options(self, package_type, runtime, base_image, dependency_manager):
+        if not self.clone_attempted:
+            self._clone_repo()
+        if self.repo_path is None:
+            return self._init_options_from_bundle(package_type, runtime, dependency_manager)
+
+        manifest_path = os.path.join(self.repo_path, "manifest.json")
+        with open(str(manifest_path)) as fp:
+            use_case_options = {}
+            body = fp.read()
+            manifest_body = json.loads(body)
+
+            for template_runtime in manifest_body:
+                # filter by runtime and base image if they are specified
+                if runtime and runtime != template_runtime:
+                    continue
+                if base_image and base_image != template_runtime:
+                    continue
+
+                for template in manifest_body[template_runtime]:
+                    # abort, we are using an older version of the manifest
+                    if "useCaseName" not in template:
+                        return self._init_options_from_manifest(package_type, runtime, base_image, dependency_manager)
+
+                    use_case_name = template["useCaseName"]
+                    if use_case_name not in use_case_options:
+                        use_case_options[use_case_name] = {}
+                    if template_runtime not in use_case_options[use_case_name]:
+                        use_case_options[use_case_name][template_runtime] = []
+
+                    use_case_options[use_case_name][template_runtime].append(template)
+
+            return use_case_options
 
     def init_options(self, package_type, runtime, base_image, dependency_manager):
         if not self.clone_attempted:

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -14,7 +14,7 @@ from samcli.commands.init.interactive_event_bridge_flow import (
 )
 from samcli.commands.exceptions import SchemasApiException
 from samcli.lib.schemas.schemas_code_manager import do_download_source_code_binding, do_extract_and_merge_schemas_code
-from samcli.local.common.runtime_template import INIT_RUNTIMES, RUNTIME_TO_DEPENDENCY_MANAGERS, LAMBDA_IMAGES_RUNTIMES
+from samcli.local.common.runtime_template import LAMBDA_IMAGES_RUNTIMES
 from samcli.commands.init.init_generator import do_generate
 from samcli.commands.init.init_templates import InitTemplates
 from samcli.lib.utils.osutils import remove
@@ -81,11 +81,11 @@ def _generate_from_use_case(
     use_case_choice = click.prompt("Use case", type=click.Choice(click_use_case_choices), show_choices=False)
 
     runtimes = list(options[use_cases[int(use_case_choice)-1]].keys())
-    if runtimes is None or len(runtimes) == 0:
+    if not runtimes:
         click.echo("No templates available for your use case and chosen runtime")
         return
 
-    chosen_runtime = ""
+    chosen_runtime = runtimes[0]
     if len(runtimes) > 1:
         click.echo("\nWhat is your runtime?")
         click_runtime_choices = []
@@ -94,12 +94,10 @@ def _generate_from_use_case(
             click_runtime_choices.append(str(idx + 1))
         runtime_choice = click.prompt("Runtime", type=click.Choice(click_runtime_choices), show_choices=False)
         chosen_runtime = runtimes[int(runtime_choice)-1]
-    else:
-        chosen_runtime = runtimes[0]
 
     # templates is already a list so no need to get the keys and cast
     app_templates = options[use_cases[int(use_case_choice)-1]][chosen_runtime]
-    chosen_template = ""
+    chosen_template = app_templates[0]
     if len(app_templates) > 1:
         click.echo("\nSelect your starter template")
         click_template_choices = []
@@ -108,8 +106,6 @@ def _generate_from_use_case(
             click_template_choices.append(str(idx + 1))
         template_choice = click.prompt("Template", type=click.Choice(click_template_choices), show_choices=False)
         chosen_template = app_templates[int(template_choice) - 1]
-    else:
-        chosen_template = app_templates[0]
 
     if not name:
         name = click.prompt("\nProject name", type=str, default="sam-app")

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -134,6 +134,8 @@ def _generate_from_use_case(
     dependency_manager = chosen_template["dependencyManager"]
     app_template = chosen_template["appTemplate"]
 
+    templates.clone_templates_repo()
+
     if package_type == ZIP:
         summary_msg = f"""
 -----------------------
@@ -161,6 +163,7 @@ Next steps can be found in the README file at {output_dir}/{name}/README.md
             """
 
     click.echo(summary_msg)
+
     do_generate(location, package_type, runtime, dependency_manager, output_dir, name, no_input, extra_context)
     # executing event_bridge logic if call is for Schema dynamic template
     if is_dynamic_schemas_template:

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -72,7 +72,7 @@ def _generate_from_use_case(
     templates = InitTemplates()
     options = templates.use_case_init_options(None, runtime, base_image, dependency_manager)
 
-    click.echo("What is your use-case?")
+    click.echo("\nWhat is your use-case?")
     use_cases = list(options.keys())
     click_use_case_choices = []
     for idx, use_case in enumerate(use_cases):


### PR DESCRIPTION
**do not merge [until the new use case field in the templates manifest is merged](https://github.com/aws/aws-sam-cli-app-templates/pull/90)**

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
Customers approach the SAM CLI with a use-case in mind first and foremost. Today, we may have init templates for their use-case only for a subset of the runtimes and customers won't be able to discover them unless they are lucky enough to select the correct runtime in the first option.

#### How does it address the issue?
This changes the `init` flow for the SAM CLI to first present a list of use-cases and then give access to the templates we have for each one. The entire init menu is dynamically generated from the `manifest.json` file in the app templates repository

#### What side effects does this change have?
We rely on GitHub to be available for the `init` flow to work

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
