### PR TITLE
Sam delete bug fixes

### DIFF
--- a/samcli/commands/delete/delete_context.py
+++ b/samcli/commands/delete/delete_context.py
@@ -64,7 +64,7 @@ class DeleteContext:
                 )
             else:
                 raise click.BadOptionUsage(
-                    option_name="delete",
+                    option_name="--stack-name",
                     message="Missing option '--stack-name', provide a stack name that needs to be deleted.",
                 )
 
@@ -107,7 +107,7 @@ class DeleteContext:
                 self.region = region if region else "us-east-1"
             else:
                 raise click.BadOptionUsage(
-                    option_name="delete",
+                    option_name="--region",
                     message="Missing option '--region', region is required to run the non guided delete command.",
                 )
 

--- a/samcli/commands/delete/delete_context.py
+++ b/samcli/commands/delete/delete_context.py
@@ -35,7 +35,7 @@ LOG = logging.getLogger(__name__)
 
 
 class DeleteContext:
-    # TODO: Separate this context into guided and non-guided just like deploy.
+    # TODO: Separate this context into 2 separate contexts guided and non-guided, just like deploy.
     def __init__(self, stack_name: str, region: str, profile: str, config_file: str, config_env: str, no_prompts: bool):
         self.stack_name = stack_name
         self.region = region

--- a/samcli/commands/delete/delete_context.py
+++ b/samcli/commands/delete/delete_context.py
@@ -60,7 +60,7 @@ class DeleteContext:
             LOG.debug("No stack-name input found")
             if not self.no_prompts:
                 self.stack_name = prompt(
-                    click.style("\tEnter stack name you want to delete:", bold=True), type=click.STRING
+                    click.style("\tEnter stack name you want to delete", bold=True), type=click.STRING
                 )
             else:
                 raise click.BadOptionUsage(

--- a/samcli/lib/delete/cf_utils.py
+++ b/samcli/lib/delete/cf_utils.py
@@ -30,6 +30,10 @@ class CfUtils:
                 return False
 
             stack = resp["Stacks"][0]
+            if stack["EnableTerminationProtection"]:
+                message = "Stack cannot be deleted while TerminationProtection is enabled."
+                raise DeleteFailedError(stack_name=stack_name, msg=message)
+
             # Note: Stacks with REVIEW_IN_PROGRESS can be deleted
             # using delete_stack but get_template does not return
             # the template_str for this stack restricting deletion of
@@ -52,11 +56,6 @@ class CfUtils:
 
             LOG.error("Botocore Exception : %s", str(e))
             raise DeleteFailedError(stack_name=stack_name, msg=str(e)) from e
-
-        except Exception as e:
-            # We don't know anything about this exception. Don't handle
-            LOG.error("Unable to get stack details.", exc_info=e)
-            raise e
 
     def get_stack_template(self, stack_name: str, stage: str) -> Dict:
         """

--- a/samcli/lib/package/ecr_uploader.py
+++ b/samcli/lib/package/ecr_uploader.py
@@ -133,8 +133,10 @@ class ECRUploader:
 
         except botocore.exceptions.ClientError as ex:
             # Handle Client errors such as RepositoryNotFoundException or InvalidParameterException
-            LOG.error("DeleteArtifactFailedError Exception : %s", str(ex))
-            raise DeleteArtifactFailedError(resource_id=resource_id, property_name=property_name, ex=ex) from ex
+            if "RepositoryNotFoundException" not in str(ex):
+                LOG.debug("DeleteArtifactFailedError Exception : %s", str(ex))
+                raise DeleteArtifactFailedError(resource_id=resource_id, property_name=property_name, ex=ex) from ex
+            LOG.debug("RepositoryNotFoundException : %s", str(ex))
 
     def delete_ecr_repository(self, physical_id: str):
         """

--- a/samcli/lib/package/packageable_resources.py
+++ b/samcli/lib/package/packageable_resources.py
@@ -178,7 +178,7 @@ class ResourceZip(Resource):
             return {"Bucket": None, "Key": None}
 
         resource_path = jmespath.search(self.PROPERTY_NAME, resource_dict)
-        if resource_path:
+        if resource_path and isinstance(resource_path, str):
             return self.uploader.parse_s3_url(resource_path)
         return {"Bucket": None, "Key": None}
 
@@ -350,7 +350,9 @@ class ResourceWithS3UrlDict(ResourceZip):
         s3_bucket = resource_path.get(self.BUCKET_NAME_PROPERTY, None)
 
         key = resource_path.get(self.OBJECT_KEY_PROPERTY, None)
-        return {"Bucket": s3_bucket, "Key": key}
+        if isinstance(s3_bucket, str) and isinstance(key, str):
+            return {"Bucket": s3_bucket, "Key": key}
+        return {"Bucket": None, "Key": None}
 
 
 class ServerlessFunctionResource(ResourceZip):

--- a/samcli/lib/package/packageable_resources.py
+++ b/samcli/lib/package/packageable_resources.py
@@ -178,6 +178,10 @@ class ResourceZip(Resource):
             return {"Bucket": None, "Key": None}
 
         resource_path = jmespath.search(self.PROPERTY_NAME, resource_dict)
+        # In the case where resource_path is pointing to an intrinsinc
+        # ref function, sam delete will delete the stack but skip the deletion of this
+        # artifact, as deletion of intrinsic ref function artifacts is not supported yet.
+        # TODO: Allow deletion of S3 artifacts with intrinsic ref functions.
         if resource_path and isinstance(resource_path, str):
             return self.uploader.parse_s3_url(resource_path)
         return {"Bucket": None, "Key": None}
@@ -233,12 +237,14 @@ class ResourceImageDict(Resource):
             return
 
         remote_path = resource_dict.get(self.PROPERTY_NAME, {}).get(self.EXPORT_PROPERTY_CODE_KEY)
-        if is_ecr_url(remote_path):
+        # In the case where remote_path is pointing to an intrinsinc
+        # ref function, sam delete will delete the stack but skip the deletion of this
+        # artifact, as deletion of intrinsic ref function artifacts is not supported yet.
+        # TODO: Allow deletion of ECR artifacts with intrinsic ref functions.
+        if isinstance(remote_path, str) and is_ecr_url(remote_path):
             self.uploader.delete_artifact(
                 image_uri=remote_path, resource_id=resource_id, property_name=self.PROPERTY_NAME
             )
-        else:
-            raise ValueError("URL given to the parse method is not a valid ECR url {0}".format(remote_path))
 
 
 class ResourceImage(Resource):
@@ -288,13 +294,15 @@ class ResourceImage(Resource):
         if resource_dict is None:
             return
 
-        remote_path = resource_dict[self.PROPERTY_NAME]
-        if is_ecr_url(remote_path):
+        remote_path = resource_dict.get(self.PROPERTY_NAME)
+        # In the case where remote_path is pointing to an intrinsinc
+        # ref function, sam delete will delete the stack but skip the deletion of this
+        # artifact, as deletion of intrinsic ref function artifacts is not supported yet.
+        # TODO: Allow deletion of ECR artifacts with intrinsic ref functions.
+        if isinstance(remote_path, str) and is_ecr_url(remote_path):
             self.uploader.delete_artifact(
                 image_uri=remote_path, resource_id=resource_id, property_name=self.PROPERTY_NAME
             )
-        else:
-            raise ValueError("URL given to the parse method is not a valid ECR url {0}".format(remote_path))
 
 
 class ResourceWithS3UrlDict(ResourceZip):
@@ -350,6 +358,10 @@ class ResourceWithS3UrlDict(ResourceZip):
         s3_bucket = resource_path.get(self.BUCKET_NAME_PROPERTY, None)
 
         key = resource_path.get(self.OBJECT_KEY_PROPERTY, None)
+        # In the case where resource_path is pointing to an intrinsinc
+        # ref function, sam delete will delete the stack but skip the deletion of this
+        # artifact, as deletion of intrinsic ref function artifacts is not supported yet.
+        # TODO: Allow deletion of S3 artifacts with intrinsic ref functions.
         if isinstance(s3_bucket, str) and isinstance(key, str):
             return {"Bucket": s3_bucket, "Key": key}
         return {"Bucket": None, "Key": None}
@@ -537,7 +549,8 @@ class ECRResource(Resource):
             return
 
         repository_name = self.get_property_value(resource_dict)
-        if repository_name:
+        # TODO: Allow deletion of ECR Repositories with intrinsic ref functions.
+        if repository_name and isinstance(repository_name, str):
             self.uploader.delete_ecr_repository(physical_id=repository_name)
 
     def get_property_value(self, resource_dict):

--- a/samcli/lib/package/s3_uploader.py
+++ b/samcli/lib/package/s3_uploader.py
@@ -189,7 +189,7 @@ class S3Uploader:
             LOG.error("Bucket not specified")
             raise BucketNotSpecifiedError()
         if self.prefix:
-            response = self.s3.list_objects_v2(Bucket=self.bucket_name, Prefix=self.prefix)
+            response = self.s3.list_objects_v2(Bucket=self.bucket_name, Prefix=self.prefix + "/")
             prefix_files = response.get("Contents", [])
             for obj in prefix_files:
                 self.delete_artifact(obj["Key"], True)

--- a/samcli/lib/package/s3_uploader.py
+++ b/samcli/lib/package/s3_uploader.py
@@ -189,6 +189,8 @@ class S3Uploader:
             LOG.error("Bucket not specified")
             raise BucketNotSpecifiedError()
         if self.prefix:
+            # Note: list_objects_v2 api uses prefix to fetch the keys that begin with the prefix
+            # To restrict fetching files with exact prefix self.prefix, "/" is used below.
             response = self.s3.list_objects_v2(Bucket=self.bucket_name, Prefix=self.prefix + "/")
             prefix_files = response.get("Contents", [])
             for obj in prefix_files:

--- a/tests/integration/delete/delete_integ_base.py
+++ b/tests/integration/delete/delete_integ_base.py
@@ -1,11 +1,12 @@
 import os
+from pathlib import Path
 from unittest import TestCase
 
 
 class DeleteIntegBase(TestCase):
     @classmethod
     def setUpClass(cls):
-        pass
+        cls.delete_test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "delete")
 
     def setUp(self):
         super().setUp()

--- a/tests/integration/testdata/delete/aws-ecr-repository.yaml
+++ b/tests/integration/testdata/delete/aws-ecr-repository.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Stack for creating ECR repository for testing
+Resources:
+  MyRepository: 
+    Type: AWS::ECR::Repository
+    Properties: 
+        RepositoryName: "test-stack-with-ecr-repository"

--- a/tests/integration/testdata/delete/aws-serverless-function-retain.yaml
+++ b/tests/integration/testdata/delete/aws-serverless-function-retain.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application.
+
+Parameters:
+  Parameter:
+    Type: String
+    Default: Sample
+    Description: A custom parameter
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.handler
+      Runtime: python3.7
+      CodeUri: .
+      Timeout: 600
+    DeletionPolicy: Retain

--- a/tests/unit/commands/delete/test_delete_context.py
+++ b/tests/unit/commands/delete/test_delete_context.py
@@ -99,7 +99,7 @@ class TestDeleteContext(TestCase):
             patched_confirm.side_effect = [True]
 
             expected_prompt_calls = [
-                call(click.style("\tEnter stack name you want to delete:", bold=True), type=click.STRING),
+                call(click.style("\tEnter stack name you want to delete", bold=True), type=click.STRING),
             ]
 
         self.assertEqual(expected_prompt_calls, patched_prompt.call_args_list)

--- a/tests/unit/lib/delete/test_cf_utils.py
+++ b/tests/unit/lib/delete/test_cf_utils.py
@@ -51,14 +51,16 @@ class TestCfUtils(TestCase):
         with self.assertRaises(DeleteFailedError):
             self.cf_utils.has_stack("test")
 
-    def test_cf_utils_has_stack_exception(self):
-        self.cf_utils._client.describe_stacks = MagicMock(side_effect=Exception())
-        with self.assertRaises(Exception):
+    def test_cf_utils_has_stack_termination_protection_enabled(self):
+        self.cf_utils._client.describe_stacks = MagicMock(
+            return_value={"Stacks": [{"StackStatus": "CREATE_COMPLETE", "EnableTerminationProtection": True}]}
+        )
+        with self.assertRaises(DeleteFailedError):
             self.cf_utils.has_stack("test")
 
     def test_cf_utils_has_stack_in_review(self):
         self.cf_utils._client.describe_stacks = MagicMock(
-            return_value={"Stacks": [{"StackStatus": "REVIEW_IN_PROGRESS"}]}
+            return_value={"Stacks": [{"StackStatus": "REVIEW_IN_PROGRESS", "EnableTerminationProtection": False}]}
         )
         self.assertEqual(self.cf_utils.has_stack("test"), False)
 


### PR DESCRIPTION
Bugs fixed and new changes:
- No stack-name present when no-prompts is provided
- No region present when no-prompts is provided
- Retaining everything when a stack has termination protection enabled
- ecr_uploader.delete_artifact tries to delete an image from a repository that is already deleted (In the case of deleting ECR Companion Stack)
- Double checking if s3_bucket and key are strings in packageable_resources
- More integration tests for guided and non-guided delete

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
