### PR TITLE
Revert "samconfig debug level logging fixed; documentation updated (#2891)"

### DIFF
--- a/designs/sam-config.md
+++ b/designs/sam-config.md
@@ -9,7 +9,7 @@ Today users of SAM CLI need to invoke the CLI directly with all parameters suppl
 
 for e.g: `sam build --use-container --debug`
 
-But often, during the lifecycle of building and deploying a serverless application. The same commands get run repeatedly to build, package and deploy, before solidifying into the final application. 
+But often, during the lifecycle of building and deploying a serverless application. the same commands get run repeatedly to build, package and deploy, before solidifying into the final application. 
 
 These CLI commands are often long and have many changing parts.
 
@@ -45,32 +45,15 @@ The suite of commands supported by SAM CLI would be aided by looking for a confi
 
 This configuration would be used for specifiying the parameters that each of SAM CLI commands use and would be in TOML format.
 
-Running a SAM CLI command now automatically looks for `samconfig.toml` file and if it finds it, it passes parameter through to the CLI.
-
-Every command which uses parameters from the configuration file, prints out the location of `samconfig.toml` file it parses.
+Running a SAM CLI command now automatically looks for `samconfig.toml` file and if its finds it goes ahead with parameter passthroughs to the CLI.
 
 ```
 sam build
-Config file location: /home/xxxxxxxxxx/projects/app-samconfig/samconfig.toml
+Default Config file location: samconfig.toml
 ..
 ..
 ..
 ```
-
-If no configuration file can be found at the project root directory, the command output will contain a warning.
-
-```
-sam local invoke -t ./out/build/template.yaml 
-Config file '/home/xxxxxxxxx/projects/app-samconfig/out/build/samconfig.toml' does not exist
-..
-..
-..
-```
-
-Where is my `samconfig.toml`?
----------------------------------
-
-SAM CLI always expects `samconfig.toml` to be in the project root directory (where the template file is located). When neither template nor config file is specified through cli options, both of them are expected to be in the current working directory where SAM CLI command is running. However, when `--template-file` is used to point to the directory without config file, addition of `--config-file` option enables the use of `samconfig.toml`.
 
 Why `samconfig.toml` not under `.aws-sam` directory?
 ---------------------------------

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -57,12 +57,14 @@ class TomlProvider:
 
         samconfig = SamConfig(config_file_dir, config_file_name)
 
-        # bringing samconfig file location up to info level,
-        # to improve UX and make it clear where we're looking for samconfig file
-        if samconfig.exists():
-            click.echo(f"Config file location: {samconfig.path()}")
-        else:
-            click.secho(f"Config file '{samconfig.path()}' does not exist", fg="yellow")
+        # Enable debug level logging by environment variable "SAM_DEBUG"
+        if os.environ.get("SAM_DEBUG", "").lower() == "true":
+            LOG.setLevel(logging.DEBUG)
+
+        LOG.debug("Config file location: %s", samconfig.path())
+
+        if not samconfig.exists():
+            LOG.debug("Config file '%s' does not exist", samconfig.path())
             return resolved_config
 
         try:
@@ -234,10 +236,8 @@ def decorator_customize_config_file(f):
     config_file_param_decls = ("--config-file",)
     config_file_attrs["help"] = (
         "The path and file name of the configuration file containing default parameter values to use. "
-        "Its default value is 'samconfig.toml' in project root directory. Project root directory is defined by the "
-        "template file location. When using config file and specifing --template-file SAM CLI expects samconfig.toml "
-        "and the template file to be in the same directory. Alternatively, if --config-file is explicitly specified, "
-        "it can point to a custom samconfig.toml location. For more information about configuration files, see "
+        "Its default value is 'samconfig.toml' in project directory. For more information about configuration files, "
+        "see: "
         "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-config.html."
     )
     config_file_attrs["default"] = "samconfig.toml"

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -74,6 +74,10 @@ def print_cmdline_args(func):
     """
 
     def wrapper(*args, **kwargs):
+        if kwargs.get("config_file") and kwargs.get("config_env"):
+            config_file = kwargs["config_file"]
+            config_env = kwargs["config_env"]
+            LOG.debug("Using config file: %s, config environment: %s", config_file, config_env)
         LOG.debug("Expand command line arguments to:")
         cmdline_args_log = ""
         for key, value in kwargs.items():
@@ -111,17 +115,8 @@ def cli(ctx):
 
     The AWS Serverless Application Model extends AWS CloudFormation to provide a simplified way of defining the
     Amazon API Gateway APIs, AWS Lambda functions, and Amazon DynamoDB tables needed by your serverless application.
-
-    SAM CLI commands run in the project root directory which is the directory with SAM template file
-    (template.{yml|yaml|json}). If no template file is specified explicitly, SAM CLI looks it up in the current
-    working directory (where SAM CLI is running).
-
-    SAM CLI options can be either passed directly to the commands and/or stored in the config file (samconfig.toml),
-    which is expected to be in the project root directory by default. It is also possible to specify a custom directory
-    for the config file if necessary.
-
-    More in-depth guide about the SAM specification:
-    https://github.com/aws/serverless-application-model.
+    You can find more in-depth guide about the SAM specification here:
+    https://github.com/awslabs/serverless-application-model.
     """
     if global_cfg.telemetry_enabled is None:
         enabled = True

--- a/samcli/cli/options.py
+++ b/samcli/cli/options.py
@@ -20,14 +20,8 @@ def debug_option(f):
         state.debug = value
         return value
 
-    # NOTE: --debug option should be eager to be evaluated before other parameters and to set log level to DEBUG
-    # before any other option/parameter processing will require to output debug info.
-    # Otherwise parameters are evaluated according to their order and if --debug is specified at the end of the command
-    # some debug output can be lost
-    # https://click.palletsprojects.com/en/7.x/advanced/#callback-evaluation-order
     return click.option(
         "--debug",
-        is_eager=True,
         expose_value=False,
         is_flag=True,
         envvar="SAM_DEBUG",

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -217,12 +217,7 @@ def template_click_option(include_build=True):
         callback=partial(get_or_default_template_file_name, include_build=include_build),
         show_default=True,
         is_eager=True,
-        help="AWS SAM template which references built artifacts for resources in the template (if applicable). "
-        "Template file defines the root directory of the project and allows to point SAM CLI to the directory "
-        "for build, local invocation etc. If template file is not specified explicitly SAM CLI expects it to be "
-        "in the current working directory (where it is running). When using config file and specifing --template-file "
-        "SAM CLI expects samconfig.toml and the template file to be in the same directory."
-        "Alternatively, if --config-file is explicitly specified, it can point to a custom samconfig.toml location."
+        help="AWS SAM template which references built artifacts for resources in the template. (if applicable)"
         if include_build
         else "AWS SAM template file.",
     )

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -172,8 +172,6 @@ class BuildIntegBase(TestCase):
         process_execute.process.wait()
 
         process_stdout = process_execute.stdout.decode("utf-8")
-        if process_stdout.startswith("Config file"):
-            *_, process_stdout = process_stdout.partition("\n")
         self.assertEqual(json.loads(process_stdout), expected_result)
 
 

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1,34 +1,32 @@
-"""
-Integration tests for Build comand
-"""
-
-import logging
-import os
-import random
+import re
 import shutil
 import sys
-from pathlib import Path
+import os
+import logging
+import random
 from unittest import skipIf
+from pathlib import Path
+from parameterized import parameterized, parameterized_class
+from subprocess import Popen, PIPE, TimeoutExpired
 
 import pytest
-from parameterized import parameterized, parameterized_class
-from samcli.lib.utils import osutils
-from tests.testing_utils import (
-    CI_OVERRIDE,
-    IS_WINDOWS,
-    RUNNING_ON_CI,
-    SKIP_DOCKER_MESSAGE,
-    SKIP_DOCKER_TESTS,
-    run_command,
-)
 
+from samcli.lib.utils import osutils
 from .build_integ_base import (
     BuildIntegBase,
-    BuildIntegRubyBase,
-    CachedBuildIntegBase,
     DedupBuildIntegBase,
-    IntrinsicIntegBase,
+    CachedBuildIntegBase,
+    BuildIntegRubyBase,
     NestedBuildIntegBase,
+    IntrinsicIntegBase,
+)
+from tests.testing_utils import (
+    IS_WINDOWS,
+    RUNNING_ON_CI,
+    CI_OVERRIDE,
+    run_command,
+    SKIP_DOCKER_TESTS,
+    SKIP_DOCKER_MESSAGE,
 )
 
 LOG = logging.getLogger(__name__)
@@ -190,8 +188,8 @@ class TestBuildCommand_ErrorCases(BuildIntegBase):
         LOG.info(cmdlist)
         process_execute = run_command(cmdlist, cwd=self.working_dir)
         self.assertEqual(1, process_execute.process.returncode)
-        output = "\n".join(process_execute.stdout.decode("utf-8").strip().splitlines())
-        self.assertIn("Build Failed", output)
+
+        self.assertIn("Build Failed", str(process_execute.stdout))
 
 
 @skipIf(
@@ -1143,8 +1141,7 @@ class TestBuildWithBuildMethod(BuildIntegBase):
         # This will error out.
         command = run_command(cmdlist, cwd=self.working_dir)
         self.assertEqual(command.process.returncode, 1)
-        output = "\n".join(command.stdout.decode("utf-8").strip().splitlines())
-        self.assertIn("Build Failed", output)
+        self.assertEqual(command.stdout.strip(), b"Build Failed")
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files):
 

--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -1,15 +1,13 @@
-"""
-Integration tests for init command
-"""
-import os
-import shutil
-import tempfile
-from pathlib import Path
-from subprocess import PIPE, Popen, TimeoutExpired
 from unittest import TestCase
 
 from parameterized import parameterized
+from subprocess import Popen, TimeoutExpired, PIPE
+import os
+import shutil
+import tempfile
 from samcli.lib.utils.packagetype import IMAGE, ZIP
+
+from pathlib import Path
 
 TIMEOUT = 300
 
@@ -227,7 +225,7 @@ Must provide one of the following required parameter combinations:
 You can also re-run without the --no-interactive flag to be prompted for required values.
             """
 
-            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_apptemplate_location(self):
         stderr = None
@@ -265,7 +263,7 @@ You can run 'sam init' without any options for an interactive initialization flo
     --location
                         """
 
-            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_runtime_location(self):
         stderr = None
@@ -303,7 +301,7 @@ You can run 'sam init' without any options for an interactive initialization flo
     --location
                         """
 
-            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_base_image_location(self):
         stderr = None
@@ -341,7 +339,7 @@ You can run 'sam init' without any options for an interactive initialization flo
     --location
                         """
 
-            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_base_image_no_dependency(self):
         stderr = None
@@ -381,7 +379,7 @@ Must provide one of the following required parameter combinations:
 You can also re-run without the --no-interactive flag to be prompted for required values.
                         """
 
-            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_packagetype_location(self):
         stderr = None
@@ -419,7 +417,7 @@ You can run 'sam init' without any options for an interactive initialization flo
     --location
                         """
 
-            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_base_image_no_packagetype(self):
         stderr = None
@@ -457,7 +455,7 @@ Must provide one of the following required parameter combinations:
 You can also re-run without the --no-interactive flag to be prompted for required values.
                         """
 
-            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_wrong_packagetype(self):
         stderr = None
@@ -491,7 +489,7 @@ Error: Invalid value for '-p' / '--package-type': invalid choice: WrongPT. (choo
                 _get_command()
             )
 
-            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
 
 class TestInitWithArbitraryProject(TestCase):


### PR DESCRIPTION
This reverts commit 2a13a69822660538c478118125eef50d0164995a.

Reverting to be able to release the new SAM CLI version.
This commit broke the local invoke integration tests.
I think we also need to review the update to the `click.echo` outputs, we may want to revert back to `LOG.debug` as this doesn't seem like a very meaningful information to display outside of the `--debug` parameter.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
