### PR TITLE
fix: use the correct content property for Lambda Layer Version

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -306,19 +306,9 @@ class ApplicationBuilder:
                 store_path = os.path.relpath(absolute_output_path, original_dir)
 
             if has_build_artifact:
-                if resource_type == AWS_SERVERLESS_FUNCTION and properties.get("PackageType", ZIP) == ZIP:
-                    properties["CodeUri"] = store_path
-
-                if resource_type == AWS_LAMBDA_FUNCTION and properties.get("PackageType", ZIP) == ZIP:
-                    properties["Code"] = store_path
-
-                if resource_type in [AWS_SERVERLESS_LAYERVERSION, AWS_LAMBDA_LAYERVERSION]:
-                    properties["ContentUri"] = store_path
-
-                if resource_type == AWS_LAMBDA_FUNCTION and properties.get("PackageType", ZIP) == IMAGE:
-                    properties["Code"] = {"ImageUri": built_artifacts[full_path]}
-                if resource_type == AWS_SERVERLESS_FUNCTION and properties.get("PackageType", ZIP) == IMAGE:
-                    properties["ImageUri"] = built_artifacts[full_path]
+                ApplicationBuilder._update_built_resource(
+                    built_artifacts[full_path], properties, resource_type, store_path
+                )
 
             if is_stack:
                 if resource_type == AWS_SERVERLESS_APPLICATION:
@@ -328,6 +318,21 @@ class ApplicationBuilder:
                     properties["TemplateURL"] = store_path
 
         return template_dict
+
+    @staticmethod
+    def _update_built_resource(path: str, resource_properties: Dict, resource_type: str, absolute_path: str) -> None:
+        if resource_type == AWS_SERVERLESS_FUNCTION and resource_properties.get("PackageType", ZIP) == ZIP:
+            resource_properties["CodeUri"] = absolute_path
+        if resource_type == AWS_LAMBDA_FUNCTION and resource_properties.get("PackageType", ZIP) == ZIP:
+            resource_properties["Code"] = absolute_path
+        if resource_type == AWS_LAMBDA_LAYERVERSION:
+            resource_properties["Content"] = absolute_path
+        if resource_type == AWS_SERVERLESS_LAYERVERSION:
+            resource_properties["ContentUri"] = absolute_path
+        if resource_type == AWS_LAMBDA_FUNCTION and resource_properties.get("PackageType", ZIP) == IMAGE:
+            resource_properties["Code"] = {"ImageUri": path}
+        if resource_type == AWS_SERVERLESS_FUNCTION and resource_properties.get("PackageType", ZIP) == IMAGE:
+            resource_properties["ImageUri"] = path
 
     def _build_lambda_image(self, function_name: str, metadata: Dict, architecture: str) -> str:
         """

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -947,8 +947,15 @@ class TestBuildCommand_LayerBuilds(BuildIntegBase):
     EXPECTED_FILES_PROJECT_MANIFEST = {"__init__.py", "main.py", "requirements.txt"}
     EXPECTED_LAYERS_FILES_PROJECT_MANIFEST = {"__init__.py", "layer.py", "numpy", "requirements.txt"}
 
-    @parameterized.expand([("python3.7", False, "LayerOne"), ("python3.7", "use_container", "LayerOne")])
-    def test_build_single_layer(self, runtime, use_container, layer_identifier):
+    @parameterized.expand(
+        [
+            ("python3.7", False, "LayerOne", "ContentUri"),
+            ("python3.7", "use_container", "LayerOne", "ContentUri"),
+            ("python3.7", False, "LambdaLayerOne", "Content"),
+            ("python3.7", "use_container", "LambdaLayerOne", "Content"),
+        ]
+    )
+    def test_build_single_layer(self, runtime, use_container, layer_identifier, content_property):
         if use_container and (SKIP_DOCKER_TESTS or SKIP_DOCKER_BUILD):
             self.skipTest(SKIP_DOCKER_MESSAGE)
 
@@ -966,7 +973,7 @@ class TestBuildCommand_LayerBuilds(BuildIntegBase):
             self.default_build_dir,
             layer_identifier,
             self.EXPECTED_LAYERS_FILES_PROJECT_MANIFEST,
-            "ContentUri",
+            content_property,
             "python",
         )
 

--- a/tests/integration/testdata/buildcmd/layers-functions-template.yaml
+++ b/tests/integration/testdata/buildcmd/layers-functions-template.yaml
@@ -37,6 +37,16 @@ Resources:
     Metadata:
       BuildMethod: !Ref LayerBuildMethod
 
+  LambdaLayerOne:
+    Type: AWS::Lambda::LayerVersion
+    Properties:
+      Description: Lambda Layer one
+      Content: !Ref LayerContentUri
+      CompatibleRuntimes:
+        - python3.7
+    Metadata:
+      BuildMethod: !Ref LayerBuildMethod
+
   LayerTwo:
     Type: AWS::Serverless::LayerVersion
     Properties:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
 use the correct content property for Lambda Layer Version

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write unit tests
- [ ] Write/update functional tests
- [X] Write/update integration tests
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
