### PR TITLE
Normalise headers dictionary keys: fixes issues 1860, 3083 etc.

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -833,8 +833,8 @@ class LocalApigwService(BaseLocalService):
         # Multi-value request headers is not really supported by Flask.
         # See https://github.com/pallets/flask/issues/850
         for header_key in flask_request.headers.keys():
-            headers_dict[header_key] = flask_request.headers.get(header_key)
-            multi_value_headers_dict[header_key] = flask_request.headers.getlist(
+            headers_dict[header_key.lower()] = flask_request.headers.get(header_key)
+            multi_value_headers_dict[header_key.lower()] = flask_request.headers.getlist(
                 header_key)
 
         headers_dict["X-Forwarded-Proto"] = flask_request.scheme

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -833,15 +833,16 @@ class LocalApigwService(BaseLocalService):
         # Multi-value request headers is not really supported by Flask.
         # See https://github.com/pallets/flask/issues/850
         for header_key in flask_request.headers.keys():
-            headers_dict[header_key.lower()] = flask_request.headers.get(header_key)
+            headers_dict[header_key.lower()] = flask_request.headers.get(
+                header_key)
             multi_value_headers_dict[header_key.lower()] = flask_request.headers.getlist(
                 header_key)
 
-        headers_dict["X-Forwarded-Proto"] = flask_request.scheme
-        multi_value_headers_dict["X-Forwarded-Proto"] = [flask_request.scheme]
+        headers_dict["x-forwarded-proto"] = flask_request.scheme
+        multi_value_headers_dict["x-forwarded-proto"] = [flask_request.scheme]
 
-        headers_dict["X-Forwarded-Port"] = str(port)
-        multi_value_headers_dict["X-Forwarded-Port"] = [str(port)]
+        headers_dict["x-forwarded-port"] = str(port)
+        multi_value_headers_dict["x-forwarded-port"] = [str(port)]
         return headers_dict, multi_value_headers_dict
 
     @staticmethod
@@ -890,8 +891,8 @@ class LocalApigwService(BaseLocalService):
         for header_key in flask_request.headers.keys():
             headers[header_key.lower()] = flask_request.headers.get(header_key)
 
-        headers["X-Forwarded-Proto"] = flask_request.scheme
-        headers["X-Forwarded-Port"] = str(port)
+        headers["x-forwarded-proto"] = flask_request.scheme
+        headers["x-forwarded-port"] = str(port)
         return headers
 
     @staticmethod

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -37,7 +37,8 @@ class TestParallelRequests(StartApiIntegBaseClass):
         start_time = time()
         with ThreadPoolExecutor(number_of_requests) as thread_pool:
             futures = [
-                thread_pool.submit(requests.get, self.url + "/sleepfortenseconds/function1", timeout=300)
+                thread_pool.submit(requests.get, self.url +
+                                   "/sleepfortenseconds/function1", timeout=300)
                 for _ in range(0, number_of_requests)
             ]
             results = [r.result() for r in as_completed(futures)]
@@ -49,7 +50,8 @@ class TestParallelRequests(StartApiIntegBaseClass):
 
             for result in results:
                 self.assertEqual(result.status_code, 200)
-                self.assertEqual(result.json(), {"message": "HelloWorld! I just slept and waking up."})
+                self.assertEqual(
+                    result.json(), {"message": "HelloWorld! I just slept and waking up."})
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -61,7 +63,8 @@ class TestParallelRequests(StartApiIntegBaseClass):
         number_of_requests = 10
         start_time = time()
         with ThreadPoolExecutor(10) as thread_pool:
-            test_url_paths = ["/sleepfortenseconds/function0", "/sleepfortenseconds/function1"]
+            test_url_paths = ["/sleepfortenseconds/function0",
+                              "/sleepfortenseconds/function1"]
 
             futures = [
                 thread_pool.submit(
@@ -78,7 +81,8 @@ class TestParallelRequests(StartApiIntegBaseClass):
 
             for result in results:
                 self.assertEqual(result.status_code, 200)
-                self.assertEqual(result.json(), {"message": "HelloWorld! I just slept and waking up."})
+                self.assertEqual(
+                    result.json(), {"message": "HelloWorld! I just slept and waking up."})
 
 
 class TestServiceErrorResponses(StartApiIntegBaseClass):
@@ -98,12 +102,14 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
         response = requests.get(self.url + "/id", timeout=300)
 
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json(), {"message": "Missing Authentication Token"})
+        self.assertEqual(response.json(), {
+                         "message": "Missing Authentication Token"})
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_invalid_response_from_lambda(self):
-        response = requests.get(self.url + "/invalidresponsereturned", timeout=300)
+        response = requests.get(
+            self.url + "/invalidresponsereturned", timeout=300)
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
@@ -143,7 +149,8 @@ class TestService(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_calling_proxy_endpoint(self):
-        response = requests.get(self.url + "/proxypath/this/is/some/path", timeout=300)
+        response = requests.get(
+            self.url + "/proxypath/this/is/some/path", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -229,7 +236,8 @@ class TestService(StartApiIntegBaseClass):
         # not exact 6 mega, as local start-api sends extra data with the input data
         around_six_mega = 6 * 1024 * 1024 - 2 * 1024
         data = "a" * around_six_mega
-        response = requests.post(self.url + "/echoeventbody", data=data, timeout=300)
+        response = requests.post(
+            self.url + "/echoeventbody", data=data, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
@@ -257,7 +265,8 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_calling_proxy_endpoint(self):
-        response = requests.get(self.url + "/proxypath/this/is/some/path", timeout=300)
+        response = requests.get(
+            self.url + "/proxypath/this/is/some/path", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -354,7 +363,8 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
         """
         Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.get(self.url + "/invalidv1responsehash", timeout=300)
+        response = requests.get(
+            self.url + "/invalidv1responsehash", timeout=300)
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
@@ -365,7 +375,8 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
         """
         Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.get(self.url + "/validv2responsestring", timeout=300)
+        response = requests.get(
+            self.url + "/validv2responsestring", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "This is invalid")
@@ -376,7 +387,8 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
         """
         Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.get(self.url + "/validv2responseinteger", timeout=300)
+        response = requests.get(
+            self.url + "/validv2responseinteger", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "2")
@@ -398,7 +410,8 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
         """
         Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.get(self.url + "/invalidv1responsestring", timeout=300)
+        response = requests.get(
+            self.url + "/invalidv1responsestring", timeout=300)
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
@@ -492,12 +505,14 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         response = requests.get(self.url + "/nofunctionfound", timeout=300)
 
         self.assertEqual(response.status_code, 502)
-        self.assertEqual(response.json(), {"message": "No function defined for resource method"})
+        self.assertEqual(response.json(), {
+                         "message": "No function defined for resource method"})
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_with_no_api_event_is_reachable(self):
-        response = requests.get(self.url + "/functionwithnoapievent", timeout=300)
+        response = requests.get(
+            self.url + "/functionwithnoapievent", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -505,7 +520,8 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
-        response = requests.get(self.url + "/nonserverlessfunction", timeout=300)
+        response = requests.get(
+            self.url + "/nonserverlessfunction", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -545,9 +561,11 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Binary data is returned correctly
         """
-        expected = base64.b64encode(self.get_binary_data(self.binary_data_file))
+        expected = base64.b64encode(
+            self.get_binary_data(self.binary_data_file))
 
-        response = requests.get(self.url + "/nondecodedbase64response", timeout=300)
+        response = requests.get(
+            self.url + "/nondecodedbase64response", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
@@ -561,7 +579,8 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         expected = self.get_binary_data(self.binary_data_file)
 
-        response = requests.get(self.url + "/decodedbase64responsebas64encoded", timeout=300)
+        response = requests.get(
+            self.url + "/decodedbase64responsebas64encoded", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
@@ -573,9 +592,11 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Binary data is returned correctly
         """
-        expected = base64.b64encode(self.get_binary_data(self.binary_data_file))
+        expected = base64.b64encode(
+            self.get_binary_data(self.binary_data_file))
 
-        response = requests.get(self.url + "/decodedbase64responsebas64encodedpriority", timeout=300)
+        response = requests.get(
+            self.url + "/decodedbase64responsebas64encodedpriority", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
@@ -606,7 +627,8 @@ class TestStartApiWithSwaggerHttpApis(StartApiIntegBaseClass):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.post(self.url + "/httpapi-anyandall", json={}, timeout=300)
+        response = requests.post(
+            self.url + "/httpapi-anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -617,7 +639,8 @@ class TestStartApiWithSwaggerHttpApis(StartApiIntegBaseClass):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.put(self.url + "/httpapi-anyandall", json={}, timeout=300)
+        response = requests.put(
+            self.url + "/httpapi-anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -638,7 +661,8 @@ class TestStartApiWithSwaggerHttpApis(StartApiIntegBaseClass):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.delete(self.url + "/httpapi-anyandall", timeout=300)
+        response = requests.delete(
+            self.url + "/httpapi-anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -649,7 +673,8 @@ class TestStartApiWithSwaggerHttpApis(StartApiIntegBaseClass):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.options(self.url + "/httpapi-anyandall", timeout=300)
+        response = requests.options(
+            self.url + "/httpapi-anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -753,12 +778,14 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         response = requests.get(self.url + "/nofunctionfound", timeout=300)
 
         self.assertEqual(response.status_code, 502)
-        self.assertEqual(response.json(), {"message": "No function defined for resource method"})
+        self.assertEqual(response.json(), {
+                         "message": "No function defined for resource method"})
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
-        response = requests.get(self.url + "/nonserverlessfunction", timeout=300)
+        response = requests.get(
+            self.url + "/nonserverlessfunction", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -811,16 +838,19 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
-        self.assertEqual(response.headers.get("MyCustomHeader"), "Value1, Value2")
+        self.assertEqual(response.headers.get(
+            "MyCustomHeader"), "Value1, Value2")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_multiple_headers_overrides_headers_response(self):
-        response = requests.get(self.url + "/multipleheadersoverridesheaders", timeout=300)
+        response = requests.get(
+            self.url + "/multipleheadersoverridesheaders", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
-        self.assertEqual(response.headers.get("MyCustomHeader"), "Value1, Value2, Custom")
+        self.assertEqual(response.headers.get(
+            "MyCustomHeader"), "Value1, Value2, Custom")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -846,7 +876,8 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "")
-        self.assertEqual(response.headers.get("Content-Type"), "application/json")
+        self.assertEqual(response.headers.get(
+            "Content-Type"), "application/json")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -961,7 +992,8 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         response_data = response.json()
 
-        self.assertEqual(response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded")
+        self.assertEqual(response_data.get("headers").get(
+            "content-type"), "application/x-www-form-urlencoded")
         self.assertEqual(response_data.get("body"), "key=value")
 
     @pytest.mark.flaky(reruns=3)
@@ -980,17 +1012,20 @@ class TestServiceRequests(StartApiIntegBaseClass):
     def test_request_with_multi_value_headers(self):
         response = requests.get(
             self.url + "/echoeventbody",
-            headers={"Content-Type": "application/x-www-form-urlencoded, image/gif"},
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded, image/gif"},
             timeout=300,
         )
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         self.assertEqual(
-            response_data.get("multiValueHeaders").get("Content-Type"), ["application/x-www-form-urlencoded, image/gif"]
+            response_data.get("multiValueHeaders").get(
+                "Content-Type"), ["application/x-www-form-urlencoded, image/gif"]
         )
         self.assertEqual(
-            response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded, image/gif"
+            response_data.get("headers").get(
+                "content-type"), "application/x-www-form-urlencoded, image/gif"
         )
 
     @pytest.mark.flaky(reruns=3)
@@ -999,14 +1034,17 @@ class TestServiceRequests(StartApiIntegBaseClass):
         """
         Query params given should be put into the Event to Lambda
         """
-        response = requests.get(self.url + "/id/4", params={"key": "value"}, timeout=300)
+        response = requests.get(
+            self.url + "/id/4", params={"key": "value"}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
 
-        self.assertEqual(response_data.get("queryStringParameters"), {"key": "value"})
-        self.assertEqual(response_data.get("multiValueQueryStringParameters"), {"key": ["value"]})
+        self.assertEqual(response_data.get(
+            "queryStringParameters"), {"key": "value"})
+        self.assertEqual(response_data.get(
+            "multiValueQueryStringParameters"), {"key": ["value"]})
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -1014,14 +1052,17 @@ class TestServiceRequests(StartApiIntegBaseClass):
         """
         Query params given should be put into the Event to Lambda
         """
-        response = requests.get(self.url + "/id/4", params={"key": ["value", "value2"]}, timeout=300)
+        response = requests.get(
+            self.url + "/id/4", params={"key": ["value", "value2"]}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
 
-        self.assertEqual(response_data.get("queryStringParameters"), {"key": "value2"})
-        self.assertEqual(response_data.get("multiValueQueryStringParameters"), {"key": ["value", "value2"]})
+        self.assertEqual(response_data.get(
+            "queryStringParameters"), {"key": "value2"})
+        self.assertEqual(response_data.get("multiValueQueryStringParameters"), {
+                         "key": ["value", "value2"]})
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -1049,7 +1090,8 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         response_data = response.json()
 
-        self.assertEqual(response_data.get("pathParameters"), {"id": "4", "user": "jacob"})
+        self.assertEqual(response_data.get("pathParameters"),
+                         {"id": "4", "user": "jacob"})
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -1061,10 +1103,14 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         response_data = response.json()
 
-        self.assertEqual(response_data.get("headers").get("X-Forwarded-Proto"), "http")
-        self.assertEqual(response_data.get("multiValueHeaders").get("X-Forwarded-Proto"), ["http"])
-        self.assertEqual(response_data.get("headers").get("X-Forwarded-Port"), self.port)
-        self.assertEqual(response_data.get("multiValueHeaders").get("X-Forwarded-Port"), [self.port])
+        self.assertEqual(response_data.get(
+            "headers").get("x-forwarded-proto"), "http")
+        self.assertEqual(response_data.get(
+            "multiValueHeaders").get("x-forwarded-proto"), ["http"])
+        self.assertEqual(response_data.get(
+            "headers").get("x-forwarded-port"), self.port)
+        self.assertEqual(response_data.get("multiValueHeaders").get(
+            "x-forwarded-port"), [self.port])
 
 
 class TestStartApiWithStage(StartApiIntegBaseClass):
@@ -1086,7 +1132,8 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
 
         response_data = response.json()
 
-        self.assertEqual(response_data.get("requestContext", {}).get("stage"), "Prod")
+        self.assertEqual(response_data.get(
+            "requestContext", {}).get("stage"), "Prod")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -1097,7 +1144,8 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
 
         response_data = response.json()
 
-        self.assertEqual(response_data.get("stageVariables"), {"VarName": "varValue"})
+        self.assertEqual(response_data.get(
+            "stageVariables"), {"VarName": "varValue"})
 
 
 class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
@@ -1118,7 +1166,8 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
-        self.assertEqual(response_data.get("requestContext", {}).get("stage"), "dev")
+        self.assertEqual(response_data.get(
+            "requestContext", {}).get("stage"), "dev")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -1128,7 +1177,8 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
-        self.assertEqual(response_data.get("stageVariables"), {"VarName": "varValue"})
+        self.assertEqual(response_data.get(
+            "stageVariables"), {"VarName": "varValue"})
 
 
 class TestStartApiWithStageAndSwaggerWithHttpApi(StartApiIntegBaseClass):
@@ -1144,22 +1194,26 @@ class TestStartApiWithStageAndSwaggerWithHttpApi(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_swagger_stage_name_httpapi(self):
-        response = requests.get(self.url + "/httpapi-echoeventbody", timeout=300)
+        response = requests.get(
+            self.url + "/httpapi-echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
-        self.assertEqual(response_data.get("requestContext", {}).get("stage"), "dev-http")
+        self.assertEqual(response_data.get(
+            "requestContext", {}).get("stage"), "dev-http")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_swagger_stage_variable_httpapi(self):
-        response = requests.get(self.url + "/httpapi-echoeventbody", timeout=300)
+        response = requests.get(
+            self.url + "/httpapi-echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
-        self.assertEqual(response_data.get("stageVariables"), {"VarNameHttpApi": "varValueV2"})
+        self.assertEqual(response_data.get("stageVariables"),
+                         {"VarNameHttpApi": "varValueV2"})
 
 
 class TestPayloadVersionWithStageAndSwaggerWithHttpApi(StartApiIntegBaseClass):
@@ -1171,7 +1225,8 @@ class TestPayloadVersionWithStageAndSwaggerWithHttpApi(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_payload_version_v1_swagger_inline_httpapi(self):
-        response = requests.get(self.url + "/httpapi-payload-format-v1", timeout=300)
+        response = requests.get(
+            self.url + "/httpapi-payload-format-v1", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
@@ -1180,7 +1235,8 @@ class TestPayloadVersionWithStageAndSwaggerWithHttpApi(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_payload_version_v2_swagger_inline_httpapi(self):
-        response = requests.get(self.url + "/httpapi-payload-format-v2", timeout=300)
+        response = requests.get(
+            self.url + "/httpapi-payload-format-v2", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
@@ -1189,7 +1245,8 @@ class TestPayloadVersionWithStageAndSwaggerWithHttpApi(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_payload_version_v1_property_httpapi(self):
-        response = requests.get(self.url + "/httpapi-payload-format-v1-property", timeout=300)
+        response = requests.get(
+            self.url + "/httpapi-payload-format-v1-property", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
@@ -1235,14 +1292,19 @@ class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
         """
         This tests that the Cors are added to option requests in the swagger template
         """
-        response = requests.options(self.url + "/echobase64eventbody", timeout=300)
+        response = requests.options(
+            self.url + "/echobase64eventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), "origin, x-requested-with")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), "GET,OPTIONS")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"), "true")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Origin"), "*")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Headers"), "origin, x-requested-with")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Methods"), "GET,OPTIONS")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Credentials"), "true")
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), "510")
 
 
@@ -1263,13 +1325,18 @@ class TestServiceCorsSwaggerRequestsWithHttpApi(StartApiIntegBaseClass):
         """
         This tests that the Cors are added to option requests in the swagger template
         """
-        response = requests.options(self.url + "/httpapi-echobase64eventbody", timeout=300)
+        response = requests.options(
+            self.url + "/httpapi-echobase64eventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), "origin")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), "GET,OPTIONS,POST")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"), "true")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Origin"), "*")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Headers"), "origin")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Methods"), "GET,OPTIONS,POST")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Credentials"), "true")
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), "42")
 
 
@@ -1289,13 +1356,18 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         """
         This tests that the Cors are added to options requests when the global property is set
         """
-        response = requests.options(self.url + "/echobase64eventbody", timeout=300)
+        response = requests.options(
+            self.url + "/echobase64eventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), None)
-        self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), ",".join(sorted(Route.ANY_HTTP_METHODS)))
-        self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"), None)
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Origin"), "*")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Headers"), None)
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Methods"), ",".join(sorted(Route.ANY_HTTP_METHODS)))
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Credentials"), None)
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), None)
 
     @pytest.mark.flaky(reruns=3)
@@ -1308,11 +1380,16 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "")
-        self.assertEqual(response.headers.get("Content-Type"), "application/json")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), None)
-        self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), None)
-        self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), None)
-        self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"), None)
+        self.assertEqual(response.headers.get(
+            "Content-Type"), "application/json")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Origin"), None)
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Headers"), None)
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Methods"), None)
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Credentials"), None)
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), None)
 
 
@@ -1334,7 +1411,8 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
-        self.assertEqual(response_data.get("requestContext", {}).get("stage"), "Dev")
+        self.assertEqual(response_data.get(
+            "requestContext", {}).get("stage"), "Dev")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -1372,7 +1450,8 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.post(self.url + "/root/anyandall", json={}, timeout=300)
+        response = requests.post(
+            self.url + "/root/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -1383,7 +1462,8 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.put(self.url + "/root/anyandall", json={}, timeout=300)
+        response = requests.put(
+            self.url + "/root/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -1433,15 +1513,18 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_not_defined_in_template(self):
-        response = requests.get(self.url + "/root/nofunctionfound", timeout=300)
+        response = requests.get(
+            self.url + "/root/nofunctionfound", timeout=300)
 
         self.assertEqual(response.status_code, 502)
-        self.assertEqual(response.json(), {"message": "No function defined for resource method"})
+        self.assertEqual(response.json(), {
+                         "message": "No function defined for resource method"})
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
-        response = requests.get(self.url + "/root/nonserverlessfunction", timeout=300)
+        response = requests.get(
+            self.url + "/root/nonserverlessfunction", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -1581,10 +1664,14 @@ class TestCFNTemplateQuickCreatedHttpApiWithDefaultRoute(StartApiIntegBaseClass)
 
         self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "https://example.com")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), "x-apigateway-header")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), "GET,OPTIONS")
-        self.assertEqual(response.headers.get("Access-Control-Allow-Credentials"), "true")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Origin"), "https://example.com")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Headers"), "x-apigateway-header")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Methods"), "GET,OPTIONS")
+        self.assertEqual(response.headers.get(
+            "Access-Control-Allow-Credentials"), "true")
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), "600")
 
 
@@ -1633,7 +1720,8 @@ class TestCFNTemplateQuickCreatedHttpApiWithOneRoute(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         self.assertEqual(response_data.get("version", {}), "2.0")
-        self.assertEqual(response_data.get("routeKey", {}), "GET /echoeventbody")
+        self.assertEqual(response_data.get(
+            "routeKey", {}), "GET /echoeventbody")
         self.assertIsNone(response_data.get("multiValueHeaders"))
         self.assertIsNotNone(response_data.get("cookies"))
 
@@ -1644,7 +1732,8 @@ class TestCFNTemplateQuickCreatedHttpApiWithOneRoute(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
-        self.assertEqual(response_data.get("requestContext", {}).get("stage"), "$default")
+        self.assertEqual(response_data.get(
+            "requestContext", {}).get("stage"), "$default")
 
 
 class TestServerlessTemplateWithRestApiAndHttpApiGateways(StartApiIntegBaseClass):
@@ -1774,7 +1863,8 @@ class TestWarmContainersMultipleInvoke(TestWarmContainersBaseClass):
         initiated_containers = self.count_running_containers()
 
         # validate that no new containers got created
-        self.assertEqual(initiated_containers, initiated_containers_before_invoking_any_function)
+        self.assertEqual(initiated_containers,
+                         initiated_containers_before_invoking_any_function)
 
 
 class TestLazyContainers(TestWarmContainersBaseClass):
@@ -1820,7 +1910,8 @@ class TestLazyContainersMultipleInvoke(TestWarmContainersBaseClass):
         initiated_containers = self.count_running_containers()
 
         # only one container is initialized
-        self.assertEqual(initiated_containers, initiated_containers_before_any_invoke + 1)
+        self.assertEqual(initiated_containers,
+                         initiated_containers_before_any_invoke + 1)
 
 
 class TestImagePackageType(StartApiIntegBaseClass):

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -17,7 +17,8 @@ from samcli.local.lambdafn.exceptions import FunctionNotFound
 class TestApiGatewayService(TestCase):
     def setUp(self):
         self.function_name = Mock()
-        self.api_gateway_route = Route(methods=["GET"], function_name=self.function_name, path="/")
+        self.api_gateway_route = Route(
+            methods=["GET"], function_name=self.function_name, path="/")
         self.http_gateway_route = Route(
             methods=["GET"], function_name=self.function_name, path="/", event_type=Route.HTTP
         )
@@ -73,7 +74,8 @@ class TestApiGatewayService(TestCase):
         self.api_service._construct_v_1_0_event = Mock()
 
         parse_output_mock = Mock()
-        parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
+        parse_output_mock.return_value = (
+            "status_code", Headers({"headers": "headers"}), "body")
         self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
@@ -85,8 +87,10 @@ class TestApiGatewayService(TestCase):
         result = self.api_service._request_handler()
 
         self.assertEqual(result, make_response_mock)
-        self.lambda_runner.invoke.assert_called_with(ANY, ANY, stdout=ANY, stderr=self.stderr)
-        self.api_service._construct_v_1_0_event.assert_called_with(ANY, ANY, ANY, ANY, ANY)
+        self.lambda_runner.invoke.assert_called_with(
+            ANY, ANY, stdout=ANY, stderr=self.stderr)
+        self.api_service._construct_v_1_0_event.assert_called_with(
+            ANY, ANY, ANY, ANY, ANY)
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     def test_http_request_must_invoke_lambda(self, request_mock):
@@ -101,7 +105,8 @@ class TestApiGatewayService(TestCase):
         self.http_service._construct_v_2_0_event_http = MagicMock()
 
         parse_output_mock = Mock()
-        parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
+        parse_output_mock.return_value = (
+            "status_code", Headers({"headers": "headers"}), "body")
         self.http_service._parse_v2_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
@@ -113,8 +118,10 @@ class TestApiGatewayService(TestCase):
         result = self.http_service._request_handler()
 
         self.assertEqual(result, make_response_mock)
-        self.lambda_runner.invoke.assert_called_with(ANY, ANY, stdout=ANY, stderr=self.stderr)
-        self.http_service._construct_v_2_0_event_http.assert_called_with(ANY, ANY, ANY, ANY, ANY, ANY)
+        self.lambda_runner.invoke.assert_called_with(
+            ANY, ANY, stdout=ANY, stderr=self.stderr)
+        self.http_service._construct_v_2_0_event_http.assert_called_with(
+            ANY, ANY, ANY, ANY, ANY, ANY)
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     def test_http_v1_payload_request_must_invoke_lambda(self, request_mock):
@@ -129,7 +136,8 @@ class TestApiGatewayService(TestCase):
         self.http_service._construct_v_2_0_event_http = MagicMock()
 
         parse_output_mock = Mock()
-        parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
+        parse_output_mock.return_value = (
+            "status_code", Headers({"headers": "headers"}), "body")
         self.http_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
@@ -141,8 +149,10 @@ class TestApiGatewayService(TestCase):
         result = self.http_service._request_handler()
 
         self.assertEqual(result, make_response_mock)
-        self.lambda_runner.invoke.assert_called_with(ANY, ANY, stdout=ANY, stderr=self.stderr)
-        self.http_service._construct_v_1_0_event.assert_called_with(ANY, ANY, ANY, ANY, ANY)
+        self.lambda_runner.invoke.assert_called_with(
+            ANY, ANY, stdout=ANY, stderr=self.stderr)
+        self.http_service._construct_v_1_0_event.assert_called_with(
+            ANY, ANY, ANY, ANY, ANY)
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     def test_http_v2_payload_request_must_invoke_lambda(self, request_mock):
@@ -157,7 +167,8 @@ class TestApiGatewayService(TestCase):
         self.http_service._construct_v_2_0_event_http = MagicMock()
 
         parse_output_mock = Mock()
-        parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
+        parse_output_mock.return_value = (
+            "status_code", Headers({"headers": "headers"}), "body")
         self.http_service._parse_v2_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
@@ -169,8 +180,10 @@ class TestApiGatewayService(TestCase):
         result = self.http_service._request_handler()
 
         self.assertEqual(result, make_response_mock)
-        self.lambda_runner.invoke.assert_called_with(ANY, ANY, stdout=ANY, stderr=self.stderr)
-        self.http_service._construct_v_2_0_event_http.assert_called_with(ANY, ANY, ANY, ANY, ANY, ANY)
+        self.lambda_runner.invoke.assert_called_with(
+            ANY, ANY, stdout=ANY, stderr=self.stderr)
+        self.http_service._construct_v_2_0_event_http.assert_called_with(
+            ANY, ANY, ANY, ANY, ANY, ANY)
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     def test_api_options_request_must_invoke_lambda(self, request_mock):
@@ -182,7 +195,8 @@ class TestApiGatewayService(TestCase):
         self.api_service._construct_v_1_0_event = Mock()
 
         parse_output_mock = Mock()
-        parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
+        parse_output_mock.return_value = (
+            "status_code", Headers({"headers": "headers"}), "body")
         self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
@@ -194,7 +208,8 @@ class TestApiGatewayService(TestCase):
         result = self.api_service._request_handler()
 
         self.assertEqual(result, make_response_mock)
-        self.lambda_runner.invoke.assert_called_with(ANY, ANY, stdout=ANY, stderr=self.stderr)
+        self.lambda_runner.invoke.assert_called_with(
+            ANY, ANY, stdout=ANY, stderr=self.stderr)
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     def test_http_options_request_must_invoke_lambda(self, request_mock):
@@ -206,7 +221,8 @@ class TestApiGatewayService(TestCase):
         self.http_service._construct_v_1_0_event = Mock()
 
         parse_output_mock = Mock()
-        parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
+        parse_output_mock.return_value = (
+            "status_code", Headers({"headers": "headers"}), "body")
         self.http_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
@@ -218,7 +234,8 @@ class TestApiGatewayService(TestCase):
         result = self.http_service._request_handler()
 
         self.assertEqual(result, make_response_mock)
-        self.lambda_runner.invoke.assert_called_with(ANY, ANY, stdout=ANY, stderr=self.stderr)
+        self.lambda_runner.invoke.assert_called_with(
+            ANY, ANY, stdout=ANY, stderr=self.stderr)
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     @patch("samcli.local.apigw.local_apigw_service.LambdaOutputParser")
@@ -235,7 +252,8 @@ class TestApiGatewayService(TestCase):
         self.api_service._construct_v_1_0_event = Mock()
 
         parse_output_mock = Mock()
-        parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
+        parse_output_mock.return_value = (
+            "status_code", Headers({"headers": "headers"}), "body")
         self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         lambda_logs = "logs"
@@ -252,7 +270,8 @@ class TestApiGatewayService(TestCase):
         lambda_output_parser_mock.get_lambda_output.assert_called_with(ANY)
 
         # Make sure the parse method is called only on the returned response and not on the raw data from stdout
-        parse_output_mock.assert_called_with(lambda_response, ANY, ANY, Route.API)
+        parse_output_mock.assert_called_with(
+            lambda_response, ANY, ANY, Route.API)
         # Make sure the logs are written to stderr
         self.stderr.write.assert_called_with(lambda_logs)
 
@@ -266,7 +285,8 @@ class TestApiGatewayService(TestCase):
         self.api_service._get_current_route.methods = []
 
         parse_output_mock = Mock()
-        parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
+        parse_output_mock.return_value = (
+            "status_code", Headers({"headers": "headers"}), "body")
         self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
 
         service_response_mock = Mock()
@@ -282,13 +302,16 @@ class TestApiGatewayService(TestCase):
         function_name_1 = Mock()
         function_name_2 = Mock()
         function_name_3 = Mock()
-        api_gateway_route_1 = Route(methods=["GET"], function_name=function_name_1, path="/")
-        api_gateway_route_2 = Route(methods=["POST"], function_name=function_name_2, path="/")
+        api_gateway_route_1 = Route(
+            methods=["GET"], function_name=function_name_1, path="/")
+        api_gateway_route_2 = Route(
+            methods=["POST"], function_name=function_name_2, path="/")
         api_gateway_route_3 = Route(
             methods=["x-amazon-apigateway-any-method"], function_name=function_name_3, path="$default"
         )
 
-        list_of_routes = [api_gateway_route_1, api_gateway_route_2, api_gateway_route_3]
+        list_of_routes = [api_gateway_route_1,
+                          api_gateway_route_2, api_gateway_route_3]
 
         lambda_runner = Mock()
 
@@ -297,19 +320,32 @@ class TestApiGatewayService(TestCase):
 
         service.create()
 
-        self.assertEqual(service._dict_of_routes["/:GET"].function_name, function_name_1)
-        self.assertEqual(service._dict_of_routes["/:POST"].function_name, function_name_2)
-        self.assertEqual(service._dict_of_routes["/:OPTIONS"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/:PATCH"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/:DELETE"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/:PUT"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/<path:any_path>:GET"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/<path:any_path>:DELETE"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/<path:any_path>:PUT"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/<path:any_path>:POST"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/<path:any_path>:HEAD"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/<path:any_path>:OPTIONS"].function_name, function_name_3)
-        self.assertEqual(service._dict_of_routes["/<path:any_path>:PATCH"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/:GET"].function_name, function_name_1)
+        self.assertEqual(
+            service._dict_of_routes["/:POST"].function_name, function_name_2)
+        self.assertEqual(
+            service._dict_of_routes["/:OPTIONS"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/:PATCH"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/:DELETE"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/:PUT"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/<path:any_path>:GET"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/<path:any_path>:DELETE"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/<path:any_path>:PUT"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/<path:any_path>:POST"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/<path:any_path>:HEAD"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/<path:any_path>:OPTIONS"].function_name, function_name_3)
+        self.assertEqual(
+            service._dict_of_routes["/<path:any_path>:PATCH"].function_name, function_name_3)
 
     @patch("samcli.local.apigw.local_apigw_service.Flask")
     def test_create_creates_flask_app_with_url_rules(self, flask):
@@ -339,13 +375,15 @@ class TestApiGatewayService(TestCase):
     def test_http_initalize_creates_default_values(self):
         self.assertEqual(self.http_service.port, 3000)
         self.assertEqual(self.http_service.host, "127.0.0.1")
-        self.assertEqual(self.http_service.api.routes, self.http_list_of_routes)
+        self.assertEqual(self.http_service.api.routes,
+                         self.http_list_of_routes)
         self.assertIsNone(self.http_service.static_dir)
         self.assertEqual(self.http_service.lambda_runner, self.lambda_runner)
 
     def test_initalize_with_values(self):
         lambda_runner = Mock()
-        local_service = LocalApigwService(Api(), lambda_runner, static_dir="dir/static", port=5000, host="129.0.0.0")
+        local_service = LocalApigwService(
+            Api(), lambda_runner, static_dir="dir/static", port=5000, host="129.0.0.0")
         self.assertEqual(local_service.port, 5000)
         self.assertEqual(local_service.host, "129.0.0.0")
         self.assertEqual(local_service.api.routes, [])
@@ -414,7 +452,8 @@ class TestApiGatewayService(TestCase):
     @patch("samcli.local.apigw.local_apigw_service.ServiceErrorResponses")
     def test_request_handler_errors_when_unable_to_read_binary_data(self, service_error_responses_patch, request_mock):
         _construct_event = Mock()
-        _construct_event.side_effect = UnicodeDecodeError("utf8", b"obj", 1, 2, "reason")
+        _construct_event.side_effect = UnicodeDecodeError(
+            "utf8", b"obj", 1, 2, "reason")
         self.api_service._get_current_route = MagicMock()
         self.api_service._get_current_route.methods = []
 
@@ -437,7 +476,8 @@ class TestApiGatewayService(TestCase):
         self.api_service._route_key = route_key_method_mock
         self.api_service._dict_of_routes = {"method:path": "function"}
 
-        self.assertEqual(self.api_service._get_current_route(request_mock), "function")
+        self.assertEqual(self.api_service._get_current_route(
+            request_mock), "function")
 
     def test_get_current_route_keyerror(self):
         """
@@ -461,8 +501,10 @@ class TestApiGatewayService(TestCase):
 class TestApiGatewayModel(TestCase):
     def setUp(self):
         self.function_name = "name"
-        self.api_gateway = Route(function_name=self.function_name, methods=["Post"], path="/")
-        self.http_gateway = Route(function_name=self.function_name, methods=["Post"], path="/", event_type=Route.HTTP)
+        self.api_gateway = Route(
+            function_name=self.function_name, methods=["Post"], path="/")
+        self.http_gateway = Route(function_name=self.function_name, methods=[
+                                  "Post"], path="/", event_type=Route.HTTP)
 
     def test_class_initialization(self):
         self.assertEqual(self.api_gateway.methods, ["POST"])
@@ -482,7 +524,8 @@ class TestLambdaHeaderDictionaryMerge(TestCase):
         headers = {}
         multi_value_headers = {}
 
-        result = LocalApigwService._merge_response_headers(headers, multi_value_headers)
+        result = LocalApigwService._merge_response_headers(
+            headers, multi_value_headers)
 
         self.assertEqual(result, Headers({}))
 
@@ -490,7 +533,8 @@ class TestLambdaHeaderDictionaryMerge(TestCase):
         headers = {"h1": "value1", "h2": "value2", "h3": "value3"}
         multi_value_headers = {"h3": ["value4"]}
 
-        result = LocalApigwService._merge_response_headers(headers, multi_value_headers)
+        result = LocalApigwService._merge_response_headers(
+            headers, multi_value_headers)
 
         self.assertIn("h1", result)
         self.assertIn("h2", result)
@@ -503,7 +547,8 @@ class TestLambdaHeaderDictionaryMerge(TestCase):
         headers = {"h1": "ValueB"}
         multi_value_headers = {"h1": ["ValueA", "ValueB", "ValueC"]}
 
-        result = LocalApigwService._merge_response_headers(headers, multi_value_headers)
+        result = LocalApigwService._merge_response_headers(
+            headers, multi_value_headers)
 
         self.assertIn("h1", result)
         self.assertEqual(result.get_all("h1"), ["ValueA", "ValueB", "ValueC"])
@@ -600,7 +645,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock(), event_type=event_type
         )
 
-        self.assertEqual(headers, Headers({"Content-Type": "application/json", "X-Foo": ["bar", "42"]}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json", "X-Foo": ["bar", "42"]}))
 
     @parameterized.expand(
         [
@@ -620,7 +666,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(
-            headers, Headers({"Content-Type": "application/json", "X-Bar": "bar", "X-Foo": ["bar", "42", "foo"]})
+            headers, Headers({"Content-Type": "application/json",
+                              "X-Bar": "bar", "X-Foo": ["bar", "42", "foo"]})
         )
 
     def test_extra_values_raise(self):
@@ -644,7 +691,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock(), event_type=Route.HTTP
         )
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     @parameterized.expand(
@@ -664,7 +712,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     @parameterized.expand(
@@ -721,11 +770,13 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         should_decode_body_patch.assert_called_with(
-            ["*/*"], flask_request_mock, Headers({"Content-Type": "application/octet-stream"}), encoded_parsed_value
+            ["*/*"], flask_request_mock, Headers(
+                {"Content-Type": "application/octet-stream"}), encoded_parsed_value
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/octet-stream"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/octet-stream"}))
         self.assertEqual(body, binary_body)
 
     @parameterized.expand(
@@ -785,11 +836,13 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         should_decode_body_patch.assert_called_with(
-            ["*/*"], flask_request_mock, Headers({"Content-Type": "application/octet-stream"}), True
+            ["*/*"], flask_request_mock, Headers(
+                {"Content-Type": "application/octet-stream"}), True
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/octet-stream"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/octet-stream"}))
         self.assertEqual(body, binary_body)
 
     @parameterized.expand(
@@ -817,8 +870,10 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/octet-stream"}))
-        self.assertEqual(body, binary_body if encoded_parsed_value else base64_body)
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/octet-stream"}))
+        self.assertEqual(
+            body, binary_body if encoded_parsed_value else base64_body)
 
     @parameterized.expand(
         [
@@ -878,7 +933,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/octet-stream"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/octet-stream"}))
         self.assertEqual(body, base64_body)
 
     def test_parse_returns_does_not_decodes_base64_to_binary_for_http_api(self):
@@ -896,7 +952,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/octet-stream"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/octet-stream"}))
         self.assertEqual(body, base64_body)
 
     @parameterized.expand(
@@ -970,7 +1027,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     @parameterized.expand(
@@ -1032,7 +1090,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, None)
 
     @parameterized.expand(
@@ -1101,7 +1160,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     def test_parse_returns_correct_tuple(self):
@@ -1115,7 +1175,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     def test_parse_raises_when_invalid_mimetype(self):
@@ -1144,7 +1205,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/octet-stream"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/octet-stream"}))
         self.assertEqual(body, base64_body)
 
     def test_parse_returns_decodes_base64_to_binary(self):
@@ -1162,7 +1224,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/octet-stream"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/octet-stream"}))
         self.assertEqual(body, binary_body)
 
     def test_status_code_int_str(self):
@@ -1212,7 +1275,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock()
         )
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, "some str")
 
     def test_lambda_output_integer(self):
@@ -1221,7 +1285,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock()
         )
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, lambda_output)
 
     def test_properties_are_null(self):
@@ -1232,7 +1297,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, None)
 
     def test_lambda_output_json_object_no_status_code(self):
@@ -1243,7 +1309,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(status_code, 200)
-        self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
+        self.assertEqual(headers, Headers(
+            {"Content-Type": "application/json"}))
         self.assertEqual(body, lambda_output)
 
 
@@ -1257,7 +1324,8 @@ class TestService_construct_event(TestCase):
         self.request_mock.host = "190.0.0.1"
         self.request_mock.get_data.return_value = b"DATA!!!!"
         query_param_args_mock = Mock()
-        query_param_args_mock.lists.return_value = {"query": ["params"]}.items()
+        query_param_args_mock.lists.return_value = {
+            "query": ["params"]}.items()
         self.request_mock.args = query_param_args_mock
         headers_mock = Mock()
         headers_mock.keys.return_value = ["Content-Type", "X-Test"]
@@ -1292,28 +1360,34 @@ class TestService_construct_event(TestCase):
 
     def validate_request_context_and_remove_request_time_data(self, event_json):
         request_time = event_json["requestContext"].pop("requestTime", None)
-        request_time_epoch = event_json["requestContext"].pop("requestTimeEpoch", None)
+        request_time_epoch = event_json["requestContext"].pop(
+            "requestTimeEpoch", None)
 
         self.assertIsInstance(request_time, str)
-        parsed_request_time = datetime.strptime(request_time, "%d/%b/%Y:%H:%M:%S +0000")
+        parsed_request_time = datetime.strptime(
+            request_time, "%d/%b/%Y:%H:%M:%S +0000")
         self.assertIsInstance(parsed_request_time, datetime)
 
         self.assertIsInstance(request_time_epoch, int)
 
     def test_construct_event_with_data(self):
-        actual_event_str = LocalApigwService._construct_v_1_0_event(self.request_mock, 3000, binary_types=[])
+        actual_event_str = LocalApigwService._construct_v_1_0_event(
+            self.request_mock, 3000, binary_types=[])
 
         actual_event_json = json.loads(actual_event_str)
-        self.validate_request_context_and_remove_request_time_data(actual_event_json)
+        self.validate_request_context_and_remove_request_time_data(
+            actual_event_json)
 
         self.assertEqual(actual_event_json["body"], self.expected_dict["body"])
 
     def test_construct_event_no_data(self):
         self.request_mock.get_data.return_value = None
 
-        actual_event_str = LocalApigwService._construct_v_1_0_event(self.request_mock, 3000, binary_types=[])
+        actual_event_str = LocalApigwService._construct_v_1_0_event(
+            self.request_mock, 3000, binary_types=[])
         actual_event_json = json.loads(actual_event_str)
-        self.validate_request_context_and_remove_request_time_data(actual_event_json)
+        self.validate_request_context_and_remove_request_time_data(
+            actual_event_json)
 
         self.assertEqual(actual_event_json["body"], None)
 
@@ -1326,9 +1400,11 @@ class TestService_construct_event(TestCase):
 
         self.request_mock.get_data.return_value = binary_body
 
-        actual_event_str = LocalApigwService._construct_v_1_0_event(self.request_mock, 3000, binary_types=[])
+        actual_event_str = LocalApigwService._construct_v_1_0_event(
+            self.request_mock, 3000, binary_types=[])
         actual_event_json = json.loads(actual_event_str)
-        self.validate_request_context_and_remove_request_time_data(actual_event_json)
+        self.validate_request_context_and_remove_request_time_data(
+            actual_event_json)
 
         self.assertEqual(actual_event_json["body"], base64_body)
         self.assertEqual(actual_event_json["isBase64Encoded"], True)
@@ -1340,7 +1416,8 @@ class TestService_construct_event(TestCase):
         request_mock.headers = headers_mock
         request_mock.scheme = "http"
 
-        actual_query_string = LocalApigwService._event_headers(request_mock, "3000")
+        actual_query_string = LocalApigwService._event_headers(
+            request_mock, "3000")
         self.assertEqual(
             actual_query_string,
             (
@@ -1358,7 +1435,8 @@ class TestService_construct_event(TestCase):
         request_mock.headers = headers_mock
         request_mock.scheme = "http"
 
-        actual_query_string = LocalApigwService._event_headers(request_mock, "3000")
+        actual_query_string = LocalApigwService._event_headers(
+            request_mock, "3000")
         self.assertEqual(
             actual_query_string,
             (
@@ -1383,7 +1461,8 @@ class TestService_construct_event(TestCase):
         query_param_args_mock.lists.return_value = {}.items()
         request_mock.args = query_param_args_mock
 
-        actual_query_string = LocalApigwService._query_string_params(request_mock)
+        actual_query_string = LocalApigwService._query_string_params(
+            request_mock)
         self.assertEqual(actual_query_string, ({}, {}))
 
     def test_query_string_params_with_param_value_being_empty_list(self):
@@ -1392,17 +1471,21 @@ class TestService_construct_event(TestCase):
         query_param_args_mock.lists.return_value = {"param": []}.items()
         request_mock.args = query_param_args_mock
 
-        actual_query_string = LocalApigwService._query_string_params(request_mock)
+        actual_query_string = LocalApigwService._query_string_params(
+            request_mock)
         self.assertEqual(actual_query_string, ({"param": ""}, {"param": [""]}))
 
     def test_query_string_params_with_param_value_being_non_empty_list(self):
         request_mock = Mock()
         query_param_args_mock = Mock()
-        query_param_args_mock.lists.return_value = {"param": ["a", "b"]}.items()
+        query_param_args_mock.lists.return_value = {
+            "param": ["a", "b"]}.items()
         request_mock.args = query_param_args_mock
 
-        actual_query_string = LocalApigwService._query_string_params(request_mock)
-        self.assertEqual(actual_query_string, ({"param": "b"}, {"param": ["a", "b"]}))
+        actual_query_string = LocalApigwService._query_string_params(
+            request_mock)
+        self.assertEqual(actual_query_string,
+                         ({"param": "b"}, {"param": ["a", "b"]}))
 
 
 class TestService_construct_event_http(TestCase):
@@ -1414,7 +1497,8 @@ class TestService_construct_event_http(TestCase):
         self.request_mock.get_data.return_value = b"DATA!!!!"
         self.request_mock.mimetype = "application/json"
         query_param_args_mock = Mock()
-        query_param_args_mock.lists.return_value = {"query": ["params"]}.items()
+        query_param_args_mock.lists.return_value = {
+            "query": ["params"]}.items()
         self.request_mock.args = query_param_args_mock
         self.request_mock.query_string = b"query=params"
         headers_mock = Mock()
@@ -1439,7 +1523,7 @@ class TestService_construct_event_http(TestCase):
             "cookies": ["cookie1=test", "cookie2=test"],
             "headers": {
                 "Content-Type": "application/json",
-                "X-Test": "Value",
+                "x-test": "Value",
                 "X-Forwarded-Proto": "http",
                 "X-Forwarded-Port": "3000"
             },
@@ -1471,10 +1555,12 @@ class TestService_construct_event_http(TestCase):
         actual_event_str = LocalApigwService._construct_v_2_0_event_http(
             self.request_mock, 3000, binary_types=[], route_key="GET /endpoint"
         )
-        print("DEBUG: json.loads(actual_event_str)", json.loads(actual_event_str))
+        print("DEBUG: json.loads(actual_event_str)",
+              json.loads(actual_event_str))
         print("DEBUG: self.expected_dict", self.expected_dict)
         actual_event_dict = json.loads(actual_event_str)
-        self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
+        self.assertEqual(
+            len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
 
@@ -1486,7 +1572,8 @@ class TestService_construct_event_http(TestCase):
             self.request_mock, 3000, binary_types=[], route_key="GET /endpoint"
         )
         actual_event_dict = json.loads(actual_event_str)
-        self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
+        self.assertEqual(
+            len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
 
@@ -1514,7 +1601,8 @@ class TestService_construct_event_http(TestCase):
             self.request_mock, 3000, binary_types=[], route_key="GET /endpoint"
         )
         actual_event_dict = json.loads(actual_event_str)
-        self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
+        self.assertEqual(
+            len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
 
@@ -1525,8 +1613,10 @@ class TestService_construct_event_http(TestCase):
         request_mock.headers = headers_mock
         request_mock.scheme = "http"
 
-        actual_query_string = LocalApigwService._event_http_headers(request_mock, "3000")
-        self.assertEqual(actual_query_string, {"X-Forwarded-Proto": "http", "X-Forwarded-Port": "3000"})
+        actual_query_string = LocalApigwService._event_http_headers(
+            request_mock, "3000")
+        self.assertEqual(actual_query_string, {
+                         "X-Forwarded-Proto": "http", "X-Forwarded-Port": "3000"})
 
     def test_event_headers_with_non_empty_list(self):
         request_mock = Mock()
@@ -1537,12 +1627,13 @@ class TestService_construct_event_http(TestCase):
         request_mock.headers = headers_mock
         request_mock.scheme = "http"
 
-        actual_query_string = LocalApigwService._event_http_headers(request_mock, "3000")
+        actual_query_string = LocalApigwService._event_http_headers(
+            request_mock, "3000")
         self.assertEqual(
             actual_query_string,
             {
                 "Content-Type": "application/json",
-                "X-Test": "Value",
+                "x-test": "Value",
                 "X-Forwarded-Proto": "http",
                 "X-Forwarded-Port": "3000",
             },
@@ -1553,16 +1644,20 @@ class TestService_should_base64_encode(TestCase):
     @parameterized.expand(
         [
             param("Mimeyype is in binary types", ["image/gif"], "image/gif"),
-            param("Mimetype defined and binary types has */*", ["*/*"], "image/gif"),
-            param("*/* is in binary types with no mimetype defined", ["*/*"], None),
+            param("Mimetype defined and binary types has */*",
+                  ["*/*"], "image/gif"),
+            param("*/* is in binary types with no mimetype defined",
+                  ["*/*"], None),
         ]
     )
     def test_should_base64_encode_returns_true(self, test_case_name, binary_types, mimetype):
-        self.assertTrue(LocalApigwService._should_base64_encode(binary_types, mimetype))
+        self.assertTrue(LocalApigwService._should_base64_encode(
+            binary_types, mimetype))
 
     @parameterized.expand([param("Mimetype is not in binary types", ["image/gif"], "application/octet-stream")])
     def test_should_base64_encode_returns_false(self, test_case_name, binary_types, mimetype):
-        self.assertFalse(LocalApigwService._should_base64_encode(binary_types, mimetype))
+        self.assertFalse(LocalApigwService._should_base64_encode(
+            binary_types, mimetype))
 
 
 class TestServiceCorsToHeaders(TestCase):
@@ -1583,12 +1678,14 @@ class TestServiceCorsToHeaders(TestCase):
         )
 
     def test_empty_elements(self):
-        cors = Cors(allow_origin="www.domain.com", allow_methods=",".join(["GET", "POST", "OPTIONS"]))
+        cors = Cors(allow_origin="www.domain.com",
+                    allow_methods=",".join(["GET", "POST", "OPTIONS"]))
         headers = Cors.cors_to_headers(cors)
 
         self.assertEqual(
             headers,
-            {"Access-Control-Allow-Origin": "www.domain.com", "Access-Control-Allow-Methods": "GET,POST,OPTIONS"},
+            {"Access-Control-Allow-Origin": "www.domain.com",
+                "Access-Control-Allow-Methods": "GET,POST,OPTIONS"},
         )
 
 
@@ -1599,55 +1696,74 @@ class TestRouteEqualsHash(TestCase):
         self.assertIn(route, routes)
 
     def test_route_method_order_equals(self):
-        route1 = Route(function_name="test", path="/test", methods=["POST", "GET"])
-        route2 = Route(function_name="test", path="/test", methods=["GET", "POST"])
+        route1 = Route(function_name="test", path="/test",
+                       methods=["POST", "GET"])
+        route2 = Route(function_name="test", path="/test",
+                       methods=["GET", "POST"])
         self.assertEqual(route1, route2)
 
     def test_route_hash(self):
-        route1 = Route(function_name="test", path="/test", methods=["POST", "GET"])
+        route1 = Route(function_name="test", path="/test",
+                       methods=["POST", "GET"])
         dic = {route1: "test"}
         self.assertEqual(dic[route1], "test")
 
     def test_route_object_equals(self):
-        route1 = Route(function_name="test", path="/test", methods=["POST", "GET"])
-        route2 = type("obj", (object,), {"function_name": "test", "path": "/test", "methods": ["GET", "POST"]})
+        route1 = Route(function_name="test", path="/test",
+                       methods=["POST", "GET"])
+        route2 = type("obj", (object,), {
+                      "function_name": "test", "path": "/test", "methods": ["GET", "POST"]})
 
         self.assertNotEqual(route1, route2)
 
     def test_route_function_name_equals(self):
-        route1 = Route(function_name="test1", path="/test", methods=["GET", "POST"])
-        route2 = Route(function_name="test2", path="/test", methods=["GET", "POST"])
+        route1 = Route(function_name="test1", path="/test",
+                       methods=["GET", "POST"])
+        route2 = Route(function_name="test2", path="/test",
+                       methods=["GET", "POST"])
         self.assertNotEqual(route1, route2)
 
     def test_route_different_path_equals(self):
-        route1 = Route(function_name="test", path="/test1", methods=["GET", "POST"])
-        route2 = Route(function_name="test", path="/test2", methods=["GET", "POST"])
+        route1 = Route(function_name="test", path="/test1",
+                       methods=["GET", "POST"])
+        route2 = Route(function_name="test", path="/test2",
+                       methods=["GET", "POST"])
         self.assertNotEqual(route1, route2)
 
     def test_same_object_equals(self):
-        route1 = Route(function_name="test", path="/test", methods=["POST", "GET"])
+        route1 = Route(function_name="test", path="/test",
+                       methods=["POST", "GET"])
         self.assertEqual(route1, copy.deepcopy(route1))
 
     def test_route_function_name_hash(self):
-        route1 = Route(function_name="test1", path="/test", methods=["GET", "POST"])
-        route2 = Route(function_name="test2", path="/test", methods=["GET", "POST"])
+        route1 = Route(function_name="test1", path="/test",
+                       methods=["GET", "POST"])
+        route2 = Route(function_name="test2", path="/test",
+                       methods=["GET", "POST"])
         self.assertNotEqual(route1.__hash__(), route2.__hash__())
 
     def test_route_different_path_hash(self):
-        route1 = Route(function_name="test", path="/test1", methods=["GET", "POST"])
-        route2 = Route(function_name="test", path="/test2", methods=["GET", "POST"])
+        route1 = Route(function_name="test", path="/test1",
+                       methods=["GET", "POST"])
+        route2 = Route(function_name="test", path="/test2",
+                       methods=["GET", "POST"])
         self.assertNotEqual(route1.__hash__(), route2.__hash__())
 
     def test_same_object_hash(self):
-        route1 = Route(function_name="test", path="/test", methods=["POST", "GET"])
+        route1 = Route(function_name="test", path="/test",
+                       methods=["POST", "GET"])
         self.assertEqual(route1.__hash__(), copy.deepcopy(route1).__hash__())
 
     def test_route_method_order_hash(self):
-        route1 = Route(function_name="test", path="/test", methods=["POST", "GET"])
-        route2 = Route(function_name="test", path="/test", methods=["GET", "POST"])
+        route1 = Route(function_name="test", path="/test",
+                       methods=["POST", "GET"])
+        route2 = Route(function_name="test", path="/test",
+                       methods=["GET", "POST"])
         self.assertEqual(route1.__hash__(), route2.__hash__())
 
     def test_route_different_stack_path_hash(self):
-        route1 = Route(function_name="test", path="/test1", methods=["GET", "POST"], stack_path="2")
-        route2 = Route(function_name="test", path="/test1", methods=["GET", "POST"], stack_path="1")
+        route1 = Route(function_name="test", path="/test1",
+                       methods=["GET", "POST"], stack_path="2")
+        route2 = Route(function_name="test", path="/test1",
+                       methods=["GET", "POST"], stack_path="1")
         self.assertNotEqual(route1.__hash__(), route2.__hash__())

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -637,7 +637,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
     )
     def test_multivalue_headers(self, event_type):
         lambda_output = (
-            '{"statusCode": 200, "multiValueHeaders":{"X-Foo": ["bar", "42"]}, '
+            '{"statusCode": 200, "multiValueHeaders":{"x-foo": ["bar", "42"]}, '
             '"body": "{\\"message\\":\\"Hello from Lambda\\"}", "isBase64Encoded": false}'
         )
 
@@ -656,8 +656,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
     )
     def test_single_and_multivalue_headers(self, event_type):
         lambda_output = (
-            '{"statusCode": 200, "headers":{"X-Foo": "foo", "X-Bar": "bar"}, '
-            '"multiValueHeaders":{"X-Foo": ["bar", "42"]}, '
+            '{"statusCode": 200, "headers":{"x-foo": "foo", "x-bar": "bar"}, '
+            '"multiValueHeaders":{"x-foo": ["bar", "42"]}, '
             '"body": "{\\"message\\":\\"Hello from Lambda\\"}", "isBase64Encoded": false}'
         )
 
@@ -771,7 +771,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         should_decode_body_patch.assert_called_with(
             ["*/*"], flask_request_mock, Headers(
-                {"Content-Type": "application/octet-stream"}), encoded_parsed_value
+                {"content-type": "application/octet-stream"}), encoded_parsed_value
         )
 
         self.assertEqual(status_code, 200)
@@ -805,7 +805,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             encoded_field_name: encoded_response_value,
         }
@@ -824,7 +824,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             "isBase64Encoded": False,
             "base64Encoded": True,
@@ -837,7 +837,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         should_decode_body_patch.assert_called_with(
             ["*/*"], flask_request_mock, Headers(
-                {"Content-Type": "application/octet-stream"}), True
+                {"content-type": "application/octet-stream"}), True
         )
 
         self.assertEqual(status_code, 200)
@@ -860,7 +860,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             "isBase64Encoded": encoded_response_value,
         }
@@ -891,7 +891,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             "isBase64Encoded": encoded_response_value,
         }
@@ -923,7 +923,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             "base64Encoded": encoded_response_value,
         }
@@ -942,7 +942,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             "isBase64Encoded": False,
         }
@@ -1139,7 +1139,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
     def test_custom_content_type_header_is_not_modified(self):
         lambda_output = (
-            '{"statusCode": 200, "headers":{"Content-Type": "text/xml"}, "body": "{}", ' '"isBase64Encoded": false}'
+            '{"statusCode": 200, "headers":{"content-type": "text/xml"}, "body": "{}", ' '"isBase64Encoded": false}'
         )
 
         (_, headers, _) = LocalApigwService._parse_v2_payload_format_lambda_output(
@@ -1181,7 +1181,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
     def test_parse_raises_when_invalid_mimetype(self):
         lambda_output = (
-            '{"statusCode": 200, "headers": {\\"Content-Type\\": \\"text\\"}, "body": "{\\"message\\":\\"Hello from Lambda\\"}", '
+            '{"statusCode": 200, "headers": {\\"content-type\\": \\"text\\"}, "body": "{\\"message\\":\\"Hello from Lambda\\"}", '
             '"isBase64Encoded": false}'
         )
 
@@ -1195,7 +1195,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             "isBase64Encoded": False,
         }
@@ -1214,7 +1214,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             "isBase64Encoded": True,
         }
@@ -1328,7 +1328,7 @@ class TestService_construct_event(TestCase):
             "query": ["params"]}.items()
         self.request_mock.args = query_param_args_mock
         headers_mock = Mock()
-        headers_mock.keys.return_value = ["Content-Type", "X-Test"]
+        headers_mock.keys.return_value = ["content-type", "X-Test"]
         headers_mock.get.side_effect = ["application/json", "Value"]
         headers_mock.getlist.side_effect = [["application/json"], ["Value"]]
         self.request_mock.headers = headers_mock
@@ -1350,7 +1350,7 @@ class TestService_construct_event(TestCase):
             '"190.0.0.0", "user": null}, "accountId": "123456789012", "domainName": "190.0.0.1", '
             '"protocol": "HTTP/1.1"}, "headers": {"content-type": '
             '"application/json", "x-test": "Value", "x-forwarded-port": "3000", "x-forwarded-proto": "http"}, '
-            '"multiValueHeaders": {"Content-Type": ["application/json"], "x-test": ["Value"], '
+            '"multiValueHeaders": {"content-type": ["application/json"], "x-test": ["Value"], '
             '"x-forwarded-port": ["3000"], "x-forwarded-proto": ["http"]}, '
             '"stageVariables": null, "path": "path", "pathParameters": {"path": "params"}, '
             '"isBase64Encoded": false}'
@@ -1429,7 +1429,7 @@ class TestService_construct_event(TestCase):
     def test_event_headers_with_non_empty_list(self):
         request_mock = Mock()
         headers_mock = Mock()
-        headers_mock.keys.return_value = ["Content-Type", "X-Test"]
+        headers_mock.keys.return_value = ["content-type", "X-Test"]
         headers_mock.get.side_effect = ["application/json", "Value"]
         headers_mock.getlist.side_effect = [["application/json"], ["Value"]]
         request_mock.headers = headers_mock
@@ -1502,7 +1502,7 @@ class TestService_construct_event_http(TestCase):
         self.request_mock.args = query_param_args_mock
         self.request_mock.query_string = b"query=params"
         headers_mock = Mock()
-        headers_mock.keys.return_value = ["Content-Type", "X-Test"]
+        headers_mock.keys.return_value = ["content-type", "X-Test"]
         headers_mock.get.side_effect = ["application/json", "Value"]
         headers_mock.getlist.side_effect = [["application/json"], ["Value"]]
         self.request_mock.headers = headers_mock
@@ -1621,7 +1621,7 @@ class TestService_construct_event_http(TestCase):
     def test_event_headers_with_non_empty_list(self):
         request_mock = Mock()
         headers_mock = Mock()
-        headers_mock.keys.return_value = ["Content-Type", "X-Test"]
+        headers_mock.keys.return_value = ["content-type", "X-Test"]
         headers_mock.get.side_effect = ["application/json", "Value"]
         headers_mock.getlist.side_effect = [["application/json"], ["Value"]]
         request_mock.headers = headers_mock

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -570,8 +570,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock(), event_type=event_type
         )
 
-        self.assertIn("Content-Type", headers)
-        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertIn("content-type", headers)
+        self.assertEqual(headers["content-type"], "application/json")
 
     @parameterized.expand(
         [
@@ -589,8 +589,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock(), event_type=event_type
         )
 
-        self.assertIn("Content-Type", headers)
-        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertIn("content-type", headers)
+        self.assertEqual(headers["content-type"], "application/json")
 
     @parameterized.expand(
         [
@@ -600,15 +600,15 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
     )
     def test_custom_content_type_header_is_not_modified(self, event_type):
         lambda_output = (
-            '{"statusCode": 200, "headers":{"Content-Type": "text/xml"}, "body": "{}", ' '"isBase64Encoded": false}'
+            '{"statusCode": 200, "headers":{"content-type": "text/xml"}, "body": "{}", ' '"isBase64Encoded": false}'
         )
 
         (_, headers, _) = LocalApigwService._parse_v1_payload_format_lambda_output(
             lambda_output, binary_types=[], flask_request=Mock(), event_type=event_type
         )
 
-        self.assertIn("Content-Type", headers)
-        self.assertEqual(headers["Content-Type"], "text/xml")
+        self.assertIn("content-type", headers)
+        self.assertEqual(headers["content-type"], "text/xml")
 
     @parameterized.expand(
         [
@@ -618,7 +618,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
     )
     def test_custom_content_type_multivalue_header_is_not_modified(self, event_type):
         lambda_output = (
-            '{"statusCode": 200, "multiValueHeaders":{"Content-Type": ["text/xml"]}, "body": "{}", '
+            '{"statusCode": 200, "multiValueHeaders":{"content-type": ["text/xml"]}, "body": "{}", '
             '"isBase64Encoded": false}'
         )
 
@@ -626,8 +626,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock(), event_type=event_type
         )
 
-        self.assertIn("Content-Type", headers)
-        self.assertEqual(headers["Content-Type"], "text/xml")
+        self.assertIn("content-type", headers)
+        self.assertEqual(headers["content-type"], "text/xml")
 
     @parameterized.expand(
         [
@@ -646,7 +646,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json", "X-Foo": ["bar", "42"]}))
+            {"content-type": "application/json", "x-foo": ["bar", "42"]}))
 
     @parameterized.expand(
         [
@@ -666,8 +666,8 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
 
         self.assertEqual(
-            headers, Headers({"Content-Type": "application/json",
-                              "X-Bar": "bar", "X-Foo": ["bar", "42", "foo"]})
+            headers, Headers({"content-type": "application/json",
+                              "x-bar": "bar", "x-foo": ["bar", "42", "foo"]})
         )
 
     def test_extra_values_raise(self):
@@ -692,7 +692,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         )
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     @parameterized.expand(
@@ -713,7 +713,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     @parameterized.expand(
@@ -724,7 +724,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
     )
     def test_parse_raises_when_invalid_mimetype(self, event_type):
         lambda_output = (
-            '{"statusCode": 200, "headers": {\\"Content-Type\\": \\"text\\"}, "body": "{\\"message\\":\\"Hello from Lambda\\"}", '
+            '{"statusCode": 200, "headers": {\\"content-type\\": \\"text\\"}, "body": "{\\"message\\":\\"Hello from Lambda\\"}", '
             '"isBase64Encoded": false}'
         )
 
@@ -759,7 +759,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
         base64_body = base64.b64encode(binary_body).decode("utf-8")
         lambda_output = {
             "statusCode": 200,
-            "headers": {"Content-Type": "application/octet-stream"},
+            "headers": {"content-type": "application/octet-stream"},
             "body": base64_body,
             encoded_field_name: encoded_response_value,
         }
@@ -776,7 +776,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/octet-stream"}))
+            {"content-type": "application/octet-stream"}))
         self.assertEqual(body, binary_body)
 
     @parameterized.expand(
@@ -842,7 +842,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/octet-stream"}))
+            {"content-type": "application/octet-stream"}))
         self.assertEqual(body, binary_body)
 
     @parameterized.expand(
@@ -871,7 +871,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/octet-stream"}))
+            {"content-type": "application/octet-stream"}))
         self.assertEqual(
             body, binary_body if encoded_parsed_value else base64_body)
 
@@ -934,7 +934,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/octet-stream"}))
+            {"content-type": "application/octet-stream"}))
         self.assertEqual(body, base64_body)
 
     def test_parse_returns_does_not_decodes_base64_to_binary_for_http_api(self):
@@ -953,7 +953,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/octet-stream"}))
+            {"content-type": "application/octet-stream"}))
         self.assertEqual(body, base64_body)
 
     @parameterized.expand(
@@ -1028,7 +1028,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     @parameterized.expand(
@@ -1091,7 +1091,7 @@ class TestServiceParsingV1PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, None)
 
     @parameterized.expand(
@@ -1121,8 +1121,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock()
         )
 
-        self.assertIn("Content-Type", headers)
-        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertIn("content-type", headers)
+        self.assertEqual(headers["content-type"], "application/json")
 
     def test_default_content_type_header_added_with_empty_headers(self):
         lambda_output = (
@@ -1134,8 +1134,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock()
         )
 
-        self.assertIn("Content-Type", headers)
-        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertIn("content-type", headers)
+        self.assertEqual(headers["content-type"], "application/json")
 
     def test_custom_content_type_header_is_not_modified(self):
         lambda_output = (
@@ -1146,8 +1146,8 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
             lambda_output, binary_types=[], flask_request=Mock()
         )
 
-        self.assertIn("Content-Type", headers)
-        self.assertEqual(headers["Content-Type"], "text/xml")
+        self.assertIn("content-type", headers)
+        self.assertEqual(headers["content-type"], "text/xml")
 
     def test_extra_values_skipped(self):
         lambda_output = (
@@ -1161,7 +1161,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     def test_parse_returns_correct_tuple(self):
@@ -1176,7 +1176,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
 
     def test_parse_raises_when_invalid_mimetype(self):
@@ -1206,7 +1206,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/octet-stream"}))
+            {"content-type": "application/octet-stream"}))
         self.assertEqual(body, base64_body)
 
     def test_parse_returns_decodes_base64_to_binary(self):
@@ -1225,7 +1225,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/octet-stream"}))
+            {"content-type": "application/octet-stream"}))
         self.assertEqual(body, binary_body)
 
     def test_status_code_int_str(self):
@@ -1276,7 +1276,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         )
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, "some str")
 
     def test_lambda_output_integer(self):
@@ -1286,7 +1286,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
         )
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, lambda_output)
 
     def test_properties_are_null(self):
@@ -1298,7 +1298,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, None)
 
     def test_lambda_output_json_object_no_status_code(self):
@@ -1310,7 +1310,7 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers(
-            {"Content-Type": "application/json"}))
+            {"content-type": "application/json"}))
         self.assertEqual(body, lambda_output)
 
 

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -1348,10 +1348,10 @@ class TestService_construct_event(TestCase):
             '"cognitoAuthenticationProvider": null, "cognitoIdentityPoolId": null, "userAgent": '
             '"Custom User Agent String", "caller": null, "cognitoAuthenticationType": null, "sourceIp": '
             '"190.0.0.0", "user": null}, "accountId": "123456789012", "domainName": "190.0.0.1", '
-            '"protocol": "HTTP/1.1"}, "headers": {"Content-Type": '
-            '"application/json", "X-Test": "Value", "X-Forwarded-Port": "3000", "X-Forwarded-Proto": "http"}, '
-            '"multiValueHeaders": {"Content-Type": ["application/json"], "X-Test": ["Value"], '
-            '"X-Forwarded-Port": ["3000"], "X-Forwarded-Proto": ["http"]}, '
+            '"protocol": "HTTP/1.1"}, "headers": {"content-type": '
+            '"application/json", "x-test": "Value", "x-forwarded-port": "3000", "x-forwarded-proto": "http"}, '
+            '"multiValueHeaders": {"Content-Type": ["application/json"], "x-test": ["Value"], '
+            '"x-forwarded-port": ["3000"], "x-forwarded-proto": ["http"]}, '
             '"stageVariables": null, "path": "path", "pathParameters": {"path": "params"}, '
             '"isBase64Encoded": false}'
         )
@@ -1421,8 +1421,8 @@ class TestService_construct_event(TestCase):
         self.assertEqual(
             actual_query_string,
             (
-                {"X-Forwarded-Proto": "http", "X-Forwarded-Port": "3000"},
-                {"X-Forwarded-Proto": ["http"], "X-Forwarded-Port": ["3000"]},
+                {"x-forwarded-proto": "http", "x-forwarded-port": "3000"},
+                {"x-forwarded-proto": ["http"], "x-forwarded-port": ["3000"]},
             ),
         )
 
@@ -1441,16 +1441,16 @@ class TestService_construct_event(TestCase):
             actual_query_string,
             (
                 {
-                    "Content-Type": "application/json",
-                    "X-Test": "Value",
-                    "X-Forwarded-Proto": "http",
-                    "X-Forwarded-Port": "3000",
+                    "content-type": "application/json",
+                    "x-test": "Value",
+                    "x-forwarded-proto": "http",
+                    "x-forwarded-port": "3000",
                 },
                 {
-                    "Content-Type": ["application/json"],
-                    "X-Test": ["Value"],
-                    "X-Forwarded-Proto": ["http"],
-                    "X-Forwarded-Port": ["3000"],
+                    "content-type": ["application/json"],
+                    "x-test": ["Value"],
+                    "x-forwarded-proto": ["http"],
+                    "x-forwarded-port": ["3000"],
                 },
             ),
         )
@@ -1522,10 +1522,10 @@ class TestService_construct_event_http(TestCase):
             "rawQueryString": "query=params",
             "cookies": ["cookie1=test", "cookie2=test"],
             "headers": {
-                "Content-Type": "application/json",
+                "content-type": "application/json",
                 "x-test": "Value",
-                "X-Forwarded-Proto": "http",
-                "X-Forwarded-Port": "3000"
+                "x-forwarded-proto": "http",
+                "x-forwarded-port": "3000"
             },
             "queryStringParameters": {"query": "params"},
             "requestContext": {
@@ -1616,7 +1616,7 @@ class TestService_construct_event_http(TestCase):
         actual_query_string = LocalApigwService._event_http_headers(
             request_mock, "3000")
         self.assertEqual(actual_query_string, {
-                         "X-Forwarded-Proto": "http", "X-Forwarded-Port": "3000"})
+                         "x-forwarded-proto": "http", "x-forwarded-port": "3000"})
 
     def test_event_headers_with_non_empty_list(self):
         request_mock = Mock()
@@ -1632,10 +1632,10 @@ class TestService_construct_event_http(TestCase):
         self.assertEqual(
             actual_query_string,
             {
-                "Content-Type": "application/json",
+                "content-type": "application/json",
                 "x-test": "Value",
-                "X-Forwarded-Proto": "http",
-                "X-Forwarded-Port": "3000",
+                "x-forwarded-proto": "http",
+                "x-forwarded-port": "3000",
             },
         )
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
fixes #1860, #3083 etc.

#### Why is this change necessary?

In API Gateway HTTP API event all headers are stored in the `headers` dictionary always lowercase, for example these raw headers:

```
Foo: baz
bar: baz
```
note how one header name is capitalised (`Foo`) and the other isn't (`bar`).

In API Gateway, this will result in 
```
"event": {
  "headers": {
    "foo": "baz",
    "bar": "baz"
  }
}
```
note how `foo` and `bar` are both lowercase.

SAM will also treat headers as case-insensitive but unfortunately the case is capitalised instead of lowercase:

```
"event": {
  "headers": {
    "Foo": "baz",
    "Bar": "baz"
  }
}
```

this PR makes SAM behave like API Gateway.

#### How does it address the issue?

By making the keys of the `headers` dictionary lowercase, as they are in API Gateway.

#### What side effects does this change have?
users who were dealing with this inconsistency as in the example below, will have to modify their code:

```
if (process.env.AWS_SAM_LOCAL) {
    myvar  = event.headers.Myheader;
} else {
    myvar = event.headers.myheader;
}
```

because now `myheader` will be found both in SAM Local and in API Gateway. So the if-else condition is not required.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
