### PR TITLE
feat: add option --container-host and --container-host-interface to sam local commands

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -76,6 +76,7 @@ class InvokeContext:
         debug_function: Optional[str] = None,
         shutdown: bool = False,
         container_host: Optional[str] = None,
+        container_host_interface: Optional[str] = None,
     ) -> None:
         """
         Initialize the context
@@ -124,6 +125,8 @@ class InvokeContext:
             Optional. If True, perform a SHUTDOWN event when tearing down containers. Default False.
         container_host string
             Optional. Host of locally emulated Lambda container
+        container_host_interface string
+            Optional. Interface that Docker host binds ports to
         """
         self._template_file = template_file
         self._function_identifier = function_identifier
@@ -150,6 +153,7 @@ class InvokeContext:
         self._shutdown = shutdown
 
         self._container_host = container_host
+        self._container_host_interface = container_host_interface
 
         self._containers_mode = ContainersMode.COLD
         self._containers_initializing_mode = ContainersInitializationMode.LAZY
@@ -248,7 +252,9 @@ class InvokeContext:
 
         def initialize_function_container(function: Function) -> None:
             function_config = self.local_lambda_runner.get_invoke_config(function)
-            self.lambda_runtime.run(None, function_config, self._debug_context, self._container_host)
+            self.lambda_runtime.run(
+                None, function_config, self._debug_context, self._container_host, self._container_host_interface
+            )
 
         try:
             async_context = AsyncContext()
@@ -333,6 +339,7 @@ class InvokeContext:
             env_vars_values=self._env_vars_value,
             debug_context=self._debug_context,
             container_host=self._container_host,
+            container_host_interface=self._container_host_interface,
         )
         return self._local_lambda_runner
 

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -248,7 +248,7 @@ class InvokeContext:
 
         def initialize_function_container(function: Function) -> None:
             function_config = self.local_lambda_runner.get_invoke_config(function)
-            self.lambda_runtime.run(None, function_config, self._debug_context)
+            self.lambda_runtime.run(None, function_config, self._debug_context, self._container_host)
 
         try:
             async_context = AsyncContext()

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -75,6 +75,7 @@ class InvokeContext:
         warm_container_initialization_mode: Optional[str] = None,
         debug_function: Optional[str] = None,
         shutdown: bool = False,
+        container_host: Optional[str] = None,
     ) -> None:
         """
         Initialize the context
@@ -121,6 +122,8 @@ class InvokeContext:
             option is enabled
         shutdown bool
             Optional. If True, perform a SHUTDOWN event when tearing down containers. Default False.
+        container_host string
+            Optional. Host of locally emulated Lambda container
         """
         self._template_file = template_file
         self._function_identifier = function_identifier
@@ -145,6 +148,8 @@ class InvokeContext:
         self._aws_region = aws_region
         self._aws_profile = aws_profile
         self._shutdown = shutdown
+
+        self._container_host = container_host
 
         self._containers_mode = ContainersMode.COLD
         self._containers_initializing_mode = ContainersInitializationMode.LAZY
@@ -327,6 +332,7 @@ class InvokeContext:
             aws_region=self._aws_region,
             env_vars_values=self._env_vars_value,
             debug_context=self._debug_context,
+            container_host=self._container_host,
         )
         return self._local_lambda_runner
 

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -58,6 +58,14 @@ def local_common_options(f):
             "For example, if you want to run SAM CLI in a Docker container on macOS, "
             "use this option with host.docker.internal",
         ),
+        click.option(
+            "--container-host-interface",
+            default="127.0.0.1",
+            show_default=True,
+            help="Interface that Docker host binds ports to. "
+            "This option is useful when users want to bind ports to a different interface. "
+            "Note: the input should be an IP address. ",
+        ),
     ]
 
     # Reverse the list to maintain ordering of options in help text printed with --help

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -63,7 +63,7 @@ def local_common_options(f):
             default="127.0.0.1",
             show_default=True,
             help="IP address of the host network interface that container ports should bind to. "
-            "Use 0.0.0.0 to bind to all interfaces."
+            "Use 0.0.0.0 to bind to all interfaces.",
         ),
     ]
 

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -62,11 +62,8 @@ def local_common_options(f):
             "--container-host-interface",
             default="127.0.0.1",
             show_default=True,
-            help="Interface that Docker host binds ports to. "
-            "This option is useful when users want to bind ports to a different interface. "
-            "It will bind ports to loopback interface by default. "
-            "For example, using 0.0.0.0 will bind ports to all interfaces. "
-            "Note: the input should be an IP address. ",
+            help="IP address of the host network interface that container ports should bind to. "
+            "Use 0.0.0.0 to bind to all interfaces."
         ),
     ]
 

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -48,7 +48,16 @@ def local_common_options(f):
             default=False,
             help="If set, will emulate a shutdown event after the invoke completes, "
             "in order to test extension handling of shutdown behavior.",
-        )
+        ),
+        click.option(
+            "--container-host",
+            default="localhost",
+            show_default=True,
+            help="Host of locally emulated Lambda container. "
+            "This option is useful when the container runs on a different host than SAM CLI. "
+            "For example, if you want to run SAM CLI in a Docker container on macOS, "
+            "use this option with host.docker.internal",
+        ),
     ]
 
     # Reverse the list to maintain ordering of options in help text printed with --help

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -64,6 +64,8 @@ def local_common_options(f):
             show_default=True,
             help="Interface that Docker host binds ports to. "
             "This option is useful when users want to bind ports to a different interface. "
+            "It will bind ports to loopback interface by default. "
+            "For example, using 0.0.0.0 will bind ports to all interfaces. "
             "Note: the input should be an IP address. ",
         ),
     ]

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -72,6 +72,7 @@ def cli(
     parameter_overrides,
     config_file,
     config_env,
+    container_host,
 ):
     """
     `sam local invoke` command entry point
@@ -97,6 +98,7 @@ def cli(
         force_image_build,
         shutdown,
         parameter_overrides,
+        container_host,
     )  # pragma: no cover
 
 
@@ -119,6 +121,7 @@ def do_cli(  # pylint: disable=R0914
     force_image_build,
     shutdown,
     parameter_overrides,
+    container_host,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -161,6 +164,7 @@ def do_cli(  # pylint: disable=R0914
             aws_region=ctx.region,
             aws_profile=ctx.profile,
             shutdown=shutdown,
+            container_host=container_host,
         ) as context:
 
             # Invoke the function

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -73,6 +73,7 @@ def cli(
     config_file,
     config_env,
     container_host,
+    container_host_interface,
 ):
     """
     `sam local invoke` command entry point
@@ -99,6 +100,7 @@ def cli(
         shutdown,
         parameter_overrides,
         container_host,
+        container_host_interface,
     )  # pragma: no cover
 
 
@@ -122,6 +124,7 @@ def do_cli(  # pylint: disable=R0914
     shutdown,
     parameter_overrides,
     container_host,
+    container_host_interface,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -165,6 +168,7 @@ def do_cli(  # pylint: disable=R0914
             aws_profile=ctx.profile,
             shutdown=shutdown,
             container_host=container_host,
+            container_host_interface=container_host_interface,
         ) as context:
 
             # Invoke the function

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -43,6 +43,7 @@ class LocalLambdaRunner:
         aws_region: Optional[str] = None,
         env_vars_values: Optional[Dict[Any, Any]] = None,
         debug_context: Optional[DebugContext] = None,
+        container_host: Optional[str] = None,
     ) -> None:
         """
         Initializes the class
@@ -55,6 +56,7 @@ class LocalLambdaRunner:
         :param string aws_region: Optional. AWS Region to use.
         :param dict env_vars_values: Optional. Dictionary containing values of environment variables.
         :param DebugContext debug_context: Optional. Debug context for the function (includes port, args, and path).
+        :param string container_host: Optional. Host of locally emulated Lambda container
         """
 
         self.local_runtime = local_runtime
@@ -66,6 +68,7 @@ class LocalLambdaRunner:
         self.debug_context = debug_context
         self._boto3_session_creds: Optional[Dict[str, str]] = None
         self._boto3_region: Optional[str] = None
+        self.container_host = container_host
 
     def invoke(
         self,
@@ -121,7 +124,14 @@ class LocalLambdaRunner:
 
         # Invoke the function
         try:
-            self.local_runtime.invoke(config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr)
+            self.local_runtime.invoke(
+                config,
+                event,
+                debug_context=self.debug_context,
+                stdout=stdout,
+                stderr=stderr,
+                container_host=self.container_host,
+            )
         except ContainerResponseException:
             # NOTE(sriram-mv): This should still result in a exit code zero to avoid regressions.
             LOG.info("No response from invoke container for %s", function.name)

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -44,6 +44,7 @@ class LocalLambdaRunner:
         env_vars_values: Optional[Dict[Any, Any]] = None,
         debug_context: Optional[DebugContext] = None,
         container_host: Optional[str] = None,
+        container_host_interface: Optional[str] = None,
     ) -> None:
         """
         Initializes the class
@@ -57,6 +58,7 @@ class LocalLambdaRunner:
         :param dict env_vars_values: Optional. Dictionary containing values of environment variables.
         :param DebugContext debug_context: Optional. Debug context for the function (includes port, args, and path).
         :param string container_host: Optional. Host of locally emulated Lambda container
+        :param string container_host_interface: Optional. Interface that Docker host binds ports to
         """
 
         self.local_runtime = local_runtime
@@ -69,6 +71,7 @@ class LocalLambdaRunner:
         self._boto3_session_creds: Optional[Dict[str, str]] = None
         self._boto3_region: Optional[str] = None
         self.container_host = container_host
+        self.container_host_interface = container_host_interface
 
     def invoke(
         self,
@@ -131,6 +134,7 @@ class LocalLambdaRunner:
                 stdout=stdout,
                 stderr=stderr,
                 container_host=self.container_host,
+                container_host_interface=self.container_host_interface,
             )
         except ContainerResponseException:
             # NOTE(sriram-mv): This should still result in a exit code zero to avoid regressions.

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -81,6 +81,7 @@ def cli(
     warm_containers,
     shutdown,
     debug_function,
+    container_host,
 ):
     """
     `sam local start-api` command entry point
@@ -108,6 +109,7 @@ def cli(
         warm_containers,
         shutdown,
         debug_function,
+        container_host,
     )  # pragma: no cover
 
 
@@ -132,6 +134,7 @@ def do_cli(  # pylint: disable=R0914
     warm_containers,
     shutdown,
     debug_function,
+    container_host,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -172,6 +175,7 @@ def do_cli(  # pylint: disable=R0914
             warm_container_initialization_mode=warm_containers,
             debug_function=debug_function,
             shutdown=shutdown,
+            container_host=container_host,
         ) as invoke_context:
 
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -82,6 +82,7 @@ def cli(
     shutdown,
     debug_function,
     container_host,
+    container_host_interface,
 ):
     """
     `sam local start-api` command entry point
@@ -110,6 +111,7 @@ def cli(
         shutdown,
         debug_function,
         container_host,
+        container_host_interface,
     )  # pragma: no cover
 
 
@@ -135,6 +137,7 @@ def do_cli(  # pylint: disable=R0914
     shutdown,
     debug_function,
     container_host,
+    container_host_interface,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -176,6 +179,7 @@ def do_cli(  # pylint: disable=R0914
             debug_function=debug_function,
             shutdown=shutdown,
             container_host=container_host,
+            container_host_interface=container_host_interface,
         ) as invoke_context:
 
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -93,6 +93,7 @@ def cli(
     shutdown,
     debug_function,
     container_host,
+    container_host_interface,
 ):
     """
     `sam local start-lambda` command entry point
@@ -120,6 +121,7 @@ def cli(
         shutdown,
         debug_function,
         container_host,
+        container_host_interface,
     )  # pragma: no cover
 
 
@@ -144,6 +146,7 @@ def do_cli(  # pylint: disable=R0914
     shutdown,
     debug_function,
     container_host,
+    container_host_interface,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -184,6 +187,7 @@ def do_cli(  # pylint: disable=R0914
             debug_function=debug_function,
             shutdown=shutdown,
             container_host=container_host,
+            container_host_interface=container_host_interface,
         ) as invoke_context:
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -92,6 +92,7 @@ def cli(
     warm_containers,
     shutdown,
     debug_function,
+    container_host,
 ):
     """
     `sam local start-lambda` command entry point
@@ -118,6 +119,7 @@ def cli(
         warm_containers,
         shutdown,
         debug_function,
+        container_host,
     )  # pragma: no cover
 
 
@@ -141,6 +143,7 @@ def do_cli(  # pylint: disable=R0914
     warm_containers,
     shutdown,
     debug_function,
+    container_host,
 ):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
@@ -180,6 +183,7 @@ def do_cli(  # pylint: disable=R0914
             warm_container_initialization_mode=warm_containers,
             debug_function=debug_function,
             shutdown=shutdown,
+            container_host=container_host,
         ) as invoke_context:
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -56,6 +56,7 @@ class Container:
         container_opts=None,
         additional_volumes=None,
         container_host="localhost",
+        container_host_interface="127.0.0.1",
     ):
         """
         Initializes the class with given configuration. This does not automatically create or run the container.
@@ -73,6 +74,7 @@ class Container:
         :param container_opts: Optional, a dictionary containing the container options
         :param additional_volumes: Optional list of additional volumes
         :param string container_host: Optional. Host of locally emulated Lambda container
+        :param string container_host_interface: Optional. Interface that Docker host binds ports to
         """
 
         self._image = image
@@ -100,6 +102,7 @@ class Container:
         self._end_port_range = 9000
 
         self._container_host = container_host
+        self._container_host_interface = container_host_interface
 
         try:
             self.rapid_port_host = find_free_port(start=self._start_port_range, end=self._end_port_range)
@@ -155,12 +158,12 @@ class Container:
         if self._env_vars:
             kwargs["environment"] = self._env_vars
 
-        kwargs["ports"] = {self.RAPID_PORT_CONTAINER: (self._container_host, self.rapid_port_host)}
+        kwargs["ports"] = {self.RAPID_PORT_CONTAINER: (self._container_host_interface, self.rapid_port_host)}
 
         if self._exposed_ports:
             kwargs["ports"].update(
                 {
-                    container_port: (self._container_host, host_port)
+                    container_port: (self._container_host_interface, host_port)
                     for container_port, host_port in self._exposed_ports.items()
                 }
             )

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -159,7 +159,10 @@ class Container:
 
         if self._exposed_ports:
             kwargs["ports"].update(
-                {container_port: (self._container_host, host_port) for container_port, host_port in self._exposed_ports.items()}
+                {
+                    container_port: (self._container_host, host_port)
+                    for container_port, host_port in self._exposed_ports.items()
+                }
             )
 
         if self._entrypoint:

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -155,11 +155,11 @@ class Container:
         if self._env_vars:
             kwargs["environment"] = self._env_vars
 
-        kwargs["ports"] = {self.RAPID_PORT_CONTAINER: ("127.0.0.1", self.rapid_port_host)}
+        kwargs["ports"] = {self.RAPID_PORT_CONTAINER: (self._container_host, self.rapid_port_host)}
 
         if self._exposed_ports:
             kwargs["ports"].update(
-                {container_port: ("127.0.0.1", host_port) for container_port, host_port in self._exposed_ports.items()}
+                {container_port: (self._container_host, host_port) for container_port, host_port in self._exposed_ports.items()}
             )
 
         if self._entrypoint:

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -38,7 +38,7 @@ class Container:
     _STDOUT_FRAME_TYPE = 1
     _STDERR_FRAME_TYPE = 2
     RAPID_PORT_CONTAINER = "8080"
-    URL = "http://localhost:{port}/2015-03-31/functions/{function_name}/invocations"
+    URL = "http://{host}:{port}/2015-03-31/functions/{function_name}/invocations"
     # Set connection timeout to 1 sec to support the large input.
     RAPID_CONNECTION_TIMEOUT = 1
 
@@ -55,6 +55,7 @@ class Container:
         docker_client=None,
         container_opts=None,
         additional_volumes=None,
+        container_host="localhost",
     ):
         """
         Initializes the class with given configuration. This does not automatically create or run the container.
@@ -71,6 +72,7 @@ class Container:
         :param docker_client: Optional, a docker client to replace the default one loaded from env
         :param container_opts: Optional, a dictionary containing the container options
         :param additional_volumes: Optional list of additional volumes
+        :param string container_host: Optional. Host of locally emulated Lambda container
         """
 
         self._image = image
@@ -96,6 +98,9 @@ class Container:
         # selecting the first free port in a range that's not ephemeral.
         self._start_port_range = 5000
         self._end_port_range = 9000
+
+        self._container_host = container_host
+
         try:
             self.rapid_port_host = find_free_port(start=self._start_port_range, end=self._end_port_range)
         except NoFreePortsError as ex:
@@ -266,8 +271,9 @@ class Container:
         # TODO(sriram-mv): `aws-lambda-rie` is in a mode where the function_name is always "function"
         # NOTE(sriram-mv): There is a connection timeout set on the http call to `aws-lambda-rie`, however there is not
         # a read time out for the response received from the server.
+
         resp = requests.post(
-            self.URL.format(port=self.rapid_port_host, function_name="function"),
+            self.URL.format(host=self._container_host, port=self.rapid_port_host, function_name="function"),
             data=event.encode("utf-8"),
             timeout=(self.RAPID_CONNECTION_TIMEOUT, None),
         )

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -45,6 +45,7 @@ class LambdaContainer(Container):
         memory_mb=128,
         env_vars=None,
         debug_options=None,
+        container_host=None,
     ):
         """
         Initializes the class
@@ -74,6 +75,8 @@ class LambdaContainer(Container):
             Optional. Dictionary containing environment variables passed to container
         debug_options DebugContext
             Optional. Contains container debugging info (port, debugger path)
+        container_host string
+            Optional. Host of locally emulated Lambda container
         """
         if not Runtime.has_value(runtime) and not packagetype == IMAGE:
             raise ValueError("Unsupported Lambda runtime {}".format(runtime))
@@ -119,6 +122,7 @@ class LambdaContainer(Container):
             env_vars=env_vars,
             container_opts=additional_options,
             additional_volumes=additional_volumes,
+            container_host=container_host,
         )
 
     @staticmethod

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -46,6 +46,7 @@ class LambdaContainer(Container):
         env_vars=None,
         debug_options=None,
         container_host=None,
+        container_host_interface=None,
     ):
         """
         Initializes the class
@@ -77,6 +78,8 @@ class LambdaContainer(Container):
             Optional. Contains container debugging info (port, debugger path)
         container_host string
             Optional. Host of locally emulated Lambda container
+        container_host_interface
+            Optional. Interface that Docker host binds ports to
         """
         if not Runtime.has_value(runtime) and not packagetype == IMAGE:
             raise ValueError("Unsupported Lambda runtime {}".format(runtime))
@@ -123,6 +126,7 @@ class LambdaContainer(Container):
             container_opts=additional_options,
             additional_volumes=additional_volumes,
             container_host=container_host,
+            container_host_interface=container_host_interface,
         )
 
     @staticmethod

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -91,7 +91,7 @@ class LambdaRuntime:
             LOG.debug("Ctrl+C was pressed. Aborting container creation")
             raise
 
-    def run(self, container, function_config, debug_context):
+    def run(self, container, function_config, debug_context, container_host=None):
         """
         Find the created container for the passed Lambda function, then using the
         ContainerManager run this container.
@@ -105,6 +105,9 @@ class LambdaRuntime:
             Configuration of the function to run its created container.
         debug_context DebugContext
             Debugging context for the function (includes port, args, and path)
+        container_host string
+            Host of locally emulated Lambda container
+
         Returns
         -------
         Container
@@ -112,7 +115,7 @@ class LambdaRuntime:
         """
 
         if not container:
-            container = self.create(function_config, debug_context)
+            container = self.create(function_config, debug_context, container_host)
 
         if container.is_running():
             LOG.info("Lambda function '%s' is already running", function_config.name)

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -44,7 +44,7 @@ class LambdaRuntime:
         self._image_builder = image_builder
         self._temp_uncompressed_paths_to_be_cleaned = []
 
-    def create(self, function_config, debug_context=None):
+    def create(self, function_config, debug_context=None, container_host=None):
         """
         Create a new Container for the passed function, then store it in a dictionary using the function name,
         so it can be retrieved later and used in the other functions. Make sure to use the debug_context only
@@ -56,6 +56,8 @@ class LambdaRuntime:
             Configuration of the function to create a new Container for it.
         debug_context DebugContext
             Debugging context for the function (includes port, args, and path)
+        container_host string
+            Host of locally emulated Lambda container
 
         Returns
         -------
@@ -78,6 +80,7 @@ class LambdaRuntime:
             memory_mb=function_config.memory,
             env_vars=env_vars,
             debug_options=debug_context,
+            container_host=container_host,
         )
         try:
             # create the container.
@@ -132,6 +135,7 @@ class LambdaRuntime:
         debug_context=None,
         stdout: Optional[StreamWriter] = None,
         stderr: Optional[StreamWriter] = None,
+        container_host=None,
     ):
         """
         Invoke the given Lambda function locally.
@@ -150,13 +154,15 @@ class LambdaRuntime:
             StreamWriter that receives stdout text from container.
         :param samcli.lib.utils.stream_writer.StreamWriter stderr: Optional.
             StreamWriter that receives stderr text from container.
+        :param string container_host: Optional.
+            Host of locally emulated Lambda container
         :raises Keyboard
         """
         timer = None
         container = None
         try:
             # Start the container. This call returns immediately after the container starts
-            container = self.create(function_config, debug_context)
+            container = self.create(function_config, debug_context, container_host)
             container = self.run(container, function_config, debug_context)
             # Setup appropriate interrupt - timeout or Ctrl+C - before function starts executing.
             #
@@ -301,7 +307,7 @@ class WarmLambdaRuntime(LambdaRuntime):
 
         super().__init__(container_manager, image_builder)
 
-    def create(self, function_config, debug_context=None):
+    def create(self, function_config, debug_context=None, container_host=None):
         """
         Create a new Container for the passed function, then store it in a dictionary using the function name,
         so it can be retrieved later and used in the other functions. Make sure to use the debug_context only
@@ -336,7 +342,7 @@ class WarmLambdaRuntime(LambdaRuntime):
             )
             debug_context = None
 
-        container = super().create(function_config, debug_context)
+        container = super().create(function_config, debug_context, container_host)
         self._containers[function_config.name] = container
 
         self._observer.watch(function_config)

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -543,6 +543,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 env_vars_values=ANY,
                 aws_profile="profile",
                 aws_region="region",
+                container_host=None,
             )
 
             result = self.context.local_lambda_runner
@@ -614,6 +615,79 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 env_vars_values=ANY,
                 aws_profile="profile",
                 aws_region="region",
+                container_host=None,
+            )
+
+            result = self.context.local_lambda_runner
+            self.assertEqual(result, runner_mock)
+            # assert that lambda runner is created only one time, and the cached version used in the second call
+            self.assertEqual(LocalLambdaMock.call_count, 1)
+
+    @patch("samcli.commands.local.cli_common.invoke_context.LambdaImage")
+    @patch("samcli.commands.local.cli_common.invoke_context.LayerDownloader")
+    @patch("samcli.commands.local.cli_common.invoke_context.LambdaRuntime")
+    @patch("samcli.commands.local.cli_common.invoke_context.LocalLambdaRunner")
+    @patch("samcli.commands.local.cli_common.invoke_context.SamFunctionProvider")
+    def test_must_create_runner_with_container_host_option(
+        self, SamFunctionProviderMock, LocalLambdaMock, LambdaRuntimeMock, download_layers_mock, lambda_image_patch
+    ):
+        runtime_mock = Mock()
+        LambdaRuntimeMock.return_value = runtime_mock
+
+        runner_mock = Mock()
+        LocalLambdaMock.return_value = runner_mock
+
+        download_mock = Mock()
+        download_layers_mock.return_value = download_mock
+
+        image_mock = Mock()
+        lambda_image_patch.return_value = image_mock
+
+        cwd = "cwd"
+        self.context = InvokeContext(
+            template_file="template_file",
+            function_identifier="id",
+            env_vars_file="env_vars_file",
+            docker_volume_basedir="volumedir",
+            docker_network="network",
+            log_file="log_file",
+            skip_pull_image=True,
+            force_image_build=True,
+            debug_ports=[1111],
+            debugger_path="path-to-debugger",
+            debug_args="args",
+            aws_profile="profile",
+            aws_region="region",
+            container_host="localhost",
+        )
+        self.context.get_cwd = Mock()
+        self.context.get_cwd.return_value = cwd
+
+        self.context._get_stacks = Mock()
+        self.context._get_stacks.return_value = [Mock()]
+        self.context._get_env_vars_value = Mock()
+        self.context._setup_log_file = Mock()
+        self.context._get_debug_context = Mock(return_value=None)
+
+        container_manager_mock = Mock()
+        container_manager_mock.is_docker_reachable = PropertyMock(return_value=True)
+        self.context._get_container_manager = Mock(return_value=container_manager_mock)
+
+        with self.context:
+            result = self.context.local_lambda_runner
+            self.assertEqual(result, runner_mock)
+
+            LambdaRuntimeMock.assert_called_with(container_manager_mock, image_mock)
+            lambda_image_patch.assert_called_once_with(download_mock, True, True)
+            LocalLambdaMock.assert_called_with(
+                local_runtime=runtime_mock,
+                function_provider=ANY,
+                cwd=cwd,
+                debug_context=None,
+                env_vars_values=ANY,
+                aws_profile="profile",
+                aws_region="region",
+                container_host="localhost",
             )
 
             result = self.context.local_lambda_runner

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -544,6 +544,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 aws_profile="profile",
                 aws_region="region",
                 container_host=None,
+                container_host_interface=None,
             )
 
             result = self.context.local_lambda_runner
@@ -616,6 +617,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 aws_profile="profile",
                 aws_region="region",
                 container_host=None,
+                container_host_interface=None,
             )
 
             result = self.context.local_lambda_runner
@@ -658,7 +660,8 @@ class TestInvokeContext_local_lambda_runner(TestCase):
             debug_args="args",
             aws_profile="profile",
             aws_region="region",
-            container_host="localhost",
+            container_host="abcdef",
+            container_host_interface="192.168.100.101",
         )
         self.context.get_cwd = Mock()
         self.context.get_cwd.return_value = cwd
@@ -687,7 +690,8 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 env_vars_values=ANY,
                 aws_profile="profile",
                 aws_region="region",
-                container_host="localhost",
+                container_host="abcdef",
+                container_host_interface="192.168.100.101",
             )
 
             result = self.context.local_lambda_runner

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -41,6 +41,7 @@ class TestCli(TestCase):
         self.shutdown = False
         self.region_name = "region"
         self.profile = "profile"
+        self.container_host = "localhost"
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
@@ -75,6 +76,7 @@ class TestCli(TestCase):
             layer_cache_basedir=self.layer_cache_basedir,
             force_image_build=self.force_image_build,
             shutdown=self.shutdown,
+            container_host=self.container_host,
         )
 
         InvokeContextMock.assert_called_with(
@@ -95,6 +97,7 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             aws_region=self.region_name,
             aws_profile=self.profile,
+            container_host=self.container_host,
         )
 
         context_mock.local_lambda_runner.invoke.assert_called_with(
@@ -133,6 +136,7 @@ class TestCli(TestCase):
             layer_cache_basedir=self.layer_cache_basedir,
             force_image_build=self.force_image_build,
             shutdown=self.shutdown,
+            container_host=self.container_host,
         )
 
         InvokeContextMock.assert_called_with(
@@ -153,6 +157,7 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             aws_region=self.region_name,
             aws_profile=self.profile,
+            container_host=self.container_host,
         )
 
         get_event_mock.assert_not_called()
@@ -205,6 +210,7 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
+                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)
@@ -257,6 +263,7 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
+                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)
@@ -307,6 +314,7 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
+                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)
@@ -345,6 +353,7 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
+                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)
@@ -397,6 +406,7 @@ class TestCli(TestCase):
                 layer_cache_basedir=self.layer_cache_basedir,
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
+                container_host=self.container_host,
             )
 
         msg = str(ex_ctx.exception)

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -42,6 +42,7 @@ class TestCli(TestCase):
         self.region_name = "region"
         self.profile = "profile"
         self.container_host = "localhost"
+        self.container_host_interface = "127.0.0.1"
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
@@ -77,6 +78,7 @@ class TestCli(TestCase):
             force_image_build=self.force_image_build,
             shutdown=self.shutdown,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )
 
         InvokeContextMock.assert_called_with(
@@ -98,6 +100,7 @@ class TestCli(TestCase):
             aws_region=self.region_name,
             aws_profile=self.profile,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )
 
         context_mock.local_lambda_runner.invoke.assert_called_with(
@@ -137,6 +140,7 @@ class TestCli(TestCase):
             force_image_build=self.force_image_build,
             shutdown=self.shutdown,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )
 
         InvokeContextMock.assert_called_with(
@@ -158,6 +162,7 @@ class TestCli(TestCase):
             aws_region=self.region_name,
             aws_profile=self.profile,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )
 
         get_event_mock.assert_not_called()
@@ -211,6 +216,7 @@ class TestCli(TestCase):
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
                 container_host=self.container_host,
+                container_host_interface=self.container_host_interface,
             )
 
         msg = str(ex_ctx.exception)
@@ -264,6 +270,7 @@ class TestCli(TestCase):
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
                 container_host=self.container_host,
+                container_host_interface=self.container_host_interface,
             )
 
         msg = str(ex_ctx.exception)
@@ -315,6 +322,7 @@ class TestCli(TestCase):
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
                 container_host=self.container_host,
+                container_host_interface=self.container_host_interface,
             )
 
         msg = str(ex_ctx.exception)
@@ -354,6 +362,7 @@ class TestCli(TestCase):
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
                 container_host=self.container_host,
+                container_host_interface=self.container_host_interface,
             )
 
         msg = str(ex_ctx.exception)
@@ -407,6 +416,7 @@ class TestCli(TestCase):
                 force_image_build=self.force_image_build,
                 shutdown=self.shutdown,
                 container_host=self.container_host,
+                container_host_interface=self.container_host_interface,
             )
 
         msg = str(ex_ctx.exception)

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -518,7 +518,13 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
+            invoke_config,
+            event,
+            debug_context=None,
+            stdout=stdout,
+            stderr=stderr,
+            container_host=None,
+            container_host_interface=None,
         )
 
     def test_must_work_packagetype_ZIP(self):
@@ -536,7 +542,13 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
+            invoke_config,
+            event,
+            debug_context=None,
+            stdout=stdout,
+            stderr=stderr,
+            container_host=None,
+            container_host_interface=None,
         )
 
     def test_must_raise_if_no_privilege(self):
@@ -609,7 +621,13 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.get_invoke_config.return_value = invoke_config
         self.local_lambda.invoke(name, event, stdout, stderr)
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
+            invoke_config,
+            event,
+            debug_context=None,
+            stdout=stdout,
+            stderr=stderr,
+            container_host=None,
+            container_host_interface=None,
         )
 
     def test_must_raise_if_imageuri_not_found(self):
@@ -635,6 +653,7 @@ class TestLocalLambda_invoke_with_container_host_option(TestCase):
         self.aws_region = "region"
         self.env_vars_values = {}
         self.container_host = "localhost"
+        self.container_host_interface = "127.0.0.1"
 
         self.local_lambda = LocalLambdaRunner(
             self.runtime_mock,
@@ -643,6 +662,7 @@ class TestLocalLambda_invoke_with_container_host_option(TestCase):
             env_vars_values=self.env_vars_values,
             debug_context=self.debug_context,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )
 
     def test_must_work(self):
@@ -660,7 +680,13 @@ class TestLocalLambda_invoke_with_container_host_option(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host="localhost"
+            invoke_config,
+            event,
+            debug_context=None,
+            stdout=stdout,
+            stderr=stderr,
+            container_host="localhost",
+            container_host_interface="127.0.0.1",
         )
 
 

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -518,7 +518,7 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr
+            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
         )
 
     def test_must_work_packagetype_ZIP(self):
@@ -536,7 +536,7 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr
+            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
         )
 
     def test_must_raise_if_no_privilege(self):
@@ -609,7 +609,7 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.get_invoke_config.return_value = invoke_config
         self.local_lambda.invoke(name, event, stdout, stderr)
         self.runtime_mock.invoke.assert_called_with(
-            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr
+            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host=None
         )
 
     def test_must_raise_if_imageuri_not_found(self):
@@ -623,6 +623,45 @@ class TestLocalLambda_invoke(TestCase):
 
         with self.assertRaises(InvalidIntermediateImageError):
             self.local_lambda.invoke(name, event, stdout, stderr)
+
+
+class TestLocalLambda_invoke_with_container_host_option(TestCase):
+    def setUp(self):
+        self.runtime_mock = Mock()
+        self.function_provider_mock = Mock()
+        self.cwd = "/my/current/working/directory"
+        self.debug_context = None
+        self.aws_profile = "myprofile"
+        self.aws_region = "region"
+        self.env_vars_values = {}
+        self.container_host = "localhost"
+
+        self.local_lambda = LocalLambdaRunner(
+            self.runtime_mock,
+            self.function_provider_mock,
+            self.cwd,
+            env_vars_values=self.env_vars_values,
+            debug_context=self.debug_context,
+            container_host=self.container_host,
+        )
+
+    def test_must_work(self):
+        name = "name"
+        event = "event"
+        stdout = "stdout"
+        stderr = "stderr"
+        function = Mock(functionname="name")
+        invoke_config = "config"
+
+        self.function_provider_mock.get_all.return_value = [function]
+        self.local_lambda.get_invoke_config = Mock()
+        self.local_lambda.get_invoke_config.return_value = invoke_config
+
+        self.local_lambda.invoke(name, event, stdout, stderr)
+
+        self.runtime_mock.invoke.assert_called_with(
+            invoke_config, event, debug_context=None, stdout=stdout, stderr=stderr, container_host="localhost"
+        )
 
 
 class TestLocalLambda_is_debugging(TestCase):
@@ -647,7 +686,6 @@ class TestLocalLambda_is_debugging(TestCase):
         self.assertTrue(self.local_lambda.is_debugging())
 
     def test_must_be_off(self):
-
         self.local_lambda = LocalLambdaRunner(
             self.runtime_mock,
             self.function_provider_mock,

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -47,6 +47,8 @@ class TestCli(TestCase):
         self.port = 123
         self.static_dir = "staticdir"
 
+        self.container_host = "localhost"
+
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.lib.local_api_service.LocalApiService")
     def test_cli_must_setup_context_and_start_service(self, local_api_service_mock, invoke_context_mock):
@@ -82,6 +84,7 @@ class TestCli(TestCase):
             warm_container_initialization_mode=self.warm_containers,
             debug_function=self.debug_function,
             shutdown=self.shutdown,
+            container_host=self.container_host,
         )
 
         local_api_service_mock.assert_called_with(
@@ -188,4 +191,5 @@ class TestCli(TestCase):
             warm_containers=self.warm_containers,
             debug_function=self.debug_function,
             shutdown=self.shutdown,
+            container_host=self.container_host,
         )

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -48,6 +48,7 @@ class TestCli(TestCase):
         self.static_dir = "staticdir"
 
         self.container_host = "localhost"
+        self.container_host_interface = "127.0.0.1"
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.lib.local_api_service.LocalApiService")
@@ -85,6 +86,7 @@ class TestCli(TestCase):
             debug_function=self.debug_function,
             shutdown=self.shutdown,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )
 
         local_api_service_mock.assert_called_with(
@@ -192,4 +194,5 @@ class TestCli(TestCase):
             debug_function=self.debug_function,
             shutdown=self.shutdown,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -41,6 +41,7 @@ class TestCli(TestCase):
         self.port = 123
 
         self.container_host = "localhost"
+        self.container_host_interface = "127.0.0.1"
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.lib.local_lambda_service.LocalLambdaService")
@@ -77,6 +78,7 @@ class TestCli(TestCase):
             debug_function=self.debug_function,
             shutdown=self.shutdown,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )
 
         local_lambda_service_mock.assert_called_with(lambda_invoke_context=context_mock, port=self.port, host=self.host)
@@ -161,4 +163,5 @@ class TestCli(TestCase):
             debug_function=self.debug_function,
             shutdown=self.shutdown,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -40,6 +40,8 @@ class TestCli(TestCase):
         self.host = "host"
         self.port = 123
 
+        self.container_host = "localhost"
+
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.lib.local_lambda_service.LocalLambdaService")
     def test_cli_must_setup_context_and_start_service(self, local_lambda_service_mock, invoke_context_mock):
@@ -74,6 +76,7 @@ class TestCli(TestCase):
             warm_container_initialization_mode=self.warm_containers,
             debug_function=self.debug_function,
             shutdown=self.shutdown,
+            container_host=self.container_host,
         )
 
         local_lambda_service_mock.assert_called_with(lambda_invoke_context=context_mock, port=self.port, host=self.host)
@@ -157,4 +160,5 @@ class TestCli(TestCase):
             warm_containers=self.warm_containers,
             debug_function=self.debug_function,
             shutdown=self.shutdown,
+            container_host=self.container_host,
         )

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -312,6 +312,7 @@ class TestSamConfigForAllCommands(TestCase):
                 True,
                 True,
                 {"Key": "Value", "Key2": "Value2"},
+                "localhost",
             )
 
     @patch("samcli.commands.local.start_api.cli.do_cli")
@@ -373,6 +374,7 @@ class TestSamConfigForAllCommands(TestCase):
                 None,
                 False,
                 None,
+                "localhost",
             )
 
     @patch("samcli.commands.local.start_lambda.cli.do_cli")
@@ -432,6 +434,7 @@ class TestSamConfigForAllCommands(TestCase):
                 None,
                 False,
                 None,
+                "localhost",
             )
 
     @patch("samcli.lib.cli_validation.image_repository_validation.get_template_function_resource_ids")
@@ -849,6 +852,8 @@ class TestSamConfigWithOverrides(TestCase):
                     "--shutdown",
                     "--parameter-overrides",
                     "A=123 C=D E=F12! G=H",
+                    "--container-host",
+                    "localhost",
                 ],
             )
 
@@ -878,6 +883,7 @@ class TestSamConfigWithOverrides(TestCase):
                 None,
                 True,
                 None,
+                "localhost",
             )
 
     @patch("samcli.commands.local.start_lambda.cli.do_cli")
@@ -969,6 +975,7 @@ class TestSamConfigWithOverrides(TestCase):
                 None,
                 False,
                 None,
+                "localhost",
             )
 
     @patch("samcli.commands.validate.validate.do_cli")

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -313,6 +313,7 @@ class TestSamConfigForAllCommands(TestCase):
                 True,
                 {"Key": "Value", "Key2": "Value2"},
                 "localhost",
+                "127.0.0.1",
             )
 
     @patch("samcli.commands.local.start_api.cli.do_cli")
@@ -375,6 +376,7 @@ class TestSamConfigForAllCommands(TestCase):
                 False,
                 None,
                 "localhost",
+                "127.0.0.1",
             )
 
     @patch("samcli.commands.local.start_lambda.cli.do_cli")
@@ -435,6 +437,7 @@ class TestSamConfigForAllCommands(TestCase):
                 False,
                 None,
                 "localhost",
+                "127.0.0.1",
             )
 
     @patch("samcli.lib.cli_validation.image_repository_validation.get_template_function_resource_ids")
@@ -854,6 +857,8 @@ class TestSamConfigWithOverrides(TestCase):
                     "A=123 C=D E=F12! G=H",
                     "--container-host",
                     "localhost",
+                    "--container-host-interface",
+                    "127.0.0.1",
                 ],
             )
 
@@ -884,6 +889,7 @@ class TestSamConfigWithOverrides(TestCase):
                 True,
                 None,
                 "localhost",
+                "127.0.0.1",
             )
 
     @patch("samcli.commands.local.start_lambda.cli.do_cli")
@@ -976,6 +982,7 @@ class TestSamConfigWithOverrides(TestCase):
                 False,
                 None,
                 "localhost",
+                "127.0.0.1",
             )
 
     @patch("samcli.commands.validate.validate.do_cli")

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -65,7 +65,8 @@ class TestContainer_create(TestCase):
         self.env_vars = {"key": "value"}
         self.container_opts = {"container": "opts"}
         self.additional_volumes = {"/somepath": {"blah": "blah value"}}
-        self.container_host = "127.0.0.2"
+        self.container_host = "localhost"
+        self.container_host_interface = "127.0.0.1"
 
         self.mock_docker_client = Mock()
         self.mock_docker_client.containers = Mock()
@@ -104,7 +105,7 @@ class TestContainer_create(TestCase):
             volumes=expected_volumes,
             tty=False,
             ports={
-                container_port: ("localhost", host_port)
+                container_port: ("127.0.0.1", host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
             },
             use_config_proxy=True,
@@ -140,6 +141,7 @@ class TestContainer_create(TestCase):
             container_opts=self.container_opts,
             additional_volumes=self.additional_volumes,
             container_host=self.container_host,
+            container_host_interface=self.container_host_interface,
         )
 
         container_id = container.create()
@@ -155,7 +157,7 @@ class TestContainer_create(TestCase):
             use_config_proxy=True,
             environment=self.env_vars,
             ports={
-                container_port: (self.container_host, host_port)
+                container_port: (self.container_host_interface, host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
             },
             entrypoint=self.entrypoint,
@@ -215,7 +217,7 @@ class TestContainer_create(TestCase):
             use_config_proxy=True,
             environment=self.env_vars,
             ports={
-                container_port: ("localhost", host_port)
+                container_port: ("127.0.0.1", host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
             },
             entrypoint=self.entrypoint,

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -513,12 +513,18 @@ class TestContainer_wait_for_result(TestCase):
         self.cmd = ["cmd"]
         self.working_dir = "working_dir"
         self.host_dir = "host_dir"
+        self.container_host = "localhost"
 
         self.mock_docker_client = Mock()
         self.mock_docker_client.containers = Mock()
         self.mock_docker_client.containers.get = Mock()
         self.container = Container(
-            self.image, self.cmd, self.working_dir, self.host_dir, docker_client=self.mock_docker_client
+            self.image,
+            self.cmd,
+            self.working_dir,
+            self.host_dir,
+            docker_client=self.mock_docker_client,
+            container_host=self.container_host,
         )
         self.container.id = "someid"
 

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -65,6 +65,7 @@ class TestContainer_create(TestCase):
         self.env_vars = {"key": "value"}
         self.container_opts = {"container": "opts"}
         self.additional_volumes = {"/somepath": {"blah": "blah value"}}
+        self.container_host = "127.0.0.2"
 
         self.mock_docker_client = Mock()
         self.mock_docker_client.containers = Mock()
@@ -103,7 +104,7 @@ class TestContainer_create(TestCase):
             volumes=expected_volumes,
             tty=False,
             ports={
-                container_port: ("127.0.0.1", host_port)
+                container_port: ("localhost", host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
             },
             use_config_proxy=True,
@@ -138,6 +139,7 @@ class TestContainer_create(TestCase):
             docker_client=self.mock_docker_client,
             container_opts=self.container_opts,
             additional_volumes=self.additional_volumes,
+            container_host=self.container_host,
         )
 
         container_id = container.create()
@@ -153,7 +155,7 @@ class TestContainer_create(TestCase):
             use_config_proxy=True,
             environment=self.env_vars,
             ports={
-                container_port: ("127.0.0.1", host_port)
+                container_port: (self.container_host, host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
             },
             entrypoint=self.entrypoint,
@@ -213,7 +215,7 @@ class TestContainer_create(TestCase):
             use_config_proxy=True,
             environment=self.env_vars,
             ports={
-                container_port: ("127.0.0.1", host_port)
+                container_port: ("localhost", host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
             },
             entrypoint=self.entrypoint,

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -81,6 +81,7 @@ class LambdaRuntime_create(TestCase):
             debug_options=debug_options,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
+            container_host=None,
         )
         # Run the container and get results
         self.manager_mock.create.assert_called_with(container)
@@ -269,6 +270,7 @@ class LambdaRuntime_invoke(TestCase):
             debug_options=debug_options,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
+            container_host=None,
         )
 
         # Run the container and get results
@@ -595,6 +597,7 @@ class TestWarmLambdaRuntime_invoke(TestCase):
             debug_options=debug_options,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
+            container_host=None,
         )
 
         # Run the container and get results
@@ -672,6 +675,7 @@ class TestWarmLambdaRuntime_create(TestCase):
             debug_options=debug_options,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
+            container_host=None,
         )
 
         self.manager_mock.create.assert_called_with(container)
@@ -737,6 +741,7 @@ class TestWarmLambdaRuntime_create(TestCase):
             debug_options=None,
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
+            container_host=None,
         )
         self.manager_mock.create.assert_called_with(container)
         # validate that the created container got cached

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -82,6 +82,7 @@ class LambdaRuntime_create(TestCase):
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
+            container_host_interface=None,
         )
         # Run the container and get results
         self.manager_mock.create.assert_called_with(container)
@@ -162,7 +163,7 @@ class LambdaRuntime_run(TestCase):
         create_mock.return_value = container
 
         self.runtime.run(None, self.func_config, debug_context=debug_options)
-        create_mock.assert_called_with(self.func_config, debug_options, None)
+        create_mock.assert_called_with(self.func_config, debug_options, None, None)
         self.manager_mock.run.assert_called_with(container)
 
     def test_must_skip_run_running_container(self):
@@ -271,6 +272,7 @@ class LambdaRuntime_invoke(TestCase):
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
+            container_host_interface=None,
         )
 
         # Run the container and get results
@@ -598,6 +600,7 @@ class TestWarmLambdaRuntime_invoke(TestCase):
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
+            container_host_interface=None,
         )
 
         # Run the container and get results
@@ -676,6 +679,7 @@ class TestWarmLambdaRuntime_create(TestCase):
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
+            container_host_interface=None,
         )
 
         self.manager_mock.create.assert_called_with(container)
@@ -742,6 +746,7 @@ class TestWarmLambdaRuntime_create(TestCase):
             env_vars=self.env_var_value,
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
+            container_host_interface=None,
         )
         self.manager_mock.create.assert_called_with(container)
         # validate that the created container got cached

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -162,7 +162,7 @@ class LambdaRuntime_run(TestCase):
         create_mock.return_value = container
 
         self.runtime.run(None, self.func_config, debug_context=debug_options)
-        create_mock.assert_called_with(self.func_config, debug_options)
+        create_mock.assert_called_with(self.func_config, debug_options, None)
         self.manager_mock.run.assert_called_with(container)
 
     def test_must_skip_run_running_container(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#2492 #2436

#### Why is this change necessary?
We found there is an issue of warm container with #2700 before release and remote Docker host is not support in that PR. So we decided to revert that change.
This PR includes following changes:

- #2700 which was reverted last week
- fix warm container issue when using `--container-host` option
- add remote Docker support by using a new option `--container-host-interface`. Customers can specify what interface they want to bind ports to with this option.

#### How does it address the issue?
For Docker API call, we was binding ports to `127.0.0.1` which makes it can not be accessed from remote. With the new change, customers can bind ports to a specific host. In this way, using remote Docker host will be available.
#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
