### PR TITLE
chore: Update Ruby build integ test to reflect new lambda-builder beh…

### DIFF
--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1143,8 +1143,8 @@ class TestBuildWithBuildMethod(BuildIntegBase):
         LOG.info("Running Command: {}".format(cmdlist))
         # This will error out.
         command = run_command(cmdlist, cwd=self.working_dir)
-        self.assertEqual(command.process.returncode, 1)
-        self.assertEqual(command.stdout.strip(), b"Build Failed")
+        self.assertEqual(command.process.returncode, 0)
+        self.assertEqual(command.stdout.strip(), b"Continuing the build without dependencies")
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files):
 


### PR DESCRIPTION
…avior

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

Since https://github.com/aws/aws-lambda-builders/pull/245, this integ test no longer expects build to fail

#### How does it address the issue?

Update the exit code and error message

#### What side effects does this change have?

Test only change

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
