### PR TITLE
Only add labels on open of PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,8 @@
+This folder has Github Actions for this repo. 
+
+** pr-labler **
+
+This is responsible for tagging our prs automattically. The primary thing it does is tags internal vs external (to the team) PRs. It will
+also tag PRs with `area/*` tags based upon the files being changes in the PR. This is run on `pull_request_target` which only runs what is 
+in the repo not what is in the Pull Request. This is done to help guard against a PR running and changing. For this, the Action should NEVER 
+download or checkout the PR. It is purely for tagging/labeling not CI.

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,7 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  pull_request_target:
+    types: [opened]
 
 jobs:
   apply-file-based-labels:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,4 +20,4 @@ pytest-timeout==1.4.2
 pytest-rerunfailures==9.1.1
 
 # formatter
-black==20.8b1
+black==21.10b0

--- a/samcli/commands/init/interactive_event_bridge_flow.py
+++ b/samcli/commands/init/interactive_event_bridge_flow.py
@@ -43,7 +43,7 @@ def get_schema_template_details(schemas_api_caller):
 
 
 def _get_registry_cli_choice(schemas_api_caller):
-    """ Returns registry choice if one registry is present otherwise prompt for selection """
+    """Returns registry choice if one registry is present otherwise prompt for selection"""
     registries = _fetch_available_registries(schemas_api_caller, dict(), None)
     registry_pages = registries["registry_pages"]
     # If only one registry don't prompt for choice
@@ -87,7 +87,7 @@ def _prompt_for_registry_choice(
 
 
 def _get_schema_cli_choice(schemas_api_caller, registry_name):
-    """ Returns registry registry choice if one registry is present otherwise prompt for  selection """
+    """Returns registry registry choice if one registry is present otherwise prompt for  selection"""
     schemas = _fetch_available_schemas(schemas_api_caller, registry_name, dict(), None)
     schema_pages = schemas["schema_pages"]
     # If only one schema don't prompt for choice
@@ -131,7 +131,7 @@ def _prompt_for_schemas_choice(
 
 
 def _fetch_available_schemas(schemas_api_caller, registry_name, schema_pages, next_token):
-    """ calls schemas api fetch schemas for given registry. Two CLI pages are fetched at a time."""
+    """calls schemas api fetch schemas for given registry. Two CLI pages are fetched at a time."""
     list_schemas_response = schemas_api_caller.list_schemas(registry_name, next_token, PAGE_LIMIT)
     schemas = list_schemas_response["schemas"]
 
@@ -144,7 +144,7 @@ def _fetch_available_schemas(schemas_api_caller, registry_name, schema_pages, ne
 
 
 def _fetch_available_registries(schemas_api_caller, registry_pages, next_token):
-    """ calls schemas api to fetch registries. Two CLI pages are fetched at a time. """
+    """calls schemas api to fetch registries. Two CLI pages are fetched at a time."""
     list_registries_response = schemas_api_caller.list_registries(next_token, PAGE_LIMIT)
     registries = list_registries_response["registries"]
 
@@ -177,7 +177,7 @@ def _construct_cli_page(items, item_per_page):
 
 
 def get_schemas_template_parameter(schema_template_details):
-    """ Schemas cookiecutter template parameter mapping """
+    """Schemas cookiecutter template parameter mapping"""
     return {
         SCHEMAS_REGISTRY: schema_template_details["registry_name"],
         SCHEMA_NAME: schema_template_details["schema_root_name"],

--- a/samcli/commands/pipeline/init/pipeline_templates_manifest.py
+++ b/samcli/commands/pipeline/init/pipeline_templates_manifest.py
@@ -29,7 +29,7 @@ from samcli.yamlhelper import parse_yaml_file
 
 
 class Provider:
-    """ CI/CD system such as Jenkins, Gitlab and GitHub-Actions"""
+    """CI/CD system such as Jenkins, Gitlab and GitHub-Actions"""
 
     def __init__(self, manifest: Dict) -> None:
         self.id: str = manifest["id"]
@@ -37,7 +37,7 @@ class Provider:
 
 
 class PipelineTemplateMetadata:
-    """ The metadata of a Given pipeline template"""
+    """The metadata of a Given pipeline template"""
 
     def __init__(self, manifest: Dict) -> None:
         self.display_name: str = manifest["displayName"]
@@ -46,7 +46,7 @@ class PipelineTemplateMetadata:
 
 
 class PipelineTemplatesManifest:
-    """ The metadata of the available CI/CD systems and the pipeline templates"""
+    """The metadata of the available CI/CD systems and the pipeline templates"""
 
     def __init__(self, manifest_path: Path) -> None:
         try:

--- a/samcli/lib/cookiecutter/question.py
+++ b/samcli/lib/cookiecutter/question.py
@@ -7,7 +7,7 @@ import click
 
 
 class QuestionKind(Enum):
-    """ An Enum of possible question types. """
+    """An Enum of possible question types."""
 
     info = "info"
     confirm = "confirm"

--- a/samcli/lib/pipeline/bootstrap/resource.py
+++ b/samcli/lib/pipeline/bootstrap/resource.py
@@ -112,7 +112,7 @@ class S3Bucket(Resource):
 
 
 class ECRImageRepository(Resource):
-    """ Represents an AWS ECR image repository resource """
+    """Represents an AWS ECR image repository resource"""
 
     def __init__(self, arn: Optional[str], comment: Optional[str]) -> None:
         super().__init__(arn=arn, comment=comment)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
n/a

#### Why is this change necessary?
By default `pull_request_target` github actions run on `opened`, `synchronize`, or `reopened`. This causes updates to the PR to be improperly tagged when a maintainer updates the PR from `HEAD` of `develop`. Instead, we will only run the PR github actions on open for the auto labeler.

#### How does it address the issue?

#### What side effects does this change have?
No

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
