### PR TITLE
fix: Only outputing remote stack warning during building

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -76,8 +76,8 @@ class BuildContext:
         if remote_stack_full_paths:
             LOG.warning(
                 "Below nested stacks(s) specify non-local URL(s), which is unsupported:\n%s\n"
-                "Skipping building resources inside this nested application.",
-                ", ".join(remote_stack_full_paths),
+                "Skipping building resources inside this these nested stacks.",
+                "\n".join([f"- {full_path}" for full_path in remote_stack_full_paths]),
             )
 
         self._function_provider = SamFunctionProvider(self.stacks)

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -69,9 +69,16 @@ class BuildContext:
 
     def __enter__(self) -> "BuildContext":
 
-        self._stacks = SamLocalStackProvider.get_stacks(
+        self._stacks, remote_stack_full_paths = SamLocalStackProvider.get_stacks(
             self._template_file, parameter_overrides=self._parameter_overrides
         )
+
+        if remote_stack_full_paths:
+            LOG.warning(
+                "Below nested stacks(s) specify non-local URL(s), which is unsupported:\n%s\n"
+                "Skipping building resources inside this nested application.",
+                ", ".join(remote_stack_full_paths),
+            )
 
         self._function_provider = SamFunctionProvider(self.stacks)
         self._layer_provider = SamLayerProvider(self.stacks)

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -75,8 +75,8 @@ class BuildContext:
 
         if remote_stack_full_paths:
             LOG.warning(
-                "Below nested stacks(s) specify non-local URL(s), which is unsupported:\n%s\n"
-                "Skipping building resources inside this these nested stacks.",
+                "Below nested stacks(s) specify non-local URL(s), which are unsupported:\n%s\n"
+                "Skipping building resources inside these nested stacks.",
                 "\n".join([f"- {full_path}" for full_path in remote_stack_full_paths]),
             )
 

--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -209,7 +209,7 @@ class DeployContext:
         confirm_changeset : bool
             Should wait for customer's confirm before executing the changeset
         """
-        stacks = SamLocalStackProvider.get_stacks(
+        stacks, _ = SamLocalStackProvider.get_stacks(
             self.template_file, parameter_overrides=sanitize_parameter_overrides(self.parameter_overrides)
         )
         auth_required_per_resource = auth_per_resource(stacks)

--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -130,7 +130,7 @@ class GuidedContext:
         input_parameter_overrides = self.prompt_parameters(
             parameter_override_keys, self.parameter_overrides_from_cmdline, self.start_bold, self.end_bold
         )
-        stacks = SamLocalStackProvider.get_stacks(
+        stacks, _ = SamLocalStackProvider.get_stacks(
             self.template_file, parameter_overrides=sanitize_parameter_overrides(input_parameter_overrides)
         )
         image_repositories = self.prompt_image_repository(stacks)

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -387,11 +387,12 @@ class InvokeContext:
 
     def _get_stacks(self) -> List[Stack]:
         try:
-            return SamLocalStackProvider.get_stacks(
+            stacks, _ = SamLocalStackProvider.get_stacks(
                 self._template_file,
                 parameter_overrides=self._parameter_overrides,
                 global_parameter_overrides=self._global_parameter_overrides,
             )
+            return stacks
         except (TemplateNotFoundException, TemplateFailedParsingException) as ex:
             raise InvokeContextException(str(ex)) from ex
 

--- a/samcli/lib/providers/exceptions.py
+++ b/samcli/lib/providers/exceptions.py
@@ -12,3 +12,7 @@ class InvalidLayerReference(Exception):
         super().__init__(
             "Layer References need to be of type " "'AWS::Serverless::LayerVersion' or 'AWS::Lambda::LayerVersion'"
         )
+
+
+class RemoteStackLocationNotSupported(Exception):
+    pass

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -418,7 +418,9 @@ class TestBuildContext__enter__(TestCase):
         # call the enter method
         context.__enter__()
         if print_warning:
-            log_mock.warning.assert_called_once_with(ANY, ", ".join(remote_stack_full_paths))
+            log_mock.warning.assert_called_once_with(
+                ANY, "\n".join([f"- {full_path}" for full_path in remote_stack_full_paths])
+            )
         else:
             log_mock.warning.assert_not_called()
 

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -143,7 +143,7 @@ class TestDeployCliCommand(TestCase):
         mock_package_context,
         mock_package_click,
     ):
-
+        mock_get_buildable_stacks.return_value = (Mock(), [])
         mock_sam_function_provider.return_value = {}
         mock_get_template_artifacts_format.return_value = [ZIP]
         context_mock = Mock()
@@ -233,6 +233,7 @@ class TestDeployCliCommand(TestCase):
         mock_package_context,
         mock_package_click,
     ):
+        mock_get_buildable_stacks.return_value = (Mock(), [])
         mock_tag_translation.return_value = "helloworld-123456-v1"
         mock_get_template_function_resource_ids.return_value = ["HelloWorldFunction"]
 
@@ -376,6 +377,7 @@ class TestDeployCliCommand(TestCase):
         mock_package_context,
         mock_package_click,
     ):
+        mock_get_buildable_stacks.return_value = (Mock(), [])
         mock_tag_translation.return_value = "helloworld-123456-v1"
         mock_get_template_function_resource_ids.return_value = ["HelloWorldFunction"]
 
@@ -536,6 +538,7 @@ class TestDeployCliCommand(TestCase):
         mock_package_context,
         mock_package_click,
     ):
+        mock_get_buildable_stacks.return_value = (Mock(), [])
         mock_tag_translation.return_value = "helloworld-123456-v1"
         mock_get_template_function_resource_ids.return_value = ["HelloWorldFunction"]
 
@@ -672,6 +675,7 @@ class TestDeployCliCommand(TestCase):
         mock_package_context,
         mock_package_click,
     ):
+        mock_get_buildable_stacks.return_value = (Mock(), [])
         mock_tag_translation.return_value = "helloworld-123456-v1"
         mock_get_template_function_resource_ids.return_value = ["HelloWorldFunction"]
 

--- a/tests/unit/commands/deploy/test_deploy_context.py
+++ b/tests/unit/commands/deploy/test_deploy_context.py
@@ -1,6 +1,6 @@
 """Test sam deploy command"""
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 import tempfile
 
 from samcli.lib.deploy.deployer import Deployer
@@ -137,6 +137,7 @@ class TestSamDeployCommand(TestCase):
     def test_template_valid_execute_changeset_with_parameters(
         self, patched_get_buildable_stacks, patched_auth_required, patched_boto
     ):
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         patched_auth_required.return_value = [("HelloWorldFunction", False)]
         with tempfile.NamedTemporaryFile(delete=False) as template_file:
             template_file.write(b'{"Parameters": {"a":"b","c":"d"}}')

--- a/tests/unit/commands/deploy/test_guided_context.py
+++ b/tests/unit/commands/deploy/test_guided_context.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch, call, ANY, MagicMock
+from unittest.mock import patch, call, ANY, MagicMock, Mock
 from parameterized import parameterized, param
 
 import click
@@ -43,6 +43,7 @@ class TestGuidedContext(TestCase):
     ):
         patched_sam_function_provider.return_value = {}
         patched_get_template_artifacts_format.return_value = [ZIP]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         # Series of inputs to confirmations so that full range of questions are asked.
         patchedauth_per_resource.return_value = [
             ("HelloWorldFunction", True),
@@ -89,6 +90,7 @@ class TestGuidedContext(TestCase):
         patched_signer_config_per_function.return_value = (None, None)
         patched_sam_function_provider.return_value = {}
         patched_get_template_artifacts_format.return_value = [ZIP]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         # Series of inputs to confirmations so that full range of questions are asked.
         patchedauth_per_resource.return_value = [("HelloWorldFunction", False)]
         patched_confirm.side_effect = [True, False, True, False, ""]
@@ -147,6 +149,7 @@ class TestGuidedContext(TestCase):
             functions={"HelloWorldFunction": MagicMock(packagetype=IMAGE, imageuri="helloworld:v1")}
         )
         patched_get_template_artifacts_format.return_value = [IMAGE]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         patched_prompt.side_effect = [
             "sam-app",
             "region",
@@ -227,6 +230,7 @@ class TestGuidedContext(TestCase):
             }
         )
         patched_get_template_artifacts_format.return_value = [IMAGE]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         patched_prompt.side_effect = [
             "sam-app",
             "region",
@@ -300,6 +304,7 @@ class TestGuidedContext(TestCase):
             functions={"HelloWorldFunction": MagicMock(packagetype=IMAGE, imageuri=None)}
         )
         patched_get_template_artifacts_format.return_value = [IMAGE]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         patched_prompt.side_effect = [
             "sam-app",
             "region",
@@ -343,6 +348,7 @@ class TestGuidedContext(TestCase):
             functions={"HelloWorldFunction": MagicMock(packagetype=IMAGE, imageuri="mysamapp:v1")}
         )
         patched_get_template_artifacts_format.return_value = [IMAGE]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         # set Image repository to be blank.
         patched_prompt.side_effect = [
             "sam-app",
@@ -392,6 +398,7 @@ class TestGuidedContext(TestCase):
         patched_prompt,
     ):
         patched_signer_config_per_function.return_value = ({}, {})
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         self.gc.capabilities = given_capabilities
         # Series of inputs to confirmations so that full range of questions are asked.
         patched_confirm.side_effect = [True, False, "", True]
@@ -434,6 +441,7 @@ class TestGuidedContext(TestCase):
     ):
         patched_sam_function_provider.return_value = {}
         patched_get_template_artifacts_format.return_value = [ZIP]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         patched_signer_config_per_function.return_value = ({}, {})
         # Series of inputs to confirmations so that full range of questions are asked.
         patchedauth_per_resource.return_value = [("HelloWorldFunction", False)]
@@ -490,6 +498,7 @@ class TestGuidedContext(TestCase):
     ):
         patched_sam_function_provider.return_value = {}
         patched_get_template_artifacts_format.return_value = [ZIP]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         # Series of inputs to confirmations so that full range of questions are asked.
         patchedauth_per_resource.return_value = [("HelloWorldFunction", False)]
         patched_confirm.side_effect = [True, False, True, False, ""]
@@ -543,6 +552,7 @@ class TestGuidedContext(TestCase):
     ):
         patched_sam_function_provider.return_value = {}
         patched_get_template_artifacts_format.return_value = [ZIP]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         # Series of inputs to confirmations so that full range of questions are asked.
         patchedauth_per_resource.return_value = [("HelloWorldFunction", False)]
         patched_confirm.side_effect = [True, False, True, False, ""]
@@ -612,6 +622,7 @@ class TestGuidedContext(TestCase):
         patched_sam_function_provider.return_value = {}
         patched_get_template_artifacts_format.return_value = [ZIP]
         patched_signer_config_per_function.return_value = given_code_signing_configs
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         # Series of inputs to confirmations so that full range of questions are asked.
         patched_confirm.side_effect = [True, False, given_sign_packages_flag, "", True]
         self.gc.guided_prompts(parameter_override_keys=None)
@@ -675,6 +686,7 @@ class TestGuidedContext(TestCase):
     ):
         patched_sam_function_provider.return_value = {}
         patched_get_template_artifacts_format.return_value = [ZIP]
+        patched_get_buildable_stacks.return_value = (Mock(), [])
         # Series of inputs to confirmations so that full range of questions are asked.
         patchedauth_per_resource.return_value = [("HelloWorldFunction", False)]
         patched_confirm.side_effect = [True, False, True, True, ""]

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -1052,6 +1052,7 @@ class TestInvokeContext_get_debug_context(TestCase):
 class TestInvokeContext_get_stacks(TestCase):
     @patch("samcli.commands.local.cli_common.invoke_context.SamLocalStackProvider.get_stacks")
     def test_must_pass_custom_region(self, get_stacks_mock):
+        get_stacks_mock.return_value = [Mock(), []]
         invoke_context = InvokeContext("template_file", aws_region="my-custom-region")
         invoke_context._get_stacks()
         get_stacks_mock.assert_called_with(

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -50,7 +50,7 @@ class TestSamBuildableStackProvider(TestCase):
             self.template_file: template,
             child_location_path: LEAF_TEMPLATE,
         }.get(t)
-        stacks = SamLocalStackProvider.get_stacks(
+        stacks, remote_stack_full_paths = SamLocalStackProvider.get_stacks(
             self.template_file,
             "",
             "",
@@ -63,6 +63,7 @@ class TestSamBuildableStackProvider(TestCase):
                 Stack("", "ChildStack", child_location_path, {}, LEAF_TEMPLATE),
             ],
         )
+        self.assertFalse(remote_stack_full_paths)
 
     def test_sam_deep_nested_stack(self):
         child_template_file = "child.yaml"
@@ -88,7 +89,7 @@ class TestSamBuildableStackProvider(TestCase):
             child_template_file: child_template,
             grand_child_template_file: LEAF_TEMPLATE,
         }.get(t)
-        stacks = SamLocalStackProvider.get_stacks(
+        stacks, remote_stack_full_paths = SamLocalStackProvider.get_stacks(
             self.template_file,
             "",
             "",
@@ -102,6 +103,7 @@ class TestSamBuildableStackProvider(TestCase):
                 Stack("ChildStack", "GrandChildStack", grand_child_template_file, {}, LEAF_TEMPLATE),
             ],
         )
+        self.assertFalse(remote_stack_full_paths)
 
     @parameterized.expand([(AWS_SERVERLESS_APPLICATION, "Location"), (AWS_CLOUDFORMATION_STACK, "TemplateURL")])
     def test_remote_stack_is_skipped(self, resource_type, location_property_name):
@@ -116,7 +118,7 @@ class TestSamBuildableStackProvider(TestCase):
         self.get_template_data_mock.side_effect = lambda t: {
             self.template_file: template,
         }.get(t)
-        stacks = SamLocalStackProvider.get_stacks(
+        stacks, remote_stack_full_paths = SamLocalStackProvider.get_stacks(
             self.template_file,
             "",
             "",
@@ -128,6 +130,7 @@ class TestSamBuildableStackProvider(TestCase):
                 Stack("", "", self.template_file, {}, template),
             ],
         )
+        self.assertEqual(remote_stack_full_paths, ["ChildStack"])
 
     @parameterized.expand(
         [
@@ -155,7 +158,7 @@ class TestSamBuildableStackProvider(TestCase):
             template_file: template,
             child_location_path: LEAF_TEMPLATE,
         }.get(t)
-        stacks = SamLocalStackProvider.get_stacks(
+        stacks, remote_stack_full_paths = SamLocalStackProvider.get_stacks(
             template_file,
             "",
             "",
@@ -168,6 +171,7 @@ class TestSamBuildableStackProvider(TestCase):
                 Stack("", "ChildStack", child_location_path, {}, LEAF_TEMPLATE),
             ],
         )
+        self.assertFalse(remote_stack_full_paths)
 
     @parameterized.expand(
         [
@@ -198,7 +202,7 @@ class TestSamBuildableStackProvider(TestCase):
 
         global_parameter_overrides = {"AWS::Region": "custom_region"}
 
-        stacks = SamLocalStackProvider.get_stacks(
+        stacks, remote_stack_full_paths = SamLocalStackProvider.get_stacks(
             template_file, "", "", parameter_overrides=None, global_parameter_overrides=global_parameter_overrides
         )
         self.assertListEqual(
@@ -208,3 +212,4 @@ class TestSamBuildableStackProvider(TestCase):
                 Stack("", "ChildStack", child_location_path, global_parameter_overrides, LEAF_TEMPLATE),
             ],
         )
+        self.assertFalse(remote_stack_full_paths)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#2689

#### Why is this change necessary?

Error message `Nested application 'Application' has specified S3 location for Location which is unsupported. Skipping resources inside this nested application.` is printed when deploying, which is misleading. 

#### How does it address the issue?

Add `ignore_code_extraction_warnings` to stack provider like the one in function provider.

#### What side effects does this change have?

No 

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
