### PR TITLE
fix(integ): Use images that are in public ecr

### DIFF
--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -32,11 +32,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def setUpClass(cls):
         cls.docker_client = docker.from_env()
         cls.local_images = [
-            ("alpine", "latest"),
-            # below 3 images are for test_deploy_nested_stacks()
-            ("python", "3.9-slim"),
-            ("python", "3.8-slim"),
-            ("python", "3.7-slim"),
+            ("public.ecr.aws/sam/emulation-python3.8", "latest"),
         ]
         # setup some images locally by pulling them.
         for repo, tag in cls.local_images:

--- a/tests/integration/package/test_package_command_image.py
+++ b/tests/integration/package/test_package_command_image.py
@@ -27,11 +27,7 @@ class TestPackageImage(PackageIntegBase):
     def setUpClass(cls):
         cls.docker_client = docker.from_env()
         cls.local_images = [
-            ("alpine", "latest"),
-            # below 3 images are for test_package_with_deep_nested_template_image()
-            ("python", "3.9-slim"),
-            ("python", "3.8-slim"),
-            ("python", "3.7-slim"),
+            ("public.ecr.aws/sam/emulation-python3.8", "latest"),
         ]
         # setup some images locally by pulling them.
         for repo, tag in cls.local_images:
@@ -211,9 +207,7 @@ class TestPackageImage(PackageIntegBase):
 
         # verify all function images are pushed
         images = [
-            ("python", "3.9-slim"),
-            ("python", "3.8-slim"),
-            ("python", "3.7-slim"),
+            ("public.ecr.aws/sam/emulation-python3.8", "latest"),
         ]
         for image, tag in images:
             # check string like this:

--- a/tests/integration/testdata/package/aws-lambda-function-image-and-api.yaml
+++ b/tests/integration/testdata/package/aws-lambda-function-image-and-api.yaml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       PackageType: Image
-      Code: alpine:latest
+      Code: public.ecr.aws/sam/emulation-python3.8:latest
       Role:
         Fn::GetAtt:
           - "LambdaExecutionRole"

--- a/tests/integration/testdata/package/aws-lambda-function-image.yaml
+++ b/tests/integration/testdata/package/aws-lambda-function-image.yaml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       PackageType: Image
-      Code: alpine:latest
+      Code: public.ecr.aws/sam/emulation-python3.8:latest
       Role:
         Fn::GetAtt:
           - "LambdaExecutionRole"

--- a/tests/integration/testdata/package/aws-serverless-function-image.yaml
+++ b/tests/integration/testdata/package/aws-serverless-function-image.yaml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       PackageType: Image
-      ImageUri: alpine:latest
+      ImageUri: public.ecr.aws/sam/emulation-python3.8:latest
       Events:
         HelloWorld:
           Type: Api

--- a/tests/integration/testdata/package/deep-nested-image/ChildStackX/ChildStackY/template.yaml
+++ b/tests/integration/testdata/package/deep-nested-image/ChildStackX/ChildStackY/template.yaml
@@ -7,4 +7,4 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       PackageType: Image
-      ImageUri: python:3.9-slim
+      ImageUri: public.ecr.aws/sam/emulation-python3.8:latest

--- a/tests/integration/testdata/package/deep-nested-image/ChildStackX/template.yaml
+++ b/tests/integration/testdata/package/deep-nested-image/ChildStackX/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       PackageType: Image
-      ImageUri: python:3.7-slim
+      ImageUri: public.ecr.aws/sam/emulation-python3.8:latest
 
   ChildStackY:
     Type: AWS::Serverless::Application

--- a/tests/integration/testdata/package/deep-nested-image/template.yaml
+++ b/tests/integration/testdata/package/deep-nested-image/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       PackageType: Image
-      ImageUri: python:3.8-slim
+      ImageUri: public.ecr.aws/sam/emulation-python3.8:latest
 
   ChildStackX:
     Type: AWS::Serverless::Application


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
Our Canaries keep failing with Dockerhub limits. We are hitting this because some of our tests are downloading and using images from Dockerhub. This PR forces us to use images that are on Public ECR.

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
