### PR TITLE
fix: Bumped Minimal boto3 Version to 1.18.32

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ chevron~=0.12
 click~=7.1
 Flask~=1.1.2
 #Need to add Schemas latest SDK.
-boto3~=1.18
+boto3>=1.18.32,==1.*
 jmespath~=0.10.0
 PyYAML~=5.3
 cookiecutter~=1.7.2


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/3417

#### Why is this change necessary?
Bump boto3 version to be minimal 1.18.32 as DisableRollback is add in this version.

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
