### PR TITLE
chore: Use BUILD_TAG instead of JENKINS_URL to identify Jenkins env

### DIFF
--- a/samcli/lib/telemetry/cicd.py
+++ b/samcli/lib/telemetry/cicd.py
@@ -53,8 +53,14 @@ def _is_jenkins(environ: Mapping) -> bool:
     https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#working-with-your-jenkinsfile
     > BUILD_TAG
     >   String of jenkins-${JOB_NAME}-${BUILD_NUMBER}.
+    > ...
+    > JENKINS_URL
+    >   Full URL of Jenkins, such as https://example.com:port/jenkins/
+    >   (NOTE: only available if Jenkins URL set in "System Configuration")
+
+    Here firstly check JENKINS_URL's presence, if not, then fallback to check BUILD_TAG starts with "jenkins"
     """
-    return bool(environ.get("BUILD_TAG", "").startswith("jenkins-"))
+    return "JENKINS_URL" in environ or environ.get("BUILD_TAG", "").startswith("jenkins-")
 
 
 _ENV_VAR_OR_CALLABLE_BY_PLATFORM: Dict[CICDPlatform, Union[str, Callable[[Mapping], bool]]] = {

--- a/samcli/lib/telemetry/cicd.py
+++ b/samcli/lib/telemetry/cicd.py
@@ -46,9 +46,19 @@ def _is_codeship(environ: Mapping) -> bool:
     return ci_name == "codeship"
 
 
+def _is_jenkins(environ: Mapping) -> bool:
+    """
+    Use environ to determine whether it is running in Jenkins.
+    According to the doc,
+    https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#working-with-your-jenkinsfile
+    > BUILD_TAG
+    >   String of jenkins-${JOB_NAME}-${BUILD_NUMBER}.
+    """
+    return bool(environ.get("BUILD_TAG", "").startswith("jenkins-"))
+
+
 _ENV_VAR_OR_CALLABLE_BY_PLATFORM: Dict[CICDPlatform, Union[str, Callable[[Mapping], bool]]] = {
-    # https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
-    CICDPlatform.Jenkins: "JENKINS_URL",
+    CICDPlatform.Jenkins: _is_jenkins,
     # https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
     CICDPlatform.GitLab: "GITLAB_CI",
     # https://docs.github.com/en/actions/reference/environment-variables

--- a/tests/unit/lib/telemetry/test_cicd.py
+++ b/tests/unit/lib/telemetry/test_cicd.py
@@ -10,6 +10,7 @@ class TestCICD(TestCase):
     @parameterized.expand(
         [
             (CICDPlatform.Jenkins, "BUILD_TAG", "jenkins-jobname-123"),
+            (CICDPlatform.Jenkins, "JENKINS_URL", Mock()),
             (CICDPlatform.GitLab, "GITLAB_CI", Mock()),
             (CICDPlatform.GitHubAction, "GITHUB_ACTION", Mock()),
             (CICDPlatform.TravisCI, "TRAVIS", Mock()),

--- a/tests/unit/lib/telemetry/test_cicd.py
+++ b/tests/unit/lib/telemetry/test_cicd.py
@@ -9,7 +9,7 @@ from samcli.lib.telemetry.cicd import CICDPlatform, _is_cicd_platform
 class TestCICD(TestCase):
     @parameterized.expand(
         [
-            (CICDPlatform.Jenkins, "JENKINS_URL", Mock()),
+            (CICDPlatform.Jenkins, "BUILD_TAG", "jenkins-jobname-123"),
             (CICDPlatform.GitLab, "GITLAB_CI", Mock()),
             (CICDPlatform.GitHubAction, "GITHUB_ACTION", Mock()),
             (CICDPlatform.TravisCI, "TRAVIS", Mock()),
@@ -26,3 +26,12 @@ class TestCICD(TestCase):
     )
     def test_is_cicd_platform(self, cicd_platform, env_var, env_var_value):
         self.assertTrue(_is_cicd_platform(cicd_platform, {env_var: env_var_value}))
+
+    @parameterized.expand(
+        [
+            (CICDPlatform.Jenkins, "BUILD_TAG", "not-jenkins-"),
+            (CICDPlatform.CodeShip, "CI_NAME", "not-CodeShip"),
+        ]
+    )
+    def test_is_not_cicd_platform(self, cicd_platform, env_var, env_var_value):
+        self.assertFalse(_is_cicd_platform(cicd_platform, {env_var: env_var_value}))


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

According to the doc https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#working-with-your-jenkinsfile

`JENKINS_URL` is only available if Jenkins URL set in "System Configuration." So here we use `BUILD_TAG` to identify Jenkins instead to ensure no false negatives

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
