### PR TITLE
feat: Support creating pipeline files directly into . without hooks

### DIFF
--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -17,6 +17,7 @@ from samcli.lib.cookiecutter.interactive_flow_creator import InteractiveFlowCrea
 from samcli.lib.cookiecutter.question import Choice
 from samcli.lib.cookiecutter.template import Template
 from samcli.lib.utils import osutils
+from samcli.lib.utils.colors import Colored
 from samcli.lib.utils.git_repo import GitRepo, CloneRepoException
 from samcli.lib.utils.osutils import copytree
 from .pipeline_templates_manifest import Provider, PipelineTemplateMetadata, PipelineTemplatesManifest
@@ -46,9 +47,9 @@ def do_interactive() -> None:
         generated_files = _generate_from_custom_location()
     else:
         generated_files = _generate_from_app_pipeline_templates()
-    click.echo("Successfully created the pipeline configuration file(s):")
+    click.secho(Colored().green("Successfully created the pipeline configuration file(s):"))
     for file in generated_files:
-        click.echo(f"  - {file}")
+        click.secho(Colored().green(f"  - {file}"))
 
 
 def _generate_from_app_pipeline_templates() -> List[str]:

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -4,7 +4,6 @@ pipeline configuration file
 """
 import logging
 import os
-import tempfile
 from pathlib import Path
 from typing import Dict, List
 
@@ -109,11 +108,11 @@ def _generate_from_pipeline_template(pipeline_template_dir: Path) -> None:
     pipeline_template: Template = _initialize_pipeline_template(pipeline_template_dir)
     bootstrap_context: Dict = _load_pipeline_bootstrap_context()
     context: Dict = pipeline_template.run_interactive_flows(bootstrap_context)
-    with tempfile.TemporaryDirectory() as tempdir:
-        LOG.debug("Generating pipeline files into %s", tempdir)
+    with osutils.mkdir_temp() as generate_dir:
+        LOG.debug("Generating pipeline files into %s", generate_dir)
         context["outputDir"] = "."  # prevent cookiecutter from generating a sub-folder
-        pipeline_template.generate_project(context, tempdir)
-        _copy_dir_contents_fail_on_exist(tempdir, ".")
+        pipeline_template.generate_project(context, generate_dir)
+        _copy_dir_contents_fail_on_exist(generate_dir, ".")
 
 
 def _copy_dir_contents_fail_on_exist(source_dir: str, target_dir: str) -> None:

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -81,13 +81,13 @@ def _generate_from_custom_location() -> List[str]:
     pipeline_template_git_location: str = click.prompt("Template Git location")
     if os.path.exists(pipeline_template_git_location):
         return _generate_from_pipeline_template(Path(pipeline_template_git_location))
-    else:
-        with osutils.mkdir_temp(ignore_errors=True) as tempdir:
-            tempdir_path = Path(tempdir)
-            pipeline_template_local_dir: Path = _clone_pipeline_templates(
-                pipeline_template_git_location, tempdir_path, CUSTOM_PIPELINE_TEMPLATE_REPO_LOCAL_NAME
-            )
-            return _generate_from_pipeline_template(pipeline_template_local_dir)
+
+    with osutils.mkdir_temp(ignore_errors=True) as tempdir:
+        tempdir_path = Path(tempdir)
+        pipeline_template_local_dir: Path = _clone_pipeline_templates(
+            pipeline_template_git_location, tempdir_path, CUSTOM_PIPELINE_TEMPLATE_REPO_LOCAL_NAME
+        )
+        return _generate_from_pipeline_template(pipeline_template_local_dir)
 
 
 def _load_pipeline_bootstrap_context() -> Dict:

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -19,7 +19,6 @@ from samcli.lib.cookiecutter.template import Template
 from samcli.lib.utils import osutils
 from samcli.lib.utils.colors import Colored
 from samcli.lib.utils.git_repo import GitRepo, CloneRepoException
-from samcli.lib.utils.osutils import copytree
 from .pipeline_templates_manifest import Provider, PipelineTemplateMetadata, PipelineTemplatesManifest
 from ..bootstrap.cli import PIPELINE_CONFIG_DIR, PIPELINE_CONFIG_FILENAME
 
@@ -132,7 +131,7 @@ def _copy_dir_contents_to_cwd_fail_on_exist(source_dir: str) -> List[str]:
                 raise PipelineFileAlreadyExistsError(target_file_path)
             copied_file_paths.append(str(target_file_path))
     LOG.debug("Copy contents of %s to cwd", source_dir)
-    copytree(source_dir, ".")
+    osutils.copytree(source_dir, ".")
     return copied_file_paths
 
 

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -112,19 +112,19 @@ def _generate_from_pipeline_template(pipeline_template_dir: Path) -> None:
         LOG.debug("Generating pipeline files into %s", generate_dir)
         context["outputDir"] = "."  # prevent cookiecutter from generating a sub-folder
         pipeline_template.generate_project(context, generate_dir)
-        _copy_dir_contents_fail_on_exist(generate_dir, ".")
+        _copy_dir_contents_to_cwd_fail_on_exist(generate_dir)
 
 
-def _copy_dir_contents_fail_on_exist(source_dir: str, target_dir: str) -> None:
+def _copy_dir_contents_to_cwd_fail_on_exist(source_dir: str) -> None:
     for root, _, files in os.walk(source_dir):
         for filename in files:
             file_path = Path(root, filename)
-            target_file_path = Path(target_dir).joinpath(file_path.relative_to(source_dir))
+            target_file_path = Path.cwd().joinpath(file_path.relative_to(source_dir))
             LOG.debug("Verify %s does not exist", target_file_path)
             if target_file_path.exists():
                 raise PipelineFileAlreadyExistsError(target_file_path)
-    LOG.debug("Copy contents of %s to %s", source_dir, target_dir)
-    copytree(source_dir, target_dir)
+    LOG.debug("Copy contents of %s to cwd", source_dir)
+    copytree(source_dir, os.getcwd())
 
 
 def _clone_app_pipeline_templates() -> Path:

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -49,7 +49,7 @@ def do_interactive() -> None:
         generated_files = _generate_from_app_pipeline_templates()
     click.secho(Colored().green("Successfully created the pipeline configuration file(s):"))
     for file in generated_files:
-        click.secho(Colored().green(f"  - {file}"))
+        click.secho(Colored().green(f"\t- {file}"))
 
 
 def _generate_from_app_pipeline_templates() -> List[str]:

--- a/samcli/lib/cookiecutter/template.py
+++ b/samcli/lib/cookiecutter/template.py
@@ -121,7 +121,7 @@ class Template:
         except Exception as e:
             raise UserException(str(e), wrapped_from=e.__class__.__name__) from e
 
-    def generate_project(self, context: Dict) -> None:
+    def generate_project(self, context: Dict, output_dir: str) -> None:
         """
         Generates a project based on this cookiecutter template and the given context. The context is first
         processed and manipulated by series of preprocessors(if any) then the project is generated and finally
@@ -131,6 +131,8 @@ class Template:
         ----------
         context: Dict
             the cookiecutter context to fulfill the values of cookiecutter.json keys
+        output_dir: str
+            the directory where project will be generated in
 
         Raise:
         ------
@@ -146,7 +148,13 @@ class Template:
 
         try:
             LOG.debug("Baking a new template with cookiecutter with all parameters")
-            cookiecutter(template=self._location, output_dir=".", no_input=True, extra_context=context)
+            cookiecutter(
+                template=self._location,
+                output_dir=output_dir,
+                no_input=True,
+                extra_context=context,
+                overwrite_if_exists=True,
+            )
         except RepositoryNotFound as e:
             # cookiecutter.json is not found in the template. Let's just clone it directly without
             # using cookiecutter and call it done.

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -105,12 +105,12 @@ class TestInteractiveInitFlow(TestCase):
     @patch("samcli.commands.pipeline.init.interactive_init_flow.PipelineTemplatesManifest")
     @patch("samcli.commands.pipeline.init.interactive_init_flow.GitRepo.clone")
     @patch("samcli.commands.pipeline.init.interactive_init_flow.tempfile.TemporaryDirectory")
-    @patch("samcli.commands.pipeline.init.interactive_init_flow._copy_dir_contents_fail_on_exist")
+    @patch("samcli.commands.pipeline.init.interactive_init_flow._copy_dir_contents_to_cwd_fail_on_exist")
     @patch("samcli.lib.cookiecutter.question.click")
     def test_generate_pipeline_configuration_file_from_app_pipeline_template_happy_case(
         self,
         click_mock,
-        _copy_dir_contents_fail_on_exist_mock,
+        _copy_dir_contents_to_cwd_fail_on_exist_mock,
         TemporaryDirectory_mock,
         clone_mock,
         PipelineTemplatesManifest_mock,
@@ -243,12 +243,12 @@ class TestInteractiveInitFlow(TestCase):
     @patch("samcli.commands.pipeline.init.interactive_init_flow.GitRepo.clone")
     @patch("samcli.commands.pipeline.init.interactive_init_flow.click")
     @patch("samcli.commands.pipeline.init.interactive_init_flow.tempfile.TemporaryDirectory")
-    @patch("samcli.commands.pipeline.init.interactive_init_flow._copy_dir_contents_fail_on_exist")
+    @patch("samcli.commands.pipeline.init.interactive_init_flow._copy_dir_contents_to_cwd_fail_on_exist")
     @patch("samcli.lib.cookiecutter.question.click")
     def test_generate_pipeline_configuration_file_from_custom_remote_pipeline_template_happy_case(
         self,
         questions_click_mock,
-        _copy_dir_contents_fail_on_exist_mock,
+        _copy_dir_contents_to_cwd_fail_on_exist_mock,
         TemporaryDirectory_mock,
         init_click_mock,
         clone_mock,

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -104,10 +104,14 @@ class TestInteractiveInitFlow(TestCase):
     @patch("samcli.commands.pipeline.init.interactive_init_flow.InteractiveFlowCreator.create_flow")
     @patch("samcli.commands.pipeline.init.interactive_init_flow.PipelineTemplatesManifest")
     @patch("samcli.commands.pipeline.init.interactive_init_flow.GitRepo.clone")
+    @patch("samcli.commands.pipeline.init.interactive_init_flow.tempfile.TemporaryDirectory")
+    @patch("samcli.commands.pipeline.init.interactive_init_flow._copy_dir_contents_fail_on_exist")
     @patch("samcli.lib.cookiecutter.question.click")
     def test_generate_pipeline_configuration_file_from_app_pipeline_template_happy_case(
         self,
         click_mock,
+        _copy_dir_contents_fail_on_exist_mock,
+        TemporaryDirectory_mock,
         clone_mock,
         PipelineTemplatesManifest_mock,
         create_interactive_flow_mock,
@@ -131,9 +135,10 @@ class TestInteractiveInitFlow(TestCase):
             templates=[jenkins_template_mock],
         )
         PipelineTemplatesManifest_mock.return_value = pipeline_templates_manifest_mock
+        cookiecutter_output_dir_mock = TemporaryDirectory_mock.return_value.__enter__.return_value = Mock()
         interactive_flow_mock = Mock()
         create_interactive_flow_mock.return_value = interactive_flow_mock
-        cookiecutter_context_mock = Mock()
+        cookiecutter_context_mock = {"key": "value"}
         interactive_flow_mock.run.return_value = cookiecutter_context_mock
         config_file = Mock()
         samconfig_mock.return_value = config_file
@@ -166,9 +171,10 @@ class TestInteractiveInitFlow(TestCase):
         )
         cookiecutter_mock.assert_called_once_with(
             template=str(expected_cookicutter_template_location),
-            output_dir=".",
+            output_dir=cookiecutter_output_dir_mock,
             no_input=True,
             extra_context=cookiecutter_context_mock,
+            overwrite_if_exists=True,
         )
 
     @patch("samcli.commands.pipeline.init.interactive_init_flow._read_app_pipeline_templates_manifest")
@@ -236,10 +242,14 @@ class TestInteractiveInitFlow(TestCase):
     @patch("samcli.commands.pipeline.init.interactive_init_flow.InteractiveFlowCreator.create_flow")
     @patch("samcli.commands.pipeline.init.interactive_init_flow.GitRepo.clone")
     @patch("samcli.commands.pipeline.init.interactive_init_flow.click")
+    @patch("samcli.commands.pipeline.init.interactive_init_flow.tempfile.TemporaryDirectory")
+    @patch("samcli.commands.pipeline.init.interactive_init_flow._copy_dir_contents_fail_on_exist")
     @patch("samcli.lib.cookiecutter.question.click")
     def test_generate_pipeline_configuration_file_from_custom_remote_pipeline_template_happy_case(
         self,
         questions_click_mock,
+        _copy_dir_contents_fail_on_exist_mock,
+        TemporaryDirectory_mock,
         init_click_mock,
         clone_mock,
         create_interactive_flow_mock,
@@ -252,9 +262,10 @@ class TestInteractiveInitFlow(TestCase):
         osutils_mock.mkdir_temp.return_value.__exit__ = Mock()
         any_custom_pipeline_templates_path = Path(os.path.join(any_temp_dir, CUSTOM_PIPELINE_TEMPLATE_REPO_LOCAL_NAME))
         clone_mock.return_value = any_custom_pipeline_templates_path
+        cookiecutter_output_dir_mock = TemporaryDirectory_mock.return_value.__enter__.return_value = Mock()
         interactive_flow_mock = Mock()
         create_interactive_flow_mock.return_value = interactive_flow_mock
-        cookiecutter_context_mock = Mock()
+        cookiecutter_context_mock = {"key": "value"}
         interactive_flow_mock.run.return_value = cookiecutter_context_mock
 
         questions_click_mock.prompt.return_value = "2"  # Custom pipeline templates
@@ -274,7 +285,8 @@ class TestInteractiveInitFlow(TestCase):
         interactive_flow_mock.run.assert_called_once()
         cookiecutter_mock.assert_called_once_with(
             template=str(any_custom_pipeline_templates_path),
-            output_dir=".",
+            output_dir=cookiecutter_output_dir_mock,
             no_input=True,
             extra_context=cookiecutter_context_mock,
+            overwrite_if_exists=True,
         )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

Need to replace `APP_PIPELINE_TEMPLATES_REPO_URL` to run it.

```
APP_PIPELINE_TEMPLATES_REPO_URL = "https://github.com/aahung/aws-sam-cli-pipeline-init-templates-1.git"
```

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
