### PR TITLE
fix: Make sam build cache robust by always using relative paths

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -191,8 +191,18 @@ class ApplicationBuilder:
 
         for function in functions:
             container_env_vars = self._make_env_vars(function, file_env_vars, inline_env_vars)
+
+            # In case of CI env, the project might have inconsistent absolute path,
+            # which will cause build cache to be invalidated.
+            # Here relative paths are always used in FunctionBuildDefinition (#2872).
+            codeuri = (
+                os.path.relpath(function.codeuri)
+                # use os.path.isabs() to opt-out URLs like file:///...
+                if isinstance(function.codeuri, str) and os.path.isabs(function.codeuri)
+                else function.codeuri
+            )
             function_build_details = FunctionBuildDefinition(
-                function.runtime, function.codeuri, function.packagetype, function.metadata, env_vars=container_env_vars
+                function.runtime, codeuri, function.packagetype, function.metadata, env_vars=container_env_vars
             )
             build_graph.put_function_build_definition(function_build_details, function)
 

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -191,18 +191,8 @@ class ApplicationBuilder:
 
         for function in functions:
             container_env_vars = self._make_env_vars(function, file_env_vars, inline_env_vars)
-
-            # In case of CI env, the project might have inconsistent absolute path,
-            # which will cause build cache to be invalidated.
-            # Here relative paths are always used in FunctionBuildDefinition (#2872).
-            codeuri = (
-                os.path.relpath(function.codeuri)
-                # use os.path.isabs() to opt-out URLs like file:///...
-                if isinstance(function.codeuri, str) and os.path.isabs(function.codeuri)
-                else function.codeuri
-            )
             function_build_details = FunctionBuildDefinition(
-                function.runtime, codeuri, function.packagetype, function.metadata, env_vars=container_env_vars
+                function.runtime, function.codeuri, function.packagetype, function.metadata, env_vars=container_env_vars
             )
             build_graph.put_function_build_definition(function_build_details, function)
 

--- a/samcli/lib/build/build_graph.py
+++ b/samcli/lib/build/build_graph.py
@@ -3,7 +3,6 @@ Holds classes and utility methods related to build graph
 """
 
 import logging
-import os
 from pathlib import Path
 from typing import Tuple, List, Any, Optional, Dict
 from uuid import uuid4
@@ -461,15 +460,9 @@ class FunctionBuildDefinition(AbstractBuildDefinition):
         if self.metadata and self.metadata.get("BuildMethod", None) == "makefile":
             return False
 
-        # In case of CI env, the project might have inconsistent absolute path,
-        # which will cause build cache to be invalidated.
-        # Here relative paths for comparison (#2872).
-        relative_codeuri = os.path.relpath(self.codeuri) if isinstance(self.codeuri, str) else self.codeuri
-        relative_other_codeuri = os.path.relpath(other.codeuri) if isinstance(other.codeuri, str) else other.codeuri
-
         return (
             self.runtime == other.runtime
-            and relative_codeuri == relative_other_codeuri
+            and self.codeuri == other.codeuri
             and self.packagetype == other.packagetype
             and self.metadata == other.metadata
             and self.env_vars == other.env_vars


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#2859

#### Why is this change necessary?

currently sam build stores absolute paths of function code in build.toml file. It needs both path and source code md5 to match to treat the cache as valid. However, in CI environment, the code might have different absolute path in different CI run. 

#### How does it address the issue?

In this PR, all paths in `FunctionBuildDefinition` is converted to relative path (and this path will be saved to build.toml after each build) to make sam build cache portable.

#### What side effects does this change have?

- When customers upgrade SAM CLI, the cache might be invalidated once.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
