### PR TITLE
Allow roles with Tag aws-sam-pipeline-codebuild-service-role to assume PipelineExecutionRole

### DIFF
--- a/samcli/lib/pipeline/bootstrap/stage_resources.yaml
+++ b/samcli/lib/pipeline/bootstrap/stage_resources.yaml
@@ -105,6 +105,20 @@ Resources:
                   - !Ref PipelineUserArn
             Action:
               - 'sts:AssumeRole'
+          - Effect: Allow
+            Principal:
+              # Allow roles with tag Role=aws-sam-pipeline-codebuild-service-role to assume this role.
+              # This is required when CodePipeline is the CI/CD system of choice.
+              AWS:
+                - !If
+                  - MissingPipelineUser
+                  - !Ref AWS::AccountId
+                  - !Select [4, !Split [':', !Ref PipelineUserArn]]
+            Action:
+              - 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                aws:PrincipalTag/Role: aws-sam-pipeline-codebuild-service-role
 
   ArtifactsBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

To support AWS CodePipeline init template

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
