### PR TITLE
Change some uses of stage name to configuration name

### DIFF
--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -114,7 +114,7 @@ def cli(
         region=ctx.region,
         profile=ctx.profile,
         interactive=interactive,
-        stage_name=stage,
+        stage_configuration_name=stage,
         pipeline_user_arn=pipeline_user,
         pipeline_execution_role_arn=pipeline_execution_role,
         cloudformation_execution_role_arn=cloudformation_execution_role,
@@ -131,7 +131,7 @@ def do_cli(
     region: Optional[str],
     profile: Optional[str],
     interactive: bool,
-    stage_name: Optional[str],
+    stage_configuration_name: Optional[str],
     pipeline_user_arn: Optional[str],
     pipeline_execution_role_arn: Optional[str],
     cloudformation_execution_role_arn: Optional[str],
@@ -167,7 +167,7 @@ def do_cli(
 
         guided_context = GuidedContext(
             profile=profile,
-            stage_name=stage_name,
+            stage_configuration_name=stage_configuration_name,
             pipeline_user_arn=pipeline_user_arn,
             pipeline_execution_role_arn=pipeline_execution_role_arn,
             cloudformation_execution_role_arn=cloudformation_execution_role_arn,
@@ -177,7 +177,7 @@ def do_cli(
             region=region,
         )
         guided_context.run()
-        stage_name = guided_context.stage_name
+        stage_configuration_name = guided_context.stage_configuration_name
         pipeline_user_arn = guided_context.pipeline_user_arn
         pipeline_execution_role_arn = guided_context.pipeline_execution_role_arn
         cloudformation_execution_role_arn = guided_context.cloudformation_execution_role_arn
@@ -187,11 +187,11 @@ def do_cli(
         region = guided_context.region
         profile = guided_context.profile
 
-    if not stage_name:
+    if not stage_configuration_name:
         raise click.UsageError("Missing required parameter '--stage'")
 
     environment: Stage = Stage(
-        name=stage_name,
+        name=stage_configuration_name,
         aws_profile=profile,
         aws_region=region,
         pipeline_user_arn=pipeline_user_arn,

--- a/samcli/commands/pipeline/bootstrap/guided_context.py
+++ b/samcli/commands/pipeline/bootstrap/guided_context.py
@@ -76,17 +76,17 @@ class GuidedContext:
 
         try:
             account_id = get_current_account_id(self.profile)
-            click.echo(self.color.green(f"Associated account {account_id} with stage {self.stage_name}."))
+            click.echo(self.color.green(f"Associated account {account_id} with configuration {self.stage_name}."))
         except CredentialsError as ex:
             click.echo(f"{self.color.red(ex.message)}\n")
             self._prompt_account_id()
 
     def _prompt_stage_name(self) -> None:
         click.echo(
-            "Enter a name for this stage. This will be referenced later when you use the sam pipeline init command:"
+            "Enter a configuration name for this stage. This will be referenced later when you use the sam pipeline init command:"
         )
         self.stage_name = click.prompt(
-            "Stage name",
+            "Configuration name",
             default=self.stage_name,
             type=click.STRING,
         )
@@ -144,7 +144,7 @@ class GuidedContext:
     def _get_user_inputs(self) -> List[Tuple[str, Callable[[], None]]]:
         return [
             (f"Account: {get_current_account_id(self.profile)}", self._prompt_account_id),
-            (f"Stage name: {self.stage_name}", self._prompt_stage_name),
+            (f"Configuration name: {self.stage_name}", self._prompt_stage_name),
             (f"Region: {self.region}", self._prompt_region_name),
             (
                 f"Pipeline user ARN: {self.pipeline_user_arn}"
@@ -186,7 +186,7 @@ class GuidedContext:
         """
         click.secho(self.color.bold("[1] Stage definition"))
         if self.stage_name:
-            click.echo(f"Stage name: {self.stage_name}")
+            click.echo(f"Configuration name: {self.stage_name}")
         else:
             self._prompt_stage_name()
         click.echo()

--- a/samcli/commands/pipeline/bootstrap/guided_context.py
+++ b/samcli/commands/pipeline/bootstrap/guided_context.py
@@ -23,7 +23,7 @@ class GuidedContext:
     def __init__(
         self,
         profile: Optional[str] = None,
-        stage_name: Optional[str] = None,
+        stage_configuration_name: Optional[str] = None,
         pipeline_user_arn: Optional[str] = None,
         pipeline_execution_role_arn: Optional[str] = None,
         cloudformation_execution_role_arn: Optional[str] = None,
@@ -33,7 +33,7 @@ class GuidedContext:
         region: Optional[str] = None,
     ) -> None:
         self.profile = profile
-        self.stage_name = stage_name
+        self.stage_configuration_name = stage_configuration_name
         self.pipeline_user_arn = pipeline_user_arn
         self.pipeline_execution_role_arn = pipeline_execution_role_arn
         self.cloudformation_execution_role_arn = cloudformation_execution_role_arn
@@ -76,19 +76,21 @@ class GuidedContext:
 
         try:
             account_id = get_current_account_id(self.profile)
-            click.echo(self.color.green(f"Associated account {account_id} with configuration {self.stage_name}."))
+            click.echo(self.color.green(
+                f"Associated account {account_id} with configuration {self.stage_configuration_name}."
+                ))
         except CredentialsError as ex:
             click.echo(f"{self.color.red(ex.message)}\n")
             self._prompt_account_id()
 
-    def _prompt_stage_name(self) -> None:
+    def _prompt_stage_configuration_name(self) -> None:
         click.echo(
             "Enter a configuration name for this stage. "
             "This will be referenced later when you use the sam pipeline init command:"
         )
-        self.stage_name = click.prompt(
+        self.stage_configuration_name = click.prompt(
             "Configuration name",
-            default=self.stage_name,
+            default=self.stage_configuration_name,
             type=click.STRING,
         )
 
@@ -145,7 +147,7 @@ class GuidedContext:
     def _get_user_inputs(self) -> List[Tuple[str, Callable[[], None]]]:
         return [
             (f"Account: {get_current_account_id(self.profile)}", self._prompt_account_id),
-            (f"Configuration name: {self.stage_name}", self._prompt_stage_name),
+            (f"Configuration name: {self.stage_configuration_name}", self._prompt_stage_configuration_name),
             (f"Region: {self.region}", self._prompt_region_name),
             (
                 f"Pipeline user ARN: {self.pipeline_user_arn}"
@@ -186,10 +188,10 @@ class GuidedContext:
         and it will be created by the bootstrap command
         """
         click.secho(self.color.bold("[1] Stage definition"))
-        if self.stage_name:
-            click.echo(f"Configuration name: {self.stage_name}")
+        if self.stage_configuration_name:
+            click.echo(f"Configuration name: {self.stage_configuration_name}")
         else:
-            self._prompt_stage_name()
+            self._prompt_stage_configuration_name()
         click.echo()
 
         click.secho(self.color.bold("[2] Account details"))

--- a/samcli/commands/pipeline/bootstrap/guided_context.py
+++ b/samcli/commands/pipeline/bootstrap/guided_context.py
@@ -76,9 +76,9 @@ class GuidedContext:
 
         try:
             account_id = get_current_account_id(self.profile)
-            click.echo(self.color.green(
-                f"Associated account {account_id} with configuration {self.stage_configuration_name}."
-                ))
+            click.echo(
+                self.color.green(f"Associated account {account_id} with configuration {self.stage_configuration_name}.")
+            )
         except CredentialsError as ex:
             click.echo(f"{self.color.red(ex.message)}\n")
             self._prompt_account_id()

--- a/samcli/commands/pipeline/bootstrap/guided_context.py
+++ b/samcli/commands/pipeline/bootstrap/guided_context.py
@@ -83,7 +83,8 @@ class GuidedContext:
 
     def _prompt_stage_name(self) -> None:
         click.echo(
-            "Enter a configuration name for this stage. This will be referenced later when you use the sam pipeline init command:"
+            "Enter a configuration name for this stage. "
+            "This will be referenced later when you use the sam pipeline init command:"
         )
         self.stage_name = click.prompt(
             "Configuration name",

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -152,8 +152,7 @@ class InteractiveInitFlow:
                         resources.
 
                         We recommend using an individual AWS account profiles for each stage in your
-                        pipeline. You can set these profiles up using [little bit of info on how to do
-                        this/docs].
+                        pipeline. You can set these profiles up using aws configure or ~/.aws/credentials see [https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-getting-started-set-up-credentials.html].
                         """
                     )
                 )

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -124,9 +124,7 @@ class InteractiveInitFlow:
             return self._generate_from_pipeline_template(pipeline_template_local_dir)
 
     def _prompt_run_bootstrap_within_pipeline_init(
-        self,
-        stage_configuration_names: List[str],
-        number_of_stages: int
+        self, stage_configuration_names: List[str], number_of_stages: int
     ) -> bool:
         """
         Prompt bootstrap if `--bootstrap` flag is provided. Return True if bootstrap process is executed.
@@ -239,10 +237,10 @@ def _load_pipeline_bootstrap_resources() -> Tuple[List[str], Dict[str, str]]:
     # bootstrapped stage names and "default" which is used to store shared values
     # we don't want to include "default" here.
     stage_configuration_names = [
-        stage_configuration_name for stage_configuration_name
-            in config.get_stage_configuration_names()
-            if stage_configuration_name != "default"
-        ]
+        stage_configuration_name
+        for stage_configuration_name in config.get_stage_configuration_names()
+        if stage_configuration_name != "default"
+    ]
     for index, stage in enumerate(stage_configuration_names):
         for key, value in config.get_all(_get_bootstrap_command_names(), section, stage).items():
             context[str([stage, key])] = value
@@ -254,10 +252,12 @@ def _load_pipeline_bootstrap_resources() -> Tuple[List[str], Dict[str, str]]:
     stage_names_message = (
         "Here are the configuration names detected "
         + f"in {os.path.join(PIPELINE_CONFIG_DIR, PIPELINE_CONFIG_FILENAME)}:\n"
-        + "\n".join([f"\t{index + 1} - {stage_configuration_name}"
-                     for index, stage_configuration_name
-                     in enumerate(stage_configuration_names)
-                    ])
+        + "\n".join(
+            [
+                f"\t{index + 1} - {stage_configuration_name}"
+                for index, stage_configuration_name in enumerate(stage_configuration_names)
+            ]
+        )
     )
     context[str(["stage_names_message"])] = stage_names_message
 

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -244,7 +244,7 @@ def _load_pipeline_bootstrap_resources() -> Tuple[List[str], Dict[str, str]]:
 
     # pre-load the list of stage names detected from pipelineconfig.toml
     stage_names_message = (
-        "Here are the stage names detected "
+        "Here are the configuration names detected "
         + f"in {os.path.join(PIPELINE_CONFIG_DIR, PIPELINE_CONFIG_FILENAME)}:\n"
         + "\n".join([f"\t{index + 1} - {stage_name}" for index, stage_name in enumerate(stage_names)])
     )

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -152,8 +152,9 @@ class InteractiveInitFlow:
                         resources.
 
                         We recommend using an individual AWS account profiles for each stage in your
-                        pipeline. You can set these profiles up using aws configure or ~/.aws/credentials see [https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-getting-started-set-up-credentials.html].
-                        """
+                        pipeline. You can set these profiles up using aws configure or ~/.aws/credentials see
+                        [https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-getting-started-set-up-credentials.html].
+                        """  # pylint: disable=C0301
                     )
                 )
 

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -41,7 +41,7 @@ class SamConfig:
         """
         self.filepath = Path(config_dir, filename or DEFAULT_CONFIG_FILE_NAME)
 
-    def get_stage_names(self):
+    def get_stage_configuration_names(self):
         self._read()
         if isinstance(self.document, dict):
             return [stage for stage, value in self.document.items() if isinstance(value, dict)]

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -151,7 +151,7 @@ class Stage:
 
         missing_resources_msg: str = self._get_non_user_provided_resources_msg()
         click.echo(
-            f"This will create the following required resources for the '{self.name}' environment: \n"
+            f"This will create the following required resources for the '{self.name}' configuration: \n"
             f"{missing_resources_msg}"
         )
         if confirm_changeset:

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -145,7 +145,9 @@ class Stage:
 
         if self.did_user_provide_all_required_resources():
             click.secho(
-                self.color.yellow(f"\nAll required resources for the {self.name} environment exist, skipping creation.")
+                self.color.yellow(
+                    f"\nAll required resources for the {self.name} configuration exist, skipping creation."
+                )
             )
             return True
 
@@ -326,5 +328,5 @@ class Stage:
             click.secho(self.color.green(f"\tAWS_SECRET_ACCESS_KEY: {self.pipeline_user.secret_access_key}"))
 
     def _get_stack_name(self) -> str:
-        sanitized_stage_name: str = re.sub("[^0-9a-zA-Z]+", "-", self.name)
-        return f"{STACK_NAME_PREFIX}-{sanitized_stage_name}-{STAGE_RESOURCES_STACK_NAME_SUFFIX}"
+        sanitized_stage_configuration_name: str = re.sub("[^0-9a-zA-Z]+", "-", self.name)
+        return f"{STACK_NAME_PREFIX}-{sanitized_stage_configuration_name}-{STAGE_RESOURCES_STACK_NAME_SUFFIX}"

--- a/tests/integration/pipeline/base.py
+++ b/tests/integration/pipeline/base.py
@@ -94,7 +94,7 @@ class BootstrapIntegBase(PipelineBase):
     def get_bootstrap_command_list(
         self,
         no_interactive: bool = False,
-        stage_name: Optional[str] = None,
+        stage_configuration_name: Optional[str] = None,
         profile_name: Optional[str] = None,
         region: Optional[str] = None,
         pipeline_user: Optional[str] = None,
@@ -109,8 +109,8 @@ class BootstrapIntegBase(PipelineBase):
 
         if no_interactive:
             command_list += ["--no-interactive"]
-        if stage_name:
-            command_list += ["--stage", stage_name]
+        if stage_configuration_name:
+            command_list += ["--stage", stage_configuration_name]
         if profile_name:
             command_list += ["--profile", profile_name]
         if region:
@@ -148,10 +148,10 @@ class BootstrapIntegBase(PipelineBase):
     def _get_stage_and_stack_name(self, suffix: str = "") -> Tuple[str, str]:
         # Method expects method name which can be a full path. Eg: test.integration.test_bootstrap_command.method_name
         method_name = self.id().split(".")[-1]
-        stage_name = method_name.replace("_", "-") + suffix + "-" + self.randomized_stage_suffix
+        stage_configuration_name = method_name.replace("_", "-") + suffix + "-" + self.randomized_stage_suffix
 
         mock_env = Mock()
-        mock_env.name = stage_name
+        mock_env.name = stage_configuration_name
         stack_name = Stage._get_stack_name(mock_env)
 
-        return stage_name, stack_name
+        return stage_configuration_name, stack_name

--- a/tests/integration/pipeline/test_bootstrap_command.py
+++ b/tests/integration/pipeline/test_bootstrap_command.py
@@ -35,13 +35,13 @@ CFN_OUTPUT_TO_CONFIG_KEY = {
 class TestBootstrap(BootstrapIntegBase):
     @parameterized.expand([("create_image_repository",), (False,)])
     def test_interactive_with_no_resources_provided(self, create_image_repository):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list()
 
         inputs = [
-            stage_name,
+            stage_configuration_name,
             CREDENTIAL_PROFILE,
             self.region,  # region
             "",  # pipeline user
@@ -86,15 +86,15 @@ class TestBootstrap(BootstrapIntegBase):
                 set(self._extract_created_resource_logical_ids(stack_name)),
             )
             CFN_OUTPUT_TO_CONFIG_KEY["ImageRepository"] = "image_repository"
-            self.validate_pipeline_config(stack_name, stage_name, list(CFN_OUTPUT_TO_CONFIG_KEY.keys()))
+            self.validate_pipeline_config(stack_name, stage_configuration_name, list(CFN_OUTPUT_TO_CONFIG_KEY.keys()))
             del CFN_OUTPUT_TO_CONFIG_KEY["ImageRepository"]
         else:
             self.assertSetEqual(common_resources, set(self._extract_created_resource_logical_ids(stack_name)))
-            self.validate_pipeline_config(stack_name, stage_name)
+            self.validate_pipeline_config(stack_name, stage_configuration_name)
 
     @parameterized.expand([("create_image_repository",), (False,)])
     def test_non_interactive_with_no_resources_provided(self, create_image_repository):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list(
@@ -111,13 +111,13 @@ class TestBootstrap(BootstrapIntegBase):
         self.assertIn("Missing required parameter", stderr)
 
     def test_interactive_with_all_required_resources_provided(self):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list()
 
         inputs = [
-            stage_name,
+            stage_configuration_name,
             CREDENTIAL_PROFILE,
             self.region,  # region
             "arn:aws:iam::123:user/user-name",  # pipeline user
@@ -135,12 +135,12 @@ class TestBootstrap(BootstrapIntegBase):
         self.assertIn("skipping creation", stdout)
 
     def test_no_interactive_with_all_required_resources_provided(self):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list(
             no_interactive=True,
-            stage_name=stage_name,
+            stage_configuration_name=stage_configuration_name,
             pipeline_user="arn:aws:iam::123:user/user-name",  # pipeline user
             pipeline_execution_role="arn:aws:iam::123:role/role-name",  # Pipeline execution role
             cloudformation_execution_role="arn:aws:iam::123:role/role-name",  # CloudFormation execution role
@@ -155,7 +155,7 @@ class TestBootstrap(BootstrapIntegBase):
         stdout = bootstrap_process_execute.stdout.decode()
         self.assertIn("skipping creation", stdout)
 
-    def validate_pipeline_config(self, stack_name, stage_name, cfn_keys_to_check=None):
+    def validate_pipeline_config(self, stack_name, stage_configuration_name, cfn_keys_to_check=None):
         # Get output values from cloudformation
         if cfn_keys_to_check is None:
             cfn_keys_to_check = list(CFN_OUTPUT_TO_CONFIG_KEY.keys())
@@ -169,7 +169,7 @@ class TestBootstrap(BootstrapIntegBase):
 
         # Get values saved in config file
         config = SamConfig(PIPELINE_CONFIG_DIR, PIPELINE_CONFIG_FILENAME)
-        config_values = config.get_all(["pipeline", "bootstrap"], "parameters", stage_name)
+        config_values = config.get_all(["pipeline", "bootstrap"], "parameters", stage_configuration_name)
         config_values = {**config_values, **config.get_all(["pipeline", "bootstrap"], "parameters")}
 
         for key in CFN_OUTPUT_TO_CONFIG_KEY:
@@ -185,12 +185,12 @@ class TestBootstrap(BootstrapIntegBase):
 
     @parameterized.expand([("confirm_changeset",), (False,)])
     def test_no_interactive_with_some_required_resources_provided(self, confirm_changeset: bool):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list(
             no_interactive=True,
-            stage_name=stage_name,
+            stage_configuration_name=stage_configuration_name,
             pipeline_user="arn:aws:iam::123:user/user-name",  # pipeline user
             pipeline_execution_role="arn:aws:iam::123:role/role-name",  # Pipeline execution role
             # CloudFormation execution role missing
@@ -212,13 +212,13 @@ class TestBootstrap(BootstrapIntegBase):
         self.assertIn("CloudFormationExecutionRole", self._extract_created_resource_logical_ids(stack_name))
 
     def test_interactive_cancelled_by_user(self):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list()
 
         inputs = [
-            stage_name,
+            stage_configuration_name,
             CREDENTIAL_PROFILE,
             self.region,  # region
             "arn:aws:iam::123:user/user-name",  # pipeline user
@@ -238,13 +238,13 @@ class TestBootstrap(BootstrapIntegBase):
         self.assertFalse(self._stack_exists(stack_name))
 
     def test_interactive_with_some_required_resources_provided(self):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list()
 
         inputs = [
-            stage_name,
+            stage_configuration_name,
             CREDENTIAL_PROFILE,
             self.region,  # region
             "arn:aws:iam::123:user/user-name",  # pipeline user
@@ -263,24 +263,24 @@ class TestBootstrap(BootstrapIntegBase):
         self.assertIn("Successfully created!", stdout)
         # make sure the not provided resource is the only resource created.
         self.assertIn("CloudFormationExecutionRole", self._extract_created_resource_logical_ids(stack_name))
-        self.validate_pipeline_config(stack_name, stage_name)
+        self.validate_pipeline_config(stack_name, stage_configuration_name)
 
     def test_interactive_pipeline_user_only_created_once(self):
         """
         Create 3 stages, only the first stage resource stack creates
         a pipeline user, and the remaining two share the same pipeline user.
         """
-        stage_names = []
+        stage_configuration_names = []
         for suffix in ["1", "2", "3"]:
-            stage_name, stack_name = self._get_stage_and_stack_name(suffix)
-            stage_names.append(stage_name)
+            stage_configuration_name, stack_name = self._get_stage_and_stack_name(suffix)
+            stage_configuration_names.append(stage_configuration_name)
             self.stack_names.append(stack_name)
 
         bootstrap_command_list = self.get_bootstrap_command_list()
 
-        for i, stage_name in enumerate(stage_names):
+        for i, stage_configuration_name in enumerate(stage_configuration_names):
             inputs = [
-                stage_name,
+                stage_configuration_name,
                 CREDENTIAL_PROFILE,
                 self.region,  # region
                 *([""] if i == 0 else []),  # pipeline user
@@ -306,17 +306,17 @@ class TestBootstrap(BootstrapIntegBase):
                 self.assertTrue("PipelineUser" in resources)
                 self.assertTrue("PipelineUserAccessKey" in resources)
                 self.assertTrue("PipelineUserSecretKey" in resources)
-                self.validate_pipeline_config(self.stack_names[i], stage_name)
+                self.validate_pipeline_config(self.stack_names[i], stage_configuration_name)
             else:
                 self.assertIn("skipping creation", stdout)
 
     @parameterized.expand([("ArtifactsBucket",), ("ArtifactsLoggingBucket",)])
     def test_bootstrapped_buckets_accept_ssl_requests_only(self, bucket_logical_id):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list(
-            stage_name=stage_name, no_interactive=True, no_confirm_changeset=True, region=self.region
+            stage_configuration_name=stage_configuration_name, no_interactive=True, no_confirm_changeset=True, region=self.region
         )
 
         bootstrap_process_execute = run_command(bootstrap_command_list)
@@ -350,11 +350,11 @@ class TestBootstrap(BootstrapIntegBase):
         )
 
     def test_bootstrapped_artifacts_bucket_has_server_access_log_enabled(self):
-        stage_name, stack_name = self._get_stage_and_stack_name()
+        stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list(
-            stage_name=stage_name, no_interactive=True, no_confirm_changeset=True, region=self.region
+            stage_configuration_name=stage_configuration_name, no_interactive=True, no_confirm_changeset=True, region=self.region
         )
 
         bootstrap_process_execute = run_command(bootstrap_command_list)

--- a/tests/integration/pipeline/test_bootstrap_command.py
+++ b/tests/integration/pipeline/test_bootstrap_command.py
@@ -316,7 +316,10 @@ class TestBootstrap(BootstrapIntegBase):
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list(
-            stage_configuration_name=stage_configuration_name, no_interactive=True, no_confirm_changeset=True, region=self.region
+            stage_configuration_name=stage_configuration_name,
+            no_interactive=True,
+            no_confirm_changeset=True,
+            region=self.region,
         )
 
         bootstrap_process_execute = run_command(bootstrap_command_list)
@@ -354,7 +357,10 @@ class TestBootstrap(BootstrapIntegBase):
         self.stack_names = [stack_name]
 
         bootstrap_command_list = self.get_bootstrap_command_list(
-            stage_configuration_name=stage_configuration_name, no_interactive=True, no_confirm_changeset=True, region=self.region
+            stage_configuration_name=stage_configuration_name,
+            no_interactive=True,
+            no_confirm_changeset=True,
+            region=self.region,
         )
 
         bootstrap_process_execute = run_command(bootstrap_command_list)

--- a/tests/integration/pipeline/test_init_command.py
+++ b/tests/integration/pipeline/test_init_command.py
@@ -243,7 +243,7 @@ class TestInitWithBootstrap(BootstrapIntegBase):
         ]
         init_process_execute = run_command_with_inputs(self.command_list, inputs)
         self.assertEqual(init_process_execute.process.returncode, 0)
-        self.assertIn("Here are the stage names detected", init_process_execute.stdout.decode())
+        self.assertIn("Here are the configuration names detected", init_process_execute.stdout.decode())
         self.assertIn(stage_names[0], init_process_execute.stdout.decode())
         self.assertIn(stage_names[1], init_process_execute.stdout.decode())
 
@@ -296,6 +296,6 @@ class TestInitWithBootstrap(BootstrapIntegBase):
         ]
         init_process_execute = run_command_with_inputs(self.command_list, inputs)
         self.assertEqual(init_process_execute.process.returncode, 0)
-        self.assertIn("Here are the stage names detected", init_process_execute.stdout.decode())
+        self.assertIn("Here are the configuration names detected", init_process_execute.stdout.decode())
         self.assertIn(stage_names[0], init_process_execute.stdout.decode())
         self.assertIn(stage_names[1], init_process_execute.stdout.decode())

--- a/tests/integration/pipeline/test_init_command.py
+++ b/tests/integration/pipeline/test_init_command.py
@@ -202,17 +202,17 @@ class TestInitWithBootstrap(BootstrapIntegBase):
         super().tearDown()
 
     def test_without_stages_in_pipeline_config(self):
-        stage_names = []
+        stage_configuration_names = []
         for suffix in ["1", "2"]:
-            stage_name, stack_name = self._get_stage_and_stack_name(suffix)
-            stage_names.append(stage_name)
+            stage_configuration_name, stack_name = self._get_stage_and_stack_name(suffix)
+            stage_configuration_names.append(stage_configuration_name)
             self.stack_names.append(stack_name)
 
         inputs = [
             "1",  # quick start
             "1",  # jenkins, this depends on the template repo.
             "y",  # Do you want to go through stage setup process now?
-            stage_names[0],
+            stage_configuration_names[0],
             CREDENTIAL_PROFILE,
             self.region,
             "",  # pipeline user
@@ -223,7 +223,7 @@ class TestInitWithBootstrap(BootstrapIntegBase):
             "",  # Confirm summary
             "y",  # Create resources
             "y",  # Do you want to go through stage setup process now?
-            stage_names[1],
+            stage_configuration_names[1],
             CREDENTIAL_PROFILE,
             self.region,
             "",  # pipeline user
@@ -244,20 +244,20 @@ class TestInitWithBootstrap(BootstrapIntegBase):
         init_process_execute = run_command_with_inputs(self.command_list, inputs)
         self.assertEqual(init_process_execute.process.returncode, 0)
         self.assertIn("Here are the configuration names detected", init_process_execute.stdout.decode())
-        self.assertIn(stage_names[0], init_process_execute.stdout.decode())
-        self.assertIn(stage_names[1], init_process_execute.stdout.decode())
+        self.assertIn(stage_configuration_names[0], init_process_execute.stdout.decode())
+        self.assertIn(stage_configuration_names[1], init_process_execute.stdout.decode())
 
     def test_with_one_stages_in_pipeline_config(self):
-        stage_names = []
+        stage_configuration_names = []
         for suffix in ["1", "2"]:
-            stage_name, stack_name = self._get_stage_and_stack_name(suffix)
-            stage_names.append(stage_name)
+            stage_configuration_name, stack_name = self._get_stage_and_stack_name(suffix)
+            stage_configuration_names.append(stage_configuration_name)
             self.stack_names.append(stack_name)
 
         bootstrap_command_list = self.get_bootstrap_command_list()
 
         inputs = [
-            stage_names[0],
+            stage_configuration_names[0],
             CREDENTIAL_PROFILE,
             self.region,  # region
             "",  # pipeline user
@@ -277,7 +277,7 @@ class TestInitWithBootstrap(BootstrapIntegBase):
             "1",  # quick start
             "1",  # jenkins, this depends on the template repo.
             "y",  # Do you want to go through stage setup process now?
-            stage_names[1],
+            stage_configuration_names[1],
             CREDENTIAL_PROFILE,
             self.region,
             "",  # Pipeline execution role
@@ -297,5 +297,5 @@ class TestInitWithBootstrap(BootstrapIntegBase):
         init_process_execute = run_command_with_inputs(self.command_list, inputs)
         self.assertEqual(init_process_execute.process.returncode, 0)
         self.assertIn("Here are the configuration names detected", init_process_execute.stdout.decode())
-        self.assertIn(stage_names[0], init_process_execute.stdout.decode())
-        self.assertIn(stage_names[1], init_process_execute.stdout.decode())
+        self.assertIn(stage_configuration_names[0], init_process_execute.stdout.decode())
+        self.assertIn(stage_configuration_names[1], init_process_execute.stdout.decode())

--- a/tests/unit/commands/pipeline/bootstrap/test_cli.py
+++ b/tests/unit/commands/pipeline/bootstrap/test_cli.py
@@ -15,7 +15,7 @@ from samcli.commands.pipeline.bootstrap.cli import do_cli as bootstrap_cli
 
 ANY_REGION = "ANY_REGION"
 ANY_PROFILE = "ANY_PROFILE"
-ANY_STAGE_NAME = "ANY_STAGE_NAME"
+ANY_STAGE_CONFIGURATION_NAME = "ANY_STAGE_CONFIGURATION_NAME"
 ANY_PIPELINE_USER_ARN = "ANY_PIPELINE_USER_ARN"
 ANY_PIPELINE_EXECUTION_ROLE_ARN = "ANY_PIPELINE_EXECUTION_ROLE_ARN"
 ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN = "ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN"
@@ -33,7 +33,7 @@ class TestCli(TestCase):
             "region": ANY_REGION,
             "profile": ANY_PROFILE,
             "interactive": True,
-            "stage_name": ANY_STAGE_NAME,
+            "stage_configuration_name": ANY_STAGE_CONFIGURATION_NAME,
             "pipeline_user_arn": ANY_PIPELINE_USER_ARN,
             "pipeline_execution_role_arn": ANY_PIPELINE_EXECUTION_ROLE_ARN,
             "cloudformation_execution_role_arn": ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
@@ -53,12 +53,12 @@ class TestCli(TestCase):
         # interactive -> True
         # create_image_repository -> False
         # confirm_changeset -> True
-        # region, profile, stage_name and all ARNs are None
+        # region, profile, stage_configuration_name and all ARNs are None
         do_cli_mock.assert_called_once_with(
             region=None,
             profile=None,
             interactive=True,
-            stage_name=None,
+            stage_configuration_name=None,
             pipeline_user_arn=None,
             pipeline_execution_role_arn=None,
             cloudformation_execution_role_arn=None,
@@ -94,7 +94,7 @@ class TestCli(TestCase):
         )
         args, kwargs = do_cli_mock.call_args
         self.assertFalse(kwargs["interactive"])
-        self.assertEqual(kwargs["stage_name"], "environment1")
+        self.assertEqual(kwargs["stage_configuration_name"], "environment1")
         self.assertEqual(kwargs["artifacts_bucket_arn"], "bucketARN")
 
     @patch("samcli.commands.pipeline.bootstrap.cli._get_bootstrap_command_names")
@@ -153,11 +153,11 @@ class TestCli(TestCase):
     @patch("samcli.commands.pipeline.bootstrap.cli._load_saved_pipeline_user_arn")
     @patch("samcli.commands.pipeline.bootstrap.cli.Stage")
     @patch("samcli.commands.pipeline.bootstrap.cli.GuidedContext")
-    def test_stage_name_is_required_to_be_provided_in_case_of_non_interactive_mode(
+    def test_stage_configuration_name_is_required_to_be_provided_in_case_of_non_interactive_mode(
         self, guided_context_mock, environment_mock, load_saved_pipeline_user_arn_mock, get_command_names_mock
     ):
         self.cli_context["interactive"] = False
-        self.cli_context["stage_name"] = None
+        self.cli_context["stage_configuration_name"] = None
         with self.assertRaises(click.UsageError):
             bootstrap_cli(**self.cli_context)
 
@@ -165,11 +165,11 @@ class TestCli(TestCase):
     @patch("samcli.commands.pipeline.bootstrap.cli._load_saved_pipeline_user_arn")
     @patch("samcli.commands.pipeline.bootstrap.cli.Stage")
     @patch("samcli.commands.pipeline.bootstrap.cli.GuidedContext")
-    def test_stage_name_is_not_required_to_be_provided_in_case_of_interactive_mode(
+    def test_stage_configuration_name_is_not_required_to_be_provided_in_case_of_interactive_mode(
         self, guided_context_mock, environment_mock, load_saved_pipeline_user_arn_mock, get_command_names_mock
     ):
         self.cli_context["interactive"] = True
-        self.cli_context["stage_name"] = None
+        self.cli_context["stage_configuration_name"] = None
         bootstrap_cli(**self.cli_context)  # No exception is thrown
 
     @patch("samcli.commands.pipeline.bootstrap.cli._get_bootstrap_command_names")

--- a/tests/unit/commands/pipeline/bootstrap/test_guided_context.py
+++ b/tests/unit/commands/pipeline/bootstrap/test_guided_context.py
@@ -56,7 +56,7 @@ class TestGuidedContext(TestCase):
         )
         gc.run()
         prompt_account_id_mock.assert_called_once()
-        self.assertTrue(self.did_prompt_text_like("Stage Name", click_mock.prompt))
+        self.assertTrue(self.did_prompt_text_like("Configuration Name", click_mock.prompt))
         self.assertTrue(self.did_prompt_text_like("Pipeline IAM user", click_mock.prompt))
         self.assertTrue(self.did_prompt_text_like("Pipeline execution role", click_mock.prompt))
         self.assertTrue(self.did_prompt_text_like("CloudFormation execution role", click_mock.prompt))

--- a/tests/unit/commands/pipeline/bootstrap/test_guided_context.py
+++ b/tests/unit/commands/pipeline/bootstrap/test_guided_context.py
@@ -5,7 +5,7 @@ from parameterized import parameterized
 
 from samcli.commands.pipeline.bootstrap.guided_context import GuidedContext
 
-ANY_STAGE_NAME = "ANY_STAGE_NAME"
+ANY_STAGE_CONFIGURATION_NAME = "ANY_STAGE_CONFIGURATION_NAME"
 ANY_PIPELINE_USER_ARN = "ANY_PIPELINE_USER_ARN"
 ANY_PIPELINE_EXECUTION_ROLE_ARN = "ANY_PIPELINE_EXECUTION_ROLE_ARN"
 ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN = "ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN"
@@ -26,7 +26,7 @@ class TestGuidedContext(TestCase):
         click_mock.confirm.return_value = False
         click_mock.prompt = Mock(return_value="0")
         gc: GuidedContext = GuidedContext(
-            stage_name=ANY_STAGE_NAME,
+            stage_configuration_name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
@@ -75,7 +75,7 @@ class TestGuidedContext(TestCase):
         # 2 - Yes, I need a help creating one
         # 3 - I already have an ECR image repository
         gc_without_ecr_info: GuidedContext = GuidedContext(
-            stage_name=ANY_STAGE_NAME,
+            stage_configuration_name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -157,8 +157,8 @@ class TestInteractiveInitFlow(TestCase):
         config_file = Mock()
         samconfig_mock.return_value = config_file
         config_file.exists.return_value = True
-        config_file.get_stage_names.return_value = ["testing", "prod"]
-        config_file.get_stage_names.return_value = ["testing", "prod"]
+        config_file.get_stage_configuration_names.return_value = ["testing", "prod"]
+        config_file.get_stage_configuration_names.return_value = ["testing", "prod"]
         config_file.get_all.return_value = {"pipeline_execution_role": "arn:aws:iam::123456789012:role/execution-role"}
 
         click_mock.prompt.side_effect = [
@@ -426,7 +426,7 @@ class TestInteractiveInitFlowWithBootstrap(TestCase):
         config_file = Mock()
         samconfig_mock.return_value = config_file
         config_file.exists.return_value = True
-        config_file.get_stage_names.return_value = ["testing"]
+        config_file.get_stage_configuration_names.return_value = ["testing"]
         config_file.get_all.return_value = {"pipeline_execution_role": "arn:aws:iam::123456789012:role/execution-role"}
         _get_pipeline_template_metadata_mock.return_value = {"number_of_stages": 2}
 
@@ -465,7 +465,7 @@ class TestInteractiveInitFlowWithBootstrap(TestCase):
     @patch("samcli.lib.cookiecutter.question.click")
     def test_with_bootstrap_answer_yes(
         self,
-        get_stage_name_side_effects,
+        get_stage_configuration_name_side_effects,
         _prompt_run_bootstrap_expected_calls,
         click_mock,
         _get_pipeline_template_metadata_mock,
@@ -504,7 +504,7 @@ class TestInteractiveInitFlowWithBootstrap(TestCase):
         config_file = Mock()
         samconfig_mock.return_value = config_file
         config_file.exists.return_value = True
-        config_file.get_stage_names.side_effect = get_stage_name_side_effects
+        config_file.get_stage_configuration_names.side_effect = get_stage_configuration_name_side_effects
         config_file.get_all.return_value = {"pipeline_execution_role": "arn:aws:iam::123456789012:role/execution-role"}
         _get_pipeline_template_metadata_mock.return_value = {"number_of_stages": 2}
 

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -185,7 +185,7 @@ class TestInteractiveInitFlow(TestCase):
                 str(["1", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["prod", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["2", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
-                str(["stage_names_message"]): "Here are the stage names detected "
+                str(["stage_names_message"]): "Here are the configuration names detected "
                 f'in {os.path.join(".aws-sam", "pipeline", "pipelineconfig.toml")}:\n\t1 - testing\n\t2 - prod',
             }
         )

--- a/tests/unit/lib/pipeline/bootstrap/test_environment.py
+++ b/tests/unit/lib/pipeline/bootstrap/test_environment.py
@@ -388,7 +388,9 @@ class TestStage(TestCase):
     def test_print_resources_summary_prints_the_credentials_of_the_pipeline_user_iff_not_provided_by_the_user(
         self, click_mock
     ):
-        stage_with_provided_pipeline_user: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME, pipeline_user_arn=ANY_PIPELINE_USER_ARN)
+        stage_with_provided_pipeline_user: Stage = Stage(
+            name=ANY_STAGE_CONFIGURATION_NAME, pipeline_user_arn=ANY_PIPELINE_USER_ARN
+        )
         stage_with_provided_pipeline_user.print_resources_summary()
         self.assert_summary_does_not_have_a_message_like("AWS_ACCESS_KEY_ID", click_mock.secho)
         self.assert_summary_does_not_have_a_message_like("AWS_SECRET_ACCESS_KEY", click_mock.secho)

--- a/tests/unit/lib/pipeline/bootstrap/test_environment.py
+++ b/tests/unit/lib/pipeline/bootstrap/test_environment.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch, call, MagicMock
 
 from samcli.lib.pipeline.bootstrap.stage import Stage
 
-ANY_STAGE_NAME = "ANY_STAGE_NAME"
+ANY_STAGE_CONFIGURATION_NAME = "ANY_STAGE_CONFIGURATION_NAME"
 ANY_PIPELINE_USER_ARN = "ANY_PIPELINE_USER_ARN"
 ANY_PIPELINE_EXECUTION_ROLE_ARN = "ANY_PIPELINE_EXECUTION_ROLE_ARN"
 ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN = "ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN"
@@ -13,9 +13,9 @@ ANY_ARN = "ANY_ARN"
 
 
 class TestStage(TestCase):
-    def test_stage_name_is_the_only_required_field_to_initialize_an_stage(self):
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
-        self.assertEqual(stage.name, ANY_STAGE_NAME)
+    def test_stage_configuration_name_is_the_only_required_field_to_initialize_an_stage(self):
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
+        self.assertEqual(stage.name, ANY_STAGE_CONFIGURATION_NAME)
         self.assertIsNone(stage.aws_profile)
         self.assertIsNone(stage.aws_region)
         self.assertIsNotNone(stage.pipeline_user)
@@ -28,25 +28,25 @@ class TestStage(TestCase):
             Stage()
 
     def test_did_user_provide_all_required_resources_when_not_all_resources_are_provided(self):
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         self.assertFalse(stage.did_user_provide_all_required_resources())
-        stage: Stage = Stage(name=ANY_STAGE_NAME, pipeline_user_arn=ANY_PIPELINE_USER_ARN)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME, pipeline_user_arn=ANY_PIPELINE_USER_ARN)
         self.assertFalse(stage.did_user_provide_all_required_resources())
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
         )
         self.assertFalse(stage.did_user_provide_all_required_resources())
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
         )
         self.assertFalse(stage.did_user_provide_all_required_resources())
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
@@ -57,7 +57,7 @@ class TestStage(TestCase):
 
     def test_did_user_provide_all_required_resources_ignore_image_repository_if_it_is_not_required(self):
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
@@ -68,7 +68,7 @@ class TestStage(TestCase):
 
     def test_did_user_provide_all_required_resources_when_image_repository_is_required(self):
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
@@ -77,7 +77,7 @@ class TestStage(TestCase):
         )
         self.assertFalse(stage.did_user_provide_all_required_resources())
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
@@ -98,7 +98,7 @@ class TestStage(TestCase):
         pipeline_user_secret_pair_mock.return_value = ("id", "secret")
         stack_output.get.return_value = ANY_ARN
         manage_stack_mock.return_value = stack_output
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
 
         self.assertFalse(stage.did_user_provide_all_required_resources())
 
@@ -121,7 +121,7 @@ class TestStage(TestCase):
         self, did_user_provide_all_required_resources_mock, manage_stack_mock, click_mock
     ):
         did_user_provide_all_required_resources_mock.return_value = True
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         stage.bootstrap(confirm_changeset=False)
         manage_stack_mock.assert_not_called()
 
@@ -133,7 +133,7 @@ class TestStage(TestCase):
     ):
         click_mock.confirm.return_value = False
         pipeline_user_secret_pair_mock.return_value = ("id", "secret")
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         stage.bootstrap(confirm_changeset=False)
         click_mock.confirm.assert_not_called()
         manage_stack_mock.assert_called_once()
@@ -148,7 +148,7 @@ class TestStage(TestCase):
         self, manage_stack_mock, click_mock
     ):
         click_mock.confirm.return_value = False
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         stage.bootstrap(confirm_changeset=True)
         manage_stack_mock.assert_not_called()
 
@@ -160,7 +160,7 @@ class TestStage(TestCase):
     ):
         click_mock.confirm.return_value = True
         pipeline_user_secret_pair_mock.return_value = ("id", "secret")
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         stage.bootstrap(confirm_changeset=True)
         manage_stack_mock.assert_called_once()
 
@@ -173,7 +173,7 @@ class TestStage(TestCase):
         click_mock.confirm.return_value = True
         pipeline_user_secret_pair_mock.return_value = ("id", "secret")
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             artifacts_bucket_arn=ANY_ARTIFACTS_BUCKET_ARN,
             create_image_repository=True,
@@ -203,7 +203,7 @@ class TestStage(TestCase):
         stack_output = Mock()
         stack_output.get.return_value = ANY_ARN
         manage_stack_mock.return_value = stack_output
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         click_mock.confirm.return_value = True
 
         # verify resources' ARNS are empty
@@ -227,12 +227,12 @@ class TestStage(TestCase):
         cmd_names = ["any", "commands"]
         samconfig_instance_mock = Mock()
         samconfig_mock.return_value = samconfig_instance_mock
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
 
         empty_ecr_call = call(
             cmd_names=cmd_names,
             section="parameters",
-            env=ANY_STAGE_NAME,
+            env=ANY_STAGE_CONFIGURATION_NAME,
             key="image_repository",
             value="",
         )
@@ -255,7 +255,7 @@ class TestStage(TestCase):
             call(
                 cmd_names=cmd_names,
                 section="parameters",
-                env=ANY_STAGE_NAME,
+                env=ANY_STAGE_CONFIGURATION_NAME,
                 key="pipeline_execution_role",
                 value=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             ),
@@ -269,7 +269,7 @@ class TestStage(TestCase):
             call(
                 cmd_names=cmd_names,
                 section="parameters",
-                env=ANY_STAGE_NAME,
+                env=ANY_STAGE_CONFIGURATION_NAME,
                 key="cloudformation_execution_role",
                 value=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
             ),
@@ -283,7 +283,7 @@ class TestStage(TestCase):
             call(
                 cmd_names=cmd_names,
                 section="parameters",
-                env=ANY_STAGE_NAME,
+                env=ANY_STAGE_CONFIGURATION_NAME,
                 key="artifacts_bucket",
                 value="artifact_bucket_name",
             ),
@@ -297,7 +297,7 @@ class TestStage(TestCase):
             call(
                 cmd_names=cmd_names,
                 section="parameters",
-                env=ANY_STAGE_NAME,
+                env=ANY_STAGE_CONFIGURATION_NAME,
                 key="image_repository",
                 value="111111111111.dkr.ecr.us-east-2.amazonaws.com/image_repository_name",
             )
@@ -329,7 +329,7 @@ class TestStage(TestCase):
     def test_save_config_ignores_exceptions_thrown_while_calculating_artifacts_bucket_name(self, samconfig_mock):
         samconfig_instance_mock = Mock()
         samconfig_mock.return_value = samconfig_instance_mock
-        stage: Stage = Stage(name=ANY_STAGE_NAME, artifacts_bucket_arn="invalid ARN")
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME, artifacts_bucket_arn="invalid ARN")
         # calling artifacts_bucket.name() during save_config() will raise a ValueError exception, we need to make sure
         # this exception is swallowed so that other configs can be safely saved to the pipelineconfig.toml file
         stage.save_config(config_dir="any_config_dir", filename="any_pipeline.toml", cmd_names=["any", "commands"])
@@ -338,7 +338,7 @@ class TestStage(TestCase):
     def test_save_config_ignores_exceptions_thrown_while_calculating_image_repository_uri(self, samconfig_mock):
         samconfig_instance_mock = Mock()
         samconfig_mock.return_value = samconfig_instance_mock
-        stage: Stage = Stage(name=ANY_STAGE_NAME, image_repository_arn="invalid ARN")
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME, image_repository_arn="invalid ARN")
         # calling image_repository.get_uri() during save_config() will raise a ValueError exception, we need to make
         # sure this exception is swallowed so that other configs can be safely saved to the pipelineconfig.toml file
         stage.save_config(config_dir="any_config_dir", filename="any_pipeline.toml", cmd_names=["any", "commands"])
@@ -346,20 +346,20 @@ class TestStage(TestCase):
     @patch.object(Stage, "save_config")
     def test_save_config_safe(self, save_config_mock):
         save_config_mock.side_effect = Exception
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         stage.save_config_safe(config_dir="any_config_dir", filename="any_pipeline.toml", cmd_names=["commands"])
         save_config_mock.assert_called_once_with("any_config_dir", "any_pipeline.toml", ["commands"])
 
     @patch("samcli.lib.pipeline.bootstrap.stage.click")
     def test_print_resources_summary_when_no_resources_provided_by_the_user(self, click_mock):
-        stage: Stage = Stage(name=ANY_STAGE_NAME)
+        stage: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         stage.print_resources_summary()
         self.assert_summary_has_a_message_like("The following resources were created in your account", click_mock.secho)
 
     @patch("samcli.lib.pipeline.bootstrap.stage.click")
     def test_print_resources_summary_when_all_resources_are_provided_by_the_user(self, click_mock):
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
@@ -375,7 +375,7 @@ class TestStage(TestCase):
     @patch("samcli.lib.pipeline.bootstrap.stage.click")
     def test_print_resources_summary_when_some_resources_are_provided_by_the_user(self, click_mock):
         stage: Stage = Stage(
-            name=ANY_STAGE_NAME,
+            name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             artifacts_bucket_arn=ANY_ARTIFACTS_BUCKET_ARN,
             create_image_repository=True,
@@ -388,13 +388,13 @@ class TestStage(TestCase):
     def test_print_resources_summary_prints_the_credentials_of_the_pipeline_user_iff_not_provided_by_the_user(
         self, click_mock
     ):
-        stage_with_provided_pipeline_user: Stage = Stage(name=ANY_STAGE_NAME, pipeline_user_arn=ANY_PIPELINE_USER_ARN)
+        stage_with_provided_pipeline_user: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME, pipeline_user_arn=ANY_PIPELINE_USER_ARN)
         stage_with_provided_pipeline_user.print_resources_summary()
         self.assert_summary_does_not_have_a_message_like("AWS_ACCESS_KEY_ID", click_mock.secho)
         self.assert_summary_does_not_have_a_message_like("AWS_SECRET_ACCESS_KEY", click_mock.secho)
         click_mock.secho.reset_mock()
 
-        stage_without_provided_pipeline_user: Stage = Stage(name=ANY_STAGE_NAME)
+        stage_without_provided_pipeline_user: Stage = Stage(name=ANY_STAGE_CONFIGURATION_NAME)
         stage_without_provided_pipeline_user.print_resources_summary()
         self.assert_summary_has_a_message_like("AWS_ACCESS_KEY_ID", click_mock.secho)
         self.assert_summary_has_a_message_like("AWS_SECRET_ACCESS_KEY", click_mock.secho)

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -38,13 +38,13 @@ class TestSamConfig(TestCase):
     def test_init(self):
         self.assertEqual(self.samconfig.filepath, Path(self.config_dir, DEFAULT_CONFIG_FILE_NAME))
 
-    def test_get_stage_names(self):
-        self.assertEqual(self.samconfig.get_stage_names(), [])
+    def test_get_stage_configuration_names(self):
+        self.assertEqual(self.samconfig.get_stage_configuration_names(), [])
         self._update_samconfig(cmd_names=["myCommand"], section="mySection", key="port", value=5401, env="stage1")
         self._update_samconfig(cmd_names=["myCommand"], section="mySection", key="port", value=5401, env="stage2")
-        self.assertEqual(self.samconfig.get_stage_names(), ["stage1", "stage2"])
+        self.assertEqual(self.samconfig.get_stage_configuration_names(), ["stage1", "stage2"])
         self._update_samconfig(cmd_names=["myCommand"], section="mySection", key="port", value=5401)
-        self.assertEqual(self.samconfig.get_stage_names(), ["stage1", "stage2", DEFAULT_ENV])
+        self.assertEqual(self.samconfig.get_stage_configuration_names(), ["stage1", "stage2", DEFAULT_ENV])
 
     def test_param_overwrite(self):
         self._update_samconfig(cmd_names=["myCommand"], section="mySection", key="port", value=5401, env="myEnv")


### PR DESCRIPTION
Change some uses of stage name to configuration name - clarifying you cannot actually name the stage

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
