### PR TITLE
Add disable rollback option

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ chevron~=0.12
 click~=7.1
 Flask~=1.1.2
 #Need to add Schemas latest SDK.
-boto3~=1.14
+boto3~=1.18
 jmespath~=0.10.0
 PyYAML~=5.3
 cookiecutter~=1.7.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ pytest-cov==2.10.1
 # here we fix its version and upgrade it manually in the future
 mypy==0.790
 # 1.17.91 has a bug, https://github.com/vemel/mypy_boto3_builder/pull/82
-boto3-stubs[essential]==1.17.90.post1
+boto3-stubs[essential]~=1.18
 
 # Test requirements
 pytest==6.1.1

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -167,6 +167,13 @@ LOG = logging.getLogger(__name__)
     "A companion stack containing ECR repos for each function will be deployed along with the template stack. "
     "Automatically created image repositories will be deleted if the corresponding functions are removed.",
 )
+@click.option(
+    "--disable-rollback/--no-disable-rollback",
+    default=False,
+    required=False,
+    is_flag=True,
+    help="Preserves the state of previously provisioned resources when an operation fails.",
+)
 @metadata_override_option
 @notification_arns_override_option
 @tags_override_option
@@ -208,6 +215,7 @@ def cli(
     resolve_image_repos,
     config_file,
     config_env,
+    disable_rollback,
 ):
     """
     `sam deploy` command entry point
@@ -241,6 +249,7 @@ def cli(
         config_file,
         config_env,
         resolve_image_repos,
+        disable_rollback,
     )  # pragma: no cover
 
 
@@ -272,6 +281,7 @@ def do_cli(
     config_file,
     config_env,
     resolve_image_repos,
+    disable_rollback,
 ):
     """
     Implementation of the ``cli`` method
@@ -299,6 +309,7 @@ def do_cli(
             config_section=CONFIG_SECTION,
             config_env=config_env,
             config_file=config_file,
+            disable_rollback=disable_rollback,
         )
         guided_context.run()
     else:
@@ -361,5 +372,6 @@ def do_cli(
             profile=profile,
             confirm_changeset=guided_context.confirm_changeset if guided else confirm_changeset,
             signing_profiles=guided_context.signing_profiles if guided else signing_profiles,
+            disable_rollback=guided_context.disable_rollback if guided else disable_rollback,
         ) as deploy_context:
             deploy_context.run()

--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -59,6 +59,7 @@ class GuidedContext:
         config_section=None,
         config_env=None,
         config_file=None,
+        disable_rollback=None,
     ):
         self.template_file = template_file
         self.stack_name = stack_name
@@ -89,6 +90,7 @@ class GuidedContext:
         self.end_bold = "\033[0m"
         self.color = Colored()
         self.function_provider = None
+        self.disable_rollback = disable_rollback
 
     @property
     def guided_capabilities(self):
@@ -146,6 +148,9 @@ class GuidedContext:
             f"\t{self.start_bold}Allow SAM CLI IAM role creation{self.end_bold}", default=True
         )
 
+        click.secho("\t#Preserves the state of previously provisioned resources when an operation fails")
+        disable_rollback = confirm(f"\t{self.start_bold}Disable rollback{self.end_bold}", default=self.disable_rollback)
+
         if not capabilities_confirm:
             input_capabilities = prompt(
                 f"\t{self.start_bold}Capabilities{self.end_bold}",
@@ -194,6 +199,7 @@ class GuidedContext:
         self.config_env = config_env if config_env else default_config_env
         self.config_file = config_file if config_file else default_config_file
         self.confirm_changeset = confirm_changeset
+        self.disable_rollback = disable_rollback
 
     def prompt_authorization(self, stacks: List[Stack]):
         auth_required_per_resource = auth_per_resource(stacks)
@@ -560,6 +566,7 @@ class GuidedContext:
                 confirm_changeset=self.confirm_changeset,
                 capabilities=self._capabilities,
                 signing_profiles=self.signing_profiles,
+                disable_rollback=self.disable_rollback,
             )
 
     @staticmethod

--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -148,15 +148,15 @@ class GuidedContext:
             f"\t{self.start_bold}Allow SAM CLI IAM role creation{self.end_bold}", default=True
         )
 
-        click.secho("\t#Preserves the state of previously provisioned resources when an operation fails")
-        disable_rollback = confirm(f"\t{self.start_bold}Disable rollback{self.end_bold}", default=self.disable_rollback)
-
         if not capabilities_confirm:
             input_capabilities = prompt(
                 f"\t{self.start_bold}Capabilities{self.end_bold}",
                 default=list(default_capabilities),
                 type=FuncParamType(func=_space_separated_list_func_type),
             )
+
+        click.secho("\t#Preserves the state of previously provisioned resources when an operation fails")
+        disable_rollback = confirm(f"\t{self.start_bold}Disable rollback{self.end_bold}", default=self.disable_rollback)
 
         self.prompt_authorization(stacks)
         self.prompt_code_signing_settings(stacks)

--- a/samcli/commands/deploy/utils.py
+++ b/samcli/commands/deploy/utils.py
@@ -18,6 +18,7 @@ def print_deploy_args(
     parameter_overrides,
     confirm_changeset,
     signing_profiles,
+    disable_rollback,
 ):
     """
     Print a table of the values that are used during a sam deploy.
@@ -30,6 +31,7 @@ def print_deploy_args(
         Stack name                 : sam-app
         Region                     : us-east-1
         Confirm changeset          : False
+        Disable rollback           : False
         Deployment s3 bucket       : aws-sam-cli-managed-default-samclisourcebucket-abcdef
         Capabilities               : ["CAPABILITY_IAM"]
         Parameter overrides        : {'MyParamater': '***', 'Parameter2': 'dd'}
@@ -43,6 +45,7 @@ def print_deploy_args(
     :param parameter_overrides: Cloudformation parameter overrides to be supplied based on the stack's template
     :param confirm_changeset: Prompt for changeset to be confirmed before going ahead with the deploy.
     :param signing_profiles: Signing profile details which will be used to sign functions/layers
+    :param disable_rollback: Preserve the state of previously provisioned resources when an operation fails.
     """
     _parameters = parameter_overrides.copy()
 
@@ -63,6 +66,7 @@ def print_deploy_args(
     click.echo(f"\tStack name                   : {stack_name}")
     click.echo(f"\tRegion                       : {region}")
     click.echo(f"\tConfirm changeset            : {confirm_changeset}")
+    click.echo(f"\tDisable rollback             : {disable_rollback}")
     if image_repository:
         msg = "Deployment image repository  : "
         # NOTE(sriram-mv): tab length is 8 spaces.

--- a/tests/integration/deploy/deploy_integ_base.py
+++ b/tests/integration/deploy/deploy_integ_base.py
@@ -47,6 +47,7 @@ class DeployIntegBase(TestCase):
         config_file=None,
         signing_profiles=None,
         resolve_image_repos=False,
+        disable_rollback=False,
     ):
         command_list = [self.base_command(), "deploy"]
 
@@ -106,6 +107,8 @@ class DeployIntegBase(TestCase):
             command_list = command_list + ["--signing-profiles", str(signing_profiles)]
         if resolve_image_repos:
             command_list = command_list + ["--resolve-image-repos"]
+        if disable_rollback:
+            command_list = command_list + ["--disable-rollback"]
 
         return command_list
 

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -5,7 +5,7 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
-from unittest import skipIf
+from unittest import skipIf, skip
 
 import boto3
 from botocore.exceptions import ClientError
@@ -928,6 +928,245 @@ to create a managed default bucket, or run sam deploy --guided",
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         # verify child stack ChildStackX's creation
         self.assertRegex(process_stdout, r"CREATE_COMPLETE.+ChildStackX")
+
+    @parameterized.expand(["aws-dynamodb-error.yaml"])
+    def test_deploy_create_failed_rollback(self, template_file):
+        template_path = self.test_data_path.joinpath(template_file)
+
+        stack_name = self._method_to_stack_name(self.id())
+        self.stacks.append({"name": stack_name})
+
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            image_repository=self.ecr_repo_name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="ShardCountParameter=1",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+        )
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
+
+        stderr = deploy_process_execute.stderr.strip()
+        self.assertIn(
+            bytes(
+                f"Error: Failed to create/update the stack: {stack_name}, Waiter StackCreateComplete failed: "
+                f'Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" '
+                f'we matched expected path: "ROLLBACK_COMPLETE" at least once',
+                encoding="utf-8",
+            ),
+            stderr,
+        )
+
+    @skip("skip until cloudformation bug is fixed")
+    @parameterized.expand(["aws-dynamodb-error.yaml"])
+    def test_deploy_create_failed_disable_rollback(self, template_file):
+        template_path = self.test_data_path.joinpath(template_file)
+
+        stack_name = self._method_to_stack_name(self.id())
+        self.stacks.append({"name": stack_name})
+
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            image_repository=self.ecr_repo_name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="ShardCountParameter=1",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+            disable_rollback=True,
+        )
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
+
+        stderr = deploy_process_execute.stderr.strip()
+        self.assertIn(
+            bytes(
+                f"Error: Failed to create/update the stack: {stack_name}, Waiter StackCreateComplete failed: "
+                f'Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" '
+                f'we matched expected path: "CREATE_FAILED" at least once',
+                encoding="utf-8",
+            ),
+            stderr,
+        )
+
+        # Fix template and deploy again
+        template_path = self.test_data_path.joinpath("aws-dynamodb-error-fixed.yaml")
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            image_repository=self.ecr_repo_name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="ShardCountParameter=1",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+            disable_rollback=True,
+        )
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
+
+    @parameterized.expand(["aws-serverless-function.yaml"])
+    def test_deploy_update_failed_rollback(self, template_file):
+        template_path = self.test_data_path.joinpath(template_file)
+
+        stack_name = self._method_to_stack_name(self.id())
+        self.stacks.append({"name": stack_name})
+
+        # First deploy a simple template that should work
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            image_repository=self.ecr_repo_name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="Parameter=Clarity",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+        )
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
+
+        # Now update stack with failing template
+        template_path = self.test_data_path.joinpath("aws-dynamodb-error.yaml")
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            image_repository=self.ecr_repo_name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="ShardCountParameter=1",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+        )
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
+
+        stderr = deploy_process_execute.stderr.strip()
+        self.assertIn(
+            bytes(
+                f"Error: Failed to create/update the stack: {stack_name}, Waiter StackUpdateComplete failed: "
+                f'Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" '
+                f'we matched expected path: "UPDATE_ROLLBACK_COMPLETE" at least once',
+                encoding="utf-8",
+            ),
+            stderr,
+        )
+
+    @parameterized.expand(["aws-serverless-function.yaml"])
+    def test_deploy_update_failed_disable_rollback(self, template_file):
+        template_path = self.test_data_path.joinpath(template_file)
+
+        stack_name = self._method_to_stack_name(self.id())
+        self.stacks.append({"name": stack_name})
+
+        # First deploy a simple template that should work
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            image_repository=self.ecr_repo_name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="Parameter=Clarity",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+        )
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
+
+        # Now update stack with failing template
+        template_path = self.test_data_path.joinpath("aws-dynamodb-error.yaml")
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            image_repository=self.ecr_repo_name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="ShardCountParameter=1",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+            disable_rollback=True,
+        )
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
+
+        stderr = deploy_process_execute.stderr.strip()
+        self.assertIn(
+            bytes(
+                f"Error: Failed to create/update the stack: {stack_name}, Waiter StackUpdateComplete failed: "
+                f'Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" '
+                f'we matched expected path: "UPDATE_FAILED" at least once',
+                encoding="utf-8",
+            ),
+            stderr,
+        )
+
+        # Fix template and deploy again
+        template_path = self.test_data_path.joinpath("aws-dynamodb-error-fixed.yaml")
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            image_repository=self.ecr_repo_name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="ShardCountParameter=1",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+            disable_rollback=True,
+        )
+
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     def _method_to_stack_name(self, method_name):
         """Method expects method name which can be a full path. Eg: test.integration.test_deploy_command.method_name"""

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -586,7 +586,7 @@ to create a managed default bucket, or run sam deploy --guided",
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\n\n\n\n\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\n\n\nn\n\n\n\n\n\n".format(stack_name).encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -606,7 +606,7 @@ to create a managed default bucket, or run sam deploy --guided",
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, f"{stack_name}\n\n\n\ny\n\n\ny\n\n\n\n".encode()
+            deploy_command_list, f"{stack_name}\n\n\n\nn\ny\n\n\ny\n\n\n\n".encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -626,7 +626,7 @@ to create a managed default bucket, or run sam deploy --guided",
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, f"{stack_name}\n\n\n\ny\n\n\n\nn\n{self.ecr_repo_name}\n\n\n\n".encode()
+            deploy_command_list, f"{stack_name}\n\n\n\nn\ny\n\n\n\nn\n{self.ecr_repo_name}\n\n\n\n".encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -654,7 +654,7 @@ to create a managed default bucket, or run sam deploy --guided",
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\nSuppliedParameter\n\n\n\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\nSuppliedParameter\n\n\nn\n\n\n\n\n".format(stack_name).encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -675,7 +675,7 @@ to create a managed default bucket, or run sam deploy --guided",
 
         deploy_process_execute = run_command_with_input(
             deploy_command_list,
-            "{}\n\nSuppliedParameter\n\nn\nCAPABILITY_IAM CAPABILITY_NAMED_IAM\n\n\n\n".format(stack_name).encode(),
+            "{}\n\nSuppliedParameter\n\nn\nCAPABILITY_IAM CAPABILITY_NAMED_IAM\nn\n\n\n\n".format(stack_name).encode(),
         )
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
@@ -695,7 +695,7 @@ to create a managed default bucket, or run sam deploy --guided",
 
         # Set no for Allow SAM CLI IAM role creation, but allow default of ["CAPABILITY_IAM"] by just hitting the return key.
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\nSuppliedParameter\n\nn\n\n\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\nSuppliedParameter\n\nn\n\nn\n\n\n\n\n".format(stack_name).encode()
         )
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
@@ -714,7 +714,7 @@ to create a managed default bucket, or run sam deploy --guided",
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\nSuppliedParameter\nY\n\nY\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\n\nSuppliedParameter\nY\n\nn\nY\n\n\n\n".format(stack_name).encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -887,7 +887,7 @@ to create a managed default bucket, or run sam deploy --guided",
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, f"{stack_name}\n{region}\n\nN\nCAPABILITY_IAM CAPABILITY_AUTO_EXPAND\nN\n".encode()
+            deploy_command_list, f"{stack_name}\n{region}\nN\nN\nCAPABILITY_IAM CAPABILITY_AUTO_EXPAND\nn\nN\n".encode()
         )
 
         if will_succeed:

--- a/tests/integration/testdata/package/aws-dynamodb-error-fixed.yaml
+++ b/tests/integration/testdata/package/aws-dynamodb-error-fixed.yaml
@@ -1,0 +1,46 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template to fix & remediate
+Parameters:
+  ShardCountParameter:
+    Type: Number
+    MinValue: 1
+    MaxValue: 10
+    Description: The number of shards for the Kinesis stream
+Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+  MyQueue:
+    Type: AWS::SQS::Queue
+  MyStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: !Ref ShardCountParameter
+  MyTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: "ArtistId"
+          AttributeType: "S"
+        - AttributeName: "Concert"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "ArtistId"
+          KeyType: "HASH"
+        - AttributeName: "Concert"
+          KeyType: "RANGE"
+      KinesisStreamSpecification:
+        StreamArn: !GetAtt MyStream.Arn
+Outputs:
+  BucketName:
+    Value: !Ref MyBucket
+    Description: The name of my S3 bucket
+  QueueName:
+    Value: !GetAtt MyQueue.QueueName
+    Description: The name of my SQS queue
+  StreamName:
+    Value: !Ref MyStream
+    Description: The name of my Kinesis stream
+  TableName:
+    Value: !Ref MyTable
+    Description: The name of my DynamoDB table

--- a/tests/integration/testdata/package/aws-dynamodb-error.yaml
+++ b/tests/integration/testdata/package/aws-dynamodb-error.yaml
@@ -1,0 +1,46 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template to fix & remediate
+Parameters:
+  ShardCountParameter:
+    Type: Number
+    Description: The number of shards for the Kinesis stream
+Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+  MyQueue:
+    Type: AWS::SQS::Queue
+  MyStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: !Ref ShardCountParameter
+  MyTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: "ArtistId"
+          AttributeType: "S"
+        - AttributeName: "Concert"
+          AttributeType: "S"
+        - AttributeName: "TicketSales"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "ArtistId"
+          KeyType: "HASH"
+        - AttributeName: "Concert"
+          KeyType: "RANGE"
+      KinesisStreamSpecification:
+        StreamArn: !GetAtt MyStream.Arn
+Outputs:
+  BucketName:
+    Value: !Ref MyBucket
+    Description: The name of my S3 bucket
+  QueueName:
+    Value: !GetAtt MyQueue.QueueName
+    Description: The name of my SQS queue
+  StreamName:
+    Value: !Ref MyStream
+    Description: The name of my Kinesis stream
+  TableName:
+    Value: !Ref MyTable
+    Description: The name of my DynamoDB table

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -48,6 +48,7 @@ class TestDeployCliCommand(TestCase):
         self.config_file = "mock-default-filename"
         self.signing_profiles = None
         self.resolve_image_repos = False
+        self.disable_rollback = False
         MOCK_SAM_CONFIG.reset_mock()
 
         self.companion_stack_manager_patch = patch("samcli.commands.deploy.guided_context.CompanionStackManager")
@@ -98,6 +99,7 @@ class TestDeployCliCommand(TestCase):
             config_env=self.config_env,
             config_file=self.config_file,
             resolve_image_repos=self.resolve_image_repos,
+            disable_rollback=self.disable_rollback,
         )
 
         mock_deploy_context.assert_called_with(
@@ -121,6 +123,7 @@ class TestDeployCliCommand(TestCase):
             profile=self.profile,
             confirm_changeset=self.confirm_changeset,
             signing_profiles=self.signing_profiles,
+            disable_rollback=self.disable_rollback,
         )
 
         context_mock.run.assert_called_with()
@@ -159,7 +162,7 @@ class TestDeployCliCommand(TestCase):
         context_mock = Mock()
         mockauth_per_resource.return_value = [("HelloWorldResource1", False), ("HelloWorldResource2", False)]
         mock_deploy_context.return_value.__enter__.return_value = context_mock
-        mock_confirm.side_effect = [True, True, True, False]
+        mock_confirm.side_effect = [True, True, False, True, False]
         mock_prompt.side_effect = [
             "sam-app",
             "us-east-1",
@@ -208,6 +211,7 @@ class TestDeployCliCommand(TestCase):
                     config_env=self.config_env,
                     config_file=self.config_file,
                     resolve_image_repos=self.resolve_image_repos,
+                    disable_rollback=self.disable_rollback,
                 )
 
     @patch("samcli.commands.package.command.click")
@@ -251,7 +255,7 @@ class TestDeployCliCommand(TestCase):
         mock_sam_function_provider.return_value.get_all.return_value = [function_mock]
         mockauth_per_resource.return_value = [("HelloWorldResource", False)]
         mock_deploy_context.return_value.__enter__.return_value = context_mock
-        mock_confirm.side_effect = [True, False, True, True, True, True]
+        mock_confirm.side_effect = [True, False, True, True, True, True, True]
         mock_prompt.side_effect = [
             "sam-app",
             "us-east-1",
@@ -300,6 +304,7 @@ class TestDeployCliCommand(TestCase):
                 config_env=self.config_env,
                 config_file=self.config_file,
                 resolve_image_repos=self.resolve_image_repos,
+                disable_rollback=self.disable_rollback,
             )
 
             mock_deploy_context.assert_called_with(
@@ -323,6 +328,7 @@ class TestDeployCliCommand(TestCase):
                 profile=self.profile,
                 confirm_changeset=True,
                 signing_profiles=self.signing_profiles,
+                disable_rollback=True,
             )
 
             context_mock.run.assert_called_with()
@@ -342,6 +348,7 @@ class TestDeployCliCommand(TestCase):
                 stack_name="sam-app",
                 s3_prefix="sam-app",
                 signing_profiles=self.signing_profiles,
+                disable_rollback=True,
             )
             mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
             self.assertEqual(context_mock.run.call_count, 1)
@@ -406,7 +413,7 @@ class TestDeployCliCommand(TestCase):
             "testconfig.toml",
             "test-env",
         ]
-        mock_confirm.side_effect = [True, False, True, True, True, True]
+        mock_confirm.side_effect = [True, False, True, True, True, True, True]
 
         mock_managed_stack.return_value = "managed-s3-bucket"
         mock_signer_config_per_function.return_value = ({}, {})
@@ -439,6 +446,7 @@ class TestDeployCliCommand(TestCase):
             config_env=self.config_env,
             config_file=self.config_file,
             resolve_image_repos=self.resolve_image_repos,
+            disable_rollback=self.disable_rollback,
         )
 
         mock_deploy_context.assert_called_with(
@@ -466,13 +474,14 @@ class TestDeployCliCommand(TestCase):
             profile=self.profile,
             confirm_changeset=True,
             signing_profiles=self.signing_profiles,
+            disable_rollback=True,
         )
 
         context_mock.run.assert_called_with()
         mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
         self.assertEqual(context_mock.run.call_count, 1)
 
-        self.assertEqual(MOCK_SAM_CONFIG.put.call_count, 8)
+        self.assertEqual(MOCK_SAM_CONFIG.put.call_count, 9)
         self.assertEqual(
             MOCK_SAM_CONFIG.put.call_args_list,
             [
@@ -482,6 +491,7 @@ class TestDeployCliCommand(TestCase):
                 call(["deploy"], "parameters", "region", "us-east-1", env="test-env"),
                 call(["deploy"], "parameters", "confirm_changeset", True, env="test-env"),
                 call(["deploy"], "parameters", "capabilities", "CAPABILITY_IAM", env="test-env"),
+                call(["deploy"], "parameters", "disable_rollback", True, env="test-env"),
                 call(
                     ["deploy"],
                     "parameters",
@@ -557,7 +567,7 @@ class TestDeployCliCommand(TestCase):
             "testconfig.toml",
             "test-env",
         ]
-        mock_confirm.side_effect = [True, False, True, True, True, True]
+        mock_confirm.side_effect = [True, False, True, True, True, True, True]
         mock_get_cmd_names.return_value = ["deploy"]
         mock_managed_stack.return_value = "managed-s3-bucket"
         mock_signer_config_per_function.return_value = ({}, {})
@@ -590,6 +600,7 @@ class TestDeployCliCommand(TestCase):
             config_file=self.config_file,
             signing_profiles=self.signing_profiles,
             resolve_image_repos=self.resolve_image_repos,
+            disable_rollback=self.disable_rollback,
         )
 
         mock_deploy_context.assert_called_with(
@@ -613,13 +624,14 @@ class TestDeployCliCommand(TestCase):
             profile=self.profile,
             confirm_changeset=True,
             signing_profiles=self.signing_profiles,
+            disable_rollback=True,
         )
 
         context_mock.run.assert_called_with()
         mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
         self.assertEqual(context_mock.run.call_count, 1)
 
-        self.assertEqual(MOCK_SAM_CONFIG.put.call_count, 8)
+        self.assertEqual(MOCK_SAM_CONFIG.put.call_count, 9)
         self.assertEqual(
             MOCK_SAM_CONFIG.put.call_args_list,
             [
@@ -629,6 +641,7 @@ class TestDeployCliCommand(TestCase):
                 call(["deploy"], "parameters", "region", "us-east-1", env="test-env"),
                 call(["deploy"], "parameters", "confirm_changeset", True, env="test-env"),
                 call(["deploy"], "parameters", "capabilities", "CAPABILITY_IAM", env="test-env"),
+                call(["deploy"], "parameters", "disable_rollback", True, env="test-env"),
                 call(["deploy"], "parameters", "parameter_overrides", 'a="b"', env="test-env"),
                 call(
                     ["deploy"],
@@ -687,7 +700,7 @@ class TestDeployCliCommand(TestCase):
             "us-east-1",
             ("CAPABILITY_IAM",),
         ]
-        mock_confirm.side_effect = [True, False, True, False, True, True]
+        mock_confirm.side_effect = [True, True, False, True, False, True, True]
 
         mock_managed_stack.return_value = "managed-s3-bucket"
         mock_signer_config_per_function.return_value = ({}, {})
@@ -722,6 +735,7 @@ class TestDeployCliCommand(TestCase):
                 config_env=self.config_env,
                 signing_profiles=self.signing_profiles,
                 resolve_image_repos=self.resolve_image_repos,
+                disable_rollback=self.disable_rollback,
             )
 
             mock_deploy_context.assert_called_with(
@@ -745,6 +759,7 @@ class TestDeployCliCommand(TestCase):
                 profile=self.profile,
                 confirm_changeset=True,
                 signing_profiles=self.signing_profiles,
+                disable_rollback=self.disable_rollback,
             )
 
             context_mock.run.assert_called_with()
@@ -792,6 +807,7 @@ class TestDeployCliCommand(TestCase):
             config_env=self.config_env,
             signing_profiles=self.signing_profiles,
             resolve_image_repos=self.resolve_image_repos,
+            disable_rollback=self.disable_rollback,
         )
 
         mock_deploy_context.assert_called_with(
@@ -815,6 +831,7 @@ class TestDeployCliCommand(TestCase):
             profile=self.profile,
             confirm_changeset=self.confirm_changeset,
             signing_profiles=self.signing_profiles,
+            disable_rollback=self.disable_rollback,
         )
 
         context_mock.run.assert_called_with()
@@ -850,6 +867,7 @@ class TestDeployCliCommand(TestCase):
                 config_env=self.config_env,
                 signing_profiles=self.signing_profiles,
                 resolve_image_repos=self.resolve_image_repos,
+                disable_rollback=self.disable_rollback,
             )
 
     @patch("samcli.commands.package.command.click")
@@ -899,6 +917,7 @@ class TestDeployCliCommand(TestCase):
             config_env=self.config_env,
             signing_profiles=self.signing_profiles,
             resolve_image_repos=True,
+            disable_rollback=self.disable_rollback,
         )
 
         mock_deploy_context.assert_called_with(
@@ -922,6 +941,7 @@ class TestDeployCliCommand(TestCase):
             profile=self.profile,
             confirm_changeset=self.confirm_changeset,
             signing_profiles=self.signing_profiles,
+            disable_rollback=self.disable_rollback,
         )
 
         context_mock.run.assert_called_with()

--- a/tests/unit/commands/deploy/test_deploy_context.py
+++ b/tests/unit/commands/deploy/test_deploy_context.py
@@ -31,6 +31,7 @@ class TestSamDeployCommand(TestCase):
             profile=None,
             confirm_changeset=False,
             signing_profiles=None,
+            disable_rollback=False,
         )
 
     def test_template_improper(self):

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -561,6 +561,7 @@ class TestSamConfigForAllCommands(TestCase):
             "confirm_changeset": True,
             "region": "myregion",
             "signing_profiles": "function=profile:owner",
+            "disable_rollback": True,
         }
 
         with samconfig_parameters(["deploy"], self.scratch_dir, **config_values) as config_path:
@@ -605,6 +606,7 @@ class TestSamConfigForAllCommands(TestCase):
                 "samconfig.toml",
                 "default",
                 False,
+                True,
             )
 
     @patch("samcli.commands.deploy.command.do_cli")
@@ -670,6 +672,7 @@ class TestSamConfigForAllCommands(TestCase):
             "confirm_changeset": True,
             "region": "myregion",
             "signing_profiles": "function=profile:owner",
+            "disable_rollback": True,
         }
 
         with samconfig_parameters(["deploy"], self.scratch_dir, **config_values) as config_path:
@@ -714,6 +717,7 @@ class TestSamConfigForAllCommands(TestCase):
                 "samconfig.toml",
                 "default",
                 False,
+                True,
             )
 
     @patch("samcli.commands.logs.command.do_cli")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
CloudFormation recently launched a new feature that allows users to specify a DisableRollback parameter for the CreateStack, UpdateStack, and ExecuteChangeSet actions. When users pass this parameter and there’s a stack failure, they can preserve the state of successfully provisioned resources and work on the template from the point of failure. Users can also call the UpdateStack and ExecuteChangeSet on stacks that are in the CREATE_FAILED or UPDATE_FAILED states.

More information can be found in this blog post: https://aws.amazon.com/blogs/aws/new-for-aws-cloudformation-quickly-retry-stack-operations-from-the-point-of-failure/

#### How does it address the issue?
This PR adds support for this new feature in SAM CLI by adding a `--disable-rollback` option when calling `sam deploy`. If users enable this option and experience a failure while deploying, they are now able to do any fixes required and then deploy again, continuing from the point of failure while preserving the successfully created resources from the previous deploy. 

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
