### PR TITLE
Point numpy version to <1.19 to avoid PEP 317 failure

### DIFF
--- a/tests/integration/testdata/buildcmd/Python/requirements.txt
+++ b/tests/integration/testdata/buildcmd/Python/requirements.txt
@@ -1,6 +1,6 @@
 # These are some hard packages to build. Using them here helps us verify that building works on various platforms
 
-numpy~=1.15
+numpy<1.19
 # `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
 # Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
 # cryptography~=2.4


### PR DESCRIPTION
#### Which issue(s) does this change fix?


#### Why is this change necessary?
Using `numpy~=1.15` will fetch the latest version of numpy (1.20.3 as of now), which caused `sam build` to fail because of this error:
```
Running PythonPipBuilder:ResolveDependencies
Error: PythonPipBuilder:ResolveDependencies - {numpy==1.20.3(wheel)}
```

Looking into the error locally, here's the full error message:
```
ERROR: Could not build wheels for numpy which use PEP 517 and cannot be installed directly
```

#### How does it address the issue?
As a quick fix, point numpy to a good version.

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
