### PR TITLE
fix: Improve the behaviour of failing sync when definition URI is not found

### DIFF
--- a/samcli/lib/sync/flows/http_api_sync_flow.py
+++ b/samcli/lib/sync/flows/http_api_sync_flow.py
@@ -58,11 +58,6 @@ class HttpApiSyncFlow(GenericApiSyncFlow):
     def sync(self) -> None:
         api_physical_id = self.get_physical_id(self._api_identifier)
         if self._definition_uri is None:
-            LOG.error(
-                "%sImport HttpApi is skipped since no DefinitionUri defined in the template, \
-if you are using DefinitionBody please run sam sync --infra",
-                self.log_prefix,
-            )
             raise MissingLocalDefinition(ResourceIdentifier(self._api_identifier), "DefinitionUri")
         LOG.debug("%sTrying to import HttpAPI through client", self.log_prefix)
         response = self._api_client.reimport_api(ApiId=api_physical_id, Body=self._swagger_body)

--- a/samcli/lib/sync/flows/rest_api_sync_flow.py
+++ b/samcli/lib/sync/flows/rest_api_sync_flow.py
@@ -58,11 +58,6 @@ class RestApiSyncFlow(GenericApiSyncFlow):
     def sync(self) -> None:
         api_physical_id = self.get_physical_id(self._api_identifier)
         if self._definition_uri is None:
-            LOG.error(
-                "%sImport HttpApi is skipped since no DefinitionUri defined in the template, \
-if you are using DefinitionBody please run sam sync --infra",
-                self.log_prefix,
-            )
             raise MissingLocalDefinition(ResourceIdentifier(self._api_identifier), "DefinitionUri")
         LOG.debug("%sTrying to put RestAPI through client", self.log_prefix)
         response = self._api_client.put_rest_api(restApiId=api_physical_id, mode="overwrite", body=self._swagger_body)

--- a/samcli/lib/sync/flows/stepfunctions_sync_flow.py
+++ b/samcli/lib/sync/flows/stepfunctions_sync_flow.py
@@ -96,11 +96,6 @@ class StepFunctionsSyncFlow(SyncFlow):
     def sync(self) -> None:
         state_machine_arn = self.get_physical_id(self._state_machine_identifier)
         if self._definition_uri is None:
-            LOG.error(
-                "%sUpdate State Machine is skipped since no DefinitionUri defined in the template, \
-if you are using inline Definition please run sam sync --infra",
-                self.log_prefix,
-            )
             raise MissingLocalDefinition(ResourceIdentifier(self._state_machine_identifier), "DefinitionUri")
         LOG.debug("%sTrying to update State Machine definition", self.log_prefix)
         response = self._stepfunctions_client.update_state_machine(

--- a/samcli/lib/sync/sync_flow_executor.py
+++ b/samcli/lib/sync/sync_flow_executor.py
@@ -81,9 +81,10 @@ def default_exception_handler(sync_flow_exception: SyncFlowException) -> None:
         LOG.error("Cannot find any versions for layer %s.%s", exception.layer_name_arn, HELP_TEXT_FOR_SYNC_INFRA)
     elif isinstance(exception, MissingLocalDefinition):
         LOG.error(
-            "Resource %s does not have %s specified. Skipping the sync.",
-            str(exception.resource_identifier),
+            "Resource %s does not have %s specified. Skipping the sync.%s",
+            exception.resource_identifier,
             exception.property_name,
+            HELP_TEXT_FOR_SYNC_INFRA,
         )
     else:
         raise exception

--- a/tests/unit/lib/sync/test_sync_flow_executor.py
+++ b/tests/unit/lib/sync/test_sync_flow_executor.py
@@ -91,9 +91,10 @@ class TestSyncFlowExecutor(TestCase):
         log_mock.error.assert_has_calls(
             [
                 call(
-                    "Resource %s does not have %s specified. Skipping the sync.",
+                    "Resource %s does not have %s specified. Skipping the sync.%s",
                     exception.resource_identifier,
                     exception.property_name,
+                    HELP_TEXT_FOR_SYNC_INFRA,
                 )
             ]
         )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#3342

#### Why is this change necessary?
To provide a smooth experience with code sync

#### How does it address the issue?
Change the exception to a message warning about definition URI not found and skipping sync

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
