### PR TITLE
fix: Revert the behavior when both ImageUri and Metadata exist for im…

### DIFF
--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -144,8 +144,12 @@ class SamFunctionProvider(SamBaseProvider):
                             SamFunctionProvider._warn_code_extraction(resource_type, name, code_property_key)
                         continue
 
-                    if resource_package_type == IMAGE and SamBaseProvider._is_ecr_uri(
-                        resource_properties.get(image_property_key)
+                    if (
+                        resource_package_type == IMAGE
+                        and SamBaseProvider._is_ecr_uri(resource_properties.get(image_property_key))
+                        and not SamFunctionProvider._metadata_has_necessary_entries_for_image_function_to_be_built(
+                            resource_metadata
+                        )
                     ):
                         # ImageUri can be an ECR uri, which is not supported
                         if not ignore_code_extraction_warnings:
@@ -460,3 +464,19 @@ class SamFunctionProvider(SamBaseProvider):
         if not candidates:
             raise RuntimeError(f"Cannot find resources with stack_path = {stack_path}")
         return candidates[0]
+
+    @staticmethod
+    def _metadata_has_necessary_entries_for_image_function_to_be_built(metadata: Optional[Dict[str, Any]]) -> bool:
+        """
+        > Note: If the PackageType property is set to Image, then either ImageUri is required,
+          or you must build your application with necessary Metadata entries in the AWS SAM template file.
+          https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-imageuri
+
+        When ImageUri and Metadata are both provided, we will try to determine whether to treat the function
+        as to be built or to be skipped. When we skip it whenever "ImageUri" is provided,
+        we introduced a breaking change https://github.com/aws/aws-sam-cli/issues/3239
+
+        This function is used to check whether there are the customers have "intention" to
+        let AWS SAM CLI to build this image function.
+        """
+        return isinstance(metadata, dict) and bool(metadata.get("DockerContext"))

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -95,6 +95,15 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     "PackageType": IMAGE,
                 },
             },
+            "SamFuncWithImage4": {
+                # ImageUri is unsupported ECR location, but metadata is still provided, build
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "ImageUri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo:myimage",
+                    "PackageType": IMAGE,
+                },
+                "Metadata": {"DockerTag": "tag", "DockerContext": "./image", "Dockerfile": "Dockerfile"},
+            },
             "LambdaFunc1": {
                 "Type": "AWS::Lambda::Function",
                 "Properties": {
@@ -125,6 +134,15 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     "Code": {"ImageUri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo"},
                     "PackageType": IMAGE,
                 },
+            },
+            "LambdaFuncWithImage4": {
+                # ImageUri is unsupported ECR location, but metadata is still provided, build
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "Code": {"ImageUri": "123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo"},
+                    "PackageType": IMAGE,
+                },
+                "Metadata": {"DockerTag": "tag", "DockerContext": "./image", "Dockerfile": "Dockerfile"},
             },
             "LambdaFuncWithInlineCode": {
                 "Type": "AWS::Lambda::Function",
@@ -338,6 +356,33 @@ class TestSamFunctionProviderEndToEnd(TestCase):
             ),
             ("SamFuncWithImage3", None),  # imageuri is ecr location, ignored
             (
+                "SamFuncWithImage4",  # despite imageuri is ecr location, the necessary metadata is still provided, build
+                Function(
+                    name="SamFuncWithImage4",
+                    functionname="SamFuncWithImage4",
+                    runtime=None,
+                    handler=None,
+                    codeuri=".",
+                    memory=None,
+                    timeout=None,
+                    environment=None,
+                    rolearn=None,
+                    layers=[],
+                    events=None,
+                    inlinecode=None,
+                    imageuri="123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo:myimage",
+                    imageconfig=None,
+                    packagetype=IMAGE,
+                    metadata={
+                        "DockerTag": "tag",
+                        "DockerContext": os.path.join("image"),
+                        "Dockerfile": "Dockerfile",
+                    },
+                    codesign_config_arn=None,
+                    stack_path="",
+                ),
+            ),
+            (
                 "SamFuncWithFunctionNameOverride-x",
                 Function(
                     name="SamFuncWithFunctionNameOverride",
@@ -416,6 +461,33 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                 ),
             ),
             ("LambdaFuncWithImage3", None),  # imageuri is a ecr location, ignored
+            (
+                "LambdaFuncWithImage4",  # despite imageuri is ecr location, the necessary metadata is still provided, build
+                Function(
+                    name="LambdaFuncWithImage4",
+                    functionname="LambdaFuncWithImage4",
+                    runtime=None,
+                    handler=None,
+                    codeuri=".",
+                    memory=None,
+                    timeout=None,
+                    environment=None,
+                    rolearn=None,
+                    layers=[],
+                    events=None,
+                    metadata={
+                        "DockerTag": "tag",
+                        "DockerContext": os.path.join("image"),
+                        "Dockerfile": "Dockerfile",
+                    },
+                    inlinecode=None,
+                    imageuri="123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo",
+                    imageconfig=None,
+                    packagetype=IMAGE,
+                    codesign_config_arn=None,
+                    stack_path="",
+                ),
+            ),
             (
                 "LambdaFuncWithInlineCode",
                 Function(
@@ -595,10 +667,12 @@ class TestSamFunctionProviderEndToEnd(TestCase):
             "SamFunctions",
             "SamFuncWithImage1",
             "SamFuncWithImage2",
+            "SamFuncWithImage4",
             "SamFuncWithInlineCode",
             "SamFuncWithFunctionNameOverride",
             "LambdaFuncWithImage1",
             "LambdaFuncWithImage2",
+            "LambdaFuncWithImage4",
             "LambdaFuncWithInlineCode",
             "LambdaFuncWithLocalPath",
             "LambdaFuncWithFunctionNameOverride",


### PR DESCRIPTION
…age func

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

Fix #3239 by breaking change #2935
When both ImageUri and Metadata are provided, previously we choose to give "Metadata" the priority and build it. But now we skip it because ImageUri is provided.

#### How does it address the issue?

Fix the logics so that function is only skipped when ImageUri is provided and related fields cannot be found in Metadata. Previous behavior is partially recovered.

#### What side effects does this change have?

N/A

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
