### PR TITLE
fix: accept AWS_PROXY as integration type

### DIFF
--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -120,7 +120,11 @@ class SwaggerParser:
 
         integration = method_config[self._INTEGRATION_KEY]
 
-        if integration and isinstance(integration, dict) and integration.get("type") == IntegrationType.aws_proxy.value:
+        if (
+            integration
+            and isinstance(integration, dict)
+            and integration.get("type").lower() == IntegrationType.aws_proxy.value
+        ):
             # Integration must be "aws_proxy" otherwise we don't care about it
             return integration
 

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -433,6 +433,17 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
+    def test_parse_swagger_body_with_non_case_sensitive_integration_type(self):
+        """
+        Get Request to a path that was defined as ANY in SAM through Swagger
+        """
+        response = requests.get(self.url + "/nonsensitiveanyandall", timeout=300)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger

--- a/tests/integration/testdata/start_api/swagger-template.yaml
+++ b/tests/integration/testdata/start_api/swagger-template.yaml
@@ -44,6 +44,14 @@ Resources:
                 uri:
                   Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaFunction.Arn}/invocations
                 responses: {}
+          "/nonsensitiveanyandall":
+            x-amazon-apigateway-any-method:
+              x-amazon-apigateway-integration:
+                httpMethod: POST
+                type: AWS_PROXY
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaFunction.Arn}/invocations
+                responses: { }
           "/nonserverlessfunction":
             get:
               x-amazon-apigateway-integration:

--- a/tests/unit/commands/local/lib/swagger/test_parser.py
+++ b/tests/unit/commands/local/lib/swagger/test_parser.py
@@ -37,7 +37,7 @@ class TestSwaggerParser_get_apis(TestCase):
         swagger = {
             "paths": {
                 "/path1": {
-                    "get": {"x-amazon-apigateway-integration": {"type": "aws_proxy", "uri": "someuri"}},
+                    "get": {"x-amazon-apigateway-integration": {"type": "AWS_PROXY", "uri": "someuri"}},
                     "delete": {"x-amazon-apigateway-integration": {"type": "aws_proxy", "uri": "someuri"}},
                 },
                 "/path2": {"post": {"x-amazon-apigateway-integration": {"type": "aws_proxy", "uri": "someuri"}}},


### PR DESCRIPTION
#### Which issue(s) does this change fix?
accept `AWS_PROXY` as integration type

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write unit tests
- [ ] Write/update functional tests
- [X] Write/update integration tests
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
