### PR TITLE
Validate 

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -14,7 +14,7 @@ from samcli.cli.types import CfnParameterOverridesType, CfnMetadataType, CfnTags
 from samcli.commands._utils.custom_options.option_nargs import OptionNargs
 from samcli.commands._utils.template import get_template_artifacts_format
 
-_TEMPLATE_OPTION_DEFAULT_VALUE = "template.[yaml|yml]"
+_TEMPLATE_OPTION_DEFAULT_VALUE = "template.[yaml|yml|json]"
 DEFAULT_STACK_NAME = "sam-app"
 
 LOG = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
 
     original_template_path = os.path.abspath(provided_value)
 
-    search_paths = ["template.yaml", "template.yml"]
+    search_paths = ["template.yaml", "template.yml", "template.json"]
 
     if include_build:
         search_paths.insert(0, os.path.join(".aws-sam", "build", "template.yaml"))
@@ -43,7 +43,7 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     if provided_value == _TEMPLATE_OPTION_DEFAULT_VALUE:
         # "--template" is an alias of "--template-file", however, only the first option name "--template-file" in
         # ctx.default_map is used as default value of provided value. Here we add "--template"'s value as second
-        # default value in this option, so that the command line paramerters from config file can load it.
+        # default value in this option, so that the command line parameters from config file can load it.
         if ctx and ctx.default_map.get("template", None):
             provided_value = ctx.default_map.get("template")
         else:

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -53,7 +53,18 @@ class TestGetOrDefaultTemplateFileName(TestCase):
     def test_must_return_yaml_extension(self, os_mock):
         expected = "template.yaml"
 
-        os_mock.path.exists.return_value = True
+        os_mock.path.exists.side_effect = lambda file_name: file_name == expected
+        os_mock.path.abspath.return_value = "absPath"
+
+        result = get_or_default_template_file_name(None, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=False)
+        self.assertEqual(result, "absPath")
+        os_mock.path.abspath.assert_called_with(expected)
+
+    @patch("samcli.commands._utils.options.os")
+    def test_must_return_json_extension(self, os_mock):
+        expected = "template.json"
+
+        os_mock.path.exists.side_effect = lambda file_name: file_name == expected
         os_mock.path.abspath.return_value = "absPath"
 
         result = get_or_default_template_file_name(None, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=False)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#2355

#### Why is this change necessary?
Allows users to validate template.json (in json instead of yaml format) without specifying `--template` argument with a path to the file. Improves user experience

#### How does it address the issue?
Adding `template.json` to the list of default file names when looking up a template file.

#### What side effects does this change have?
None

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
