### PR TITLE
small UX improvements:

### DIFF
--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -2,6 +2,8 @@
 Class containing error conditions that are exposed to the user.
 """
 
+import os
+
 import click
 
 
@@ -72,3 +74,10 @@ class AppPipelineTemplateManifestException(UserException):
     Exception class when SAM is not able to parse the "manifest.yaml" file located in the SAM pipeline templates
     Git repo: "github.com/aws/aws-sam-cli-pipeline-init-templates.git
     """
+
+
+class PipelineFileAlreadyExistsError(UserException):
+    def __init__(self, file_path: os.PathLike) -> None:
+        super().__init__(
+            f'Pipeline file "{file_path}" already exists in project root directory, please remove it first.'
+        )

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -10,7 +10,7 @@ from typing import Dict, List
 import click
 
 from samcli.cli.main import global_cfg
-from samcli.commands.exceptions import PipelineTemplateCloneException
+from samcli.commands.exceptions import PipelineTemplateCloneException, PipelineFileAlreadyExistsError
 from samcli.lib.config.samconfig import SamConfig
 from samcli.lib.cookiecutter.interactive_flow import InteractiveFlow
 from samcli.lib.cookiecutter.interactive_flow_creator import InteractiveFlowCreator
@@ -225,6 +225,9 @@ def _prompt_cicd_provider(available_providers: List[Provider]) -> Provider:
     Returns:
         The chosen provider
     """
+    if len(available_providers) == 1:
+        return available_providers[0]
+
     question_to_choose_provider = Choice(
         key="provider",
         text="CI/CD provider",
@@ -246,6 +249,8 @@ def _prompt_provider_pipeline_template(
     Returns:
         The chosen pipeline template manifest
     """
+    if len(provider_available_pipeline_templates_metadata) == 1:
+        return provider_available_pipeline_templates_metadata[0]
     question_to_choose_pipeline_template = Choice(
         key="pipeline-template",
         text="Which pipeline template would you like to use?",
@@ -291,10 +296,3 @@ def _get_pipeline_template_interactive_flow(pipeline_template_dir: Path) -> Inte
     """
     flow_definition_path: Path = pipeline_template_dir.joinpath("questions.json")
     return InteractiveFlowCreator.create_flow(str(flow_definition_path))
-
-
-class PipelineFileAlreadyExistsError(Exception):
-    def __init__(self, file_path: os.PathLike) -> None:
-        Exception.__init__(
-            self, f'Pipeline file "{file_path}" already exists in project root directory, please remove it first.'
-        )

--- a/samcli/lib/cookiecutter/question.py
+++ b/samcli/lib/cookiecutter/question.py
@@ -104,6 +104,10 @@ class Question:
         The user provided answer.
         """
         resolved_default_answer = self._resolve_default_answer(context)
+        # if it is an optional question with no default answer,
+        # set an empty default answer to prevent click from keep asking for an answer
+        if not self._required and resolved_default_answer is None:
+            resolved_default_answer = ""
         return click.prompt(text=self._text, default=resolved_default_answer)
 
     def get_next_question_key(self, answer: Any) -> Optional[str]:

--- a/samcli/lib/pipeline/bootstrap/environment.py
+++ b/samcli/lib/pipeline/bootstrap/environment.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 import click
 
 from samcli.lib.config.samconfig import SamConfig
+from samcli.lib.utils.colors import Colored
 from samcli.lib.utils.managed_cloudformation_stack import manage_stack, StackOutput
 from .resource import Resource, IAMUser, ECRImageRepository
 
@@ -94,6 +95,7 @@ class Environment:
         self.artifacts_bucket: Resource = Resource(arn=artifacts_bucket_arn)
         self.create_image_repository: bool = create_image_repository
         self.image_repository: ECRImageRepository = ECRImageRepository(arn=image_repository_arn)
+        self.color = Colored()
 
     def did_user_provide_all_required_resources(self) -> bool:
         """Check if the user provided all of the environment resources or not"""
@@ -138,7 +140,7 @@ class Environment:
 
         if self.did_user_provide_all_required_resources():
             click.secho(
-                f"\nAll required resources for the {self.name} environment exist, skipping creation.", fg="yellow"
+                self.color.yellow(f"\nAll required resources for the {self.name} environment exist, skipping creation.")
             )
             return True
 
@@ -150,6 +152,7 @@ class Environment:
         if confirm_changeset:
             confirmed: bool = click.confirm("Should we proceed with the creation?")
             if not confirmed:
+                click.secho(self.color.red("Canceling pipeline bootstrap creation."))
                 return False
 
         sanitized_environment_name: str = re.sub("[^0-9a-zA-Z]+", "-", self.name)
@@ -274,25 +277,27 @@ class Environment:
                 created_resources.append(resource)
 
         if created_resources:
-            click.secho("\nWe have created the following resources:", fg="green")
+            click.secho(self.color.green("\nWe have created the following resources:"))
             for resource in created_resources:
                 click.secho(f"\t{resource.arn}", fg="green")
 
         if provided_resources:
             click.secho(
-                "\nYou provided the following resources. Please make sure it has the required permissions as shown at "
-                "https://github.com/aws/aws-sam-cli/blob/develop/"
-                "samcli/lib/pipeline/bootstrap/environment_resources.yaml",
-                fg="green",
+                self.color.green(
+                    "\nYou provided the following resources. Please make sure it has the required permissions "
+                    "as shown at https://github.com/aws/aws-sam-cli/blob/develop/"
+                    "samcli/lib/pipeline/bootstrap/environment_resources.yaml",
+                )
             )
             for resource in provided_resources:
-                click.secho(f"\t{resource.arn}", fg="green")
+                click.secho(self.color.green(f"\t{resource.arn}"))
 
         if not self.pipeline_user.is_user_provided:
             click.secho(
-                "Please configure your CI/CD project with the following pipeline user credentials and "
-                "make sure to periodically rotate it:",
-                fg="green",
+                self.color.green(
+                    "Please configure your CI/CD project with the following pipeline user credentials and "
+                    "make sure to periodically rotate it:",
+                )
             )
-            click.secho(f"\tACCESS_KEY_ID: {self.pipeline_user.access_key_id}", fg="green")
-            click.secho(f"\tSECRET_ACCESS_KEY: {self.pipeline_user.secret_access_key}", fg="green")
+            click.secho(self.color.green(f"\tACCESS_KEY_ID: {self.pipeline_user.access_key_id}"))
+            click.secho(self.color.green(f"\tSECRET_ACCESS_KEY: {self.pipeline_user.secret_access_key}"))

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -8,6 +8,8 @@ from samcli.commands.pipeline.init.interactive_init_flow import (
     APP_PIPELINE_TEMPLATES_REPO_LOCAL_NAME,
     shared_path,
     CUSTOM_PIPELINE_TEMPLATE_REPO_LOCAL_NAME,
+    _prompt_cicd_provider,
+    _prompt_provider_pipeline_template,
 )
 from samcli.commands.pipeline.init.pipeline_templates_manifest import AppPipelineTemplateManifestException
 from samcli.lib.utils.git_repo import CloneRepoException
@@ -292,3 +294,37 @@ class TestInteractiveInitFlow(TestCase):
             extra_context=cookiecutter_context_mock,
             overwrite_if_exists=True,
         )
+
+    @patch("samcli.lib.cookiecutter.question.click")
+    def test_prompt_cicd_provider_will_not_prompt_if_the_list_of_providers_has_only_one_provider(self, click_mock):
+        gitlab_provider = Mock(id="gitlab", display_name="Gitlab CI/CD")
+        providers = [gitlab_provider]
+
+        chosen_provider = _prompt_cicd_provider(providers)
+        click_mock.prompt.assert_not_called()
+        self.assertEqual(chosen_provider, gitlab_provider)
+
+        jenkins_provider = Mock(id="jenkins", display_name="Jenkins")
+        providers.append(jenkins_provider)
+        click_mock.prompt.return_value = "2"
+        chosen_provider = _prompt_cicd_provider(providers)
+        click_mock.prompt.assert_called_once()
+        self.assertEqual(chosen_provider, jenkins_provider)
+
+    @patch("samcli.lib.cookiecutter.question.click")
+    def test_prompt_provider_pipeline_template_will_not_prompt_if_the_list_of_templatess_has_only_one_provider(
+        self, click_mock
+    ):
+        template1 = Mock(display_name="anyName1", location="anyLocation1", provider="a provider")
+        template2 = Mock(display_name="anyName2", location="anyLocation2", provider="a provider")
+        templates = [template1]
+
+        chosen_template = _prompt_provider_pipeline_template(templates)
+        click_mock.prompt.assert_not_called()
+        self.assertEqual(chosen_template, template1)
+
+        templates.append(template2)
+        click_mock.prompt.return_value = "2"
+        chosen_template = _prompt_provider_pipeline_template(templates)
+        click_mock.prompt.assert_called_once()
+        self.assertEqual(chosen_template, template2)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#1713 

#### Why is this change necessary?
Improving `sam pipeline` UX

#### How does it address the issue?
1. show a message when the user cancels a bootstrapping command.
2. Don't prompt for CI/CD provider or provider templates if there is only one choice.
3. Make PipelineFileAlreadyExistsError a UserError.
4. use the Colored class instead of fg='color' when prompting a colored message.
5. Fix a bug where we were not allowing empty response for not required questions.

#### What side effects does this change have?
N/A

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
