### PR TITLE
feat: add unsupported command to asm validate in case of CDK synthesized templates

### DIFF
--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -10,6 +10,7 @@ import click
 from samtranslator.translator.arn_generator import NoRegionFound
 
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options, print_cmdline_args
+from samcli.commands._utils.cdk_support_decorators import unsupported_command_cdk
 from samcli.commands._utils.options import template_option_without_build
 from samcli.lib.telemetry.metric import track_command
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
@@ -25,6 +26,7 @@ from samcli.lib.utils.version_checker import check_newer_version
 @track_command
 @check_newer_version
 @print_cmdline_args
+@unsupported_command_cdk(alternative_command="cdk doctor")
 def cli(
     ctx,
     template_file,

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -74,7 +74,7 @@ class TestValidate(TestCase):
         self.assertEqual(command_result.process.returncode, 0)
         self.assertRegex(output, pattern)
 
-    def test_package_logs_warning_for_cdk_project(self):
+    def test_validate_logs_warning_for_cdk_project(self):
         test_data_path = Path(__file__).resolve().parents[2] / "integration" / "testdata" / "package"
         template_file = "aws-serverless-function-cdk.yaml"
         template_path = test_data_path.joinpath(template_file)

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -73,3 +73,17 @@ class TestValidate(TestCase):
         output = command_result.stdout.decode("utf-8")
         self.assertEqual(command_result.process.returncode, 0)
         self.assertRegex(output, pattern)
+
+    def test_package_logs_warning_for_cdk_project(self):
+        test_data_path = Path(__file__).resolve().parents[2] / "integration" / "testdata" / "package"
+        template_file = "aws-serverless-function-cdk.yaml"
+        template_path = test_data_path.joinpath(template_file)
+        command_result = run_command(self.command_list(template_file=template_path))
+        output = command_result.stdout.decode("utf-8")
+
+        warning_message = (
+            "Warning: CDK apps are not officially supported with this command.\n"
+            "We recommend you use this alternative command: cdk doctor"
+        )
+
+        self.assertIn(warning_message, output)


### PR DESCRIPTION


#### Which issue(s) does this change fix?
add unsupported command to asm validate in case of CDK synthesized templates

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [X] Write/update integration tests
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
