### PR TITLE
fix: Windows default template validation integration test

### DIFF
--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -28,8 +28,8 @@ class TestValidate(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.patterns = {
-            TemplateFileTypes.JSON: re.compile(r"^/.+/template[.]json is a valid SAM Template$"),
-            TemplateFileTypes.YAML: re.compile(r"^/.+/template[.]yaml is a valid SAM Template$"),
+            TemplateFileTypes.JSON: re.compile(r"template\.json is a valid SAM Template$"),
+            TemplateFileTypes.YAML: re.compile(r"template\.yaml is a valid SAM Template$"),
         }
 
     @staticmethod


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Fixes the TestValidate::test_default_template_file_choice  tests for Windows.
The previous code was checking for a path starting with a `/` which is only for Unix/MacOS.
This fix doesn't check the beginning of the message anymore (unnecessary)

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
