### PR TITLE
fix: dont pass dependencies dir if experimental is not enabled

### DIFF
--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -162,7 +162,7 @@ class DefaultBuildStrategy(BuildStrategy):
             single_build_dir,
             build_definition.metadata,
             container_env_vars,
-            build_definition.dependencies_dir,
+            build_definition.dependencies_dir if is_experimental_enabled(ExperimentalFlag.Accelerate) else None,
             build_definition.download_dependencies,
         )
         function_build_results[single_full_path] = result


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
