### PR TITLE
Fix: Make resource syncs respect base dir option

### DIFF
--- a/samcli/lib/sync/flows/generic_api_sync_flow.py
+++ b/samcli/lib/sync/flows/generic_api_sync_flow.py
@@ -1,5 +1,6 @@
 """SyncFlow interface for HttpApi and RestApi"""
 import logging
+from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
 
 from samcli.lib.sync.sync_flow import SyncFlow, ResourceAPICall
@@ -74,6 +75,8 @@ class GenericApiSyncFlow(SyncFlow):
             return None
         properties = api_resource.get("Properties", {})
         definition_file = properties.get("DefinitionUri")
+        if self._build_context.base_dir:
+            definition_file = str(Path(self._build_context.base_dir).joinpath(definition_file))
         return cast(Optional[str], definition_file)
 
     def compare_remote(self) -> bool:

--- a/samcli/lib/sync/flows/stepfunctions_sync_flow.py
+++ b/samcli/lib/sync/flows/stepfunctions_sync_flow.py
@@ -1,5 +1,6 @@
 """Base SyncFlow for StepFunctions"""
 import logging
+from pathlib import Path
 from typing import Any, Dict, List, TYPE_CHECKING, cast, Optional
 
 
@@ -83,6 +84,8 @@ class StepFunctionsSyncFlow(SyncFlow):
             return None
         properties = self._resource.get("Properties", {})
         definition_file = properties.get("DefinitionUri")
+        if self._build_context.base_dir:
+            definition_file = str(Path(self._build_context.base_dir).joinpath(definition_file))
         return cast(Optional[str], definition_file)
 
     def compare_remote(self) -> bool:

--- a/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
@@ -44,9 +44,12 @@ class TestHttpApiSyncFlow(TestCase):
         sync_flow._api_client.reimport_api.assert_called_once_with(ApiId="PhysicalApi1", Body='{"key": "value"}')
 
     @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_resource_by_id")
-    def test_get_definition_file(self, get_resource_mock):
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Path.joinpath")
+    def test_get_definition_file(self, join_path_mock, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
+        sync_flow._build_context.base_dir = None
+        join_path_mock.return_value = "test_uri"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 

--- a/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
@@ -60,6 +60,16 @@ class TestHttpApiSyncFlow(TestCase):
 
         self.assertEqual(result_uri, None)
 
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_resource_by_id")
+    def test_get_definition_file_with_base_dir(self, get_resource_mock):
+        sync_flow = self.create_sync_flow()
+
+        sync_flow._build_context.base_dir = "base_dir"
+        get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
+        result_uri = sync_flow._get_definition_file("test")
+
+        self.assertEqual(result_uri, "base_dir/test_uri")
+
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()
         sync_flow._definition_uri = "path"

--- a/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, mock_open, patch
+from pathlib import Path
 
 from samcli.lib.sync.flows.http_api_sync_flow import HttpApiSyncFlow
 from samcli.lib.providers.exceptions import MissingLocalDefinition
@@ -68,7 +69,7 @@ class TestHttpApiSyncFlow(TestCase):
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 
-        self.assertEqual(result_uri, "base_dir/test_uri")
+        self.assertEqual(result_uri, str(Path("base_dir").joinpath("test_uri")))
 
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()

--- a/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, mock_open, patch, call
+from pathlib import Path
 
 from botocore.exceptions import ClientError
 
@@ -286,7 +287,7 @@ please check the console to see if you have other stages that needs to be update
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 
-        self.assertEqual(result_uri, "base_dir/test_uri")
+        self.assertEqual(result_uri, str(Path("base_dir").joinpath("test_uri")))
 
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()

--- a/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
@@ -278,6 +278,16 @@ please check the console to see if you have other stages that needs to be update
 
         self.assertEqual(result_uri, None)
 
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_resource_by_id")
+    def test_get_definition_file_with_base_dir(self, get_resource_mock):
+        sync_flow = self.create_sync_flow()
+
+        sync_flow._build_context.base_dir = "base_dir"
+        get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
+        result_uri = sync_flow._get_definition_file("test")
+
+        self.assertEqual(result_uri, "base_dir/test_uri")
+
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()
         sync_flow._definition_uri = "path"

--- a/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
@@ -262,9 +262,12 @@ please check the console to see if you have other stages that needs to be update
             )
 
     @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_resource_by_id")
-    def test_get_definition_file(self, get_resource_mock):
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Path.joinpath")
+    def test_get_definition_file(self, join_path_mock, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
+        sync_flow._build_context.base_dir = None
+        join_path_mock.return_value = "test_uri"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -54,7 +54,7 @@ class TestStepFunctionsSyncFlow(TestCase):
         )
 
     @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.get_resource_by_id")
-    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Path.joinpath")
+    @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.Path.joinpath")
     def test_get_definition_file(self, join_path_mock, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
@@ -69,6 +69,16 @@ class TestStepFunctionsSyncFlow(TestCase):
         result_uri = sync_flow._get_definition_file("test")
 
         self.assertEqual(result_uri, None)
+
+    @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.get_resource_by_id")
+    def test_get_definition_file_with_base_dir(self, get_resource_mock):
+        sync_flow = self.create_sync_flow()
+
+        sync_flow._build_context.base_dir = "base_dir"
+        sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
+        result_uri = sync_flow._get_definition_file("test")
+
+        self.assertEqual(result_uri, "base_dir/test_uri")
 
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -1,9 +1,10 @@
-from samcli.lib.providers.exceptions import MissingLocalDefinition
 from unittest import TestCase
 from unittest.mock import ANY, MagicMock, mock_open, patch
+from pathlib import Path
 
 from samcli.lib.sync.flows.stepfunctions_sync_flow import StepFunctionsSyncFlow
 from samcli.lib.sync.exceptions import InfraSyncRequiredError
+from samcli.lib.providers.exceptions import MissingLocalDefinition
 
 
 class TestStepFunctionsSyncFlow(TestCase):
@@ -78,7 +79,7 @@ class TestStepFunctionsSyncFlow(TestCase):
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 
-        self.assertEqual(result_uri, "base_dir/test_uri")
+        self.assertEqual(result_uri, str(Path("base_dir").joinpath("test_uri")))
 
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -54,9 +54,12 @@ class TestStepFunctionsSyncFlow(TestCase):
         )
 
     @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.get_resource_by_id")
-    def test_get_definition_file(self, get_resource_mock):
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Path.joinpath")
+    def test_get_definition_file(self, join_path_mock, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
+        sync_flow._build_context.base_dir = None
+        join_path_mock.return_value = "test_uri"
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N.A.

#### Why is this change necessary?
Without this change any definition files will not be found correctly if base_dir option is not respected for customers who have code directory somewhere else

#### How does it address the issue?
It adds the base_dir into the full path of the definition files

#### What side effects does this change have?
N.A.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
