### PR TITLE
Revert "Fix #3334"

### DIFF
--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -23,7 +23,7 @@ fi
 
 set -eu
 
-yum install -y zlib-devel openssl-devel libffi-devel
+yum install -y zlib-devel openssl-devel
 
 echo "Making Folders"
 mkdir -p .build/src
@@ -43,7 +43,6 @@ cd Python-$python_version
 ./configure --enable-shared
 make -j8
 make install
-ldconfig
 cd ..
 
 echo "Installing Python Libraries"


### PR DESCRIPTION
Reverting as this may cause issue with PyInstaller artifact generation pipeline which uses a different image.
An alternative solution of pointing to that specific version of manylinux image will be explored.
https://quay.io/repository/pypa/manylinux2014_x86_64/manifest/sha256:80f84a1c8b6d25d7ec4d89cc909c734266fa34cf14d20fd54859fca0a20248f4
Reverts aws/aws-sam-cli#3355