### PR TITLE
fix: sam build fails when layer logicalID shared across stacks

### DIFF
--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -145,6 +145,8 @@ class LayerVersion:
             compatible_runtimes = []
         if metadata is None:
             metadata = {}
+        if not isinstance(arn, str):
+            raise UnsupportedIntrinsic("{} is an Unsupported Intrinsic".format(arn))
 
         self._stack_path = stack_path
         self._arn = arn
@@ -222,11 +224,6 @@ class LayerVersion:
 
     @property
     def arn(self) -> str:
-        # because self.arn is only used in local invoke.
-        # here we delay the validation process for self._arn, rather than in __init__() to ensure
-        # customers still have a smooth build experience.
-        if not isinstance(self._arn, str):
-            raise UnsupportedIntrinsic("{} is an Unsupported Intrinsic".format(self._arn))
         return self._arn
 
     @property

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -421,6 +421,16 @@ class SamFunctionProvider(SamBaseProvider):
                         stack_path=stack.stack_path,
                     )
                 )
+            else:
+                # layer is not recognizable, it might be an intrinsic function that we don't support yet.
+                # LayerVersion will raise exceptions in its own methods.
+                layers.append(
+                    LayerVersion(
+                        layer,
+                        None,
+                        stack_path=stack.stack_path,
+                    )
+                )
 
         return layers
 

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -422,14 +422,10 @@ class SamFunctionProvider(SamBaseProvider):
                     )
                 )
             else:
-                # layer is not recognizable, it might be an intrinsic function that we don't support yet.
-                # LayerVersion will raise exceptions in its own methods.
-                layers.append(
-                    LayerVersion(
-                        layer,
-                        None,
-                        stack_path=stack.stack_path,
-                    )
+                LOG.debug(
+                    'layer "%s" is not recognizable, '
+                    "it might be using intrinsic functions that we don't support yet. Skipping.",
+                    str(layer),
                 )
 
         return layers

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -304,3 +304,69 @@ class NestedBuildIntegBase(BuildIntegBase):
     def _verify_invoke_built_functions(self, template_path, overrides, function_and_expected):
         for function_identifier, expected in function_and_expected:
             self._verify_invoke_built_function(template_path, function_identifier, overrides, expected)
+
+
+class IntrinsicIntegBase(BuildIntegBase):
+    """
+    Currently sam-cli does not have great support for intrinsic functions,
+    in this kind of integ tests, there are functions that are buildable but not invocable.
+    """
+
+    def _verify_build(self, function_full_paths, layer_full_path, stack_paths, command_result):
+        """
+        Verify resources have their build artifact folders, stack has their own template.yaml, and command succeeds.
+        """
+        self._verify_process_code_and_output(command_result, function_full_paths, layer_full_path)
+        for function_full_path in function_full_paths:
+            self._verify_build_artifact(self.default_build_dir, function_full_path)
+        for stack_path in stack_paths:
+            self._verify_move_template(self.default_build_dir, stack_path)
+
+    def _verify_build_artifact(self, build_dir, function_full_path):
+        self.assertTrue(build_dir.exists(), "Build directory should be created")
+
+        build_dir_files = os.listdir(str(build_dir))
+        self.assertIn("template.yaml", build_dir_files)
+        # full_path is always posix path
+        path_components = posixpath.split(function_full_path)
+        artifact_path = Path(build_dir, *path_components)
+        self.assertTrue(artifact_path.exists())
+
+    def _verify_move_template(self, build_dir, stack_path):
+        path_components = posixpath.split(stack_path)
+        stack_build_dir_path = Path(build_dir, Path(*path_components), "template.yaml")
+        self.assertTrue(stack_build_dir_path.exists())
+
+    def _verify_process_code_and_output(self, command_result, function_full_paths, layer_full_path):
+        self.assertEqual(command_result.process.returncode, 0)
+        # check HelloWorld and HelloMars functions are built in the same build
+        for function_full_path in function_full_paths:
+            self.assertRegex(
+                command_result.stderr.decode("utf-8"),
+                f"Building codeuri: .* runtime: .* metadata: .* functions: \\[.*'{function_full_path}'.*\\]",
+            )
+        self.assertIn(
+            f"Building layer '{layer_full_path}'",
+            command_result.stderr.decode("utf-8"),
+        )
+
+    def _verify_cannot_invoke_built_functions(self, template_path, functions, error_message):
+        for function_logical_id in functions:
+            LOG.info("Invoking built function '{}'".format(function_logical_id))
+
+            cmdlist = [
+                self.cmd,
+                "local",
+                "invoke",
+                function_logical_id,
+                "-t",
+                str(template_path),
+                "--no-event",
+            ]
+
+            process_execute = run_command(cmdlist)
+            process_execute.process.wait()
+
+            process_stderr = process_execute.stderr.decode("utf-8")
+            self.assertNotEqual(0, process_execute.process.returncode)
+            self.assertIn(error_message, process_stderr)

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -350,7 +350,10 @@ class IntrinsicIntegBase(BuildIntegBase):
             command_result.stderr.decode("utf-8"),
         )
 
-    def _verify_cannot_invoke_built_functions(self, template_path, functions, error_message):
+    def _verify_invoke_built_functions(self, template_path, functions, error_message):
+        """
+        Invoke the function, if error_message is not None, the invoke should fail.
+        """
         for function_logical_id in functions:
             LOG.info("Invoking built function '{}'".format(function_logical_id))
 
@@ -368,5 +371,8 @@ class IntrinsicIntegBase(BuildIntegBase):
             process_execute.process.wait()
 
             process_stderr = process_execute.stderr.decode("utf-8")
-            self.assertNotEqual(0, process_execute.process.returncode)
-            self.assertIn(error_message, process_stderr)
+            if error_message:
+                self.assertNotEqual(0, process_execute.process.returncode)
+                self.assertIn(error_message, process_stderr)
+            else:
+                self.assertEqual(0, process_execute.process.returncode)

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1832,7 +1832,9 @@ class TestBuildWithNestedStacksImage(NestedBuildIntegBase):
             ["", "ChildApp"],
             "ChildApp/MyLayerVersion",
             ["FunctionInRoot"],
-            "Unsupported Intrinsic",
+            # for this pass-up use case, since we are not sure whether there are valid local invoke cases out there,
+            # so we don't want to block customers from local invoking it.
+            None,
         ),
     ],
 )
@@ -1864,6 +1866,6 @@ class TestBuildPassingLayerAcrossStacks(IntrinsicIntegBase):
                 command_result,
             )
 
-            self._verify_cannot_invoke_built_functions(
+            self._verify_invoke_built_functions(
                 self.built_template, self.function_full_paths, self.invoke_error_message
             )

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1837,7 +1837,7 @@ class TestBuildWithNestedStacksImage(NestedBuildIntegBase):
     ],
 )
 class TestBuildPassingLayerAcrossStacks(IntrinsicIntegBase):
-    # @pytest.mark.flaky(reruns=3)
+    @pytest.mark.flaky(reruns=3)
     def test_nested_build(self):
         if SKIP_DOCKER_TESTS:
             self.skipTest(SKIP_DOCKER_MESSAGE)

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -17,6 +17,7 @@ from .build_integ_base import (
     CachedBuildIntegBase,
     BuildIntegRubyBase,
     NestedBuildIntegBase,
+    IntrinsicIntegBase,
 )
 from tests.testing_utils import (
     IS_WINDOWS,
@@ -1811,4 +1812,58 @@ class TestBuildWithNestedStacksImage(NestedBuildIntegBase):
                     ("Function2", "Hello Mars"),
                     ("LocalNestedStack/Function2", {"pi": "3.14"}),
                 ],
+            )
+
+
+@parameterized_class(
+    ("template", "stack_paths", "layer_full_path", "function_full_paths", "invoke_error_message"),
+    [
+        (
+            os.path.join("nested-with-intrinsic-functions", "template-pass-down.yaml"),
+            ["", "AppUsingRef", "AppUsingJoin"],
+            "MyLayerVersion",
+            ["AppUsingRef/FunctionInChild", "AppUsingJoin/FunctionInChild"],
+            # Note(xinhol), intrinsic function passed by parameter are resolved as string,
+            # therefore it is being treated as an Arn, it is a bug in intrinsic resolver
+            "Invalid Layer Arn",
+        ),
+        (
+            os.path.join("nested-with-intrinsic-functions", "template-pass-up.yaml"),
+            ["", "ChildApp"],
+            "ChildApp/MyLayerVersion",
+            ["FunctionInRoot"],
+            "Unsupported Intrinsic",
+        ),
+    ],
+)
+class TestBuildPassingLayerAcrossStacks(IntrinsicIntegBase):
+    # @pytest.mark.flaky(reruns=3)
+    def test_nested_build(self):
+        if SKIP_DOCKER_TESTS:
+            self.skipTest(SKIP_DOCKER_MESSAGE)
+
+        """
+        Build template above and verify that each function call returns as expected
+        """
+        cmdlist = self.get_command_list(
+            use_container=True,
+            cached=True,
+            parallel=True,
+        )
+
+        LOG.info("Running Command: %s", cmdlist)
+        LOG.info(self.working_dir)
+
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+
+        if not SKIP_DOCKER_TESTS:
+            self._verify_build(
+                self.function_full_paths,
+                self.layer_full_path,
+                self.stack_paths,
+                command_result,
+            )
+
+            self._verify_cannot_invoke_built_functions(
+                self.built_template, self.function_full_paths, self.invoke_error_message
             )

--- a/tests/integration/testdata/buildcmd/nested-with-intrinsic-functions/child-pass-down.yaml
+++ b/tests/integration/testdata/buildcmd/nested-with-intrinsic-functions/child-pass-down.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  Layer:
+    Type: String
+
+Resources:
+  FunctionInChild:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../Python
+      Handler: main.handler
+      Runtime: python3.8
+      Layers:
+        - !Ref Layer

--- a/tests/integration/testdata/buildcmd/nested-with-intrinsic-functions/child-pass-up.yaml
+++ b/tests/integration/testdata/buildcmd/nested-with-intrinsic-functions/child-pass-up.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  MyLayerVersion:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: MyLayerInChild
+      ContentUri: ../PyLayer
+      CompatibleRuntimes:
+        - python3.8
+    Metadata:
+      BuildMethod: python3.8
+
+Outputs:
+  LayerVersion:
+    Value: !Ref MyLayerVersion
+    Description: MyLayerVersion in child.yaml

--- a/tests/integration/testdata/buildcmd/nested-with-intrinsic-functions/template-pass-down.yaml
+++ b/tests/integration/testdata/buildcmd/nested-with-intrinsic-functions/template-pass-down.yaml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  MyLayerVersion:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: MyLayerInRoot
+      ContentUri: ../PyLayer
+      CompatibleRuntimes:
+        - python3.8
+    Metadata:
+      BuildMethod: python3.8
+
+  AppUsingRef:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./child-pass-down.yaml
+      Parameters:
+        Layer: !Ref MyLayerVersion
+
+  AppUsingJoin:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./child-pass-down.yaml
+      Parameters:
+        Layer: !Ref MyLayerVersion

--- a/tests/integration/testdata/buildcmd/nested-with-intrinsic-functions/template-pass-up.yaml
+++ b/tests/integration/testdata/buildcmd/nested-with-intrinsic-functions/template-pass-up.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  ChildApp:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: ./child-pass-up.yaml
+
+  FunctionInRoot:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../Python
+      Handler: main.handler
+      Runtime: python3.8
+      Layers:
+        - !GetAtt ChildApp.Outputs.LayerVersion

--- a/tests/unit/commands/local/lib/test_provider.py
+++ b/tests/unit/commands/local/lib/test_provider.py
@@ -49,8 +49,9 @@ class TestLayerVersion(TestCase):
         ]
     )
     def test_invalid_arn(self, arn):
+        layer = LayerVersion(arn, None)  # creation of layer does not raise exception
         with self.assertRaises(InvalidLayerVersionArn):
-            LayerVersion(arn, None)
+            layer.version, layer.name
 
     def test_layer_version_returned(self):
         layer_version = LayerVersion("arn:aws:lambda:region:account-id:layer:layer-name:1", None)
@@ -90,5 +91,6 @@ class TestLayerVersion(TestCase):
             "Fn::Sub": ["arn:aws:lambda:region:account-id:layer:{layer_name}:1", {"layer_name": "layer-name"}]
         }
 
+        layer = LayerVersion(intrinsic_arn, ".")  # creation of layer does not raise exception
         with self.assertRaises(UnsupportedIntrinsic):
-            LayerVersion(intrinsic_arn, ".")
+            layer.arn

--- a/tests/unit/commands/local/lib/test_provider.py
+++ b/tests/unit/commands/local/lib/test_provider.py
@@ -91,6 +91,5 @@ class TestLayerVersion(TestCase):
             "Fn::Sub": ["arn:aws:lambda:region:account-id:layer:{layer_name}:1", {"layer_name": "layer-name"}]
         }
 
-        layer = LayerVersion(intrinsic_arn, ".")  # creation of layer does not raise exception
         with self.assertRaises(UnsupportedIntrinsic):
-            layer.arn
+            LayerVersion(intrinsic_arn, ".")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

fix #2724

#### Why is this change necessary?

sam-cli does not support resolving intrinsic functions in parameters/outputs, which results in incorrect layer reference when the layer is passed from some other stacks using intrinsic functions.

Before we have a great support of intrinsic functions, customers should still be able to build their stacks. Incorrect resolution of layers should only affect `local *`.

#### How does it address the issue?

Delay the validation process and only raise exception when certain layer properties are used.
I added two integration tests to cover both using parameters (pass down) and outputs (pass up). 

*pass up: template-pass-up.yaml, pass down: template-pass-down.yaml
- pass up before: 
  - `sam build` works, 
  - `sam local invoke` works
- pass up now: 
  - `sam build` works, 
  - `sam local invoke`: ~`Error: {'Fn::GetAtt': ['ChildApp', 'Outputs.LayerVersion']} is an Unsupported Intrinsic`~ works
- pass down before: 
  - `sam build` failed with `invalid layer arn` error
  - `sam local invoke` failed with `invalid layer arn` error
- pass down now: 
  - `sam build` works
  - `sam local invoke` failed with `invalid layer arn` error

#### What side effects does this change have?

~for the "pass up" case, customers won't be able to local invoke anymore. This should be the expected behavior.~

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
