### PR TITLE
fix: Build fails when child templates are symbolic links

### DIFF
--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -332,7 +332,6 @@ class SamLocalStackProvider(SamBaseProvider):
         if os.path.isabs(path):
             return path
 
-        # in case stack_file_path is symlink, resolve its real path (in relative path form)
         if os.path.islink(stack_file_path):
             stack_file_path = os.path.realpath(stack_file_path)
 

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -300,6 +300,22 @@ class SamLocalStackProvider(SamBaseProvider):
           the correct normalized path being returned should be '../folder2/t.yaml' but if we don't resolve the
           symlink first, it would return 'folder/src.'
 
+        * symlinks on Windows might not work properly.
+          https://stackoverflow.com/questions/43333640/python-os-path-realpath-for-symlink-in-windows
+          For example, using Python 3.7, realpath() is a no-op (same as abspath):
+            ```
+            Python 3.7.8 (tags/v3.7.8:4b47a5b6ba, Jun 28 2020, 08:53:46) [MSC v.1916 64 bit (AMD64)] on win32
+            Type "help", "copyright", "credits" or "license" for more information.
+            >>> import os
+            >>> os.symlink('some\\path', 'link1')
+            >>> os.path.realpath('link1')
+            'C:\\Users\\Administrator\\AppData\\Local\\Programs\\Python\\Python37\\link1'
+            >>> os.path.islink('link1')
+            True
+            ```
+          For Python 3.8, according to manual tests, 3.8.8 can resolve symlinks correctly while 3.8.0 cannot.
+
+
         Parameters
         ----------
         stack_file_path

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -295,6 +295,11 @@ class SamLocalStackProvider(SamBaseProvider):
         the resource path is "resource" because it is extracted from child stack, the path is relative to child stack.
         here we normalize the resource path into relative paths to root stack, which is "folder/resource"
 
+        * since stack_file_path might be a symlink, os.path.join() won't be able to derive the correct path.
+          for example, stack_file_path = 'folder/t.yaml' -> '../folder2/t.yaml' and the path = 'src'
+          the correct normalized path being returned should be '../folder2/t.yaml' but if we don't resolve the
+          symlink first, it would return 'folder/src.'
+
         Parameters
         ----------
         stack_file_path
@@ -310,4 +315,9 @@ class SamLocalStackProvider(SamBaseProvider):
         """
         if os.path.isabs(path):
             return path
+
+        # in case stack_file_path is symlink, resolve its real path (in relative path form)
+        if os.path.islink(stack_file_path):
+            stack_file_path = os.path.relpath(os.path.realpath(stack_file_path))
+
         return os.path.normpath(os.path.join(os.path.dirname(stack_file_path), path))

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -334,6 +334,6 @@ class SamLocalStackProvider(SamBaseProvider):
 
         # in case stack_file_path is symlink, resolve its real path (in relative path form)
         if os.path.islink(stack_file_path):
-            stack_file_path = os.path.relpath(os.path.realpath(stack_file_path))
+            stack_file_path = os.path.realpath(stack_file_path)
 
         return os.path.normpath(os.path.join(os.path.dirname(stack_file_path), path))

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -333,6 +333,10 @@ class SamLocalStackProvider(SamBaseProvider):
             return path
 
         if os.path.islink(stack_file_path):
-            stack_file_path = os.path.realpath(stack_file_path)
+            # os.path.realpath() always returns an absolute path while
+            # the return value of this method will show up in build artifacts,
+            # in case customers move the build artifacts among different machines (e.g., git or file sharing)
+            # absolute paths are not robust as relative paths. So here prefer to use relative path.
+            stack_file_path = os.path.relpath(os.path.realpath(stack_file_path))
 
         return os.path.normpath(os.path.join(os.path.dirname(stack_file_path), path))

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1588,11 +1588,12 @@ class TestBuildWithNestedStacks(NestedBuildIntegBase):
             )
 
 
-class TestBuildWithNestedStacks3Level(NestedBuildIntegBase):
+class TestBuildWithNestedStacks3LevelWithSymlink(NestedBuildIntegBase):
     """
     In this template, it has the same structure as .aws-sam/build
     build
         - template.yaml
+        - child-stack-x-template-symlink.yaml (symlink to ChildStackX/template.yaml)
         - FunctionA
         - ChildStackX
             - template.yaml
@@ -1617,8 +1618,20 @@ class TestBuildWithNestedStacks3Level(NestedBuildIntegBase):
 
         command_result = run_command(cmdlist, cwd=self.working_dir)
 
-        function_full_paths = ["FunctionA", "ChildStackX/FunctionB", "ChildStackX/ChildStackY/FunctionA"]
-        stack_paths = ["", "ChildStackX", "ChildStackX/ChildStackY"]
+        function_full_paths = [
+            "FunctionA",
+            "ChildStackX/FunctionB",
+            "ChildStackX/ChildStackY/FunctionA",
+            "ChildStackXViaSymlink/FunctionB",
+            "ChildStackXViaSymlink/ChildStackY/FunctionA",
+        ]
+        stack_paths = [
+            "",
+            "ChildStackX",
+            "ChildStackX/ChildStackY",
+            "ChildStackXViaSymlink",
+            "ChildStackXViaSymlink/ChildStackY",
+        ]
         if not SKIP_DOCKER_TESTS:
             self._verify_build(
                 function_full_paths,
@@ -1634,6 +1647,8 @@ class TestBuildWithNestedStacks3Level(NestedBuildIntegBase):
                     ("FunctionB", {"body": '{"hello": "b"}', "statusCode": 200}),
                     ("ChildStackX/FunctionB", {"body": '{"hello": "b"}', "statusCode": 200}),
                     ("ChildStackX/ChildStackY/FunctionA", {"body": '{"hello": "a2"}', "statusCode": 200}),
+                    ("ChildStackXViaSymlink/FunctionB", {"body": '{"hello": "b"}', "statusCode": 200}),
+                    ("ChildStackXViaSymlink/ChildStackY/FunctionA", {"body": '{"hello": "a2"}', "statusCode": 200}),
                 ],
             )
 

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1588,6 +1588,65 @@ class TestBuildWithNestedStacks(NestedBuildIntegBase):
             )
 
 
+class TestBuildWithNestedStacks3Level(NestedBuildIntegBase):
+    """
+    In this template, it has the same structure as .aws-sam/build
+    build
+        - template.yaml
+        - FunctionA
+        - ChildStackX
+            - template.yaml
+            - FunctionB
+            - ChildStackY
+                - template.yaml
+                - FunctionA
+                - MyLayerVersion
+    """
+
+    template = os.path.join("deep-nested", "template.yaml")
+
+    @pytest.mark.flaky(reruns=3)
+    def test_nested_build(self):
+        if SKIP_DOCKER_TESTS:
+            self.skipTest(SKIP_DOCKER_MESSAGE)
+
+        cmdlist = self.get_command_list(use_container=True, cached=True, parallel=True)
+
+        LOG.info("Running Command: %s", cmdlist)
+        LOG.info(self.working_dir)
+
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+
+        function_full_paths = [
+            "FunctionA",
+            "ChildStackX/FunctionB",
+            "ChildStackX/ChildStackY/FunctionA",
+        ]
+        stack_paths = [
+            "",
+            "ChildStackX",
+            "ChildStackX/ChildStackY",
+        ]
+        if not SKIP_DOCKER_TESTS:
+            self._verify_build(
+                function_full_paths,
+                stack_paths,
+                command_result,
+            )
+
+            self._verify_invoke_built_functions(
+                self.built_template,
+                "",
+                [
+                    ("FunctionA", {"body": '{"hello": "a"}', "statusCode": 200}),
+                    ("FunctionB", {"body": '{"hello": "b"}', "statusCode": 200}),
+                    ("ChildStackX/FunctionB", {"body": '{"hello": "b"}', "statusCode": 200}),
+                    ("ChildStackX/ChildStackY/FunctionA", {"body": '{"hello": "a2"}', "statusCode": 200}),
+                ],
+            )
+
+
+@skipIf(IS_WINDOWS, "symlink is not resolved consistently on windows")
 class TestBuildWithNestedStacks3LevelWithSymlink(NestedBuildIntegBase):
     """
     In this template, it has the same structure as .aws-sam/build
@@ -1604,7 +1663,7 @@ class TestBuildWithNestedStacks3LevelWithSymlink(NestedBuildIntegBase):
                 - MyLayerVersion
     """
 
-    template = os.path.join("deep-nested", "template.yaml")
+    template = os.path.join("deep-nested", "template-with-symlink.yaml")
 
     @pytest.mark.flaky(reruns=3)
     def test_nested_build(self):

--- a/tests/integration/testdata/buildcmd/deep-nested/child-stack-x-template-symlink.yaml
+++ b/tests/integration/testdata/buildcmd/deep-nested/child-stack-x-template-symlink.yaml
@@ -1,0 +1,1 @@
+ChildStackX/template.yaml

--- a/tests/integration/testdata/buildcmd/deep-nested/template-with-symlink.yaml
+++ b/tests/integration/testdata/buildcmd/deep-nested/template-with-symlink.yaml
@@ -15,3 +15,8 @@ Resources:
     Type: AWS::Serverless::Application
     Properties:
       Location: ChildStackX/template.yaml
+
+  ChildStackXViaSymlink:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: child-stack-x-template-symlink.yaml

--- a/tests/integration/testdata/buildcmd/deep-nested/template.yaml
+++ b/tests/integration/testdata/buildcmd/deep-nested/template.yaml
@@ -15,3 +15,8 @@ Resources:
     Type: AWS::Serverless::Application
     Properties:
       Location: ChildStackX/template.yaml
+
+  ChildStackXViaSymlink:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: child-stack-x-template-symlink.yaml

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -283,7 +283,7 @@ class TestSamBuildableStackProvider(TestCase):
             real_tmp_dir = os.path.realpath(tmp_dir)
             # SamLocalStackProvider.normalize_resource_path() always returns a relative path.
             # so expected is converted to relative path
-            expected = os.path.relpath(os.path.join(real_tmp_dir, os.path.join("some", "path", "src")))
+            expected = os.path.join(real_tmp_dir, os.path.join("some", "path", "src"))
 
             os.symlink(os.path.join("..", "some", "path", "template.yaml"), link1)
             os.symlink("link1", link2)

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -285,6 +285,7 @@ class TestSamBuildableStackProvider(TestCase):
             os.symlink("link1", link2)
 
             # sanity checks (debug)
+            self.assertTrue(link1.startswith("C:"))
             self.assertTrue(os.path.islink(link1))
             self.assertTrue(os.path.islink(link2))
             self.assertEqual(os.path.realpath(link1), os.path.join(real_tmp_dir, "some", "path", "template.yaml"))

--- a/tests/unit/commands/local/lib/test_stack_provider.py
+++ b/tests/unit/commands/local/lib/test_stack_provider.py
@@ -283,7 +283,7 @@ class TestSamBuildableStackProvider(TestCase):
             real_tmp_dir = os.path.realpath(tmp_dir)
             # SamLocalStackProvider.normalize_resource_path() always returns a relative path.
             # so expected is converted to relative path
-            expected = os.path.join(real_tmp_dir, os.path.join("some", "path", "src"))
+            expected = os.path.relpath(os.path.join(real_tmp_dir, os.path.join("some", "path", "src")))
 
             os.symlink(os.path.join("..", "some", "path", "template.yaml"), link1)
             os.symlink("link1", link2)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

reported by @kornicameister in #2690  
When child templates are symbolic link, the resources' paths in them cannot be resolved.

for example, stack_file_path = 'folder/t.yaml' -> '../folder2/t.yaml' and the path = 'src' the correct normalized path being returned should be '../folder2/t.yaml' but if we don't resolve the symlink first, it would return 'folder/src.'

#### How does it address the issue?

resolve the symlink in `normalize_resource_path()`

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
