### PR TITLE
feat: sam deploy: Support - which indicates stdin

### DIFF
--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -28,6 +28,7 @@ from samcli.commands._utils.options import (
     resolve_s3_option,
     role_arn_option,
     resolve_image_repos_option,
+    remove_stdin_tmpfile,
 )
 from samcli.commands.deploy.utils import sanitize_parameter_overrides
 from samcli.lib.telemetry.metric import track_command
@@ -127,6 +128,7 @@ LOG = logging.getLogger(__name__)
 @track_command
 @check_newer_version
 @print_cmdline_args
+@remove_stdin_tmpfile
 def cli(
     ctx,
     template_file,

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -4,6 +4,7 @@ Test the common CLI options
 
 import os
 from datetime import datetime
+import tempfile
 
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
@@ -38,6 +39,24 @@ class TestGetOrDefaultTemplateFileName(TestCase):
 
         result = get_or_default_template_file_name(None, None, filename, include_build=False)
         self.assertEqual(result, expected)
+
+    @patch("samcli.commands._utils.options.tempfile")
+    @patch("samcli.commands._utils.options.sys")
+    def test_must_return_stdin_temp_file(self, sys_mock, tempfile_mock):
+        ctx = Mock()
+        fp = tempfile.NamedTemporaryFile()
+
+        filename = "-"
+        expected = fp.name
+
+        tempfile_mock.mkstemp.return_value = (None, fp.name)
+        sys_mock.stdin.read.return_value = "foo"
+
+        result = get_or_default_template_file_name(ctx, None, filename, include_build=False)
+        self.assertEqual(result, expected)
+        self.assertEqual(ctx.tmpfile, expected)
+
+        fp.close()
 
     @patch("samcli.commands._utils.options.os")
     def test_must_return_yml_extension(self, os_mock):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#2990

#### Why is this change necessary?
`-` support allows users to explicitly type stdin directly into sam.
By supporting this feature, users can transform YAML using a YAML template engine such as ytt, which increases flexibility.

#### How does it address the issue?
When `-` is specified, it saves stdin to a temporary file and assumes that the file is specified.

When sam finishes executing, it will delete the temporary file it created.

#### What side effects does this change have?
When a user creates a template file that is really `-`, specifying `--template-file -` will result in unintended behavior because it indicates stdin.

As with other commands that support `-`, users can use `./-`, explicitly specifying the current directory `-` file.

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).