### PR TITLE
loosen requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ aws-sam-translator==1.40.0
 #docker minor version updates can include breaking changes. Auto update micro version only.
 docker~=4.2.0
 dateparser~=1.0
-requests>=2.25,<3
+requests~=2.25
 serverlessrepo==0.1.10
 aws_lambda_builders==1.9.0
 tomlkit==0.7.2
@@ -23,4 +23,4 @@ dataclasses==0.8; python_version < '3.7'
 # NOTE: regex is not a direct dependency of SAM CLI, but pin to 2021.9.30 due to 2021.10.8 not working on M1 Mac - https://bitbucket.org/mrabarnett/mrab-regex/issues/399/missing-wheel-for-macosx-and-the-new-m1
 regex==2021.9.30
 # NOTE: tzlocal is not a direct dependency of SAM CLI, but pin to 3.0 as 4.0 break appveyor jobs
-tzlocal<4
+tzlocal~=3.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,17 +10,17 @@ aws-sam-translator==1.40.0
 #docker minor version updates can include breaking changes. Auto update micro version only.
 docker~=4.2.0
 dateparser~=1.0
-requests==2.25.1
+requests>=2.25,<3
 serverlessrepo==0.1.10
 aws_lambda_builders==1.9.0
 tomlkit==0.7.2
-watchdog==2.1.2
+watchdog~=2.1
 
 # Needed for supporting Protocol in Python 3.6
-typing_extensions==3.10.0.0
+typing_extensions~=3.10
 # Needed for supporting dataclasses decorator in Python3.6
 dataclasses==0.8; python_version < '3.7'
 # NOTE: regex is not a direct dependency of SAM CLI, but pin to 2021.9.30 due to 2021.10.8 not working on M1 Mac - https://bitbucket.org/mrabarnett/mrab-regex/issues/399/missing-wheel-for-macosx-and-the-new-m1
 regex==2021.9.30
 # NOTE: tzlocal is not a direct dependency of SAM CLI, but pin to 3.0 as 4.0 break appveyor jobs
-tzlocal==3.0
+tzlocal<4


### PR DESCRIPTION
use ~= for some entries in requirements.txt in order to make life eaiser for users

#### Why is this change necessary?
If I want to install aws-sam-cli in the same environment as other tools I generally end up with pip complaining about incompatibile dependency versions and occasionally refusing to install or (in recent versions) going into a loop.

#### How does it address the issue?
uses ~= to allow any [compatible release](https://www.python.org/dev/peps/pep-0440/#compatible-release) as defined in PEP-440

#### What side effects does this change have?
It may change the versions of some dependencies, albeit to compatible versions. 

#### Checklist

I believe none of the below apply here

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).