### PR TITLE
Enabled ability to provide tags as list in samconfig.toml file

### DIFF
--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -208,6 +208,12 @@ class CfnTags(click.ParamType):
         if value == ("",):
             return result
 
+        # if value comes in via samconfig file and is a list, it is parsed to string.
+        if isinstance(value, list):
+            if not value:
+                return result
+            value = " ".join(value)
+            
         # if value comes in a via configuration file, it will be a string. So we should still convert it.
         value = (value,) if not isinstance(value, tuple) else value
 

--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -213,7 +213,6 @@ class CfnTags(click.ParamType):
             if not value:
                 return result
             value = " ".join(value)
-            
         # if value comes in a via configuration file, it will be a string. So we should still convert it.
         value = (value,) if not isinstance(value, tuple) else value
 

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -684,6 +684,15 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_process_execute = run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
+    @parameterized.expand([("aws-serverless-function.yaml", "samconfig-tags-string.toml")])
+    def test_deploy_with_valid_config_tags_string(self, template_file, config_file):
+        template_path = self.test_data_path.joinpath(template_file)
+        config_path = self.test_data_path.joinpath(config_file)
+
+        deploy_command_list = self.get_deploy_command_list(template_file=template_path, config_file=config_path)
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
+
     @parameterized.expand([(True, True, True), (False, True, False), (False, False, True), (True, False, True)])
     def test_deploy_with_code_signing_params(self, should_sign, should_enforce, will_succeed):
         """

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -675,6 +675,15 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         self.assertEqual(deploy_process_execute.process.returncode, 1)
         self.assertIn("Error reading configuration: Unexpected character", str(deploy_process_execute.stderr))
 
+    @parameterized.expand([("aws-serverless-function.yaml", "samconfig-tags-list.toml")])
+    def test_deploy_with_valid_config_tags_list(self, template_file, config_file):
+        template_path = self.test_data_path.joinpath(template_file)
+        config_path = self.test_data_path.joinpath(config_file)
+
+        deploy_command_list = self.get_deploy_command_list(template_file=template_path, config_file=config_path)
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
+
     @parameterized.expand([(True, True, True), (False, True, False), (False, False, True), (True, False, True)])
     def test_deploy_with_code_signing_params(self, should_sign, should_enforce, will_succeed):
         """

--- a/tests/integration/testdata/package/samconfig-tags-list.toml
+++ b/tests/integration/testdata/package/samconfig-tags-list.toml
@@ -1,0 +1,16 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "test-deploy-with-valid-config-tags-list-0-aws-serverless-function-yaml-0-0-0"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-1tbnwiiw7bwlv"
+s3_prefix = "test-deploy-with-valid-config-tags-list-0-aws-serverless-function-yaml-0-0-0"
+region = "us-east-1"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Parameter=\"SuppliedParameter\""
+tags = [
+    "stage=int",
+    "company:application=awesome-service",
+    "company:department=engineering",
+    "company:staff=12"
+    ] 

--- a/tests/integration/testdata/package/samconfig-tags-string.toml
+++ b/tests/integration/testdata/package/samconfig-tags-string.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "test-deploy-with-valid-config-tags-string-0-aws-serverless-function-yaml-0-0-0"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-1tbnwiiw7bwlv"
+s3_prefix = "test-deploy-with-valid-config-tags-string-0-aws-serverless-function-yaml-0-0-0"
+region = "us-east-1"
+capabilities = "CAPABILITY_IAM"
+parameter_overrides = "Parameter=\"SuppliedParameter\""
+tags = "stage=int company:application=awesome-service company:department=engineering company:staff=12"

--- a/tests/unit/cli/test_types.py
+++ b/tests/unit/cli/test_types.py
@@ -230,8 +230,10 @@ class TestCfnTags(TestCase):
             (("",), {}),
             # list as input
             ([], {}),
-            (["stage=int", "company:application=awesome-service", "company:department=engineering"],
-            {"stage":"int", "company:application":"awesome-service", "company:department":"engineering"})
+            (
+                ["stage=int", "company:application=awesome-service", "company:department=engineering"],
+                {"stage": "int", "company:application": "awesome-service", "company:department": "engineering"},
+            ),
         ]
     )
     def test_successful_parsing(self, input, expected):

--- a/tests/unit/cli/test_types.py
+++ b/tests/unit/cli/test_types.py
@@ -228,6 +228,10 @@ class TestCfnTags(TestCase):
                 {"a": "012345678901234567890123456789", "c": "012345678901234567890123456789"},
             ),
             (("",), {}),
+            # list as input
+            ([], {}),
+            (["stage=int", "company:application=awesome-service", "company:department=engineering"],
+            {"stage":"int", "company:application":"awesome-service", "company:department":"engineering"})
         ]
     )
     def test_successful_parsing(self, input, expected):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#2559 
#### Why is this change necessary?
Adds convenience for users to input tags as a string or a list in samconfig.toml file.
#### How does it address the issue?
Allows user to write tags as a list or a string in samconfig.toml file.
#### What side effects does this change have?
None found
#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
