### PR TITLE
List detected env names in pipeline init when prompt to input the env name

### DIFF
--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -111,7 +111,7 @@ def _load_pipeline_bootstrap_context() -> Dict:
     environment_names_message = (
         "Here are the environment names detected "
         + f"in {os.path.join(PIPELINE_CONFIG_DIR, PIPELINE_CONFIG_FILENAME)}:\n"
-        + "\n".join([f"- {env_name}" for env_name in env_names])
+        + "\n".join([f"\t- {env_name}" for env_name in env_names])
     )
     context[str(["environment_names_message"])] = environment_names_message
 

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -96,10 +96,24 @@ def _load_pipeline_bootstrap_context() -> Dict:
 
     config = SamConfig(PIPELINE_CONFIG_DIR, PIPELINE_CONFIG_FILENAME)
     if not config.exists():
+        context[str(["environment_names_message"])] = ""
         return context
-    for env in config.get_env_names():
+
+    # config.get_env_names() will return the list of
+    # bootstrapped env names and "default" which is used to store shared values
+    # we don't want to include "default" here.
+    env_names = [env_name for env_name in config.get_env_names() if env_name != "default"]
+    for env in env_names:
         for key, value in config.get_all(bootstrap_command_names, section, env).items():
             context[str([env, key])] = value
+
+    # pre-load the list of env names detected from pipelineconfig.toml
+    environment_names_message = (
+        "Here are the environment names detected "
+        + f"in {os.path.join(PIPELINE_CONFIG_DIR, PIPELINE_CONFIG_FILENAME)}:\n"
+        + "\n".join([f"- {env_name}" for env_name in env_names])
+    )
+    context[str(["environment_names_message"])] = environment_names_message
 
     return context
 

--- a/samcli/lib/cookiecutter/question.py
+++ b/samcli/lib/cookiecutter/question.py
@@ -191,7 +191,7 @@ class Question:
 
     def _resolve_text(self, context: Optional[Dict] = None) -> str:
         resolved_text = self._resolve_value_from_expression(self._text, context)
-        if not resolved_text:
+        if resolved_text is None:
             raise ValueError(f"Cannot resolve value from expression: {self._text}")
         return str(resolved_text)
 

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -172,7 +172,7 @@ class TestInteractiveInitFlow(TestCase):
                 str(["testing", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["prod", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["environment_names_message"]): "Here are the environment names detected "
-                "in .aws-sam/pipeline/pipelineconfig.toml:\n- testing\n- prod",
+                "in .aws-sam/pipeline/pipelineconfig.toml:\n\t- testing\n\t- prod",
             }
         )
         cookiecutter_mock.assert_called_once_with(

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -171,6 +171,8 @@ class TestInteractiveInitFlow(TestCase):
             {
                 str(["testing", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["prod", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
+                str(["environment_names_message"]): "Here are the environment names detected "
+                "in .aws-sam/pipeline/pipelineconfig.toml:\n- testing\n- prod",
             }
         )
         cookiecutter_mock.assert_called_once_with(

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -172,7 +172,7 @@ class TestInteractiveInitFlow(TestCase):
                 str(["testing", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["prod", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["environment_names_message"]): "Here are the environment names detected "
-                "in .aws-sam/pipeline/pipelineconfig.toml:\n\t- testing\n\t- prod",
+                f'in {os.path.join(".aws-sam", "pipeline", "pipelineconfig.toml")}:\n\t- testing\n\t- prod',
             }
         )
         cookiecutter_mock.assert_called_once_with(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?

**Template diff:**

```diff
diff --git a/GitHub-Actions/two-environment-pipeline-template/questions.json b/GitHub-Actions/two-environment-pipeline-template/questions.json
index 6133a8c..bc25eaf 100644
--- a/GitHub-Actions/two-environment-pipeline-template/questions.json
+++ b/GitHub-Actions/two-environment-pipeline-template/questions.json
@@ -15,6 +15,12 @@
     "key": "sam_template",
     "question": "What is the template file path?",
     "default": "template.yaml"
+  }, {
+    "key": "message_list_environment_names_testing",
+    "question": {
+      "keyPath": ["environment_names_message"]
+    },
+    "kind": "info"
   }, {
     "key": "message_testing_environment_name",
     "question": "We use the environment name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`",
@@ -76,6 +82,12 @@
           "region"
       ]
     }
+  }, {
+    "key": "message_list_environment_names_prod",
+    "question": {
+      "keyPath": ["environment_names_message"]
+    },
+    "kind": "info"
   }, {
     "key": "prod_environment_name",
     "question": "What is the production environment name (as provided during the bootstrapping)?",
```

**UX diff:**

```diff
samdev pipeline init                                                                                                                                          ✘ 1 
Which pipeline template source would you like to use?
        1 - AWS Quick Start Pipeline Templates
        2 - Custom Pipeline Template Location
Choice []: 2
Template Git location: /Users/xinhol/Projects/aws-sam-cli-pipeline-init-templates/GitHub-Actions/two-environment-pipeline-template
What is the GitHub Secret name for pipeline user account access key id? [AWS_ACCESS_KEY_ID]: 
What is the GitHub Secret name for pipeline user account access key secret? [AWS_SECRET_ACCESS_KEY]: 
What is the git branch used for production deployments? [main]: 
What is the template file path? [template.yaml]: 
+ Here are the environment names detected in .aws-sam/pipeline/pipelineconfig.toml:
+ - 20210628
+ - 20210628-2
We use the environment name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`
What is the testing environment name (as provided during the bootstrapping)?: 20210628
What is the testing stack name?: test
What is the testing pipeline execution role ARN? [arn:aws:iam::916108123774:role/aws-sam-cli-managed-20210628-PipelineExecutionRole-BX43A50MRGD]: 
What is the testing CloudFormation execution role ARN? [arn:aws:iam::916108123774:role/aws-sam-cli-managed-20210-CloudFormationExecutionR-1XU2JJLG5G96C]: 
What is the testing S3 bucket name for artifacts? [aws-sam-cli-managed-20210628-pipe-artifactsbucket-1j7bzybfgkpor]: 
What is the testing ECR repository URI? []: 
What is the testing AWS region? [us-east-1]: 
+ Here are the environment names detected in .aws-sam/pipeline/pipelineconfig.toml:
+ - 20210628
+ - 20210628-2
What is the production environment name (as provided during the bootstrapping)?: 20210628-2
What is the production stack name?: prod
What is the production pipeline execution role ARN? [arn:aws:iam::916108123774:role/aws-sam-cli-managed-20210628-PipelineExecutionRole-BX43A50MRGD]: 
What is the production CloudFormation execution role ARN? [arn:aws:iam::916108123774:role/aws-sam-cli-managed-20210-CloudFormationExecutionR-1XU2JJLG5G96C]:
```

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
