### PR TITLE
ci: Pin boto3-stubs to 1.17.90 due to a bug in 1.17.91

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,8 @@ pytest-cov==2.10.1
 # mypy adds new rules in new minor versions, which could cause our PR check to fail
 # here we fix its version and upgrade it manually in the future
 mypy==0.790
-boto3-stubs[essential]~=1.14
+# 1.17.91 has a bug, https://github.com/vemel/mypy_boto3_builder/pull/82
+boto3-stubs[essential]==1.17.90.post1
 
 # Test requirements
 pytest==6.1.1


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

a bug in 1.17.91, the fix https://github.com/vemel/mypy_boto3_builder/pull/82 has not yet been released. 

#### How does it address the issue?

Pin to the latest version without the buggy
> [botocore-stubs] all exceptions kwargs are annotated properly

#### What side effects does this change have?

None, it is only used in CI

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
