### PR TITLE
WIP ci: Make tests run in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ init:
 test:
 	# Run unit tests
 	# Fail if coverage falls below 95%
-	pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit
+	# Run unit test in parallel (4 worker) with guarantees that all tests in a module run in the same worker.
+	pytest --cov samcli --cov-report term-missing --cov-fail-under 95 -n 4 --dist loadscope tests/unit
 
 test-cov-report:
 	# Run unit tests with html coverage report
@@ -22,11 +23,11 @@ integ-test:
 func-test:
 	# Verify function test coverage only for `samcli.local` package
 	@echo Telemetry Status: $(SAM_CLI_TELEMETRY)
-	pytest --cov samcli.local --cov samcli.commands.local --cov-report term-missing tests/functional
+	pytest --cov samcli.local --cov samcli.commands.local --cov-report term-missing -n 4 --dist loadscope tests/functional
 
 regres-test:
 	@echo Telemetry Status: $(SAM_CLI_TELEMETRY)
-	SAM_CLI_DEV=1 pytest tests/regression
+	SAM_CLI_DEV=1 pytest -n 4 --dist loadscope tests/regression
 
 smoke-test:
 	# Smoke tests run in parallel

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	# Run unit tests
 	# Fail if coverage falls below 95%
 	# Run unit test in parallel (4 worker) with guarantees that all tests in a module run in the same worker.
-	pytest --cov samcli --cov-report term-missing --cov-fail-under 95 -n 4 --dist loadscope tests/unit
+	pytest --cov samcli --cov-report term-missing --cov-fail-under 95 -n 4 --dist loadfile tests/unit
 
 test-cov-report:
 	# Run unit tests with html coverage report
@@ -23,11 +23,11 @@ integ-test:
 func-test:
 	# Verify function test coverage only for `samcli.local` package
 	@echo Telemetry Status: $(SAM_CLI_TELEMETRY)
-	pytest --cov samcli.local --cov samcli.commands.local --cov-report term-missing -n 4 --dist loadscope tests/functional
+	pytest --cov samcli.local --cov samcli.commands.local --cov-report term-missing -n 4 --dist loadfile tests/functional
 
 regres-test:
 	@echo Telemetry Status: $(SAM_CLI_TELEMETRY)
-	SAM_CLI_DEV=1 pytest -n 4 --dist loadscope tests/regression
+	SAM_CLI_DEV=1 pytest -n 4 --dist loadfile tests/regression
 
 smoke-test:
 	# Smoke tests run in parallel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -169,7 +169,11 @@ for:
         if [[ -n $BY_CANARY ]] && [[ -n $DOCKER_USER ]] && [[ -n $DOCKER_PASS ]];
           then echo Logging in Docker Hub; echo $DOCKER_PASS | docker login --username $DOCKER_USER --password-stdin;
         fi"
-      - sh: "pytest -vv -n 2 --dist loadfile tests/integration"
+      # warm container integration tests might be interfered by other tests using docker.
+      # To grant exclusive access to docker, here we run warm container integration tests in sequential,
+      # then run everything else in parallel.
+      - sh: "pytest -vv -k 'TestWarmContainers' tests/integration"
+      - sh: "pytest -vv -n 2 --dist loadfile -k 'not TestWarmContainers' tests/integration"
       - sh: "pytest -vv -n 4 --dist loadfile tests/regression"
       - sh: "black --check setup.py tests samcli"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,7 +99,7 @@ for:
 
       # Run tests with dev env
       - "venv\\Scripts\\activate"
-      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 -n 4 --dist loadscope tests/unit"
+      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 -n 4 --dist loadfile tests/unit"
       - "pylint --rcfile .pylintrc samcli"
       - "mypy setup.py samcli tests"
       - "pytest -n 4 tests/functional"
@@ -159,7 +159,7 @@ for:
       
       # Dev Tests
       - "pip install -e \".[dev]\""
-      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 -n 4 --dist loadscope tests/unit"
+      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 -n 4 --dist loadfile tests/unit"
       - "pylint --rcfile .pylintrc samcli"
       - "mypy setup.py samcli tests"
       - "pytest -n 4 tests/functional"
@@ -169,8 +169,8 @@ for:
         if [[ -n $BY_CANARY ]] && [[ -n $DOCKER_USER ]] && [[ -n $DOCKER_PASS ]];
           then echo Logging in Docker Hub; echo $DOCKER_PASS | docker login --username $DOCKER_USER --password-stdin;
         fi"
-      - sh: "pytest -vv -n 2 --dist loadscope tests/integration "
-      - sh: "pytest -vv -n 4 --dist loadscope tests/regression"
+      - sh: "pytest -vv -n 2 --dist loadfile tests/integration"
+      - sh: "pytest -vv -n 4 --dist loadfile tests/regression"
       - sh: "black --check setup.py tests samcli"
 
       # Set JAVA_HOME to java11

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,7 +99,7 @@ for:
 
       # Run tests with dev env
       - "venv\\Scripts\\activate"
-      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit"
+      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 -n 4 --dist loadscope tests/unit"
       - "pylint --rcfile .pylintrc samcli"
       - "mypy setup.py samcli tests"
       - "pytest -n 4 tests/functional"
@@ -159,7 +159,7 @@ for:
       
       # Dev Tests
       - "pip install -e \".[dev]\""
-      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit"
+      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 -n 4 --dist loadscope tests/unit"
       - "pylint --rcfile .pylintrc samcli"
       - "mypy setup.py samcli tests"
       - "pytest -n 4 tests/functional"
@@ -169,8 +169,8 @@ for:
         if [[ -n $BY_CANARY ]] && [[ -n $DOCKER_USER ]] && [[ -n $DOCKER_PASS ]];
           then echo Logging in Docker Hub; echo $DOCKER_PASS | docker login --username $DOCKER_USER --password-stdin;
         fi"
-      - sh: "pytest -vv tests/integration"
-      - sh: "pytest -vv tests/regression"
+      - sh: "pytest -vv -n 2 --dist loadscope tests/integration "
+      - sh: "pytest -vv -n 4 --dist loadscope tests/regression"
       - sh: "black --check setup.py tests samcli"
 
       # Set JAVA_HOME to java11

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -511,7 +511,8 @@ class TestLambdaContainer_get_debug_settings(TestCase):
 
         self.assertIsNotNone(container_env_vars)
 
-    @parameterized.expand([param(r) for r in set(RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT)])
+    # sort the parameters is essential making unit test names deterministic, which is required by pytest-xdist
+    @parameterized.expand([param(r) for r in sorted(set(RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT))])
     def test_debug_arg_must_be_split_by_spaces_and_appended_to_bootstrap_based_entrypoint(self, runtime):
         """
         Debug args list is appended as arguments to bootstrap-args, which is past the fourth position in the array


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

CI check is slow, especially canary.

#### How does it address the issue?

<img width="541" alt="image" src="https://user-images.githubusercontent.com/3804518/109881212-c1fe3600-7c2c-11eb-83c0-73cd6a28dd0e.png">

Run tests in parallel (4 workers), for integration tests, 2 workers according to [AppVeyor resources](https://www.appveyor.com/docs/build-environment/) (2 or 4 cores)

Tests in the same module are run in sequential via `--dist loadfile` to avoid situation like stack name reuse in deployment tests. This is based on the assumption tests in two files won't affect each other, which at the first scan, I did not find any. (For example, all deployment integ tests are in the same file)

> --dist loadfile: Tests are grouped by their containing file. Groups are distributed to available workers as whole units. This guarantees that all tests in a file run in the same worker. https://pypi.org/project/pytest-xdist/

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
