### PR TITLE
WIP: `sam build` Resolve layer ARN passed from to parent stacks (not covering all intrinsic functions)

### DIFF
--- a/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
+++ b/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
@@ -331,6 +331,11 @@ class IntrinsicsSymbolTable:
                 # here we use a special function "CrossStackRef" to refer a logicalID from other stacks
                 # ".." means the parent stack
                 return {"Ref": {"CrossStackRef": ["..", logical_id_item.get("Ref")]}}
+            if "Fn::Join" in logical_id_item:
+                delimiter, items = logical_id_item.get("Fn::Join")
+                if delimiter == "," and all("Ref" in item for item in items):
+                    return [{"Ref": {"CrossStackRef": ["..", item.get("Ref")]}} for item in items]
+
             LOG.warning('"sam build" currently does not support the resolution of parameter %s.', logical_id_item)
 
         return logical_id_item.get(resource_attributes)

--- a/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
+++ b/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
@@ -325,6 +325,14 @@ class IntrinsicsSymbolTable:
                 return None
             return logical_id_item
 
+        if logical_id in self._parameters and isinstance(logical_id_item, dict):
+            if "Ref" in logical_id_item:
+                # It is a parameter passed down from the parent
+                # here we use a special function "CrossStackRef" to refer a logicalID from other stacks
+                # ".." means the parent stack
+                return {"Ref": {"CrossStackRef": ["..", logical_id_item.get("Ref")]}}
+            LOG.warning('"sam build" currently does not support the resolution of parameter %s.', logical_id_item)
+
         return logical_id_item.get(resource_attributes)
 
     @staticmethod

--- a/samcli/lib/providers/sam_stack_provider.py
+++ b/samcli/lib/providers/sam_stack_provider.py
@@ -3,6 +3,7 @@ Class that provides all nested stacks from a given SAM template
 """
 import logging
 import os
+import posixpath
 from typing import Optional, Dict, cast, List, Iterator, Tuple
 from urllib.parse import unquote, urlparse
 
@@ -340,3 +341,14 @@ class SamLocalStackProvider(SamBaseProvider):
             stack_file_path = os.path.relpath(os.path.realpath(stack_file_path))
 
         return os.path.normpath(os.path.join(os.path.dirname(stack_file_path), path))
+
+    @staticmethod
+    def resolve_stack(stacks: List[Stack], base_stack: Stack, relative_stack_path: str) -> Stack:
+        target_stack_path = posixpath.normpath(posixpath.join(base_stack.stack_path, relative_stack_path))
+        if target_stack_path == ".":
+            # root stack
+            target_stack_path = ""
+        try:
+            return next(stack for stack in stacks if stack.stack_path == target_stack_path)
+        except StopIteration as ex:
+            raise ValueError(f"Cannot find stack with path {target_stack_path}") from ex


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

Attempt to fix #2724

#### Why is this change necessary?

When `sam` tries to resolve intrinsic functions in `Parameters` passed from parent, it simply does this replacement:

##### single `!Ref` used in parent

```diff
# parent.yaml
Type: AWS::Serverless::Application
Properties:
  Location: child.yaml
  Parameters:
    XXX: !Ref SomeLogicalID

# child.yaml
Parameters:
  XXX:
    Type: String

.....
-     Layers: 
-      - !Ref XXX
+      - SomeLogicalID
```

##### Compound intrinsic function like `!Join`

```diff
# parent.yaml
Type: AWS::Serverless::Application
Properties:
  Location: child.yaml
  Parameters:
    XXX: !Join [",", [!Ref SomeLogicalID, !Ref SomeLogicalID2]]

# child.yaml
Parameters:
  XXX:
    Type: CommaDelimitedList

.....
-     Layers: !Ref XXX
+     Layers: XXX
```

In either case, `sam` won't be able to link the resolved value to original resources passed from the parent

#### How does it address the issue?

1. Have special handling in `get_translation()`.
2. Add a new special function "CrossStackRef" used by `SamFunctionProvider` to locate resource reference across different stacks.

Support these methods:

##### Directly passed down using `!Ref`

```yaml
Resources:
  MyLayerVersion:
    Type: AWS::Serverless::LayerVersion
    Properties:
      LayerName: MyLayer
      Description: Layer description
      ContentUri: MyLayerVersion
      CompatibleRuntimes:
        - python3.8

  App:
    Type: AWS::Serverless::Application
    Properties:
      Location: ./child.yaml
      Parameters:
        Layer: !Ref MyLayerVersion
```

- [x] support multi-level passing?

##### Using `!Join [",", [..., ..., ...]]`

```yaml
Resources:
  MyLayerVersion:
    Type: AWS::Serverless::LayerVersion
    Properties:
      LayerName: MyLayer
      Description: Layer description
      ContentUri: MyLayerVersion
      CompatibleRuntimes:
        - python3.8
  
  MyLayerVersion2:
    Type: AWS::Serverless::LayerVersion
    Properties:
      LayerName: MyLayer
      Description: Layer description
      ContentUri: MyLayerVersion
      CompatibleRuntimes:
        - python3.8

  App:
    Type: AWS::Serverless::Application
    Properties:
      Location: ./b_child.yaml
      Parameters:
        Layers: !Join [",", [!Ref MyLayerVersion, !Ref MyLayerVersion2]]
        ParentLayerVersion2: !Ref MyLayerVersion2
```

- [ ] support multi-level passing?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
