### PR TITLE
fix: create deps dir

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional, List
 import click
 
 from samcli.commands.build.exceptions import InvalidBuildDirException, MissingBuildMethodException
+from samcli.lib.build.build_graph import DEFAULT_DEPENDENCIES_DIR
 from samcli.lib.intrinsic_resolver.intrinsics_symbol_table import IntrinsicsSymbolTable
 from samcli.lib.providers.provider import ResourcesToBuildCollector, Stack, Function, LayerVersion
 from samcli.lib.providers.sam_function_provider import SamFunctionProvider
@@ -134,6 +135,9 @@ class BuildContext:
             cache_path = pathlib.Path(self._cache_dir)
             cache_path.mkdir(mode=self._BUILD_DIR_PERMISSIONS, parents=True, exist_ok=True)
             self._cache_dir = str(cache_path.resolve())
+
+            dependencies_path = pathlib.Path(DEFAULT_DEPENDENCIES_DIR)
+            dependencies_path.mkdir(mode=self._BUILD_DIR_PERMISSIONS, parents=True, exist_ok=True)
 
         if self._use_container:
             self._container_manager = ContainerManager(

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, Mock, ANY, call
 
 from parameterized import parameterized
 
+from samcli.lib.build.build_graph import DEFAULT_DEPENDENCIES_DIR
 from samcli.local.lambdafn.exceptions import ResourceNotFound
 from samcli.commands.build.build_context import BuildContext
 from samcli.commands.build.exceptions import InvalidBuildDirException, MissingBuildMethodException
@@ -586,6 +587,46 @@ class TestBuildContext_setup_build_dir(TestCase):
         shutil_patch.rmtree.assert_not_called()
         pathlib_patch.Path.cwd.assert_called_once()
 
+class TestBuildContext_setup_cached_and_deps_dir(TestCase):
+
+    @parameterized.expand([
+        (True,),
+        (False,)
+    ])
+    @patch("samcli.commands.build.build_context.pathlib.Path")
+    @patch("samcli.commands.build.build_context.SamLocalStackProvider")
+    @patch("samcli.commands.build.build_context.SamFunctionProvider")
+    @patch("samcli.commands.build.build_context.SamLayerProvider")
+    def test_cached_dir_and_deps_dir_creation(self, cached, patched_layer, patched_function, patched_stack, patched_path):
+        patched_stack.get_stacks.return_value = ([], None)
+        build_context = BuildContext(
+            resource_identifier="function_identifier",
+            template_file="template_file",
+            base_dir="base_dir",
+            build_dir="build_dir",
+            cache_dir="cache_dir",
+            parallel=False,
+            mode="mode",
+            cached=cached
+        )
+
+        with patch.object(build_context, "_setup_build_dir"):
+            build_context.set_up()
+
+            call_assertion = lambda: patched_path.assert_has_calls([
+                call("cache_dir"),
+                call().mkdir(exist_ok=True, mode=BuildContext._BUILD_DIR_PERMISSIONS, parents=True),
+                call(DEFAULT_DEPENDENCIES_DIR),
+                call().mkdir(exist_ok=True, mode=BuildContext._BUILD_DIR_PERMISSIONS, parents=True)
+            ], any_order=True)
+
+            # if it is cached validate calls above is made,
+            # otherwise validate an assertion will be raised since they are not called
+            if cached:
+                call_assertion()
+            else:
+                with self.assertRaises(AssertionError):
+                    call_assertion()
 
 class TestBuildContext_run(TestCase):
     @patch("samcli.commands.build.build_context.SamLocalStackProvider.get_stacks")


### PR DESCRIPTION
Always create dependencies directory, if cached build is enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
