### PR TITLE
fix: Java Gradle 7 Build Test Data Issue

### DIFF
--- a/samcli/__init__.py
+++ b/samcli/__init__.py
@@ -2,4 +2,4 @@
 SAM CLI version
 """
 
-__version__ = "1.21.1"
+__version__ = "1.22.0"

--- a/tests/integration/testdata/buildcmd/Java/gradle-kotlin/build.gradle.kts
+++ b/tests/integration/testdata/buildcmd/Java/gradle-kotlin/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 
 dependencies {
     implementation("software.amazon.awssdk:annotations:2.1.0")
-	compile("com.amazonaws:aws-lambda-java-core:1.1.0")
+	implementation("com.amazonaws:aws-lambda-java-core:1.1.0")
 }

--- a/tests/integration/testdata/buildcmd/Java/gradle-kotlin/build.gradle.kts
+++ b/tests/integration/testdata/buildcmd/Java/gradle-kotlin/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 
 dependencies {
     implementation("software.amazon.awssdk:annotations:2.1.0")
-	implementation("com.amazonaws:aws-lambda-java-core:1.1.0")
+    implementation("com.amazonaws:aws-lambda-java-core:1.1.0")
 }

--- a/tests/integration/testdata/buildcmd/Java/gradle/build.gradle
+++ b/tests/integration/testdata/buildcmd/Java/gradle/build.gradle
@@ -8,5 +8,5 @@ repositories {
 
 dependencies {
     implementation 'software.amazon.awssdk:annotations:2.1.0'
-	implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'
 }

--- a/tests/integration/testdata/buildcmd/Java/gradle/build.gradle
+++ b/tests/integration/testdata/buildcmd/Java/gradle/build.gradle
@@ -8,7 +8,5 @@ repositories {
 
 dependencies {
     implementation 'software.amazon.awssdk:annotations:2.1.0'
-	compile (
-        'com.amazonaws:aws-lambda-java-core:1.1.0'
-    )
+	implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'
 }

--- a/tests/integration/testdata/buildcmd/Java/gradlew/build.gradle
+++ b/tests/integration/testdata/buildcmd/Java/gradlew/build.gradle
@@ -8,5 +8,5 @@ repositories {
 
 dependencies {
     implementation 'software.amazon.awssdk:annotations:2.1.0'
-	implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'
+    implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'
 }

--- a/tests/integration/testdata/buildcmd/Java/gradlew/build.gradle
+++ b/tests/integration/testdata/buildcmd/Java/gradlew/build.gradle
@@ -8,7 +8,5 @@ repositories {
 
 dependencies {
     implementation 'software.amazon.awssdk:annotations:2.1.0'
-	compile (
-        'com.amazonaws:aws-lambda-java-core:1.1.0'
-    )
+	implementation 'com.amazonaws:aws-lambda-java-core:1.1.0'
 }


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Gradle java build failures.
#### Why is this change necessary?
`compile` was deprecated from Gradle
#### How does it address the issue?
Replace `compile` to `implementation` in build.gradle
#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
