### PR TITLE
fix: Nodejs debug paths different than non debug

### DIFF
--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -108,7 +108,8 @@ class LambdaDebugSettings:
                 + ["--no-lazy", "--expose-gc"]
                 + ["/var/runtime/index.js"],
                 container_env_vars={
-                    "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node10/node_modules:/var/runtime/node_modules",
+                    "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node10/node_modules:/var/runtime/node_modules:"
+                    "/var/runtime:/var/task",
                     "NODE_OPTIONS": f"--inspect-brk=0.0.0.0:{str(debug_port)} --max-http-header-size 81920",
                     "AWS_EXECUTION_ENV": "AWS_Lambda_nodejs10.x",
                     **_container_env_vars,
@@ -121,7 +122,8 @@ class LambdaDebugSettings:
                 + ["--no-lazy", "--expose-gc"]
                 + ["/var/runtime/index.js"],
                 container_env_vars={
-                    "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node12/node_modules:/var/runtime/node_modules",
+                    "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node12/node_modules:/var/runtime/node_modules:"
+                    "/var/runtime:/var/task",
                     "NODE_OPTIONS": f"--inspect-brk=0.0.0.0:{str(debug_port)} --max-http-header-size 81920",
                     "AWS_EXECUTION_ENV": "AWS_Lambda_nodejs12.x",
                     **_container_env_vars,
@@ -134,7 +136,8 @@ class LambdaDebugSettings:
                 + ["--no-lazy", "--expose-gc"]
                 + ["/var/runtime/index.js"],
                 container_env_vars={
-                    "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node14/node_modules:/var/runtime/node_modules",
+                    "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node14/node_modules:/var/runtime/node_modules:"
+                    "/var/runtime:/var/task",
                     "NODE_OPTIONS": f"--inspect-brk=0.0.0.0:{str(debug_port)} --max-http-header-size 81920",
                     "AWS_EXECUTION_ENV": "AWS_Lambda_nodejs14.x",
                     **_container_env_vars,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#3205 

#### Why is this change necessary?
To fix difference in node paths between debug and non debug

#### How does it address the issue?
Added missing path entries in proper settings object.

#### What side effects does this change have?
None

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
