### PR TITLE
fix: Skip image-repository validation of ECR images (#2934)

### DIFF
--- a/samcli/commands/_utils/parameters.py
+++ b/samcli/commands/_utils/parameters.py
@@ -1,6 +1,13 @@
+"""
+Template parameters utilities shared by various commands
+"""
+
 from typing import Dict, Union, Optional
 
-def sanitize_parameter_overrides(parameter_overrides: Dict[str, Union[Dict[str, str], str]]) -> Dict[str, Optional[str]]:
+
+def sanitize_parameter_overrides(
+    parameter_overrides: Dict[str, Union[Dict[str, str], str]]
+) -> Dict[str, Optional[str]]:
     """
     Get sanitized parameter override values based on if the workflow went via a guided deploy to set the
     parameter overrides for deployment. If a guided deploy was followed the parameter overrides consists

--- a/samcli/commands/_utils/parameters.py
+++ b/samcli/commands/_utils/parameters.py
@@ -1,0 +1,12 @@
+import copy
+from typing import Dict, Union, Optional
+
+def sanitize_parameter_overrides(parameter_overrides: Dict[str, Union[Dict[str, str], str]]) -> Dict[str, Optional[str]]:
+    """
+    Get sanitized parameter override values based on if the workflow went via a guided deploy to set the
+    parameter overrides for deployment. If a guided deploy was followed the parameter overrides consists
+    of additional information such as if a given parameter's value is hidden or not.
+    :param parameter_overrides: dictionary of parameter key values.
+    :return:
+    """
+    return {key: value.get("Value") if isinstance(value, dict) else value for key, value in parameter_overrides.items()}

--- a/samcli/commands/_utils/parameters.py
+++ b/samcli/commands/_utils/parameters.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Dict, Union, Optional
 
 def sanitize_parameter_overrides(parameter_overrides: Dict[str, Union[Dict[str, str], str]]) -> Dict[str, Optional[str]]:

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -20,7 +20,7 @@ from samcli.commands._utils.options import (
     signing_profiles_option,
     image_repositories_callback,
 )
-from samcli.commands.deploy.utils import sanitize_parameter_overrides
+from samcli.commands._utils.parameters import sanitize_parameter_overrides
 from samcli.lib.telemetry.metric import track_command
 from samcli.lib.cli_validation.image_repository_validation import image_repository_validation
 from samcli.lib.utils import osutils

--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -24,8 +24,8 @@ import click
 
 from samcli.commands.deploy import exceptions as deploy_exceptions
 from samcli.commands.deploy.auth_utils import auth_per_resource
+from samcli.commands._utils.parameters import sanitize_parameter_overrides
 from samcli.commands.deploy.utils import (
-    sanitize_parameter_overrides,
     print_deploy_args,
     hide_noecho_parameter_overrides,
 )

--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -22,7 +22,7 @@ from samcli.commands.deploy.code_signer_utils import (
 )
 from samcli.commands.deploy.exceptions import GuidedDeployFailedError
 from samcli.commands.deploy.guided_config import GuidedConfig
-from samcli.commands.deploy.utils import sanitize_parameter_overrides
+from samcli.commands._utils.parameters import sanitize_parameter_overrides
 from samcli.lib.bootstrap.bootstrap import manage_stack
 from samcli.lib.config.samconfig import DEFAULT_ENV, DEFAULT_CONFIG_FILE_NAME
 from samcli.lib.intrinsic_resolver.intrinsics_symbol_table import IntrinsicsSymbolTable

--- a/samcli/commands/deploy/utils.py
+++ b/samcli/commands/deploy/utils.py
@@ -77,17 +77,6 @@ def print_deploy_args(
     click.secho("\nInitiating deployment\n=====================", fg="yellow")
 
 
-def sanitize_parameter_overrides(parameter_overrides):
-    """
-    Get sanitized parameter override values based on if the workflow went via a guided deploy to set the
-    parameter overrides for deployment. If a guided deploy was followed the parameter overrides consists
-    of additional information such as if a given parameter's value is hidden or not.
-    :param parameter_overrides: dictionary of parameter key values.
-    :return:
-    """
-    return {key: value.get("Value") if isinstance(value, dict) else value for key, value in parameter_overrides.items()}
-
-
 def hide_noecho_parameter_overrides(template_parameters, parameter_overrides):
     hidden_params = copy.deepcopy(parameter_overrides)
     params = template_parameters.get("Parameters", None)

--- a/samcli/lib/cli_validation/image_repository_validation.py
+++ b/samcli/lib/cli_validation/image_repository_validation.py
@@ -9,7 +9,7 @@ from samcli.lib.utils.packagetype import IMAGE
 from samcli.lib.providers.sam_stack_provider import SamLocalStackProvider
 from samcli.lib.providers.sam_function_provider import SamFunctionProvider
 from samcli.lib.intrinsic_resolver.intrinsics_symbol_table import IntrinsicsSymbolTable
-from samcli.commands.deploy.utils import sanitize_parameter_overrides
+from samcli.commands._utils.parameters import sanitize_parameter_overrides
 from samcli.cli.context import Context
 
 

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -144,8 +144,10 @@ class SamFunctionProvider(SamBaseProvider):
                             SamFunctionProvider._warn_code_extraction(resource_type, name, code_property_key)
                         continue
 
-                    if resource_package_type == IMAGE and SamBaseProvider._is_ecr_uri(
-                        resource_properties.get(image_property_key)
+                    if (
+                        resource_package_type == IMAGE
+                        and ("DockerContext" not in (resource_metadata or {}))
+                        and SamBaseProvider._is_ecr_uri(resource_properties.get(image_property_key))
                     ):
                         # ImageUri can be an ECR uri, which is not supported
                         if not ignore_code_extraction_warnings:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

Issue #2934

#### Why is this change necessary?

- Fix/Resolve the `image_repository_validation` for Docker-packaged lambda functions with valid ECR locations (Issue #2934, introduced in PR #2935);
- Remove Docker-packaged lambda functions with valid ECR locations from the `--guided` guided context prompts.
- Check for `DockerContext` resource metadata prior to skipping the image build.

#### How does it address the issue?

- Instead of resolving packageable Image functions from the raw template file(s) (`get_template_function_resource_ids`, `get_template_artifacts_format`), use the `SamFunctionProvider` to do so (evaluating template parameters values, so the template must go through the IntrinsicResolver).

#### What side effects does this change have?

- `get_template_function_resource_ids`, `get_template_artifacts_format` are obsolete (not yet deleted from the repo);

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
