### PR TITLE
fix: KeyError caused by not loading assets

### DIFF
--- a/samcli/lib/iac/cdk/cloud_assembly.py
+++ b/samcli/lib/iac/cdk/cloud_assembly.py
@@ -293,11 +293,13 @@ class CloudAssemblyStack:
         return None
 
     def _extract_assets(self) -> None:
-        for item in self.metadata.get(f"/{self.stack_name}", {}):
-            assert "type" in item
-            if item["type"] == ASSET_TYPE:
-                self._assets_by_id[item["data"]["id"]] = item["data"]
-                self._assets_by_path[item["data"]["path"]] = item["data"]
+        for key in self.metadata.keys():
+            items = self.metadata.get(key)
+            for item in items:
+                assert "type" in item
+                if item["type"] == ASSET_TYPE:
+                    self._assets_by_id[item["data"]["id"]] = item["data"]
+                    self._assets_by_path[item["data"]["path"]] = item["data"]
 
     def _update_resources_paths(self) -> None:
         update_relative_paths(self.template, self.source_directory, self.directory, skip_assets=True)


### PR DESCRIPTION
#### Which issue(s) does this change fix?

I think this fixes the following issues

https://github.com/aws/aws-sam-cli/issues/2968

https://github.com/aws/aws-sam-cli/issues/2849

#### Why is this change necessary?

The current `_extract_assets` method doesn't seem to load the assets correctly, resulting in `KeyError`'s later down the line when trying to extract the stack from the cloud assembly

#### How does it address the issue?

Reads assets from the manifest successfully when it's in this format

![Screen Shot 2021-11-26 at 10 57 34 am](https://user-images.githubusercontent.com/4339582/143509083-ee0c0032-4d3a-4a11-be1c-fe85925fea43.png)

#### What side effects does this change have?

I have no idea

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
