### PR TITLE
Ensure the ArtifactsLoggingBucket denies non ssl requests

### DIFF
--- a/samcli/lib/pipeline/bootstrap/environment_resources.yaml
+++ b/samcli/lib/pipeline/bootstrap/environment_resources.yaml
@@ -199,15 +199,15 @@ Resources:
     Type: AWS::S3::BucketPolicy
     Condition: MissingArtifactsBucket
     Properties:
-      Bucket: !Ref ArtifactsBucket
+      Bucket: !Ref ArtifactsLoggingBucket
       PolicyDocument:
         Statement:
           - Effect: "Deny"
             Action: "s3:*"
             Principal: "*"
             Resource:
-              - !Join [ '',[ !GetAtt ArtifactsBucket.Arn, '/*' ] ]
-              - !GetAtt ArtifactsBucket.Arn
+              - !Join [ '',[ !GetAtt ArtifactsLoggingBucket.Arn, '/*' ] ]
+              - !GetAtt ArtifactsLoggingBucket.Arn
             Condition:
               Bool:
                 aws:SecureTransport: false


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#1713 

#### Why is this change necessary?
Fix a typo that caused the ArtifactsLoggingBucketPolicy policy to be assigned to the Artifacts Bucket instead of ArtifactsLogging Bucket

#### How does it address the issue?
Corrects the typo in the "Bucket" CFN property

#### What side effects does this change have?
Ensuring the ArtifactsLoggingBucketPolicy denies non ssl requests

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
