### PR TITLE
fix: don't pull partial xray traces

### DIFF
--- a/samcli/lib/observability/xray_traces/xray_event_puller.py
+++ b/samcli/lib/observability/xray_traces/xray_event_puller.py
@@ -114,7 +114,8 @@ class XRayTracePuller(AbstractXRayPuller):
             trace_summaries = result.get("TraceSummaries", [])
             for trace_summary in trace_summaries:
                 trace_id = trace_summary.get("Id", None)
-                if trace_id not in self._previous_trace_ids:
+                is_partial = trace_summary.get("IsPartial", False)
+                if not is_partial and trace_id not in self._previous_trace_ids:
                     trace_ids.append(trace_id)
                     self._previous_trace_ids.add(trace_id)
 


### PR DESCRIPTION
When pulling XRay traces, it sometimes returns partial results where the trace recording is not completed, and their times have been reported wrong (zeros or negative values).

This change will fix this issue by not pulling certain XRay trace if it is still marked as partial

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
