### PR TITLE
Adding account condition for CFN execution role.

### DIFF
--- a/samcli/lib/pipeline/bootstrap/environment.py
+++ b/samcli/lib/pipeline/bootstrap/environment.py
@@ -11,7 +11,6 @@ import click
 from samcli.lib.config.samconfig import SamConfig
 from samcli.lib.utils.colors import Colored
 from samcli.lib.utils.managed_cloudformation_stack import manage_stack, StackOutput
-from samcli.lib.utils.botoconfig import get_boto_config_with_user_agent
 from samcli.lib.pipeline.bootstrap.resource import Resource, IAMUser, ECRImageRepository
 
 CFN_TEMPLATE_PATH = str(pathlib.Path(os.path.dirname(__file__)))
@@ -182,7 +181,9 @@ class Environment:
             (
                 self.pipeline_user.access_key_id,
                 self.pipeline_user.secret_access_key,
-            ) = Environment._get_pipeline_user_secret_pair(pipeline_user_secret_sm_id)
+            ) = Environment._get_pipeline_user_secret_pair(
+                pipeline_user_secret_sm_id, self.aws_profile, self.aws_region
+            )
         self.pipeline_execution_role.arn = output.get("PipelineExecutionRole")
         self.cloudformation_execution_role.arn = output.get("CloudFormationExecutionRole")
         self.artifacts_bucket.arn = output.get("ArtifactsBucket")
@@ -190,7 +191,9 @@ class Environment:
         return True
 
     @staticmethod
-    def _get_pipeline_user_secret_pair(secret_manager_arn: str) -> Tuple[str, str]:
+    def _get_pipeline_user_secret_pair(
+        secret_manager_arn: str, profile: Optional[str], region: Optional[str]
+    ) -> Tuple[str, str]:
         """
         Helper method to fetch pipeline user's AWS Credentials from secrets manager.
         SecretString need to be in following JSON format:
@@ -202,12 +205,16 @@ class Environment:
         ----------
         secret_manager_arn:
             ARN of secret manager entry which holds pipeline user key.
+        profile:
+            The named AWS profile (in user's machine) of the AWS account to deploy this environment to.
+        region:
+            The AWS region to deploy this environment to.
 
         Returns tuple of aws_access_key_id and aws_secret_access_key.
 
         """
-        boto_config = get_boto_config_with_user_agent()
-        secrets_manager_client = boto3.client("secretsmanager", config=boto_config)
+        session = boto3.Session(profile_name=profile, region_name=region if region else None)  # type: ignore
+        secrets_manager_client = session.client("secretsmanager")
         response = secrets_manager_client.get_secret_value(SecretId=secret_manager_arn)
         secret_string = response["SecretString"]
         secret_json = json.loads(secret_string)

--- a/samcli/lib/pipeline/bootstrap/environment_resources.yaml
+++ b/samcli/lib/pipeline/bootstrap/environment_resources.yaml
@@ -88,6 +88,9 @@ Resources:
               Service: cloudformation.amazonaws.com
             Action:
               - 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
       Policies:
         - PolicyName: GrantCloudFormationFullAccess
           PolicyDocument:

--- a/tests/unit/lib/pipeline/bootstrap/test_environment.py
+++ b/tests/unit/lib/pipeline/bootstrap/test_environment.py
@@ -299,9 +299,11 @@ class TestEnvironment(TestCase):
         sm_client_mock.get_secret_value.return_value = {
             "SecretString": '{"aws_access_key_id": "AccessKeyId", "aws_secret_access_key": "SuperSecretKey"}'
         }
-        boto3_mock.client.return_value = sm_client_mock
+        session_mock = MagicMock()
+        session_mock.client.return_value = sm_client_mock
+        boto3_mock.Session.return_value = session_mock
 
-        (key, secret) = Environment._get_pipeline_user_secret_pair("dummy_arn")
+        (key, secret) = Environment._get_pipeline_user_secret_pair("dummy_arn", None, "dummy-region")
         self.assertEqual(key, "AccessKeyId")
         self.assertEqual(secret, "SuperSecretKey")
         sm_client_mock.get_secret_value.assert_called_once_with(SecretId="dummy_arn")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
Adding condition so that Cloudformation execution role can only be assumed by CFN from one account.

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
