### PR TITLE
feat: Supports uncompression local layer zips in sam local

### DIFF
--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -254,7 +254,7 @@ class LambdaRuntime:
 
     def _get_code_dir(self, code_path: str) -> str:
         """
-        Method to get a path to a directory where the Lambda function code is available. This directory will
+        Method to get a path to a directory where the function/layer code is available. This directory will
         be mounted directly inside the Docker container.
 
         This method handles a few different cases for ``code_path``:

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -1,20 +1,21 @@
 """
 Classes representing a local Lambda runtime
 """
-
+import copy
 import os
 import shutil
 import tempfile
 import signal
 import logging
 import threading
-from typing import Optional
+from typing import Optional, Union, Dict
 
 from samcli.local.docker.lambda_container import LambdaContainer
 from samcli.lib.utils.file_observer import LambdaFunctionObserver
 from samcli.lib.utils.packagetype import ZIP
 from samcli.lib.telemetry.metric import capture_parameter
 from .zip import unzip
+from ...lib.providers.provider import LayerVersion
 from ...lib.utils.stream_writer import StreamWriter
 
 LOG = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ class LambdaRuntime:
         env_vars = function_config.env_vars.resolve()
 
         code_dir = self._get_code_dir(function_config.code_abs_path)
+        layers = [self._unarchived_layer(layer) for layer in function_config.layers]
         container = LambdaContainer(
             function_config.runtime,
             function_config.imageuri,
@@ -75,7 +77,7 @@ class LambdaRuntime:
             function_config.packagetype,
             function_config.imageconfig,
             code_dir,
-            function_config.layers,
+            layers,
             self._image_builder,
             memory_mb=function_config.memory,
             env_vars=env_vars,
@@ -250,7 +252,7 @@ class LambdaRuntime:
         timer.start()
         return timer
 
-    def _get_code_dir(self, code_path):
+    def _get_code_dir(self, code_path: str) -> str:
         """
         Method to get a path to a directory where the Lambda function code is available. This directory will
         be mounted directly inside the Docker container.
@@ -274,12 +276,33 @@ class LambdaRuntime:
         """
 
         if code_path and os.path.isfile(code_path) and code_path.endswith(self.SUPPORTED_ARCHIVE_EXTENSIONS):
-            decompressed_dir = _unzip_file(code_path)
+            decompressed_dir: str = _unzip_file(code_path)
             self._temp_uncompressed_paths_to_be_cleaned += [decompressed_dir]
             return decompressed_dir
 
         LOG.debug("Code %s is not a zip/jar file", code_path)
         return code_path
+
+    def _unarchived_layer(self, layer: Union[str, Dict, LayerVersion]) -> Union[str, Dict, LayerVersion]:
+        """
+        If the layer's content uri points to a supported local archive file, use self._get_code_dir() to
+        un-archive it and so that it can be mounted directly inside the Docker container.
+        Parameters
+        ----------
+        layer
+            a str, dict or a LayerVersion object representing a layer
+
+        Returns
+        -------
+            as it is (if no archived file is identified)
+            or a LayerVersion with ContentUri pointing to an unarchived directory
+        """
+        if isinstance(layer, LayerVersion) and isinstance(layer.codeuri, str):
+            unarchived_layer = copy.deepcopy(layer)
+            unarchived_layer.codeuri = self._get_code_dir(layer.codeuri)
+            return unarchived_layer if unarchived_layer.codeuri != layer.codeuri else layer
+
+        return layer
 
     def _clean_decompressed_paths(self):
         """

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -13,7 +13,7 @@ import docker
 
 from tests.integration.local.invoke.layer_utils import LayerUtils
 from .invoke_integ_base import InvokeIntegBase
-from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
+from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY, run_command
 
 # Layers tests require credentials and Appveyor will only add credentials to the env if the PR is from the same repo.
 # This is to restrict layers tests to run outside of Appveyor, when the branch is not master and tests are not run by Canary.
@@ -882,6 +882,24 @@ class TestLayerVersion(InvokeIntegBase):
             raise
 
         self.assertEqual(2, len(os.listdir(str(self.layer_cache))))
+
+
+@skipIf(SKIP_LAYERS_TESTS, "Skip layers tests in Appveyor only")
+class TestLocalZipLayerVersion(InvokeIntegBase):
+    template = Path("layers", "local-zip-layer-template.yml")
+
+    def test_local_zip_layers(
+        self,
+    ):
+        command_list = self.get_command_list(
+            "OneLayerVersionServerlessFunction",
+            template_path=self.template_path,
+            no_event=True,
+        )
+
+        execute = run_command(command_list)
+        self.assertEqual(0, execute.process.returncode)
+        self.assertEqual('"Layer1"', execute.stdout.decode())
 
 
 @skipIf(SKIP_LAYERS_TESTS, "Skip layers tests in Appveyor only")

--- a/tests/integration/testdata/invoke/layers/local-zip-layer-template.yml
+++ b/tests/integration/testdata/invoke/layers/local-zip-layer-template.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Resources:
+  LayerOne:
+    Type: AWS::Lambda::LayerVersion
+    Properties:
+      Content: ../layer_zips/layer1.zip
+
+  OneLayerVersionServerlessFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: layer-main.one_layer_hanlder
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 20
+      Layers:
+        - !Ref LayerOne


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#947

#### Why is this change necessary?

Support passing a local archive file in "AWS::Serverless::LayerVersion" in local invoke

#### How does it address the issue?

We already handle when function's codeuri points to a zip file, this PR extend that to `ContentUri` of LayerVersion

#### What side effects does this change have?

N/A

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
