### PR TITLE
fix: Skip build of Docker image if ImageUri is a valid ECR URL (#2934)

### DIFF
--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -316,7 +316,7 @@ class GuidedContext:
                     if isinstance(self.image_repositories, dict)
                     else "" or self.image_repository,
                 )
-                if not is_ecr_url(image_repositories.get(resource_id)):
+                if resource_id not in image_repositories or not is_ecr_url(str(image_repositories[resource_id])):
                     raise GuidedDeployFailedError(
                         f"Invalid Image Repository ECR URI: {image_repositories.get(resource_id)}"
                     )

--- a/samcli/lib/package/ecr_utils.py
+++ b/samcli/lib/package/ecr_utils.py
@@ -6,5 +6,5 @@ import re
 from samcli.lib.package.regexpr import ECR_URL
 
 
-def is_ecr_url(url):
+def is_ecr_url(url: str) -> bool:
     return bool(re.match(ECR_URL, url)) if url else False

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -130,11 +130,26 @@ class SamFunctionProvider(SamBaseProvider):
                     resource_properties["Metadata"] = resource_metadata
 
                 if resource_type in [SamFunctionProvider.SERVERLESS_FUNCTION, SamFunctionProvider.LAMBDA_FUNCTION]:
+                    resource_package_type = resource_properties.get("PackageType", ZIP)
+
                     code_property_key = SamBaseProvider.CODE_PROPERTY_KEYS[resource_type]
-                    if SamBaseProvider._is_s3_location(resource_properties.get(code_property_key)):
+                    image_property_key = SamBaseProvider.IMAGE_PROPERTY_KEYS[resource_type]
+
+                    if resource_package_type == ZIP and SamBaseProvider._is_s3_location(
+                        resource_properties.get(code_property_key)
+                    ):
+
                         # CodeUri can be a dictionary of S3 Bucket/Key or a S3 URI, neither of which are supported
                         if not ignore_code_extraction_warnings:
                             SamFunctionProvider._warn_code_extraction(resource_type, name, code_property_key)
+                        continue
+
+                    if resource_package_type == IMAGE and SamBaseProvider._is_ecr_uri(
+                        resource_properties.get(image_property_key)
+                    ):
+                        # ImageUri can be an ECR uri, which is not supported
+                        if not ignore_code_extraction_warnings:
+                            SamFunctionProvider._warn_imageuri_extraction(resource_type, name, image_property_key)
                         continue
 
                 if resource_type == SamFunctionProvider.SERVERLESS_FUNCTION:

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -63,10 +63,6 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     "Handler": "index.handler",
                 },
             },
-            "SamFunc4": {
-                "Type": "AWS::Serverless::Function",
-                "Properties": {"ImageUri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo", "PackageType": IMAGE},
-            },
             "SamFuncWithFunctionNameOverride": {
                 "Type": "AWS::Serverless::Function",
                 "Properties": {
@@ -74,6 +70,29 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     "CodeUri": "/usr/foo/bar",
                     "Runtime": "nodejs4.3",
                     "Handler": "index.handler",
+                },
+            },
+            "SamFuncWithImage1": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "PackageType": IMAGE,
+                },
+                "Metadata": {"DockerTag": "tag", "DockerContext": "./image", "Dockerfile": "Dockerfile"},
+            },
+            "SamFuncWithImage2": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "ImageUri": "image:tag",
+                    "PackageType": IMAGE,
+                },
+                "Metadata": {"DockerTag": "tag", "DockerContext": "./image", "Dockerfile": "Dockerfile"},
+            },
+            "SamFuncWithImage3": {
+                # ImageUri is unsupported ECR location
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "ImageUri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo:myimage",
+                    "PackageType": IMAGE,
                 },
             },
             "LambdaFunc1": {
@@ -84,19 +103,35 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     "Handler": "index.handler",
                 },
             },
+            "LambdaFuncWithImage1": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "PackageType": IMAGE,
+                },
+                "Metadata": {"DockerTag": "tag", "DockerContext": "./image", "Dockerfile": "Dockerfile"},
+            },
+            "LambdaFuncWithImage2": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "Code": {"ImageUri": "image:tag"},
+                    "PackageType": IMAGE,
+                },
+                "Metadata": {"DockerTag": "tag", "DockerContext": "./image", "Dockerfile": "Dockerfile"},
+            },
+            "LambdaFuncWithImage3": {
+                # ImageUri is unsupported ECR location
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "Code": {"ImageUri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo"},
+                    "PackageType": IMAGE,
+                },
+            },
             "LambdaFuncWithInlineCode": {
                 "Type": "AWS::Lambda::Function",
                 "Properties": {
                     "Code": {"ZipFile": "testcode"},
                     "Runtime": "nodejs4.3",
                     "Handler": "index.handler",
-                },
-            },
-            "LambdaFunc2": {
-                "Type": "AWS::Lambda::Function",
-                "Properties": {
-                    "Code": {"ImageUri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo"},
-                    "PackageType": IMAGE,
                 },
             },
             "LambdaFuncWithLocalPath": {
@@ -248,10 +283,10 @@ class TestSamFunctionProviderEndToEnd(TestCase):
             ("SamFunc2", None),  # codeuri is a s3 location, ignored
             ("SamFunc3", None),  # codeuri is a s3 location, ignored
             (
-                "SamFunc4",
+                "SamFuncWithImage1",
                 Function(
-                    name="SamFunc4",
-                    functionname="SamFunc4",
+                    name="SamFuncWithImage1",
+                    functionname="SamFuncWithImage1",
                     runtime=None,
                     handler=None,
                     codeuri=".",
@@ -262,14 +297,46 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     layers=[],
                     events=None,
                     inlinecode=None,
-                    imageuri="123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo",
+                    imageuri=None,
                     imageconfig=None,
                     packagetype=IMAGE,
-                    metadata=None,
+                    metadata={
+                        "DockerTag": "tag",
+                        "DockerContext": os.path.join("image"),
+                        "Dockerfile": "Dockerfile",
+                    },
                     codesign_config_arn=None,
                     stack_path="",
                 ),
             ),
+            (
+                "SamFuncWithImage2",
+                Function(
+                    name="SamFuncWithImage2",
+                    functionname="SamFuncWithImage2",
+                    runtime=None,
+                    handler=None,
+                    codeuri=".",
+                    memory=None,
+                    timeout=None,
+                    environment=None,
+                    rolearn=None,
+                    layers=[],
+                    events=None,
+                    inlinecode=None,
+                    imageuri="image:tag",
+                    imageconfig=None,
+                    packagetype=IMAGE,
+                    metadata={
+                        "DockerTag": "tag",
+                        "DockerContext": os.path.join("image"),
+                        "Dockerfile": "Dockerfile",
+                    },
+                    codesign_config_arn=None,
+                    stack_path="",
+                ),
+            ),
+            ("SamFuncWithImage3", None),  # imageuri is ecr location, ignored
             (
                 "SamFuncWithFunctionNameOverride-x",
                 Function(
@@ -295,6 +362,61 @@ class TestSamFunctionProviderEndToEnd(TestCase):
             ),
             ("LambdaFunc1", None),  # codeuri is a s3 location, ignored
             (
+                "LambdaFuncWithImage1",
+                Function(
+                    name="LambdaFuncWithImage1",
+                    functionname="LambdaFuncWithImage1",
+                    runtime=None,
+                    handler=None,
+                    codeuri=".",
+                    memory=None,
+                    timeout=None,
+                    environment=None,
+                    rolearn=None,
+                    layers=[],
+                    events=None,
+                    metadata={
+                        "DockerTag": "tag",
+                        "DockerContext": os.path.join("image"),
+                        "Dockerfile": "Dockerfile",
+                    },
+                    inlinecode=None,
+                    imageuri=None,
+                    imageconfig=None,
+                    packagetype=IMAGE,
+                    codesign_config_arn=None,
+                    stack_path="",
+                ),
+            ),
+            (
+                "LambdaFuncWithImage2",
+                Function(
+                    name="LambdaFuncWithImage2",
+                    functionname="LambdaFuncWithImage2",
+                    runtime=None,
+                    handler=None,
+                    codeuri=".",
+                    memory=None,
+                    timeout=None,
+                    environment=None,
+                    rolearn=None,
+                    layers=[],
+                    events=None,
+                    metadata={
+                        "DockerTag": "tag",
+                        "DockerContext": os.path.join("image"),
+                        "Dockerfile": "Dockerfile",
+                    },
+                    inlinecode=None,
+                    imageuri="image:tag",
+                    imageconfig=None,
+                    packagetype=IMAGE,
+                    codesign_config_arn=None,
+                    stack_path="",
+                ),
+            ),
+            ("LambdaFuncWithImage3", None),  # imageuri is a ecr location, ignored
+            (
                 "LambdaFuncWithInlineCode",
                 Function(
                     name="LambdaFuncWithInlineCode",
@@ -314,29 +436,6 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     imageuri=None,
                     imageconfig=None,
                     packagetype=ZIP,
-                    stack_path="",
-                ),
-            ),
-            (
-                "LambdaFunc2",
-                Function(
-                    name="LambdaFunc2",
-                    functionname="LambdaFunc2",
-                    runtime=None,
-                    handler=None,
-                    codeuri=".",
-                    memory=None,
-                    timeout=None,
-                    environment=None,
-                    rolearn=None,
-                    layers=[],
-                    events=None,
-                    metadata=None,
-                    inlinecode=None,
-                    imageuri="123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo",
-                    imageconfig=None,
-                    packagetype=IMAGE,
-                    codesign_config_arn=None,
                     stack_path="",
                 ),
             ),
@@ -494,11 +593,13 @@ class TestSamFunctionProviderEndToEnd(TestCase):
         result = {posixpath.join(f.stack_path, f.name) for f in self.provider.get_all()}
         expected = {
             "SamFunctions",
+            "SamFuncWithImage1",
+            "SamFuncWithImage2",
             "SamFuncWithInlineCode",
-            "SamFunc4",
             "SamFuncWithFunctionNameOverride",
+            "LambdaFuncWithImage1",
+            "LambdaFuncWithImage2",
             "LambdaFuncWithInlineCode",
-            "LambdaFunc2",
             "LambdaFuncWithLocalPath",
             "LambdaFuncWithFunctionNameOverride",
             "LambdaFuncWithCodeSignConfig",


### PR DESCRIPTION
#### Which issue(s) does this change fix?

<!-- Use the format #<issue-number>, e.g. #42 -->
#2934 

#### Why is this change necessary?

- Support deployment of `PackageType: Image` lambda functions of which the underlying Docker image is built/deployed externally to SAM.

#### How does it address the issue?

- Checks whether or not the `ImageUri` property of a `AWS::Serverless::Function`, or `Code.ImageUri` property of a `AWS::Lambda::Function` is a valid ECR URL, based on the resource `PackageType`. If so, skips the local image build and prompts the user with a proper warning, similarly to `Zip` packaged lambdas.

```
  Function:
    Type: AWS::Serverless::Function
    Properties:
      PackageType: Image
      ImageUri: 123456789012.dkr.ecr.eu-west-1.amazonaws.com/function:latest
```

```
% sam build
The resource AWS::Serverless::Function 'Function' has specified ECR registry image for ImageUri. It will not be built and SAM CLI does not support invoking it locally.
```

#### What side effects does this change have?

TBD

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write unit tests
- [x] `make pr` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
