### PR TITLE
Revert "Revert "Fix #3334""

### DIFF
--- a/installer/pyinstaller/Instruction.md
+++ b/installer/pyinstaller/Instruction.md
@@ -1,6 +1,6 @@
 Running build script
 ```
-docker run --mount type=bind,src="{Absolute path to AWS SAM CLI source}",dst="/aws-sam-cli" -it quay.io/pypa/manylinux2014_x86_64
+docker run --mount type=bind,src="{Absolute path to AWS SAM CLI source}",dst="/aws-sam-cli" -it quay.io/pypa/manylinux2014_x86_64:2021-01-24-91ce2b8
 cd aws-sam-cli
 ./installer/pyinstaller/build-linux.sh aws-sam-cli-linux-x86_64.zip
 ```

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -23,7 +23,7 @@ fi
 
 set -eu
 
-yum install -y zlib-devel openssl-devel
+yum install -y zlib-devel openssl-devel libffi-devel
 
 echo "Making Folders"
 mkdir -p .build/src
@@ -43,6 +43,7 @@ cd Python-$python_version
 ./configure --enable-shared
 make -j8
 make install
+ldconfig
 cd ..
 
 echo "Installing Python Libraries"


### PR DESCRIPTION
Reverts aws/aws-sam-cli#3393

https://github.com/aws/aws-sam-cli/issues/3416

Tested on Ubuntu 20.04. Compared ldd with previous script, no diff was found.
ldd output on `quay.io/pypa/manylinux2014_x86_64:2021-01-24-91ce2b8`:
```
.build/output/pyinstaller-output/dist/array.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_asyncio.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/aws_lambda_builders:
.build/output/pyinstaller-output/dist/backports:
.build/output/pyinstaller-output/dist/base_library.zip:
	not a dynamic executable
.build/output/pyinstaller-output/dist/binascii.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libz.so.1 => /lib64/libz.so.1 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_bisect.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_blake2.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/boto3:
.build/output/pyinstaller-output/dist/botocore:
.build/output/pyinstaller-output/dist/certifi:
.build/output/pyinstaller-output/dist/_codecs_cn.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_codecs_hk.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_codecs_iso2022.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_codecs_jp.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_codecs_kr.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_codecs_tw.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_contextvars.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_csv.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_ctypes.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libffi.so.6 => /lib64/libffi.so.6 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
.build/output/pyinstaller-output/dist/_datetime.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libm.so.6 => /lib64/libm.so.6 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
.build/output/pyinstaller-output/dist/_decimal.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libm.so.6 => /lib64/libm.so.6 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
.build/output/pyinstaller-output/dist/_elementtree.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/fcntl.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/grp.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_hashlib.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libssl.so.10 => /lib64/libssl.so.10 ()
	libcrypto.so.10 => /lib64/libcrypto.so.10 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libgssapi_krb5.so.2 => /lib64/libgssapi_krb5.so.2 ()
	libkrb5.so.3 => /lib64/libkrb5.so.3 ()
	libcom_err.so.2 => /lib64/libcom_err.so.2 ()
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libz.so.1 => /lib64/libz.so.1 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 ()
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 ()
	libresolv.so.2 => /lib64/libresolv.so.2 ()
	libselinux.so.1 => /lib64/libselinux.so.1 ()
	libpcre.so.1 => /lib64/libpcre.so.1 ()
.build/output/pyinstaller-output/dist/_heapq.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/importlib_metadata-4.8.1-py3.7.egg-info:
.build/output/pyinstaller-output/dist/include:
.build/output/pyinstaller-output/dist/_json.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/jsonschema:
.build/output/pyinstaller-output/dist/jsonschema-3.2.0-py3.7.egg-info:
.build/output/pyinstaller-output/dist/lib:
.build/output/pyinstaller-output/dist/libcom_err.so.2:
	linux-vdso.so.1 =>  ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/libcrypto.so.10:
	linux-vdso.so.1 =>  ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libz.so.1 => /lib64/libz.so.1 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/libcrypt.so.2:
	linux-vdso.so.1 =>  ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/libffi.so.6:
	linux-vdso.so.1 =>  ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/libgssapi_krb5.so.2:
	linux-vdso.so.1 =>  ()
	libkrb5.so.3 => /lib64/libkrb5.so.3 ()
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 ()
	libcom_err.so.2 => /lib64/libcom_err.so.2 ()
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 ()
	libresolv.so.2 => /lib64/libresolv.so.2 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libselinux.so.1 => /lib64/libselinux.so.1 ()
	libpcre.so.1 => /lib64/libpcre.so.1 ()
.build/output/pyinstaller-output/dist/libk5crypto.so.3:
	linux-vdso.so.1 =>  ()
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 ()
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 ()
	libresolv.so.2 => /lib64/libresolv.so.2 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libselinux.so.1 => /lib64/libselinux.so.1 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libpcre.so.1 => /lib64/libpcre.so.1 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
.build/output/pyinstaller-output/dist/libkeyutils.so.1:
	linux-vdso.so.1 =>  ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/libkrb5.so.3:
	linux-vdso.so.1 =>  ()
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 ()
	libcom_err.so.2 => /lib64/libcom_err.so.2 ()
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 ()
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 ()
	libresolv.so.2 => /lib64/libresolv.so.2 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libselinux.so.1 => /lib64/libselinux.so.1 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libpcre.so.1 => /lib64/libpcre.so.1 ()
.build/output/pyinstaller-output/dist/libkrb5support.so.0:
	linux-vdso.so.1 =>  ()
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 ()
	libresolv.so.2 => /lib64/libresolv.so.2 ()
	libselinux.so.1 => /lib64/libselinux.so.1 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libpcre.so.1 => /lib64/libpcre.so.1 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
.build/output/pyinstaller-output/dist/libpcre.so.1:
	linux-vdso.so.1 =>  ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/libpython3.7m.so.1.0:
	linux-vdso.so.1 =>  ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/libselinux.so.1:
	linux-vdso.so.1 =>  ()
	libpcre.so.1 => /lib64/libpcre.so.1 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
.build/output/pyinstaller-output/dist/libssl.so.10:
	linux-vdso.so.1 =>  ()
	libgssapi_krb5.so.2 => /lib64/libgssapi_krb5.so.2 ()
	libkrb5.so.3 => /lib64/libkrb5.so.3 ()
	libcom_err.so.2 => /lib64/libcom_err.so.2 ()
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 ()
	libcrypto.so.10 => /lib64/libcrypto.so.10 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libz.so.1 => /lib64/libz.so.1 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 ()
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 ()
	libresolv.so.2 => /lib64/libresolv.so.2 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libselinux.so.1 => /lib64/libselinux.so.1 ()
	libpcre.so.1 => /lib64/libpcre.so.1 ()
.build/output/pyinstaller-output/dist/libuuid.so.1:
	linux-vdso.so.1 =>  ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/libz.so.1:
	linux-vdso.so.1 =>  ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/markupsafe:
.build/output/pyinstaller-output/dist/math.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libm.so.6 => /lib64/libm.so.6 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
.build/output/pyinstaller-output/dist/_md5.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/mmap.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_multibytecodec.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_multiprocessing.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_opcode.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_pickle.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_posixsubprocess.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/pvectorc.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/pyexpat.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/pytz:
.build/output/pyinstaller-output/dist/_queue.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_random.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/regex:
.build/output/pyinstaller-output/dist/resource.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/sam:
	linux-vdso.so.1 =>  ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libz.so.1 => /lib64/libz.so.1 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/samcli:
.build/output/pyinstaller-output/dist/samtranslator:
.build/output/pyinstaller-output/dist/select.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_sha1.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_sha256.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_sha3.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_sha512.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_socket.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_ssl.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libssl.so.10 => /lib64/libssl.so.10 ()
	libcrypto.so.10 => /lib64/libcrypto.so.10 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libgssapi_krb5.so.2 => /lib64/libgssapi_krb5.so.2 ()
	libkrb5.so.3 => /lib64/libkrb5.so.3 ()
	libcom_err.so.2 => /lib64/libcom_err.so.2 ()
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libz.so.1 => /lib64/libz.so.1 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 ()
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 ()
	libresolv.so.2 => /lib64/libresolv.so.2 ()
	libselinux.so.1 => /lib64/libselinux.so.1 ()
	libpcre.so.1 => /lib64/libpcre.so.1 ()
.build/output/pyinstaller-output/dist/_struct:
.build/output/pyinstaller-output/dist/_struct.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/termios.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/text_unidecode:
.build/output/pyinstaller-output/dist/unicodedata.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
.build/output/pyinstaller-output/dist/_uuid.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libuuid.so.1 => /lib64/libuuid.so.1 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
.build/output/pyinstaller-output/dist/yaml:
.build/output/pyinstaller-output/dist/zlib:
.build/output/pyinstaller-output/dist/zlib.cpython-37m-x86_64-linux-gnu.so:
	linux-vdso.so.1 =>  ()
	libz.so.1 => /lib64/libz.so.1 ()
	libpython3.7m.so.1.0 => /usr/local/lib/libpython3.7m.so.1.0 ()
	libpthread.so.0 => /lib64/libpthread.so.0 ()
	libc.so.6 => /lib64/libc.so.6 ()
	libcrypt.so.2 => /usr/local/lib/libcrypt.so.2 ()
	libdl.so.2 => /lib64/libdl.so.2 ()
	libutil.so.1 => /lib64/libutil.so.1 ()
	libm.so.6 => /lib64/libm.so.6 ()
	/lib64/ld-linux-x86-64.so.2 ()

```