### PR TITLE
Revert "feat: add option --container-host to commands local start-api, local start-lambda and local invoke (#2700)"

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -75,7 +75,6 @@ class InvokeContext:
         warm_container_initialization_mode: Optional[str] = None,
         debug_function: Optional[str] = None,
         shutdown: bool = False,
-        container_host: Optional[str] = None,
     ) -> None:
         """
         Initialize the context
@@ -122,8 +121,6 @@ class InvokeContext:
             option is enabled
         shutdown bool
             Optional. If True, perform a SHUTDOWN event when tearing down containers. Default False.
-        container_host string
-            Optional. Host of locally emulated Lambda container
         """
         self._template_file = template_file
         self._function_identifier = function_identifier
@@ -148,8 +145,6 @@ class InvokeContext:
         self._aws_region = aws_region
         self._aws_profile = aws_profile
         self._shutdown = shutdown
-
-        self._container_host = container_host
 
         self._containers_mode = ContainersMode.COLD
         self._containers_initializing_mode = ContainersInitializationMode.LAZY
@@ -332,7 +327,6 @@ class InvokeContext:
             aws_region=self._aws_region,
             env_vars_values=self._env_vars_value,
             debug_context=self._debug_context,
-            container_host=self._container_host,
         )
         return self._local_lambda_runner
 

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -48,16 +48,7 @@ def local_common_options(f):
             default=False,
             help="If set, will emulate a shutdown event after the invoke completes, "
             "in order to test extension handling of shutdown behavior.",
-        ),
-        click.option(
-            "--container-host",
-            default="localhost",
-            show_default=True,
-            help="Host of locally emulated Lambda container. "
-            "This option is useful when the container runs on a different host than SAM CLI. "
-            "For example, if you want to run SAM CLI in a Docker container on macOS, "
-            "use this option with host.docker.internal",
-        ),
+        )
     ]
 
     # Reverse the list to maintain ordering of options in help text printed with --help

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -72,7 +72,6 @@ def cli(
     parameter_overrides,
     config_file,
     config_env,
-    container_host,
 ):
     """
     `sam local invoke` command entry point
@@ -98,7 +97,6 @@ def cli(
         force_image_build,
         shutdown,
         parameter_overrides,
-        container_host,
     )  # pragma: no cover
 
 
@@ -121,7 +119,6 @@ def do_cli(  # pylint: disable=R0914
     force_image_build,
     shutdown,
     parameter_overrides,
-    container_host,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -164,7 +161,6 @@ def do_cli(  # pylint: disable=R0914
             aws_region=ctx.region,
             aws_profile=ctx.profile,
             shutdown=shutdown,
-            container_host=container_host,
         ) as context:
 
             # Invoke the function

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -43,7 +43,6 @@ class LocalLambdaRunner:
         aws_region: Optional[str] = None,
         env_vars_values: Optional[Dict[Any, Any]] = None,
         debug_context: Optional[DebugContext] = None,
-        container_host: Optional[str] = None,
     ) -> None:
         """
         Initializes the class
@@ -56,7 +55,6 @@ class LocalLambdaRunner:
         :param string aws_region: Optional. AWS Region to use.
         :param dict env_vars_values: Optional. Dictionary containing values of environment variables.
         :param DebugContext debug_context: Optional. Debug context for the function (includes port, args, and path).
-        :param string container_host: Optional. Host of locally emulated Lambda container
         """
 
         self.local_runtime = local_runtime
@@ -68,7 +66,6 @@ class LocalLambdaRunner:
         self.debug_context = debug_context
         self._boto3_session_creds: Optional[Dict[str, str]] = None
         self._boto3_region: Optional[str] = None
-        self.container_host = container_host
 
     def invoke(
         self,
@@ -124,14 +121,7 @@ class LocalLambdaRunner:
 
         # Invoke the function
         try:
-            self.local_runtime.invoke(
-                config,
-                event,
-                debug_context=self.debug_context,
-                stdout=stdout,
-                stderr=stderr,
-                container_host=self.container_host,
-            )
+            self.local_runtime.invoke(config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr)
         except ContainerResponseException:
             # NOTE(sriram-mv): This should still result in a exit code zero to avoid regressions.
             LOG.info("No response from invoke container for %s", function.name)

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -81,7 +81,6 @@ def cli(
     warm_containers,
     shutdown,
     debug_function,
-    container_host,
 ):
     """
     `sam local start-api` command entry point
@@ -109,7 +108,6 @@ def cli(
         warm_containers,
         shutdown,
         debug_function,
-        container_host,
     )  # pragma: no cover
 
 
@@ -134,7 +132,6 @@ def do_cli(  # pylint: disable=R0914
     warm_containers,
     shutdown,
     debug_function,
-    container_host,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -175,7 +172,6 @@ def do_cli(  # pylint: disable=R0914
             warm_container_initialization_mode=warm_containers,
             debug_function=debug_function,
             shutdown=shutdown,
-            container_host=container_host,
         ) as invoke_context:
 
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -92,7 +92,6 @@ def cli(
     warm_containers,
     shutdown,
     debug_function,
-    container_host,
 ):
     """
     `sam local start-lambda` command entry point
@@ -119,7 +118,6 @@ def cli(
         warm_containers,
         shutdown,
         debug_function,
-        container_host,
     )  # pragma: no cover
 
 
@@ -143,7 +141,6 @@ def do_cli(  # pylint: disable=R0914
     warm_containers,
     shutdown,
     debug_function,
-    container_host,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -183,7 +180,6 @@ def do_cli(  # pylint: disable=R0914
             warm_container_initialization_mode=warm_containers,
             debug_function=debug_function,
             shutdown=shutdown,
-            container_host=container_host,
         ) as invoke_context:
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -38,7 +38,7 @@ class Container:
     _STDOUT_FRAME_TYPE = 1
     _STDERR_FRAME_TYPE = 2
     RAPID_PORT_CONTAINER = "8080"
-    URL = "http://{host}:{port}/2015-03-31/functions/{function_name}/invocations"
+    URL = "http://localhost:{port}/2015-03-31/functions/{function_name}/invocations"
     # Set connection timeout to 1 sec to support the large input.
     RAPID_CONNECTION_TIMEOUT = 1
 
@@ -55,7 +55,6 @@ class Container:
         docker_client=None,
         container_opts=None,
         additional_volumes=None,
-        container_host="localhost",
     ):
         """
         Initializes the class with given configuration. This does not automatically create or run the container.
@@ -72,7 +71,6 @@ class Container:
         :param docker_client: Optional, a docker client to replace the default one loaded from env
         :param container_opts: Optional, a dictionary containing the container options
         :param additional_volumes: Optional list of additional volumes
-        :param string container_host: Optional. Host of locally emulated Lambda container
         """
 
         self._image = image
@@ -98,9 +96,6 @@ class Container:
         # selecting the first free port in a range that's not ephemeral.
         self._start_port_range = 5000
         self._end_port_range = 9000
-
-        self._container_host = container_host
-
         try:
             self.rapid_port_host = find_free_port(start=self._start_port_range, end=self._end_port_range)
         except NoFreePortsError as ex:
@@ -271,9 +266,8 @@ class Container:
         # TODO(sriram-mv): `aws-lambda-rie` is in a mode where the function_name is always "function"
         # NOTE(sriram-mv): There is a connection timeout set on the http call to `aws-lambda-rie`, however there is not
         # a read time out for the response received from the server.
-
         resp = requests.post(
-            self.URL.format(host=self._container_host, port=self.rapid_port_host, function_name="function"),
+            self.URL.format(port=self.rapid_port_host, function_name="function"),
             data=event.encode("utf-8"),
             timeout=(self.RAPID_CONNECTION_TIMEOUT, None),
         )

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -45,7 +45,6 @@ class LambdaContainer(Container):
         memory_mb=128,
         env_vars=None,
         debug_options=None,
-        container_host=None,
     ):
         """
         Initializes the class
@@ -75,8 +74,6 @@ class LambdaContainer(Container):
             Optional. Dictionary containing environment variables passed to container
         debug_options DebugContext
             Optional. Contains container debugging info (port, debugger path)
-        container_host string
-            Optional. Host of locally emulated Lambda container
         """
         if not Runtime.has_value(runtime) and not packagetype == IMAGE:
             raise ValueError("Unsupported Lambda runtime {}".format(runtime))
@@ -122,7 +119,6 @@ class LambdaContainer(Container):
             env_vars=env_vars,
             container_opts=additional_options,
             additional_volumes=additional_volumes,
-            container_host=container_host,
         )
 
     @staticmethod

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -44,7 +44,7 @@ class LambdaRuntime:
         self._image_builder = image_builder
         self._temp_uncompressed_paths_to_be_cleaned = []
 
-    def create(self, function_config, debug_context=None, container_host=None):
+    def create(self, function_config, debug_context=None):
         """
         Create a new Container for the passed function, then store it in a dictionary using the function name,
         so it can be retrieved later and used in the other functions. Make sure to use the debug_context only
@@ -56,8 +56,6 @@ class LambdaRuntime:
             Configuration of the function to create a new Container for it.
         debug_context DebugContext
             Debugging context for the function (includes port, args, and path)
-        container_host string
-            Host of locally emulated Lambda container
 
         Returns
         -------
@@ -80,7 +78,6 @@ class LambdaRuntime:
             memory_mb=function_config.memory,
             env_vars=env_vars,
             debug_options=debug_context,
-            container_host=container_host,
         )
         try:
             # create the container.
@@ -135,7 +132,6 @@ class LambdaRuntime:
         debug_context=None,
         stdout: Optional[StreamWriter] = None,
         stderr: Optional[StreamWriter] = None,
-        container_host=None,
     ):
         """
         Invoke the given Lambda function locally.
@@ -154,15 +150,13 @@ class LambdaRuntime:
             StreamWriter that receives stdout text from container.
         :param samcli.lib.utils.stream_writer.StreamWriter stderr: Optional.
             StreamWriter that receives stderr text from container.
-        :param string container_host: Optional.
-            Host of locally emulated Lambda container
         :raises Keyboard
         """
         timer = None
         container = None
         try:
             # Start the container. This call returns immediately after the container starts
-            container = self.create(function_config, debug_context, container_host)
+            container = self.create(function_config, debug_context)
             container = self.run(container, function_config, debug_context)
             # Setup appropriate interrupt - timeout or Ctrl+C - before function starts executing.
             #
@@ -307,7 +301,7 @@ class WarmLambdaRuntime(LambdaRuntime):
 
         super().__init__(container_manager, image_builder)
 
-    def create(self, function_config, debug_context=None, container_host=None):
+    def create(self, function_config, debug_context=None):
         """
         Create a new Container for the passed function, then store it in a dictionary using the function name,
         so it can be retrieved later and used in the other functions. Make sure to use the debug_context only
@@ -342,7 +336,7 @@ class WarmLambdaRuntime(LambdaRuntime):
             )
             debug_context = None
 
-        container = super().create(function_config, debug_context, container_host)
+        container = super().create(function_config, debug_context)
         self._containers[function_config.name] = container
 
         self._observer.watch(function_config)

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -543,7 +543,6 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 env_vars_values=ANY,
                 aws_profile="profile",
                 aws_region="region",
-                container_host=None,
             )
 
             result = self.context.local_lambda_runner
@@ -615,79 +614,6 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 env_vars_values=ANY,
                 aws_profile="profile",
                 aws_region="region",
-                container_host=None,
-            )
-
-            result = self.context.local_lambda_runner
-            self.assertEqual(result, runner_mock)
-            # assert that lambda runner is created only one time, and the cached version used in the second call
-            self.assertEqual(LocalLambdaMock.call_count, 1)
-
-    @patch("samcli.commands.local.cli_common.invoke_context.LambdaImage")
-    @patch("samcli.commands.local.cli_common.invoke_context.LayerDownloader")
-    @patch("samcli.commands.local.cli_common.invoke_context.LambdaRuntime")
-    @patch("samcli.commands.local.cli_common.invoke_context.LocalLambdaRunner")
-    @patch("samcli.commands.local.cli_common.invoke_context.SamFunctionProvider")
-    def test_must_create_runner_with_container_host_option(
-        self, SamFunctionProviderMock, LocalLambdaMock, LambdaRuntimeMock, download_layers_mock, lambda_image_patch
-    ):
-        runtime_mock = Mock()
-        LambdaRuntimeMock.return_value = runtime_mock
-
-        runner_mock = Mock()
-        LocalLambdaMock.return_value = runner_mock
-
-        download_mock = Mock()
-        download_layers_mock.return_value = download_mock
-
-        image_mock = Mock()
-        lambda_image_patch.return_value = image_mock
-
-        cwd = "cwd"
-        self.context = InvokeContext(
-            template_file="template_file",
-            function_identifier="id",
-            env_vars_file="env_vars_file",
-            docker_volume_basedir="volumedir",
-            docker_network="network",
-            log_file="log_file",
-            skip_pull_image=True,
-            force_image_build=True,
-            debug_ports=[1111],
-            debugger_path="path-to-debugger",
-            debug_args="args",
-            aws_profile="profile",
-            aws_region="region",
-            container_host="localhost",
-        )
-        self.context.get_cwd = Mock()
-        self.context.get_cwd.return_value = cwd
-
-        self.context._get_stacks = Mock()
-        self.context._get_stacks.return_value = [Mock()]
-        self.context._get_env_vars_value = Mock()
-        self.context._setup_log_file = Mock()
-        self.context._get_debug_context = Mock(return_value=None)
-
-        container_manager_mock = Mock()
-        container_manager_mock.is_docker_reachable = PropertyMock(return_value=True)
-        self.context._get_container_manager = Mock(return_value=container_manager_mock)
-
-        with self.context:
-            result = self.context.local_lambda_runner
-            self.assertEqual(result, runner_mock)
-
-            LambdaRuntimeMock.assert_called_with(container_manager_mock, image_mock)
-            lambda_image_patch.assert_called_once_with(download_mock, True, True)
-            LocalLambdaMock.assert_called_with(
-                local_runtime=runtime_mock,
-                function_provider=ANY,
-                cwd=cwd,
-                debug_context=None,
-                env_vars_values=ANY,
-                aws_profile="profile",
-                aws_region="region",
-                container_host="localhost",
             )
 
             result = self.context.local_lambda_runner

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -41,7 +41,6 @@ class TestCli(TestCase):
         self.shutdown = False
         self.region_name = "region"
         self.profile = "profile"
-        self.container_host = "localhost"
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
@@ -76,7 +75,6 @@ class TestCli(TestCase):
             layer_cache_basedir=self.layer_cache_basedir,
             force_image_build=self.force_image_build,
             shutdown=self.shutdown,
-            container_host=self.container_host,
         )
 
         InvokeContextMock.assert_called_with(
@@ -97,7 +95,6 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             aws_region=self.region_name,
             aws_profile=self.profile,
-            container_host=self.container_host,
         )
 
         context_mock.local_lambda_runner.invoke.assert_called_with(
@@ -136,7 +133,6 @@ class TestCli(TestCase):
             layer_cache_basedir=self.layer_cache_basedir,
             force_image_build=self.force_image_build,
             shutdown=self.shutdown,
-            container_host=self.container_host,
         )
 
         InvokeContextMock.assert_called_with(
@@ -157,7 +153,6 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             aws_region=self.region_name,
             aws_profile=self.profile,
-            container_host=self.container_host,
         )
 
         get_event_mock.assert_not_called()
@@ -210,7 +205,6 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
-                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)
@@ -263,7 +257,6 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
-                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)
@@ -314,7 +307,6 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
-                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)
@@ -353,7 +345,6 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
-                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)
@@ -406,7 +397,6 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
-                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -518,7 +518,7 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
+            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr
         )
 
     def test_must_work_packagetype_ZIP(self):
@@ -536,7 +536,7 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
+            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr
         )
 
     def test_must_raise_if_no_privilege(self):
@@ -609,7 +609,7 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.get_invoke_config.return_value = invoke_config
         self.local_lambda.invoke(name, event, stdout, stderr)
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
+            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr
         )
 
     def test_must_raise_if_imageuri_not_found(self):
@@ -623,45 +623,6 @@ class TestLocalLambda_invoke(TestCase):
 
         with self.assertRaises(InvalidIntermediateImageError):
             self.local_lambda.invoke(name, event, stdout, stderr)
-
-
-class TestLocalLambda_invoke_with_container_host_option(TestCase):
-    def setUp(self):
-        self.runtime_mock = Mock()
-        self.function_provider_mock = Mock()
-        self.cwd = "/my/current/working/directory"
-        self.debug_context = None
-        self.aws_profile = "myprofile"
-        self.aws_region = "region"
-        self.env_vars_values = {}
-        self.container_host = "localhost"
-
-        self.local_lambda = LocalLambdaRunner(
-            self.runtime_mock,
-            self.function_provider_mock,
-            self.cwd,
-            env_vars_values=self.env_vars_values,
-            debug_context=self.debug_context,
-            container_host=self.container_host,
-        )
-
-    def test_must_work(self):
-        name = "name"
-        event = "event"
-        stdout = "stdout"
-        stderr = "stderr"
-        function = Mock(functionname="name")
-        invoke_config = "config"
-
-        self.function_provider_mock.get_all.return_value = [function]
-        self.local_lambda.get_invoke_config = Mock()
-        self.local_lambda.get_invoke_config.return_value = invoke_config
-
-        self.local_lambda.invoke(name, event, stdout, stderr)
-
-        self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host="localhost"
-        )
 
 
 class TestLocalLambda_is_debugging(TestCase):
@@ -686,6 +647,7 @@ class TestLocalLambda_is_debugging(TestCase):
         self.assertTrue(self.local_lambda.is_debugging())
 
     def test_must_be_off(self):
+
         self.local_lambda = LocalLambdaRunner(
             self.runtime_mock,
             self.function_provider_mock,

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -47,8 +47,6 @@ class TestCli(TestCase):
         self.port = 123
         self.static_dir = "staticdir"
 
-        self.container_host = "localhost"
-
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.lib.local_api_service.LocalApiService")
     def test_cli_must_setup_context_and_start_service(self, local_api_service_mock, invoke_context_mock):
@@ -84,7 +82,6 @@ class TestCli(TestCase):
             warm_container_initialization_mode=self.warm_containers,
             debug_function=self.debug_function,
             shutdown=self.shutdown,
-            container_host=self.container_host,
         )
 
         local_api_service_mock.assert_called_with(
@@ -191,5 +188,4 @@ class TestCli(TestCase):
             warm_containers=self.warm_containers,
             debug_function=self.debug_function,
             shutdown=self.shutdown,
-            container_host=self.container_host,
         )

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -40,8 +40,6 @@ class TestCli(TestCase):
         self.host = "host"
         self.port = 123
 
-        self.container_host = "localhost"
-
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.lib.local_lambda_service.LocalLambdaService")
     def test_cli_must_setup_context_and_start_service(self, local_lambda_service_mock, invoke_context_mock):
@@ -76,7 +74,6 @@ class TestCli(TestCase):
             warm_container_initialization_mode=self.warm_containers,
             debug_function=self.debug_function,
             shutdown=self.shutdown,
-            container_host=self.container_host,
         )
 
         local_lambda_service_mock.assert_called_with(lambda_invoke_context=context_mock, port=self.port, host=self.host)
@@ -160,5 +157,4 @@ class TestCli(TestCase):
             warm_containers=self.warm_containers,
             debug_function=self.debug_function,
             shutdown=self.shutdown,
-            container_host=self.container_host,
         )

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -312,7 +312,6 @@ class TestSamConfigForAllCommands(TestCase):
                 True,
                 True,
                 {"Key": "Value", "Key2": "Value2"},
-                "localhost",
             )
 
     @patch("samcli.commands.local.start_api.cli.do_cli")
@@ -374,7 +373,6 @@ class TestSamConfigForAllCommands(TestCase):
                 None,
                 False,
                 None,
-                "localhost",
             )
 
     @patch("samcli.commands.local.start_lambda.cli.do_cli")
@@ -434,7 +432,6 @@ class TestSamConfigForAllCommands(TestCase):
                 None,
                 False,
                 None,
-                "localhost",
             )
 
     @patch("samcli.lib.cli_validation.image_repository_validation.get_template_function_resource_ids")
@@ -852,8 +849,6 @@ class TestSamConfigWithOverrides(TestCase):
                     "--shutdown",
                     "--parameter-overrides",
                     "A=123 C=D E=F12! G=H",
-                    "--container-host",
-                    "localhost",
                 ],
             )
 
@@ -883,7 +878,6 @@ class TestSamConfigWithOverrides(TestCase):
                 None,
                 True,
                 None,
-                "localhost",
             )
 
     @patch("samcli.commands.local.start_lambda.cli.do_cli")
@@ -975,7 +969,6 @@ class TestSamConfigWithOverrides(TestCase):
                 None,
                 False,
                 None,
-                "localhost",
             )
 
     @patch("samcli.commands.validate.validate.do_cli")

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -513,18 +513,12 @@ class TestContainer_wait_for_result(TestCase):
         self.cmd = ["cmd"]
         self.working_dir = "working_dir"
         self.host_dir = "host_dir"
-        self.container_host = "localhost"
 
         self.mock_docker_client = Mock()
         self.mock_docker_client.containers = Mock()
         self.mock_docker_client.containers.get = Mock()
         self.container = Container(
-            self.image,
-            self.cmd,
-            self.working_dir,
-            self.host_dir,
-            docker_client=self.mock_docker_client,
-            container_host=self.container_host,
+            self.image, self.cmd, self.working_dir, self.host_dir, docker_client=self.mock_docker_client
         )
         self.container.id = "someid"
 

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -81,7 +81,6 @@ class LambdaRuntime_create(TestCase):
             debug_options=debug_options,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
-            container_host=None,
         )
         # Run the container and get results
         self.manager_mock.create.assert_called_with(container)
@@ -270,7 +269,6 @@ class LambdaRuntime_invoke(TestCase):
             debug_options=debug_options,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
-            container_host=None,
         )
 
         # Run the container and get results
@@ -597,7 +595,6 @@ class TestWarmLambdaRuntime_invoke(TestCase):
             debug_options=debug_options,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
-            container_host=None,
         )
 
         # Run the container and get results
@@ -675,7 +672,6 @@ class TestWarmLambdaRuntime_create(TestCase):
             debug_options=debug_options,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
-            container_host=None,
         )
 
         self.manager_mock.create.assert_called_with(container)
@@ -741,7 +737,6 @@ class TestWarmLambdaRuntime_create(TestCase):
             debug_options=None,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
-            container_host=None,
         )
         self.manager_mock.create.assert_called_with(container)
         # validate that the created container got cached


### PR DESCRIPTION
This reverts commit e653fe214255357aa6eb025dc060b2672d9e8e51.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
