### PR TITLE
fix: `sam deploy` fails because bootstap stack is not created 

### DIFF
--- a/samcli/lib/bootstrap/bootstrap.py
+++ b/samcli/lib/bootstrap/bootstrap.py
@@ -81,7 +81,13 @@ def _get_stack_template():
                                 "Resource": {
                                     "Fn::Join": [
                                         "",
-                                        ["arn:", {"Ref": "AWS::Partition"}, ":s3:::", {"Ref": "SamCliSourceBucket"}, "/*"],
+                                        [
+                                            "arn:",
+                                            {"Ref": "AWS::Partition"},
+                                            ":s3:::",
+                                            {"Ref": "SamCliSourceBucket"},
+                                            "/*",
+                                        ],
                                     ]
                                 },
                                 "Principal": {"Service": "serverlessrepo.amazonaws.com"},

--- a/samcli/lib/bootstrap/bootstrap.py
+++ b/samcli/lib/bootstrap/bootstrap.py
@@ -72,7 +72,7 @@ def _get_stack_template():
             "SamCliSourceBucketBucketPolicy": {
                 "Type": "AWS::S3::BucketPolicy",
                 "Properties": {
-                    "Bucket": "!Ref SamCliSourceBucket",
+                    "Bucket": {"Ref": "SamCliSourceBucket"},
                     "PolicyDocument": {
                         "Statement": [
                             {
@@ -81,17 +81,17 @@ def _get_stack_template():
                                 "Resource": {
                                     "Fn::Join": [
                                         "",
-                                        ["arn:", "!Ref AWS::Partition", ":s3:::", "!Ref SamCliSourceBucket", "/*"],
+                                        ["arn:", {"Ref": "AWS::Partition"}, ":s3:::", {"Ref": "SamCliSourceBucket"}, "/*"],
                                     ]
                                 },
                                 "Principal": {"Service": "serverlessrepo.amazonaws.com"},
-                                "Condition": {"StringEquals": {"aws:SourceAccount": "!Ref AWS::AccountId"}},
+                                "Condition": {"StringEquals": {"aws:SourceAccount": {"Ref": "AWS::AccountId"}}},
                             }
                         ]
                     },
                 },
             },
         },
-        "Outputs": {"SourceBucket": {"Value": "!Ref SamCliSourceBucket"}},
+        "Outputs": {"SourceBucket": {"Value": {"Ref": "SamCliSourceBucket"}}},
     }
     return json.dumps(template)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#3243

#### Why is this change necessary?

`sam deploy` fails if the bootstrap CFn stack is not created yet.

The reason is that the creation of `SamCliSourceBucketBucketPolicy` fails.
The Events tab of CFn console tells "The specified bucket is not valid. (Service: Amazon S3; Status Code: 400; Error Code: InvalidBucketName)".

<img width="1468" alt="2021-09-04 0 27 29" src="https://user-images.githubusercontent.com/47307/132031368-9bcc5c9c-98e6-4b1b-9ac2-0f5e2a68c083.png">

#### How does it address the issue?

`!Ref` can only be used in YAML.
All `"!Ref foo"` are changed to `{"Ref": "foo"}`.

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
