### PR TITLE
ignoring temp dirs used by dotnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -389,6 +389,9 @@ tests/integration/testdata/buildcmd/Dotnetcore2.0/bin
 tests/integration/testdata/buildcmd/Dotnetcore2.0/obj
 tests/integration/testdata/buildcmd/Dotnetcore2.1/bin
 tests/integration/testdata/buildcmd/Dotnetcore2.1/obj
+tests/integration/testdata/buildcmd/Dotnetcore3.1/bin
+tests/integration/testdata/buildcmd/Dotnetcore3.1/obj
+tests/integration/testdata/invoke/credential_tests/inprocess/dotnet/STS/obj
 
 # End of https://www.gitignore.io/api/osx,node,macos,linux,python,windows,pycharm,intellij,sublimetext,visualstudiocode
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
No issue

#### Why is this change necessary?
After .Net Core 3.1 test data was added directories with temporary generated files where not added to .gitignore. As a result, in an environment with installed .Net Core and VSCode with OmniSharp server, those temporary files are generated on IDE startup.

#### How does it address the issue?
Adding above mentioned directories to .gitignore

#### What side effects does this change have?
None

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
