### PR TITLE
fix: Cookiecutter template generation failed when related dir exists

### DIFF
--- a/samcli/lib/cookiecutter/template.py
+++ b/samcli/lib/cookiecutter/template.py
@@ -144,7 +144,9 @@ class Template:
 
         try:
             LOG.debug("Baking a new template with cookiecutter with all parameters")
-            cookiecutter(template=self._location, output_dir=".", no_input=True, extra_context=context)
+            cookiecutter(
+                template=self._location, overwrite_if_exists=True, output_dir=".", no_input=True, extra_context=context
+            )
         except RepositoryNotFound as e:
             # cookiecutter.json is not found in the template. Let's just clone it directly without
             # using cookiecutter and call it done.

--- a/tests/unit/lib/cookiecutter/test_template.py
+++ b/tests/unit/lib/cookiecutter/test_template.py
@@ -118,7 +118,11 @@ class TestTemplate(TestCase):
         mock_interactive_flow.run.assert_not_called()
         mock_preprocessor.run.assert_called_once_with(self._ANY_INTERACTIVE_FLOW_CONTEXT)
         mock_cookiecutter.assert_called_with(
-            template=self._ANY_LOCATION, output_dir=".", no_input=True, extra_context=self._ANY_PROCESSOR_CONTEXT
+            template=self._ANY_LOCATION,
+            overwrite_if_exists=True,
+            output_dir=".",
+            no_input=True,
+            extra_context=self._ANY_PROCESSOR_CONTEXT,
         )
         mock_postprocessor.run.assert_called_once_with(self._ANY_PROCESSOR_CONTEXT)
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

The output directory might exist already (very possible for pipeline generation, e.g., adding a new gh action workflow when `.github/workflows` contains other workflow files), not having `overwrite_if_exists` will cause the `cookiecutter()` to fail

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
