### PR TITLE
Adding AWS_ prefix to displayed out.

### DIFF
--- a/samcli/lib/pipeline/bootstrap/environment.py
+++ b/samcli/lib/pipeline/bootstrap/environment.py
@@ -297,8 +297,8 @@ class Environment:
                     "make sure to periodically rotate it:",
                 )
             )
-            click.secho(self.color.green(f"\tACCESS_KEY_ID: {self.pipeline_user.access_key_id}"))
-            click.secho(self.color.green(f"\tSECRET_ACCESS_KEY: {self.pipeline_user.secret_access_key}"))
+            click.secho(self.color.green(f"\tAWS_ACCESS_KEY_ID: {self.pipeline_user.access_key_id}"))
+            click.secho(self.color.green(f"\tAWS_SECRET_ACCESS_KEY: {self.pipeline_user.secret_access_key}"))
 
     def _get_stack_name(self) -> str:
         sanitized_environment_name: str = re.sub("[^0-9a-zA-Z]+", "-", self.name)

--- a/tests/unit/lib/pipeline/bootstrap/test_environment.py
+++ b/tests/unit/lib/pipeline/bootstrap/test_environment.py
@@ -351,14 +351,14 @@ class TestEnvironment(TestCase):
             name=ANY_ENVIRONMENT_NAME, pipeline_user_arn=ANY_PIPELINE_USER_ARN
         )
         environment_with_provided_pipeline_user.print_resources_summary()
-        self.assert_summary_does_not_have_a_message_like("ACCESS_KEY_ID", click_mock.secho)
-        self.assert_summary_does_not_have_a_message_like("SECRET_ACCESS_KEY", click_mock.secho)
+        self.assert_summary_does_not_have_a_message_like("AWS_ACCESS_KEY_ID", click_mock.secho)
+        self.assert_summary_does_not_have_a_message_like("AWS_SECRET_ACCESS_KEY", click_mock.secho)
         click_mock.secho.reset_mock()
 
         environment_without_provided_pipeline_user: Environment = Environment(name=ANY_ENVIRONMENT_NAME)
         environment_without_provided_pipeline_user.print_resources_summary()
-        self.assert_summary_has_a_message_like("ACCESS_KEY_ID", click_mock.secho)
-        self.assert_summary_has_a_message_like("SECRET_ACCESS_KEY", click_mock.secho)
+        self.assert_summary_has_a_message_like("AWS_ACCESS_KEY_ID", click_mock.secho)
+        self.assert_summary_has_a_message_like("AWS_SECRET_ACCESS_KEY", click_mock.secho)
 
     def assert_summary_has_a_message_like(self, msg, click_secho_mock):
         self.assertTrue(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
This change is maintaining consistency with AWS environment variable names.

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
