### PR TITLE
Add :Z to fix selinux labels

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -124,7 +124,7 @@ class Container:
         _volumes = {}
 
         if self._host_dir:
-            LOG.info("Mounting %s as %s:ro,delegated inside runtime container", self._host_dir, self._working_dir)
+            LOG.info("Mounting %s as %s:ro,delegated,Z inside runtime container", self._host_dir, self._working_dir)
 
             _volumes = {
                 self._host_dir: {
@@ -132,7 +132,7 @@ class Container:
                     # https://docs.docker.com/storage/bind-mounts
                     # Mount the host directory as "read only" inside container
                     "bind": self._working_dir,
-                    "mode": "ro,delegated",
+                    "mode": "ro,delegated,Z",
                 }
             }
 

--- a/samcli/local/docker/lambda_build_container.py
+++ b/samcli/local/docker/lambda_build_container.py
@@ -84,7 +84,7 @@ class LambdaBuildContainer(Container):
         additional_volumes = {
             # Manifest is mounted separately in order to support the case where manifest
             # is outside of source directory
-            manifest_dir: {"bind": container_dirs["manifest_dir"], "mode": "ro"}
+            manifest_dir: {"bind": container_dirs["manifest_dir"], "mode": "ro,Z"}
         }
 
         if log_level:

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -30,7 +30,7 @@ class LambdaContainer(Container):
     _DEBUG_ENTRYPOINT_OPTIONS = {"delvePath": _DEFAULT_CONTAINER_DBG_GO_PATH}
 
     # This is the dictionary that represents where the debugger_path arg is mounted in docker to as readonly.
-    _DEBUGGER_VOLUME_MOUNT = {"bind": _DEBUGGER_VOLUME_MOUNT_PATH, "mode": "ro"}
+    _DEBUGGER_VOLUME_MOUNT = {"bind": _DEBUGGER_VOLUME_MOUNT_PATH, "mode": "ro,Z"}
 
     def __init__(
         self,  # pylint: disable=R0914

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -80,7 +80,7 @@ class TestContainer_create(TestCase):
         :return:
         """
 
-        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
+        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated,Z"}}
         generated_id = "fooobar"
         self.mock_docker_client.containers.create.return_value = Mock()
         self.mock_docker_client.containers.create.return_value.id = generated_id
@@ -119,7 +119,7 @@ class TestContainer_create(TestCase):
         """
 
         expected_volumes = {
-            self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"},
+            self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated,Z"},
             "/somepath": {"blah": "blah value"},
         }
         expected_memory = "{}m".format(self.memory_mb)
@@ -178,7 +178,7 @@ class TestContainer_create(TestCase):
         additional_volumes = {"C:\\Users\\Username\\AppData\\Local\\Temp\\tmp1338": {"blah": "blah value"}}
 
         translated_volumes = {
-            "/c/Users/Username/AppData/Local/Temp/tmp1337": {"bind": self.working_dir, "mode": "ro,delegated"}
+            "/c/Users/Username/AppData/Local/Temp/tmp1337": {"bind": self.working_dir, "mode": "ro,delegated,Z"}
         }
 
         translated_additional_volumes = {"/c/Users/Username/AppData/Local/Temp/tmp1338": {"blah": "blah value"}}
@@ -231,7 +231,7 @@ class TestContainer_create(TestCase):
         Create a container with only required values. Optional values are not provided
         :return:
         """
-        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
+        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated,Z"}}
 
         network_id = "some id"
         generated_id = "fooobar"
@@ -269,7 +269,7 @@ class TestContainer_create(TestCase):
         Create a container with only required values. Optional values are not provided
         :return:
         """
-        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
+        expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated,Z"}}
 
         network_id = "host"
         generated_id = "fooobar"

--- a/tests/unit/local/docker/test_lambda_build_container.py
+++ b/tests/unit/local/docker/test_lambda_build_container.py
@@ -53,7 +53,7 @@ class TestLambdaBuildContainer_init(TestCase):
         self.assertEqual(container._env_vars, {"LAMBDA_BUILDERS_LOG_LEVEL": "log-level"})
         self.assertEqual(
             container._additional_volumes,
-            {str(pathlib.Path("/bar").resolve()): {"bind": container_dirs["manifest_dir"], "mode": "ro"}},
+            {str(pathlib.Path("/bar").resolve()): {"bind": container_dirs["manifest_dir"], "mode": "ro,Z"}},
         )
 
         self.assertEqual(container._exposed_ports, None)

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -583,7 +583,7 @@ class TestLambdaContainer_get_additional_volumes(TestCase):
     @parameterized.expand([param(r) for r in RUNTIMES_WITH_ENTRYPOINT if r.startswith("go")])
     def test_additional_volumes_returns_volume_with_debugger_path_is_set(self, runtime):
         expected = {
-            "/somepath": {"bind": "/tmp/lambci_debug_files", "mode": "ro"},
+            "/somepath": {"bind": "/tmp/lambci_debug_files", "mode": "ro,Z"},
         }
 
         debug_options = DebugContext(debug_ports=[1234], debugger_path="/somepath")


### PR DESCRIPTION
Might be duplicate of #2970 

#### Which issue(s) does this change fix?

Issue #2360 

#### Why is this change necessary?
When docker is used in an SELinux environment the container can't access files from a bind mounted volume without the proper labels. 

#### How does it address the issue?
By adding :Z to the volume options docker automatically sets the right labels.

#### What side effects does this change have?
None that I know of, this is compatible with docker machine on MacOS.

#### Checklist

- ~Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods~
- ~Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))~
- ~Write unit tests~
- [x] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- ~`make update-reproducible-reqs` if dependencies were changed~
- ~Write documentation~

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).