### PR TITLE
let pipeline IAM user assume only IAM roles tagged with Role=pipeline…

### DIFF
--- a/samcli/lib/pipeline/bootstrap/environment_resources.yaml
+++ b/samcli/lib/pipeline/bootstrap/environment_resources.yaml
@@ -45,6 +45,9 @@ Resources:
                 Action:
                   - "sts:AssumeRole"
                 Resource: "*"
+                Condition:
+                  StringEquals:
+                    aws:ResourceTag/Role: pipeline-execution-role
               - Fn::If:
                 - HasPipelineIpRange
                 - Effect: Deny
@@ -95,6 +98,8 @@ Resources:
       Tags:
         - Key: ManagedStackSource
           Value: AwsSamCli
+        - Key: Role
+          Value: pipeline-execution-role
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#1713 
#### Why is this change necessary?
To limit the ability of the pipeline IAM user to only assume PipelineExecutionRole IAM roles
#### How does it address the issue?
By adding a condition to the pipeline IAM user's AssumeRoles policy that the assumed resource must have a tag Role=pipeline-execution-role
#### What side effects does this change have?
N/A
#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
