### PR TITLE
Use :Z label to mount host dir for SELinux

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -2,9 +2,6 @@
 Representation of a generic Docker container
 """
 import logging
-import os
-import subprocess
-import sys
 import tarfile
 import tempfile
 import threading

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -16,7 +16,7 @@ from docker.errors import NotFound as DockerNetworkNotFound
 from samcli.lib.utils.retry import retry
 from .exceptions import ContainerNotStartableException
 
-from .utils import to_posix_path, find_free_port, NoFreePortsError
+from .utils import to_posix_path, find_free_port, NoFreePortsError, is_selinux_enabled
 
 LOG = logging.getLogger(__name__)
 
@@ -132,17 +132,12 @@ class Container:
 
         if self._host_dir:
 
-            # When SELinux is enabled add the z label to mount the host volume
+            # When SELinux is enabled add the Z label to mount the host volume
             # inside the container.
-            if (
-                sys.platform == "linux"
-                and os.path.isfile("/usr/sbin/sestatus")
-                and "enabled"
-                in subprocess.Popen("/usr/sbin/sestatus", stdout=subprocess.PIPE).stdout.readline().decode("UTF-8")
-            ):
+            if is_selinux_enabled():
 
-                mount_mode = "z," + mount_mode
-                mount_options_msg = "Mounting %s as %s:z,ro,delegated inside runtime container"
+                mount_mode = "Z," + mount_mode
+                mount_options_msg = "Mounting %s as %s:Z,ro,delegated inside runtime container"
 
             LOG.info(mount_options_msg, self._host_dir, self._working_dir)
 

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -13,7 +13,7 @@ from docker.errors import NotFound as DockerNetworkNotFound
 from samcli.lib.utils.retry import retry
 from .exceptions import ContainerNotStartableException
 
-from .utils import to_posix_path, find_free_port, NoFreePortsError, is_selinux_enabled
+from .utils import to_posix_path, find_free_port, NoFreePortsError
 
 LOG = logging.getLogger(__name__)
 
@@ -129,12 +129,10 @@ class Container:
 
         if self._host_dir:
 
-            # When SELinux is enabled add the Z label to mount the host volume
-            # inside the container.
-            if is_selinux_enabled():
-
-                mount_mode = "Z," + mount_mode
-                mount_options_msg = "Mounting %s as %s:Z,ro,delegated inside runtime container"
+            # Add the SELinux Z label to mount the host volume inside the
+            # container, if SELinux is not present Docker will ignore the label.
+            mount_mode = "Z," + mount_mode
+            mount_options_msg = "Mounting %s as %s:Z,ro,delegated inside runtime container"
 
             LOG.info(mount_options_msg, self._host_dir, self._working_dir)
 

--- a/samcli/local/docker/lambda_build_container.py
+++ b/samcli/local/docker/lambda_build_container.py
@@ -8,6 +8,8 @@ import pathlib
 
 from samcli.local.docker.container import Container
 
+from .utils import is_selinux_enabled
+
 LOG = logging.getLogger(__name__)
 
 
@@ -82,10 +84,15 @@ class LambdaBuildContainer(Container):
         entry = LambdaBuildContainer._get_entrypoint(request_json)
         cmd = []
 
+        if is_selinux_enabled():
+            mount_mode = "Z,ro"
+        else:
+            mount_mode = "ro"
+
         additional_volumes = {
             # Manifest is mounted separately in order to support the case where manifest
             # is outside of source directory
-            manifest_dir: {"bind": container_dirs["manifest_dir"], "mode": "ro"}
+            manifest_dir: {"bind": container_dirs["manifest_dir"], "mode": mount_mode}
         }
 
         if log_level:

--- a/samcli/local/docker/lambda_build_container.py
+++ b/samcli/local/docker/lambda_build_container.py
@@ -8,8 +8,6 @@ import pathlib
 
 from samcli.local.docker.container import Container
 
-from .utils import is_selinux_enabled
-
 LOG = logging.getLogger(__name__)
 
 
@@ -84,10 +82,7 @@ class LambdaBuildContainer(Container):
         entry = LambdaBuildContainer._get_entrypoint(request_json)
         cmd = []
 
-        if is_selinux_enabled():
-            mount_mode = "Z,ro"
-        else:
-            mount_mode = "ro"
+        mount_mode = "Z,ro"
 
         additional_volumes = {
             # Manifest is mounted separately in order to support the case where manifest

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -10,8 +10,6 @@ import logging
 import posixpath
 import pathlib
 import socket
-import subprocess
-import sys
 
 import docker
 import requests
@@ -156,12 +154,3 @@ def get_docker_platform(architecture: str) -> str:
     validate_architecture(architecture)
 
     return f"linux/{get_image_arch(architecture)}"
-
-
-def is_selinux_enabled():
-    """Return True if SELinux is enabled, False otherwise."""
-    if sys.platform == "linux":
-        return os.path.isfile("/usr/sbin/sestatus") and "enabled" in subprocess.Popen(
-            "/usr/sbin/sestatus", stdout=subprocess.PIPE
-        ).stdout.readline().decode("UTF-8")
-    return False

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -161,9 +161,7 @@ def get_docker_platform(architecture: str) -> str:
 def is_selinux_enabled():
     """Return True if SELinux is enabled, False otherwise."""
     if sys.platform == "linux":
-        if os.path.isfile("/usr/sbin/sestatus") and "enabled" in subprocess.Popen(
+        return os.path.isfile("/usr/sbin/sestatus") and "enabled" in subprocess.Popen(
             "/usr/sbin/sestatus", stdout=subprocess.PIPE
-        ).stdout.readline().decode("UTF-8"):
-            return True
-        else:
-            return False
+        ).stdout.readline().decode("UTF-8")
+    return False

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -10,6 +10,8 @@ import logging
 import posixpath
 import pathlib
 import socket
+import subprocess
+import sys
 
 import docker
 import requests
@@ -154,3 +156,14 @@ def get_docker_platform(architecture: str) -> str:
     validate_architecture(architecture)
 
     return f"linux/{get_image_arch(architecture)}"
+
+
+def is_selinux_enabled():
+    """Return True if SELinux is enabled, False otherwise."""
+    if sys.platform == "linux":
+        if os.path.isfile("/usr/sbin/sestatus") and "enabled" in subprocess.Popen(
+            "/usr/sbin/sestatus", stdout=subprocess.PIPE
+        ).stdout.readline().decode("UTF-8"):
+            return True
+        else:
+            return False

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -11,8 +11,6 @@ from requests import RequestException
 from samcli.lib.utils.packagetype import IMAGE
 from samcli.local.docker.container import Container, ContainerResponseException
 
-from samcli.local.docker.utils import is_selinux_enabled
-
 
 class TestContainer_init(TestCase):
     def setUp(self):
@@ -82,10 +80,7 @@ class TestContainer_create(TestCase):
         :return:
         """
 
-        if is_selinux_enabled():
-            mount_mode = "Z,ro,delegated"
-        else:
-            mount_mode = "ro,delegated"
+        mount_mode = "Z,ro,delegated"
 
         expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": mount_mode}}
         generated_id = "fooobar"
@@ -125,10 +120,7 @@ class TestContainer_create(TestCase):
         :return:
         """
 
-        if is_selinux_enabled():
-            mount_mode = "Z,ro,delegated"
-        else:
-            mount_mode = "ro"
+        mount_mode = "Z,ro,delegated"
 
         expected_volumes = {
             self.host_dir: {"bind": self.working_dir, "mode": mount_mode},
@@ -185,10 +177,7 @@ class TestContainer_create(TestCase):
         :return:
         """
 
-        if is_selinux_enabled():
-            mount_mode = "Z,ro,delegated"
-        else:
-            mount_mode = "ro,delegated"
+        mount_mode = "Z,ro,delegated"
 
         os_mock.name = "nt"
         host_dir = "C:\\Users\\Username\\AppData\\Local\\Temp\\tmp1337"
@@ -249,10 +238,7 @@ class TestContainer_create(TestCase):
         :return:
         """
 
-        if is_selinux_enabled():
-            mount_mode = "Z,ro,delegated"
-        else:
-            mount_mode = "ro,delegated"
+        mount_mode = "Z,ro,delegated"
 
         expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": mount_mode}}
 
@@ -293,10 +279,7 @@ class TestContainer_create(TestCase):
         :return:
         """
 
-        if is_selinux_enabled():
-            mount_mode = "Z,ro,delegated"
-        else:
-            mount_mode = "ro,delegated"
+        mount_mode = "Z,ro,delegated"
 
         expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": mount_mode}}
 

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -11,6 +11,8 @@ from requests import RequestException
 from samcli.lib.utils.packagetype import IMAGE
 from samcli.local.docker.container import Container, ContainerResponseException
 
+from samcli.local.docker.utils import is_selinux_enabled
+
 
 class TestContainer_init(TestCase):
     def setUp(self):
@@ -80,7 +82,12 @@ class TestContainer_create(TestCase):
         :return:
         """
 
-        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
+        if is_selinux_enabled():
+            mount_mode = "Z,ro,delegated"
+        else:
+            mount_mode = "ro,delegated"
+
+        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": mount_mode}}
         generated_id = "fooobar"
         self.mock_docker_client.containers.create.return_value = Mock()
         self.mock_docker_client.containers.create.return_value.id = generated_id
@@ -118,8 +125,13 @@ class TestContainer_create(TestCase):
         :return:
         """
 
+        if is_selinux_enabled():
+            mount_mode = "Z,ro,delegated"
+        else:
+            mount_mode = "ro"
+
         expected_volumes = {
-            self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"},
+            self.host_dir: {"bind": self.working_dir, "mode": mount_mode},
             "/somepath": {"blah": "blah value"},
         }
         expected_memory = "{}m".format(self.memory_mb)
@@ -173,12 +185,17 @@ class TestContainer_create(TestCase):
         :return:
         """
 
+        if is_selinux_enabled():
+            mount_mode = "Z,ro,delegated"
+        else:
+            mount_mode = "ro,delegated"
+
         os_mock.name = "nt"
         host_dir = "C:\\Users\\Username\\AppData\\Local\\Temp\\tmp1337"
         additional_volumes = {"C:\\Users\\Username\\AppData\\Local\\Temp\\tmp1338": {"blah": "blah value"}}
 
         translated_volumes = {
-            "/c/Users/Username/AppData/Local/Temp/tmp1337": {"bind": self.working_dir, "mode": "ro,delegated"}
+            "/c/Users/Username/AppData/Local/Temp/tmp1337": {"bind": self.working_dir, "mode": mount_mode}
         }
 
         translated_additional_volumes = {"/c/Users/Username/AppData/Local/Temp/tmp1338": {"blah": "blah value"}}
@@ -231,7 +248,13 @@ class TestContainer_create(TestCase):
         Create a container with only required values. Optional values are not provided
         :return:
         """
-        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
+
+        if is_selinux_enabled():
+            mount_mode = "Z,ro,delegated"
+        else:
+            mount_mode = "ro,delegated"
+
+        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": mount_mode}}
 
         network_id = "some id"
         generated_id = "fooobar"
@@ -269,7 +292,13 @@ class TestContainer_create(TestCase):
         Create a container with only required values. Optional values are not provided
         :return:
         """
-        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
+
+        if is_selinux_enabled():
+            mount_mode = "Z,ro,delegated"
+        else:
+            mount_mode = "ro,delegated"
+
+        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": mount_mode}}
 
         network_id = "host"
         generated_id = "fooobar"

--- a/tests/unit/local/docker/test_lambda_build_container.py
+++ b/tests/unit/local/docker/test_lambda_build_container.py
@@ -13,8 +13,6 @@ from parameterized import parameterized
 from samcli.lib.utils.architecture import X86_64, ARM64
 from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 
-from samcli.local.docker.utils import is_selinux_enabled
-
 
 class TestLambdaBuildContainer_init(TestCase):
     @patch.object(LambdaBuildContainer, "_make_request")
@@ -23,10 +21,7 @@ class TestLambdaBuildContainer_init(TestCase):
     @patch.object(LambdaBuildContainer, "_get_container_dirs")
     def test_must_init_class(self, get_container_dirs_mock, get_entrypoint_mock, get_image_mock, make_request_mock):
 
-        if is_selinux_enabled():
-            mount_mode = "Z,ro"
-        else:
-            mount_mode = "ro"
+        mount_mode = "Z,ro"
 
         request = make_request_mock.return_value = "somerequest"
         entry = get_entrypoint_mock.return_value = "entrypoint"


### PR DESCRIPTION
SELinux by default prevents mounting volumes from the host OS in
a docker container. To allow it to mount the host volume use the
:Z mount option.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#2360 

#### Why is this change necessary?
To allow Linux users with SELinux enabled to mount host volumes in SAM local invoke docker containers.

#### How does it address the issue?
If SELinux is not enabled, nothing is changed for the end user. If SELinux is enabled we add the `:Z` mount option to allow the host volume mount to proceed with the proper context.

#### What side effects does this change have?
N/A

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
