### PR TITLE
chore: Replace deprecated self.assertEquals() with assertEqual()

### DIFF
--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -1127,7 +1127,7 @@ class TestService_construct_event_http(TestCase):
         print("DEBUG: json.loads(actual_event_str)", json.loads(actual_event_str))
         print("DEBUG: self.expected_dict", self.expected_dict)
         actual_event_dict = json.loads(actual_event_str)
-        self.assertEquals(len(actual_event_dict["requestContext"]["requestId"]), 36)
+        self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
 
@@ -1139,17 +1139,17 @@ class TestService_construct_event_http(TestCase):
             self.request_mock, 3000, binary_types=[], route_key="GET /endpoint"
         )
         actual_event_dict = json.loads(actual_event_str)
-        self.assertEquals(len(actual_event_dict["requestContext"]["requestId"]), 36)
+        self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
 
     def test_v2_route_key(self):
         route_key = LocalApigwService._v2_route_key("GET", "/path", False)
-        self.assertEquals(route_key, "GET /path")
+        self.assertEqual(route_key, "GET /path")
 
     def test_v2_default_route_key(self):
         route_key = LocalApigwService._v2_route_key("GET", "/path", True)
-        self.assertEquals(route_key, "$default")
+        self.assertEqual(route_key, "$default")
 
     @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._should_base64_encode")
     def test_construct_event_with_binary_data(self, should_base64_encode_patch):
@@ -1167,7 +1167,7 @@ class TestService_construct_event_http(TestCase):
             self.request_mock, 3000, binary_types=[], route_key="GET /endpoint"
         )
         actual_event_dict = json.loads(actual_event_str)
-        self.assertEquals(len(actual_event_dict["requestContext"]["requestId"]), 36)
+        self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
 

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -495,7 +495,7 @@ class TestLambdaContainer_get_debug_settings(TestCase):
 
         elif runtime in RUNTIMES_WITH_DEBUG_ENV_VARS_ONLY:
             result, _ = LambdaContainer._get_debug_settings(runtime, self.debug_options)
-            self.assertEquals(
+            self.assertEqual(
                 ["/var/rapid/aws-lambda-rie", "--log-level", "error"],
                 result,
                 "{} runtime must not override entrypoint".format(runtime),

--- a/tests/unit/local/events/test_api_event.py
+++ b/tests/unit/local/events/test_api_event.py
@@ -219,7 +219,7 @@ class TestRequestContext(TestCase):
         }
 
         request_context_dict = request_context.to_dict()
-        self.assertEquals(len(request_context_dict["requestId"]), 36)
+        self.assertEqual(len(request_context_dict["requestId"]), 36)
         request_context_dict["requestId"] = ""
         self.assertEqual(request_context_dict, expected)
 
@@ -267,7 +267,7 @@ class TestRequestContextV2(TestCase):
         }
 
         request_context_dict = request_context.to_dict()
-        self.assertEquals(len(request_context_dict["requestId"]), 36)
+        self.assertEqual(len(request_context_dict["requestId"]), 36)
         request_context_dict["requestId"] = ""
         self.assertEqual(request_context_dict, expected)
 

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -793,14 +793,14 @@ class TestWarmLambdaRuntime_clean_warm_containers_related_resources(TestCase):
     def test_must_container_stopped_when_its_code_dir_got_changed(self, shutil_mock):
 
         self.runtime.clean_running_containers_and_related_resources()
-        self.assertEquals(
+        self.assertEqual(
             self.runtime._container_manager.stop.call_args_list,
             [
                 call(self.func1_container_mock),
                 call(self.func2_container_mock),
             ],
         )
-        self.assertEquals(
+        self.assertEqual(
             shutil_mock.rmtree.call_args_list,
             [
                 call("path1"),


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

pytest keeps complaining

```
DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(route_key, "$default")
```

> For historical reasons, some of the TestCase methods had one or more aliases that are now deprecated. The following table lists the correct names along with their deprecated aliases:
Method Name   | Deprecated alias | Deprecated alias
--------------+------------------+-----------------
assertEqual() | failUnlessEqual  | assertEquals
...
http://docs.python.org/3.3/library/unittest.html#deprecated-aliases


#### How does it address the issue?

Replace deprecated self.assertEquals() with assertEqual()

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
