### PR TITLE
Fix code formatting in installer script

### DIFF
--- a/installer/assets/install
+++ b/installer/assets/install
@@ -37,27 +37,27 @@ parse_commandline() {
   while test $# -gt 0
   do
     key="$1"
-	case "$key" in
-	  -i|--install-dir)
-	    PARSED_INSTALL_DIR="$2"
-		shift
-	   ;;
-	  -b|--bin-dir)
-	    PARSED_BIN_DIR="$2"
-		shift
-	   ;;
-	  -u|--update)
-	    PARSED_UPGRADE="yes"
-	  ;;
-	  -h|--help)
-	    usage
+    case "$key" in
+      -i|--install-dir)
+        PARSED_INSTALL_DIR="$2"
+        shift
+        ;;
+      -b|--bin-dir)
+        PARSED_BIN_DIR="$2"
+        shift
+        ;;
+      -u|--update)
+        PARSED_UPGRADE="yes"
+        ;;
+      -h|--help)
+        usage
         exit 0
-	  ;;
-	  *)
-	   die "Got an unexpected argument: $1"
-	  ;;
+        ;;
+      *)
+        die "Got an unexpected argument: $1"
+        ;;
     esac
-	shift
+    shift
   done
 }
 
@@ -127,9 +127,9 @@ create_bin_symlinks() {
 }
 
 die() {
-	err_msg="$1"
-	echo "$err_msg" >&2
-	exit 1
+  err_msg="$1"
+  echo "$err_msg" >&2
+  exit 1
 }
 
 main() {


### PR DESCRIPTION
My editor shows tabs and spaces differently, so it stood out that tabs were mixed in with spaces in the indentation.

This commit formats the code to be more readable and eliminates the tabs.

--

#### Which issue(s) does this change fix?

None

#### Why is this change necessary?

Makes code more readable

#### What side effects does this change have?

None

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
