### PR TITLE
Validate default template.json

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -14,7 +14,7 @@ from samcli.cli.types import CfnParameterOverridesType, CfnMetadataType, CfnTags
 from samcli.commands._utils.custom_options.option_nargs import OptionNargs
 from samcli.commands._utils.template import get_template_artifacts_format
 
-_TEMPLATE_OPTION_DEFAULT_VALUE = "template.[yaml|yml]"
+_TEMPLATE_OPTION_DEFAULT_VALUE = "template.[yaml|yml|json]"
 DEFAULT_STACK_NAME = "sam-app"
 
 LOG = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
 
     original_template_path = os.path.abspath(provided_value)
 
-    search_paths = ["template.yaml", "template.yml"]
+    search_paths = ["template.yaml", "template.yml", "template.json"]
 
     if include_build:
         search_paths.insert(0, os.path.join(".aws-sam", "build", "template.yaml"))
@@ -43,7 +43,7 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     if provided_value == _TEMPLATE_OPTION_DEFAULT_VALUE:
         # "--template" is an alias of "--template-file", however, only the first option name "--template-file" in
         # ctx.default_map is used as default value of provided value. Here we add "--template"'s value as second
-        # default value in this option, so that the command line paramerters from config file can load it.
+        # default value in this option, so that the command line parameters from config file can load it.
         if ctx and ctx.default_map.get("template", None):
             provided_value = ctx.default_map.get("template")
         else:

--- a/tests/integration/testdata/validate/default_json/template.json
+++ b/tests/integration/testdata/validate/default_json/template.json
@@ -1,0 +1,15 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+
+  "Resources": {
+    "HelloWorldFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "CodeUri": "hello-world/",
+        "Handler": "app.lambdaHandler",
+        "Runtime": "nodejs14.x"
+      }
+    }
+  }
+}

--- a/tests/integration/testdata/validate/default_yaml/template.yaml
+++ b/tests/integration/testdata/validate/default_yaml/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: HelloWorldFunction
+      Handler: app.lambdaHandler
+      Runtime: nodejs14.x

--- a/tests/integration/testdata/validate/multiple_files/template.json
+++ b/tests/integration/testdata/validate/multiple_files/template.json
@@ -1,0 +1,15 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+
+  "Resources": {
+    "HelloWorldFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "CodeUri": "hello-world/",
+        "Handler": "app.lambdaHandler",
+        "Runtime": "nodejs14.x"
+      }
+    }
+  }
+}

--- a/tests/integration/testdata/validate/multiple_files/template.yaml
+++ b/tests/integration/testdata/validate/multiple_files/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: HelloWorldFunction
+      Handler: app.lambdaHandler
+      Runtime: nodejs14.x

--- a/tests/integration/testdata/validate/with_build/.aws-sam/build/template.yaml
+++ b/tests/integration/testdata/validate/with_build/.aws-sam/build/template.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: HelloWorldFunction
+      Handler: app.lambdaHandler
+      Runtime: nodejs14.x

--- a/tests/integration/testdata/validate/with_build/template.json
+++ b/tests/integration/testdata/validate/with_build/template.json
@@ -1,0 +1,15 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+
+  "Resources": {
+    "HelloWorldFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "CodeUri": "hello-world/",
+        "Handler": "app.lambdaHandler",
+        "Runtime": "nodejs14.x"
+      }
+    }
+  }
+}

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -62,7 +62,7 @@ class TestValidate(TestCase):
     def test_default_template(self, relative_folder: str, expected_file: TemplateFileTypes):
         cwd = f"tests/integration/testdata/validate/{relative_folder}"
         command_result = run_command(self.command_list(), cwd=cwd)
-        pattern = self.patterns[expected_file]
+        pattern = self.patterns[expected_file]  # type: ignore
         output = command_result.stdout.decode("utf-8")
         self.assertEqual(command_result.process.returncode, 0)
         self.assertIsNotNone(pattern.match(output))

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -23,7 +23,7 @@ class TemplateFileTypes(Enum):
     YAML = auto()
 
 
-@skipIf(SKIP_VALIDATE_TESTS, "Skip deploy tests in CI/CD only")
+@skipIf(SKIP_VALIDATE_TESTS, "Skip validate tests in CI/CD only")
 class TestValidate(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -1,0 +1,68 @@
+"""
+Integration tests for sam validate
+"""
+
+import os
+import re
+from enum import Enum, auto
+from pathlib import Path
+from typing import List, Optional
+from unittest import TestCase
+
+from parameterized import parameterized
+from tests.testing_utils import run_command
+
+
+class TemplateFileTypes(Enum):
+    JSON = auto()
+    YAML = auto()
+
+
+class TestValidate(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.patterns = {
+            TemplateFileTypes.JSON: re.compile(r"^/.+/template[.]json is a valid SAM Template$"),
+            TemplateFileTypes.YAML: re.compile(r"^/.+/template[.]yaml is a valid SAM Template$"),
+        }
+
+    @staticmethod
+    def base_command() -> str:
+        return "samdev" if os.getenv("SAM_CLI_DEV") else "sam"
+
+    def command_list(
+        self,
+        template_file: Optional[Path] = None,
+        profile: Optional[str] = None,
+        region: Optional[str] = None,
+        config_file: Optional[Path] = None,
+    ) -> List[str]:
+        command_list = [self.base_command(), "validate"]
+        if template_file:
+            command_list += ["--template-file", str(template_file)]
+        if profile:
+            command_list += ["--profile", profile]
+        if region:
+            command_list += ["--region", region]
+        if config_file:
+            command_list = ["--config_file", str(config_file)]
+        return command_list
+
+    @parameterized.expand(
+        [
+            ("default_yaml", TemplateFileTypes.YAML),  # project with template.yaml
+            ("default_json", TemplateFileTypes.JSON),  # project with template.json
+            ("multiple_files", TemplateFileTypes.YAML),  # project with both template.yaml and template.json
+            (
+                "with_build",
+                TemplateFileTypes.JSON,
+            ),  # project with template.json and standard build directory .aws-sam/build/template.yaml
+        ]
+    )
+    def test_default_template(self, relative_folder: str, expected_file: TemplateFileTypes):
+        cwd = f"tests/integration/testdata/validate/{relative_folder}"
+        command_result = run_command(self.command_list(), cwd=cwd)
+        pattern = self.patterns[expected_file]
+        output = command_result.stdout.decode("utf-8")
+        self.assertEqual(command_result.process.returncode, 0)
+        self.assertIsNotNone(pattern.match(output))

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -53,7 +53,18 @@ class TestGetOrDefaultTemplateFileName(TestCase):
     def test_must_return_yaml_extension(self, os_mock):
         expected = "template.yaml"
 
-        os_mock.path.exists.return_value = True
+        os_mock.path.exists.side_effect = lambda file_name: file_name == expected
+        os_mock.path.abspath.return_value = "absPath"
+
+        result = get_or_default_template_file_name(None, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=False)
+        self.assertEqual(result, "absPath")
+        os_mock.path.abspath.assert_called_with(expected)
+
+    @patch("samcli.commands._utils.options.os")
+    def test_must_return_json_extension(self, os_mock):
+        expected = "template.json"
+
+        os_mock.path.exists.side_effect = lambda file_name: file_name == expected
         os_mock.path.abspath.return_value = "absPath"
 
         result = get_or_default_template_file_name(None, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=False)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#2355

#### Why is this change necessary?
Allows users to validate template.json (in json instead of yaml format) without specifying `--template` argument with a path to the file. Improves user experience

#### How does it address the issue?
Adding `template.json` to the list of default file names when looking up a template file.

#### What side effects does this change have?
None

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
