### PR TITLE
Add to PipelineExecutionRolePermissions to allow stack deletion

### DIFF
--- a/samcli/lib/pipeline/bootstrap/stage_resources.yaml
+++ b/samcli/lib/pipeline/bootstrap/stage_resources.yaml
@@ -228,13 +228,16 @@ Resources:
               - "cloudformation:CreateChangeSet"
               - "cloudformation:DescribeChangeSet"
               - "cloudformation:ExecuteChangeSet"
+              - "cloudformation:DeleteStack"
               - "cloudformation:DescribeStackEvents"
               - "cloudformation:DescribeStacks"
+              - "cloudformation:GetTemplate"
               - "cloudformation:GetTemplateSummary"
               - "cloudformation:DescribeStackResource"
             Resource: '*'
           - Effect: Allow
             Action:
+              - 's3:DeleteObject'
               - 's3:GetObject*'
               - 's3:PutObject*'
               - 's3:GetBucket*'


### PR DESCRIPTION
Why
---

The `PipelineExecutionRole` is assumed by the `PipelineUser` when deploying CI/CD pipelines.
This role doesn't have permission to delete stacks via `sam delete`. This means that any stacks
created need to be deleted manually. In order to support automated stack deletions for feature
branches, this role needs a few extra permissions.

This change is needed to support the this PR in the sam pipeline
templates:

https://github.com/aws/aws-sam-cli-pipeline-init-templates/pull/42

How
---

- Add three additional IAM permissions which allow the `sam delete` command to work as 
expected in `PipelineExecutionRolePermissions`.

Next Steps
----------

- After this is merged, [this PR in the Pipeline templates for GitHub Actions](https://github.com/aws/aws-sam-cli-pipeline-init-templates/pull/42) 
can be merged.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
