### PR TITLE
feat: command to add additional host

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -77,6 +77,7 @@ class InvokeContext:
         shutdown: bool = False,
         container_host: Optional[str] = None,
         container_host_interface: Optional[str] = None,
+        container_add_host: Optional[str] = None,
         invoke_images: Optional[str] = None,
     ) -> None:
         """
@@ -128,6 +129,8 @@ class InvokeContext:
             Optional. Host of locally emulated Lambda container
         container_host_interface string
             Optional. Interface that Docker host binds ports to
+        container_add_host string
+            Optional. Additional host to add to the container
         invoke_images dict
             Optional. A dictionary that defines the custom invoke image URI of each function
         """
@@ -157,6 +160,7 @@ class InvokeContext:
 
         self._container_host = container_host
         self._container_host_interface = container_host_interface
+        self._container_add_host = container_add_host
         self._invoke_images = invoke_images
 
         self._containers_mode = ContainersMode.COLD
@@ -257,7 +261,7 @@ class InvokeContext:
         def initialize_function_container(function: Function) -> None:
             function_config = self.local_lambda_runner.get_invoke_config(function)
             self.lambda_runtime.run(
-                None, function_config, self._debug_context, self._container_host, self._container_host_interface
+                None, function_config, self._debug_context, self._container_host, self._container_host_interface, self._container_add_host
             )
 
         try:
@@ -346,6 +350,7 @@ class InvokeContext:
             debug_context=self._debug_context,
             container_host=self._container_host,
             container_host_interface=self._container_host_interface,
+            container_add_host=self._container_add_host,
         )
         return self._local_lambda_runner
 

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -66,6 +66,13 @@ def local_common_options(f):
             "Use 0.0.0.0 to bind to all interfaces.",
         ),
         click.option(
+            "--container-add-host",
+            default="host.docker.internal",
+            show_default=True,
+            help="Additional host to add to the container. "
+            "Use host.docker.internal or any hostname to connect to localhost services",
+        ),
+        click.option(
             "--invoke-image",
             "-ii",
             default=None,

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -75,6 +75,7 @@ def cli(
     config_env,
     container_host,
     container_host_interface,
+    container_add_host,
     invoke_image,
 ):
     """
@@ -103,6 +104,7 @@ def cli(
         parameter_overrides,
         container_host,
         container_host_interface,
+        container_add_host,
         invoke_image,
     )  # pragma: no cover
 
@@ -128,6 +130,7 @@ def do_cli(  # pylint: disable=R0914
     parameter_overrides,
     container_host,
     container_host_interface,
+    container_add_host,
     invoke_image,
 ):
     """
@@ -175,6 +178,7 @@ def do_cli(  # pylint: disable=R0914
             shutdown=shutdown,
             container_host=container_host,
             container_host_interface=container_host_interface,
+            container_add_host=container_add_host,
             invoke_images=processed_invoke_images,
         ) as context:
 

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -49,6 +49,7 @@ class LocalLambdaRunner:
         debug_context: Optional[DebugContext] = None,
         container_host: Optional[str] = None,
         container_host_interface: Optional[str] = None,
+        container_add_host: Optional[str] = None,
     ) -> None:
         """
         Initializes the class
@@ -63,6 +64,7 @@ class LocalLambdaRunner:
         :param DebugContext debug_context: Optional. Debug context for the function (includes port, args, and path).
         :param string container_host: Optional. Host of locally emulated Lambda container
         :param string container_host_interface: Optional. Interface that Docker host binds ports to
+        :param string container_add_host: Optional. Additional host to add to the container
         """
 
         self.local_runtime = local_runtime
@@ -76,6 +78,7 @@ class LocalLambdaRunner:
         self._boto3_region: Optional[str] = None
         self.container_host = container_host
         self.container_host_interface = container_host_interface
+        self.container_add_host = container_add_host
 
     def invoke(
         self,
@@ -142,6 +145,7 @@ class LocalLambdaRunner:
                 stderr=stderr,
                 container_host=self.container_host,
                 container_host_interface=self.container_host_interface,
+                container_add_host=self.container_add_host,
             )
         except ContainerResponseException:
             # NOTE(sriram-mv): This should still result in a exit code zero to avoid regressions.

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -84,6 +84,7 @@ def cli(
     debug_function,
     container_host,
     container_host_interface,
+    container_add_host,
     invoke_image,
 ):
     """
@@ -114,6 +115,7 @@ def cli(
         debug_function,
         container_host,
         container_host_interface,
+        container_add_host,
         invoke_image,
     )  # pragma: no cover
 
@@ -141,6 +143,7 @@ def do_cli(  # pylint: disable=R0914
     debug_function,
     container_host,
     container_host_interface,
+    container_add_host,
     invoke_image,
 ):
     """
@@ -186,6 +189,7 @@ def do_cli(  # pylint: disable=R0914
             shutdown=shutdown,
             container_host=container_host,
             container_host_interface=container_host_interface,
+            container_add_host=container_add_host,
             invoke_images=processed_invoke_images,
         ) as invoke_context:
 

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -95,6 +95,7 @@ def cli(
     debug_function,
     container_host,
     container_host_interface,
+    container_add_host,
     invoke_image,
 ):
     """
@@ -124,6 +125,7 @@ def cli(
         debug_function,
         container_host,
         container_host_interface,
+        container_add_host,
         invoke_image,
     )  # pragma: no cover
 
@@ -150,6 +152,7 @@ def do_cli(  # pylint: disable=R0914
     debug_function,
     container_host,
     container_host_interface,
+    container_add_host,
     invoke_image,
 ):
     """
@@ -194,6 +197,7 @@ def do_cli(  # pylint: disable=R0914
             shutdown=shutdown,
             container_host=container_host,
             container_host_interface=container_host_interface,
+            container_add_host=container_add_host,
             invoke_images=processed_invoke_images,
         ) as invoke_context:
 

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -57,6 +57,7 @@ class Container:
         additional_volumes=None,
         container_host="localhost",
         container_host_interface="127.0.0.1",
+        container_add_host="host.docker.internal"
     ):
         """
         Initializes the class with given configuration. This does not automatically create or run the container.
@@ -75,6 +76,7 @@ class Container:
         :param additional_volumes: Optional list of additional volumes
         :param string container_host: Optional. Host of locally emulated Lambda container
         :param string container_host_interface: Optional. Interface that Docker host binds ports to
+        :param string container_add_host: Optional. Add additional host to the container
         """
 
         self._image = image
@@ -103,6 +105,7 @@ class Container:
 
         self._container_host = container_host
         self._container_host_interface = container_host_interface
+        self._container_add_host = container_add_host
 
         try:
             self.rapid_port_host = find_free_port(start=self._start_port_range, end=self._end_port_range)
@@ -159,6 +162,8 @@ class Container:
             kwargs["environment"] = self._env_vars
 
         kwargs["ports"] = {self.RAPID_PORT_CONTAINER: (self._container_host_interface, self.rapid_port_host)}
+
+        kwargs["extra_hosts"] = {self._container_add_host + ":host-gateway"}
 
         if self._exposed_ports:
             kwargs["ports"].update(

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -48,6 +48,7 @@ class LambdaContainer(Container):
         debug_options=None,
         container_host=None,
         container_host_interface=None,
+        container_add_host=None,
         function_name=None,
     ):
         """
@@ -84,6 +85,8 @@ class LambdaContainer(Container):
             Optional. Host of locally emulated Lambda container
         container_host_interface
             Optional. Interface that Docker host binds ports to
+        container_add_host
+            Optional. Add additional host to the container
         function_name str
             Optional. Logical ID of the function
         """
@@ -135,6 +138,7 @@ class LambdaContainer(Container):
             additional_volumes=additional_volumes,
             container_host=container_host,
             container_host_interface=container_host_interface,
+            container_add_host=container_add_host,
         )
 
     @staticmethod

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -554,6 +554,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 aws_region="region",
                 container_host=None,
                 container_host_interface=None,
+                container_add_host=None,
             )
 
             result = self.context.local_lambda_runner
@@ -627,6 +628,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 aws_region="region",
                 container_host=None,
                 container_host_interface=None,
+                container_add_host=None,
             )
 
             result = self.context.local_lambda_runner
@@ -671,6 +673,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
             aws_region="region",
             container_host="abcdef",
             container_host_interface="192.168.100.101",
+            container_add_host="my.internal.host",
         )
         self.context.get_cwd = Mock()
         self.context.get_cwd.return_value = cwd
@@ -701,6 +704,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                 aws_region="region",
                 container_host="abcdef",
                 container_host_interface="192.168.100.101",
+                container_add_host="my.internal.host",
             )
 
             result = self.context.local_lambda_runner

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -43,6 +43,7 @@ class TestCli(TestCase):
         self.profile = "profile"
         self.container_host = "localhost"
         self.container_host_interface = "127.0.0.1"
+        self.container_add_host = "host.docker.internal"
         self.invoke_image = ("amazon/aws-sam-cli-emulation-image-python3.6",)
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
@@ -80,6 +81,7 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
             invoke_image=self.invoke_image,
         )
 
@@ -103,6 +105,7 @@ class TestCli(TestCase):
             aws_profile=self.profile,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
             invoke_images={None: "amazon/aws-sam-cli-emulation-image-python3.6"},
         )
 
@@ -144,6 +147,7 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
             invoke_image=self.invoke_image,
         )
 
@@ -167,6 +171,7 @@ class TestCli(TestCase):
             aws_profile=self.profile,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
             invoke_images={None: "amazon/aws-sam-cli-emulation-image-python3.6"},
         )
 
@@ -222,6 +227,7 @@ class TestCli(TestCase):
                 shutdown=self.shutdown,
                 container_host=self.container_host,
                 container_host_interface=self.container_host_interface,
+                container_add_host=self.container_add_host,
                 invoke_image=self.invoke_image,
             )
 
@@ -277,6 +283,7 @@ class TestCli(TestCase):
                 shutdown=self.shutdown,
                 container_host=self.container_host,
                 container_host_interface=self.container_host_interface,
+                container_add_host=self.container_add_host,
                 invoke_image=self.invoke_image,
             )
 
@@ -330,6 +337,7 @@ class TestCli(TestCase):
                 shutdown=self.shutdown,
                 container_host=self.container_host,
                 container_host_interface=self.container_host_interface,
+                container_add_host=self.container_add_host,
                 invoke_image=self.invoke_image,
             )
 
@@ -371,6 +379,7 @@ class TestCli(TestCase):
                 shutdown=self.shutdown,
                 container_host=self.container_host,
                 container_host_interface=self.container_host_interface,
+                container_add_host=self.container_add_host,
                 invoke_image=self.invoke_image,
             )
 
@@ -426,6 +435,7 @@ class TestCli(TestCase):
                 shutdown=self.shutdown,
                 container_host=self.container_host,
                 container_host_interface=self.container_host_interface,
+                container_add_host=self.container_add_host,
                 invoke_image=self.invoke_image,
             )
 

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -547,6 +547,7 @@ class TestLocalLambda_invoke(TestCase):
             stderr=stderr,
             container_host=None,
             container_host_interface=None,
+            container_add_host=None,
         )
 
     @patch("samcli.commands.local.lib.local_lambda.validate_architecture_runtime")
@@ -572,6 +573,7 @@ class TestLocalLambda_invoke(TestCase):
             stderr=stderr,
             container_host=None,
             container_host_interface=None,
+            container_add_host=None,
         )
 
     @patch("samcli.commands.local.lib.local_lambda.validate_architecture_runtime")
@@ -655,6 +657,7 @@ class TestLocalLambda_invoke(TestCase):
             stderr=stderr,
             container_host=None,
             container_host_interface=None,
+            container_add_host=None,
         )
 
     def test_must_raise_if_imageuri_not_found(self):
@@ -690,6 +693,7 @@ class TestLocalLambda_invoke_with_container_host_option(TestCase):
             debug_context=self.debug_context,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
         )
 
     @patch("samcli.commands.local.lib.local_lambda.validate_architecture_runtime")
@@ -715,6 +719,7 @@ class TestLocalLambda_invoke_with_container_host_option(TestCase):
             stderr=stderr,
             container_host="localhost",
             container_host_interface="127.0.0.1",
+            container_add_host="host.docker.internal"
         )
 
 

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -49,6 +49,7 @@ class TestCli(TestCase):
 
         self.container_host = "localhost"
         self.container_host_interface = "127.0.0.1"
+        self.container_add_host = "host.docker.internal"
         self.invoke_image = ()
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
@@ -88,6 +89,7 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
             invoke_images={},
         )
 
@@ -197,5 +199,6 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
             invoke_image=self.invoke_image,
         )

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -42,6 +42,7 @@ class TestCli(TestCase):
 
         self.container_host = "localhost"
         self.container_host_interface = "127.0.0.1"
+        self.container_add_host = "host.docker.internal"
         self.invoke_image = ()
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
@@ -80,6 +81,7 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
             invoke_images={},
         )
 
@@ -166,5 +168,6 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
             invoke_image=self.invoke_image,
         )

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -320,6 +320,7 @@ class TestSamConfigForAllCommands(TestCase):
                 {"Key": "Value", "Key2": "Value2"},
                 "localhost",
                 "127.0.0.1",
+                "host.docker.internal"
                 ("image",),
             )
 
@@ -385,6 +386,7 @@ class TestSamConfigForAllCommands(TestCase):
                 None,
                 "localhost",
                 "127.0.0.1",
+                "host.docker.internal"
                 ("image",),
             )
 
@@ -448,6 +450,7 @@ class TestSamConfigForAllCommands(TestCase):
                 None,
                 "localhost",
                 "127.0.0.1",
+                "host.docker.internal"
                 ("image",),
             )
 
@@ -1026,6 +1029,7 @@ class TestSamConfigWithOverrides(TestCase):
                     "localhost",
                     "--container-host-interface",
                     "127.0.0.1",
+                    "host.docker.internal"
                 ],
             )
 
@@ -1057,6 +1061,7 @@ class TestSamConfigWithOverrides(TestCase):
                 None,
                 "localhost",
                 "127.0.0.1",
+                "host.docker.internal"
                 ("image",),
             )
 
@@ -1152,6 +1157,7 @@ class TestSamConfigWithOverrides(TestCase):
                 None,
                 "localhost",
                 "127.0.0.1",
+                "host.docker.internal"
                 ("image",),
             )
 

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -67,6 +67,7 @@ class TestContainer_create(TestCase):
         self.additional_volumes = {"/somepath": {"blah": "blah value"}}
         self.container_host = "localhost"
         self.container_host_interface = "127.0.0.1"
+        self.container_add_host = "host.docker.internal"
 
         self.mock_docker_client = Mock()
         self.mock_docker_client.containers = Mock()
@@ -108,6 +109,9 @@ class TestContainer_create(TestCase):
                 container_port: ("127.0.0.1", host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
             },
+            extra_hosts={
+                self.container+":host-gateway"
+            },
             use_config_proxy=True,
         )
         self.mock_docker_client.networks.get.assert_not_called()
@@ -142,6 +146,7 @@ class TestContainer_create(TestCase):
             additional_volumes=self.additional_volumes,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
+            container_add_host=self.container_add_host,
         )
 
         container_id = container.create()
@@ -159,6 +164,9 @@ class TestContainer_create(TestCase):
             ports={
                 container_port: (self.container_host_interface, host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
+            },
+            extra_hosts={
+                self.container+":host-gateway"
             },
             entrypoint=self.entrypoint,
             mem_limit=expected_memory,
@@ -219,6 +227,9 @@ class TestContainer_create(TestCase):
             ports={
                 container_port: ("127.0.0.1", host_port)
                 for container_port, host_port in {**self.exposed_ports, **self.always_exposed_ports}.items()
+            },
+            extra_hosts={
+                self.container+":host-gateway"
             },
             entrypoint=self.entrypoint,
             mem_limit=expected_memory,

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -86,6 +86,7 @@ class LambdaRuntime_create(TestCase):
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
             container_host_interface=None,
+            container_add_host=None,
             function_name=self.name,
         )
         # Run the container and get results
@@ -169,7 +170,7 @@ class LambdaRuntime_run(TestCase):
         create_mock.return_value = container
 
         self.runtime.run(None, self.func_config, debug_context=debug_options)
-        create_mock.assert_called_with(self.func_config, debug_options, None, None)
+        create_mock.assert_called_with(self.func_config, debug_options, None, None, None)
         self.manager_mock.run.assert_called_with(container)
 
     def test_must_skip_run_running_container(self):
@@ -282,6 +283,7 @@ class LambdaRuntime_invoke(TestCase):
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
             container_host_interface=None,
+            container_add_host=None,
             function_name=self.name,
         )
 
@@ -636,6 +638,7 @@ class TestWarmLambdaRuntime_invoke(TestCase):
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
             container_host_interface=None,
+            container_add_host=None,
             function_name=self.name,
         )
 
@@ -719,6 +722,7 @@ class TestWarmLambdaRuntime_create(TestCase):
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
             container_host_interface=None,
+            container_add_host=None,
             function_name=self.name,
         )
 
@@ -788,6 +792,7 @@ class TestWarmLambdaRuntime_create(TestCase):
             memory_mb=self.DEFAULT_MEMORY,
             container_host=None,
             container_host_interface=None,
+            container_add_host=None,
             function_name=self.name,
         )
         self.manager_mock.create.assert_called_with(container)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
Because on Linux environment, the host.docker.internal host  is not enable by default, which it is use to connect to local services in other O.S  and doing this via docker-compose seems an overkill.  Window and Mac users use host.docker.internal so easy, I think this will be good for the Linux users too

Reference: https://github.com/docker/for-linux/issues/264

#### How does it address the issue?
Add one more command to the container command

#### What side effects does this change have?
Make host.docker.internal usable to connect with localhost services 

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [x] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
