### PR TITLE
Fix pipeline init integ test because of pipelineconfig file exists

### DIFF
--- a/tests/integration/pipeline/test_init_command.py
+++ b/tests/integration/pipeline/test_init_command.py
@@ -46,6 +46,10 @@ class TestInit(InitIntegBase):
         if pipelineconfig_file.exists():
             pipelineconfig_file.unlink()
 
+    def tearDown(self) -> None:
+        super().tearDown()
+        shutil.rmtree(PIPELINE_CONFIG_DIR, ignore_errors=True)
+
     def test_quick_start(self):
         generated_jenkinsfile_path = Path("Jenkinsfile")
         self.generated_files.append(generated_jenkinsfile_path)
@@ -96,6 +100,7 @@ class TestInit(InitIntegBase):
         generated_jenkinsfile_path = Path("Jenkinsfile")
         self.generated_files.append(generated_jenkinsfile_path)
 
+        Path(PIPELINE_CONFIG_DIR).mkdir(parents=True, exist_ok=True)
         pipelineconfig_path = Path(PIPELINE_CONFIG_DIR, PIPELINE_CONFIG_FILENAME)
         with open(pipelineconfig_path, "w") as f:
             f.write(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
