### PR TITLE
Fix: Use Internal CLI templates

### DIFF
--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -128,7 +128,7 @@ class InitTemplates:
         return os.path.normpath(os.path.join(self._git_repo.local_path, template_directory))
 
     def get_manifest_path(self):
-        if self._git_repo.local_path and os.path.exists(Path(self._git_repo.local_path, self.manifest_file_name)):
+        if self._git_repo.local_path and Path(self._git_repo.local_path, self.manifest_file_name).exists():
             return Path(self._git_repo.local_path, self.manifest_file_name)
         return get_local_manifest_path()
 

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -13,7 +13,11 @@ from samcli.cli.global_config import GlobalConfig
 from samcli.commands.exceptions import UserException, AppTemplateUpdateException
 from samcli.lib.utils.git_repo import GitRepo, CloneRepoException, CloneRepoUnstableStateException
 from samcli.lib.utils.packagetype import IMAGE
-from samcli.local.common.runtime_template import RUNTIME_DEP_TEMPLATE_MAPPING, get_local_lambda_images_location
+from samcli.local.common.runtime_template import (
+    RUNTIME_DEP_TEMPLATE_MAPPING,
+    get_local_lambda_images_location,
+    get_local_manifest_path,
+)
 
 LOG = logging.getLogger(__name__)
 APP_TEMPLATES_REPO_URL = "https://github.com/aws/aws-sam-cli-app-templates"
@@ -124,7 +128,9 @@ class InitTemplates:
         return os.path.normpath(os.path.join(self._git_repo.local_path, template_directory))
 
     def get_manifest_path(self):
-        return Path(self._git_repo.local_path, self.manifest_file_name)
+        if self._git_repo.local_path and os.path.exists(Path(self._git_repo.local_path, self.manifest_file_name)):
+            return Path(self._git_repo.local_path, self.manifest_file_name)
+        return get_local_manifest_path()
 
     def get_preprocessed_manifest(
         self,

--- a/samcli/lib/init/local_manifest.json
+++ b/samcli/lib/init/local_manifest.json
@@ -1,0 +1,176 @@
+{
+    "dotnetcore3.1": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-dotnet",
+            "displayName": "Hello World Example",
+            "dependencyManager": "cli-package",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "dotnetcore2.1": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-dotnet",
+            "displayName": "Hello World Example",
+            "dependencyManager": "cli-package",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "go1.x": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-golang",
+            "displayName": "Hello World Example",
+            "dependencyManager": "mod",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "java11": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-java-gradle",
+            "displayName": "Hello World Example: Gradle",
+            "dependencyManager": "gradle",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        },
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-java-gradle",
+            "displayName": "Hello World Example: Maven",
+            "dependencyManager": "maven",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "java8": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-java-gradle",
+            "displayName": "Hello World Example: Gradle",
+            "dependencyManager": "gradle",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        },
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-java-gradle",
+            "displayName": "Hello World Example: Maven",
+            "dependencyManager": "maven",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "java8.al2": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-java-gradle",
+            "displayName": "Hello World Example: Gradle",
+            "dependencyManager": "gradle",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        },
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-java-maven",
+            "displayName": "Hello World Example: Maven",
+            "dependencyManager": "maven",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "nodejs14.x": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-nodejs",
+            "displayName": "Hello World Example",
+            "dependencyManager": "npm",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "nodejs12.x": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-nodejs",
+            "displayName": "Hello World Example",
+            "dependencyManager": "npm",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "nodejs10.x": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-nodejs",
+            "displayName": "Hello World Example",
+            "dependencyManager": "npm",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "python3.9": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-python",
+            "displayName": "Hello World Example",
+            "dependencyManager": "pip",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "python3.8": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-python",
+            "displayName": "Hello World Example",
+            "dependencyManager": "pip",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "python3.7": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-python",
+            "displayName": "Hello World Example",
+            "dependencyManager": "pip",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "python3.6": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-python",
+            "displayName": "Hello World Example",
+            "dependencyManager": "pip",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "ruby2.7": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-ruby",
+            "displayName": "Hello World Example",
+            "dependencyManager": "bundler",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ],
+    "ruby2.5": [
+        {
+            "directory": "template/cookiecutter-aws-sam-hello-ruby",
+            "displayName": "Hello World Example",
+            "dependencyManager": "bundler",
+            "appTemplate": "hello-world",
+            "packageType": "Zip",
+            "useCaseName": "Hello World Example"
+        }
+    ]
+}

--- a/samcli/lib/init/local_manifest.json
+++ b/samcli/lib/init/local_manifest.json
@@ -9,16 +9,6 @@
             "useCaseName": "Hello World Example"
         }
     ],
-    "dotnetcore2.1": [
-        {
-            "directory": "template/cookiecutter-aws-sam-hello-dotnet",
-            "displayName": "Hello World Example",
-            "dependencyManager": "cli-package",
-            "appTemplate": "hello-world",
-            "packageType": "Zip",
-            "useCaseName": "Hello World Example"
-        }
-    ],
     "go1.x": [
         {
             "directory": "template/cookiecutter-aws-sam-hello-golang",
@@ -103,16 +93,6 @@
             "useCaseName": "Hello World Example"
         }
     ],
-    "nodejs10.x": [
-        {
-            "directory": "template/cookiecutter-aws-sam-hello-nodejs",
-            "displayName": "Hello World Example",
-            "dependencyManager": "npm",
-            "appTemplate": "hello-world",
-            "packageType": "Zip",
-            "useCaseName": "Hello World Example"
-        }
-    ],
     "python3.9": [
         {
             "directory": "template/cookiecutter-aws-sam-hello-python",
@@ -154,16 +134,6 @@
         }
     ],
     "ruby2.7": [
-        {
-            "directory": "template/cookiecutter-aws-sam-hello-ruby",
-            "displayName": "Hello World Example",
-            "dependencyManager": "bundler",
-            "appTemplate": "hello-world",
-            "packageType": "Zip",
-            "useCaseName": "Hello World Example"
-        }
-    ],
-    "ruby2.5": [
         {
             "directory": "template/cookiecutter-aws-sam-hello-ruby",
             "displayName": "Hello World Example",

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -71,7 +71,7 @@ RUNTIME_DEP_TEMPLATE_MAPPING = {
 
 
 def get_local_manifest_path():
-    return os.path.join(_init_path, "lib", "init", "local_manifest.json")
+    return pathlib.Path(_init_path, "lib", "init", "local_manifest.json")
 
 
 def get_local_lambda_images_location(mapping, runtime):

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -70,6 +70,10 @@ RUNTIME_DEP_TEMPLATE_MAPPING = {
 }
 
 
+def get_local_manifest_path():
+    return os.path.join(_init_path, "lib", "init", "local_manifest.json")
+
+
 def get_local_lambda_images_location(mapping, runtime):
     dir_name = os.path.basename(mapping["init_location"])
     if dir_name.endswith("-lambda-image"):

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -2467,3 +2467,46 @@ test-project
         }
         dependency_manager = "Gradle"
         self.assertTrue(template_does_not_meet_filter_criteria(app_template, None, dependency_manager, template3))
+
+    @patch("samcli.lib.utils.git_repo.GitRepo")
+    @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
+    def test_must_get_local_manifest_path(self, git_repo):
+        template = InitTemplates()
+        template._git_repo.local_path = None
+        manifest_path = template.get_manifest_path()
+        expected_path = "samcli/lib/init/local_manifest.json"
+        self.assertIn(expected_path, manifest_path)
+
+    # @patch("samcli.commands.init.init_templates.InitTemplates.get_preprocessed_manifest")
+    # @patch("samcli.commands.init.init_templates.InitTemplates._init_options_from_manifest")
+    @patch("os.path.exists")
+    @patch("samcli.commands.init.init_generator.generate_project")
+    @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
+    def test_init_cli_generate_app_template_from_local_cli_templates(self, generate_project_patch, path_exist_mock):
+        path_exist_mock.return_value = False
+
+        # WHEN the user follows interactive init prompts
+        # 1: AWS Quick Start Templates
+        # 2: Java 11
+        # test-project: response to name
+        user_input = """
+1
+N
+4
+2
+test-project
+        """
+
+        runner = CliRunner()
+        result = runner.invoke(init_cmd, input=user_input)
+        self.assertFalse(result.exception)
+        generate_project_patch.assert_called_once_with(
+            ANY,
+            ZIP,
+            "java11",
+            "maven",
+            ".",
+            "test-project",
+            True,
+            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
+        )

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -2474,8 +2474,8 @@ test-project
         template = InitTemplates()
         template._git_repo.local_path = None
         manifest_path = template.get_manifest_path()
-        expected_path = "samcli/lib/init/local_manifest.json"
-        self.assertIn(expected_path, manifest_path)
+        file_name_path = "local_manifest.json"
+        self.assertIn(file_name_path, manifest_path)
 
     # @patch("samcli.commands.init.init_templates.InitTemplates.get_preprocessed_manifest")
     # @patch("samcli.commands.init.init_templates.InitTemplates._init_options_from_manifest")

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -2473,13 +2473,11 @@ test-project
     def test_must_get_local_manifest_path(self, git_repo):
         template = InitTemplates()
         template._git_repo.local_path = None
-        manifest_path = template.get_manifest_path()
+        manifest_path = str(template.get_manifest_path())
         file_name_path = "local_manifest.json"
         self.assertIn(file_name_path, manifest_path)
 
-    # @patch("samcli.commands.init.init_templates.InitTemplates.get_preprocessed_manifest")
-    # @patch("samcli.commands.init.init_templates.InitTemplates._init_options_from_manifest")
-    @patch("os.path.exists")
+    @patch.object(Path, "exists")
     @patch("samcli.commands.init.init_generator.generate_project")
     @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
     def test_init_cli_generate_app_template_from_local_cli_templates(self, generate_project_patch, path_exist_mock):
@@ -2492,7 +2490,7 @@ test-project
         user_input = """
 1
 N
-4
+3
 2
 test-project
         """


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/3576
#### Why is this change necessary?
Customers are currently experience issues when they can't clone
#### How does it address the issue?
Allow customers without internet or who can't clone the git repo access internal template without breaking

#### What side effects does this change have?
None
#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
