### PR TITLE
fix: Added Template User Input to Unit Test for Python Image Init Templates

### DIFF
--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -1089,6 +1089,7 @@ foo
         user_input = """
 1
 2
+1
         """
         args = [
             "--no-input",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
New templates added in https://github.com/aws/aws-sam-cli-app-templates/pull/86 will require one more user input instead of defaulting to the first and only template.
This hangs test_init_cli_no_package_type unit test.

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
