### PR TITLE
ci: Do apt update before installing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,6 +111,9 @@ for:
         - image: Ubuntu
 
     install:
+      # AppVeyor's apt-get cache might be outdated, and the package could potentially be 404.
+      - sh: "sudo apt-get update"
+
       - sh: "gvm use go1.13"
       - sh: "echo $PATH"
       - sh: "ls /usr/"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux/builds/38069583/job/by3koa2559sqtxrc

python 3.8 could not be installed due to apt cache outdated.

#### How does it address the issue?

run apt update before installing anything.

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
