### PR TITLE
fix: Remove CI Scripts from PyInstaller Package

### DIFF
--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -36,6 +36,9 @@ echo "Copying Source"
 cp -r ../[!.]* ./src
 cp -r ./src/* ./output/aws-sam-cli-src
 
+echo "Removing CI Scripts"
+rm -vf ./output/aws-sam-cli-src/appveyor*.yml
+
 echo "Installing Python"
 curl "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz" --output python.tgz
 tar -xzf python.tgz


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?

#### How does it address the issue?
```
Removing CI Scripts
removed ‘./output/aws-sam-cli-src/appveyor-windows-build-dotnet.yml’
removed ‘./output/aws-sam-cli-src/appveyor-windows-build-go.yml’
removed ‘./output/aws-sam-cli-src/appveyor-windows-build-java-container.yml’
removed ‘./output/aws-sam-cli-src/appveyor-windows-build-java-ruby-inprocess.yml’
removed ‘./output/aws-sam-cli-src/appveyor-windows-build-nodejs.yml’
removed ‘./output/aws-sam-cli-src/appveyor-windows-build-python.yml’
removed ‘./output/aws-sam-cli-src/appveyor-windows-build-ruby.yml’
removed ‘./output/aws-sam-cli-src/appveyor-windows.yml’
removed ‘./output/aws-sam-cli-src/appveyor.yml’
Installing Python
```

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
