### PR TITLE
feat: Increase awareness of same file warning during package

### DIFF
--- a/samcli/lib/package/s3_uploader.py
+++ b/samcli/lib/package/s3_uploader.py
@@ -85,7 +85,7 @@ class S3Uploader:
 
         # Check if a file with same data exists
         if not self.force_upload and self.file_exists(remote_path):
-            LOG.info("File with same data is already exists at %s. " "Skipping upload", remote_path)
+            LOG.info("File with same data already exists at %s, skipping upload", remote_path)
             return self.make_url(remote_path)
 
         try:

--- a/samcli/lib/package/s3_uploader.py
+++ b/samcli/lib/package/s3_uploader.py
@@ -85,7 +85,7 @@ class S3Uploader:
 
         # Check if a file with same data exists
         if not self.force_upload and self.file_exists(remote_path):
-            LOG.debug("File with same data is already exists at %s. " "Skipping upload", remote_path)
+            LOG.info("File with same data is already exists at %s. " "Skipping upload", remote_path)
             return self.make_url(remote_path)
 
         try:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/2665

#### Why is this change necessary?
If same package is tried to be packaged and/or deployed, same file exists message is printed as `debug` where it makes harder to be visible.

#### How does it address the issue?
By changing the `debug` into `info`

#### What side effects does this change have?
N/A

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
