### PR TITLE
Let 'sam pipeline init'  prefills pipeline's infrastructure resources…

### DIFF
--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -44,7 +44,7 @@ class SamConfig:
     def get_env_names(self):
         self._read()
         if isinstance(self.document, dict):
-            return [env for env in self.document.keys() if env != VERSION_KEY]
+            return [env for env, value in self.document.items() if isinstance(value, dict)]
         return []
 
     def get_all(self, cmd_names, section, env=DEFAULT_ENV):

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -41,6 +41,12 @@ class SamConfig:
         """
         self.filepath = Path(config_dir, filename or DEFAULT_CONFIG_FILE_NAME)
 
+    def get_env_names(self):
+        self._read()
+        if isinstance(self.document, dict):
+            return [env for env in self.document.keys() if env != VERSION_KEY]
+        return []
+
     def get_all(self, cmd_names, section, env=DEFAULT_ENV):
         """
         Gets a value from the configuration file for the given environment, command and section

--- a/samcli/lib/cookiecutter/question.py
+++ b/samcli/lib/cookiecutter/question.py
@@ -75,8 +75,8 @@ class Question:
         return self._text
 
     @property
-    def default_answer(self) -> Optional[str]:
-        return self._default_answer
+    def default_answer(self) -> Optional[Any]:
+        return self._resolve_default_answer()
 
     @property
     def required(self) -> Optional[bool]:
@@ -90,7 +90,7 @@ class Question:
     def default_next_question_key(self) -> Optional[str]:
         return self._default_next_question_key
 
-    def ask(self, context: Dict) -> Any:
+    def ask(self, context: Optional[Dict] = None) -> Any:
         """
         prompt the user this question
 
@@ -150,7 +150,7 @@ class Question:
                 raise ValueError(f'Invalid value "{unresolved_key}" in key path')
         return resolved_key_path
 
-    def _resolve_default_answer(self, context: Dict) -> Optional[Any]:
+    def _resolve_default_answer(self, context: Optional[Dict] = None) -> Optional[Any]:
         """
         a question may have a default answer provided directly through the "default_answer" value
         or indirectly from cookiecutter context using a key path
@@ -173,6 +173,8 @@ class Question:
 
         """
         if isinstance(self._default_answer, dict):
+            context = context if context else {}
+
             # load value using key path from cookiecutter
             if "keyPath" not in self._default_answer:
                 raise KeyError(f'Missing key "keyPath" in question default "{self._default_answer}".')
@@ -186,12 +188,12 @@ class Question:
 
 
 class Info(Question):
-    def ask(self, context: Dict) -> None:
+    def ask(self, context: Optional[Dict] = None) -> None:
         return click.echo(message=self._text)
 
 
 class Confirm(Question):
-    def ask(self, context: Dict) -> bool:
+    def ask(self, context: Optional[Dict] = None) -> bool:
         return click.confirm(text=self._text)
 
 
@@ -211,7 +213,7 @@ class Choice(Question):
         self._options = options
         super().__init__(key, text, default, is_required, next_question_map, default_next_question_key)
 
-    def ask(self, context: Dict) -> str:
+    def ask(self, context: Optional[Dict] = None) -> str:
         resolved_default_answer = self._resolve_default_answer(context)
         click.echo(self._text)
         for index, option in enumerate(self._options):

--- a/samcli/lib/cookiecutter/template.py
+++ b/samcli/lib/cookiecutter/template.py
@@ -3,15 +3,17 @@ This is the core module of the cookiecutter workflow, it defines how to create a
 values of the context and how to generate a project from the given template and provided context
 """
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
+
 from cookiecutter.exceptions import RepositoryNotFound, UnknownRepoType
 from cookiecutter.main import cookiecutter
+
 from samcli.commands.exceptions import UserException
 from samcli.lib.init.arbitrary_project import generate_non_cookiecutter_project
+from .exceptions import GenerateProjectFailedError, InvalidLocationError, PreprocessingError, PostprocessingError
 from .interactive_flow import InteractiveFlow
 from .plugin import Plugin
 from .processor import Processor
-from .exceptions import GenerateProjectFailedError, InvalidLocationError, PreprocessingError, PostprocessingError
 
 LOG = logging.getLogger(__name__)
 
@@ -98,7 +100,7 @@ class Template:
             if plugin.postprocessor:
                 self._postprocessors.append(plugin.postprocessor)
 
-    def run_interactive_flows(self) -> Dict:
+    def run_interactive_flows(self, context: Optional[Dict] = None) -> Dict:
         """
         prompt the user a series of questions' flows and gather the answers to create the cookiecutter context.
         The questions are identified by keys. If multiple questions, whether within the same flow or across
@@ -112,7 +114,7 @@ class Template:
             A Dictionary in the form of {question.key: answer} representing user's answers to the flows' questions
         """
         try:
-            context: Dict[str, Any] = {}
+            context = context if context else {}
             for flow in self._interactive_flows:
                 context = flow.run(context)
             return context

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -19,6 +19,7 @@ PIPELINE_EXECUTION_ROLE = "pipeline_execution_role"
 CLOUDFORMATION_EXECUTION_ROLE = "cloudformation_execution_role"
 ARTIFACTS_BUCKET = "artifacts_bucket"
 ECR_REPO = "ecr_repo"
+REGION = "region"
 
 
 class Stage:
@@ -223,6 +224,7 @@ class Stage:
             CLOUDFORMATION_EXECUTION_ROLE: self.cloudformation_execution_role.arn,
             ARTIFACTS_BUCKET: artifacts_bucket_name,
             ECR_REPO: ecr_repo_uri,
+            REGION: self.aws_region
         }
 
         for key, value in stage_specific_configs.items():

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -224,7 +224,7 @@ class Stage:
             CLOUDFORMATION_EXECUTION_ROLE: self.cloudformation_execution_role.arn,
             ARTIFACTS_BUCKET: artifacts_bucket_name,
             ECR_REPO: ecr_repo_uri,
-            REGION: self.aws_region
+            REGION: self.aws_region,
         }
 
         for key, value in stage_specific_configs.items():


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#1713 

#### Why is this change necessary?
Better user experience for "sam pipeline init" by pre-loading the values of the infrastructure resources instead of having the user manually entering it

#### How does it address the issue?
reading the saved values at pipeline.config.toml file 

#### What side effects does this change have?
N/A
#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
