### PR TITLE
feat: sam init changes to improve getting manifest time and clone messaging

### DIFF
--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -72,6 +72,11 @@ or you can provide one of the following required parameter combinations:
 
 REQUIRED_PARAMS_HINT = "You can also re-run without the --no-interactive flag to be prompted for required values."
 
+INIT_INTERACTIVE_OPTION_GUIDE = """
+You can preselect a particular runtime or package type when using the `sam init` experience.
+Call `sam init --help` to learn more.
+"""
+
 
 class PackageType:
     """
@@ -335,6 +340,9 @@ def do_cli(
             extra_context,
         )
     else:
+        if not (pt_explicit or runtime or dependency_manager or base_image or architecture):
+            click.secho(INIT_INTERACTIVE_OPTION_GUIDE, fg="yellow", bold=True)
+
         # proceed to interactive state machine, which will call do_generate
         do_interactive(
             location,

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -214,7 +214,6 @@ class InitTemplates:
             body = response.text
         except (requests.Timeout, requests.ConnectionError):
             LOG.debug("Request to get Manifest failed, attempting to clone the repository")
-            LOG.debug("Clone error, attempting to use an old clone from a previous run")
             self.clone_templates_repo()
             manifest_path = self.get_manifest_path()
             with open(str(manifest_path)) as fp:

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -21,6 +21,7 @@ from samcli.local.common.runtime_template import (
 )
 
 LOG = logging.getLogger(__name__)
+MANIFEST_URL = "https://raw.githubusercontent.com/aws/aws-sam-cli-app-templates/master/manifest.json"
 APP_TEMPLATES_REPO_URL = "https://github.com/aws/aws-sam-cli-app-templates"
 APP_TEMPLATES_REPO_NAME = "aws-sam-cli-app-templates"
 
@@ -33,7 +34,6 @@ class InitTemplates:
     def __init__(self):
         self._git_repo: GitRepo = GitRepo(url=APP_TEMPLATES_REPO_URL)
         self.manifest_file_name = "manifest.json"
-        self.manifest_url = "https://raw.githubusercontent.com/aws/aws-sam-cli-app-templates/master/manifest.json"
 
     def location_from_app_template(self, package_type, runtime, base_image, dependency_manager, app_template):
         options = self.init_options(package_type, runtime, base_image, dependency_manager)
@@ -210,9 +210,11 @@ class InitTemplates:
         use local cli template
         """
         try:
-            response = requests.get(self.manifest_url, timeout=10)
+            response = requests.get(MANIFEST_URL, timeout=10)
             body = response.text
         except (requests.Timeout, requests.ConnectionError):
+            LOG.debug("Request to get Manifest failed, attempting to clone the repository")
+            LOG.debug("Clone error, attempting to use an old clone from a previous run")
             self.clone_templates_repo()
             manifest_path = self.get_manifest_path()
             with open(str(manifest_path)) as fp:

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -229,7 +229,7 @@ def _generate_default_hello_world_application(
     """
     is_package_type_image = bool(package_type == IMAGE)
     if use_case == "Hello World Example" and not (runtime or base_image or is_package_type_image or dependency_manager):
-        if click.confirm("\n Use the most popular runtime and package type? (Nodejs and zip)"):
+        if click.confirm("\n Use the most popular runtime and package type? (Python and zip)"):
             runtime, package_type, dependency_manager, pt_explicit = "python3.9", ZIP, "pip", True
     return (runtime, package_type, dependency_manager, pt_explicit)
 

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -154,10 +154,11 @@ def _generate_from_use_case(
     base_image = (
         LAMBDA_IMAGES_RUNTIMES_MAP.get(str(runtime)) if not base_image and package_type == IMAGE else base_image
     )
-    location = templates.location_from_app_template(package_type, runtime, base_image, dependency_manager, app_template)
 
     if not name:
         name = click.prompt("\nProject name", type=str, default="sam-app")
+
+    location = templates.location_from_app_template(package_type, runtime, base_image, dependency_manager, app_template)
 
     final_architecture = get_architectures(architecture)
     extra_context = {
@@ -229,7 +230,7 @@ def _generate_default_hello_world_application(
     is_package_type_image = bool(package_type == IMAGE)
     if use_case == "Hello World Example" and not (runtime or base_image or is_package_type_image or dependency_manager):
         if click.confirm("\n Use the most popular runtime and package type? (Nodejs and zip)"):
-            runtime, package_type, dependency_manager, pt_explicit = "nodejs14.x", ZIP, "npm", True
+            runtime, package_type, dependency_manager, pt_explicit = "python3.9", ZIP, "pip", True
     return (runtime, package_type, dependency_manager, pt_explicit)
 
 

--- a/samcli/lib/utils/git_repo.py
+++ b/samcli/lib/utils/git_repo.py
@@ -121,7 +121,7 @@ class GitRepo:
             try:
                 temp_path = os.path.normpath(os.path.join(tempdir, clone_name))
                 git_executable: str = GitRepo._git_executable()
-                LOG.info("\nCloning from %s", self.url)
+                LOG.info("\nCloning from %s (process may take a moment)", self.url)
                 check_output(
                     [git_executable, "clone", self.url, clone_name],
                     cwd=tempdir,

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -7,7 +7,7 @@ import requests
 from pathlib import Path
 from typing import Dict, Any
 from unittest import TestCase
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import patch, ANY
 
 import botocore.exceptions
 import click
@@ -42,7 +42,6 @@ class MockInitTemplates:
         self._git_repo.clone_attempted = True
         self._git_repo.local_path = Path("tests/unit/commands/init")
         self.manifest_file_name = "test_manifest.json"
-        self.manifest_url = Mock()
 
 
 class TestCli(TestCase):

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -1,14 +1,13 @@
-import os
+import json
 import shutil
 import subprocess
 import tempfile
-import logging
 from unittest.case import expectedFailure
-import pytest
+import requests
 from pathlib import Path
 from typing import Dict, Any
 from unittest import TestCase
-from unittest.mock import patch, ANY
+from unittest.mock import Mock, patch, ANY
 
 import botocore.exceptions
 import click
@@ -43,6 +42,7 @@ class MockInitTemplates:
         self._git_repo.clone_attempted = True
         self._git_repo.local_path = Path("tests/unit/commands/init")
         self.manifest_file_name = "test_manifest.json"
+        self.manifest_url = Mock()
 
 
 class TestCli(TestCase):
@@ -61,6 +61,9 @@ class TestCli(TestCase):
         self.no_input = False
         self.extra_context = '{"project_name": "testing project", "runtime": "python3.6"}'
         self.extra_context_as_json = {"project_name": "testing project", "runtime": "python3.6"}
+
+        with open("tests/unit/commands/init/test_manifest.json") as f:
+            self.data = json.load(f)
 
     # setup cache for clone, so that if `git clone` is called multiple times on the same URL,
     # only one clone will happen.
@@ -1381,10 +1384,14 @@ foo
             None,
         )
 
+    @patch("samcli.commands.init.init_templates.InitTemplates._get_manifest")
     @patch("samcli.lib.utils.git_repo.GitRepo.clone")
     @patch("samcli.commands.init.init_generator.generate_project")
     @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
-    def test_init_cli_no_package_type(self, generate_project_patch, git_repo_clone_mock):
+    def test_init_cli_no_package_type(self, generate_project_patch, git_repo_clone_mock, _get_manifest_mock):
+
+        _get_manifest_mock.return_value = self.data
+
         # WHEN the user follows interactive init prompts
 
         # 1: selecting template source
@@ -1713,16 +1720,18 @@ n
             False  # Other tests fail after we pass --packge-type in this test, so let's reset this variable
         )
 
+    @patch("requests.get")
     @patch("samcli.commands.init.init_templates.InitTemplates.get_preprocessed_manifest")
     @patch("samcli.commands.init.init_templates.InitTemplates._init_options_from_manifest")
     @patch("samcli.commands.init.init_generator.generate_project")
     @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
     def test_init_cli_generate_default_hello_world_app(
-        self, generate_project_patch, init_options_from_manifest_mock, get_preprocessed_manifest_mock
+        self, generate_project_patch, init_options_from_manifest_mock, get_preprocessed_manifest_mock, request_mock
     ):
+        request_mock.side_effect = requests.Timeout()
         init_options_from_manifest_mock.return_value = [
             {
-                "directory": "nodejs14.x/cookiecutter-aws-sam-hello-nodejs",
+                "directory": "python3.9/cookiecutter-aws-sam-hello-python",
                 "displayName": "Hello World Example",
                 "dependencyManager": "npm",
                 "appTemplate": "hello-world",
@@ -1742,12 +1751,12 @@ n
 
         get_preprocessed_manifest_mock.return_value = {
             "Hello World Example": {
-                "nodejs14.x": {
+                "python3.9": {
                     "Zip": [
                         {
-                            "directory": "nodejs14.x/cookiecutter-aws-sam-hello-nodejs",
+                            "directory": "python3.9/cookiecutter-aws-sam-hello-python3.9",
                             "displayName": "Hello World Example",
-                            "dependencyManager": "npm",
+                            "dependencyManager": "pip",
                             "appTemplate": "hello-world",
                             "packageType": "Zip",
                             "useCaseName": "Hello World Example",
@@ -1777,7 +1786,6 @@ n
         # test-project: response to name
         user_input = """
 1
-1
 y
 test-project
         """
@@ -1788,12 +1796,12 @@ test-project
         generate_project_patch.assert_called_once_with(
             ANY,
             ZIP,
-            "nodejs14.x",
-            "npm",
+            "python3.9",
+            "pip",
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "nodejs14.x", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "python3.9", "architectures": {"value": ["x86_64"]}},
         )
 
     @patch("samcli.commands.init.init_templates.InitTemplates.get_preprocessed_manifest")
@@ -1906,9 +1914,11 @@ test-project
             runtime = get_runtime(IMAGE, base_image)
             self.assertEqual(runtime, expected_runtime[index])
 
+    @patch("samcli.commands.init.init_templates.InitTemplates._get_manifest")
     @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
-    def test_must_process_manifest(self):
+    def test_must_process_manifest(self, _get_manifest_mock):
         template = InitTemplates()
+        _get_manifest_mock.return_value = self.data
         preprocess_manifest = template.get_preprocessed_manifest()
         expected_result = {
             "Hello World Example": {
@@ -1964,10 +1974,12 @@ test-project
         }
         self.assertEqual(preprocess_manifest, expected_result)
 
+    @patch("samcli.commands.init.init_templates.InitTemplates._get_manifest")
     @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
-    def test_must_process_manifest_with_runtime_as_filter_value(self):
+    def test_must_process_manifest_with_runtime_as_filter_value(self, _get_manifest_mock):
         template = InitTemplates()
         filter_value = "go1.x"
+        _get_manifest_mock.return_value = self.data
         preprocess_manifest = template.get_preprocessed_manifest(filter_value)
         expected_result = {
             "Hello World Example": {
@@ -1987,10 +1999,12 @@ test-project
         }
         self.assertEqual(preprocess_manifest, expected_result)
 
+    @patch("samcli.commands.init.init_templates.InitTemplates._get_manifest")
     @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
-    def test_must_process_manifest_with_image_as_filter_value(self):
+    def test_must_process_manifest_with_image_as_filter_value(self, _get_manifest_mock):
         template = InitTemplates()
         filter_value = "amazon/nodejs14.x-base"
+        _get_manifest_mock.return_value = self.data
         preprocess_manifest = template.get_preprocessed_manifest(filter_value)
         expected_result = {
             "Hello World Example": {
@@ -2036,9 +2050,11 @@ test-project
         )
         self.assertEqual(str(ex.exception), expected_error_message)
 
+    @patch("samcli.commands.init.init_templates.InitTemplates._get_manifest")
     @patch("samcli.lib.utils.git_repo.GitRepo.clone")
     @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
-    def test_init_cli_with_mismatch_dep_runtime(self, git_repo_clone_mock):
+    def test_init_cli_with_mismatch_dep_runtime(self, git_repo_clone_mock, _get_manifest_mock):
+        _get_manifest_mock = self.data
         # WHEN the user follows interactive init prompts
 
         # 1: selecting template source
@@ -2478,9 +2494,13 @@ test-project
         self.assertIn(file_name_path, manifest_path)
 
     @patch.object(Path, "exists")
+    @patch("requests.get")
     @patch("samcli.commands.init.init_generator.generate_project")
     @patch.object(InitTemplates, "__init__", MockInitTemplates.__init__)
-    def test_init_cli_generate_app_template_from_local_cli_templates(self, generate_project_patch, path_exist_mock):
+    def test_init_cli_generate_app_template_from_local_cli_templates(
+        self, generate_project_patch, request_mock, path_exist_mock
+    ):
+        request_mock.side_effect = requests.Timeout()
         path_exist_mock.return_value = False
 
         # WHEN the user follows interactive init prompts


### PR DESCRIPTION
This pr addresses issues raised by customers with respect to new revamped SAM CLI Init interactive experience:

1. In this PR the wait time to get the manifest file from the cli template was reduced by 80%. Additional robust fault tolerance has been added to ensure that customers always get a vended app template.
2. CLl depends on the manifest file in the cli template repo to create the new, easy and quick interactive experience. This update in the PR ensures that the cli 
      - Attempts to first get just the Manifest file directly from github
      - If this fails, the CLI then resorts to cloning the cli template repo and using the cloned manifest
      - if the cloning fails, a local manifest which acts as reference to all local app templates in SAM CLI is used.
This way ensures that customers always have access to a vended serverless template.
3. Finally, the new SAM CLI has the ability to filter through options therefore reducing the number of steps to a vended serverless application template  via the interactive flow by at-most 70%. This PR adds a text/helper to help make customers aware of those preselected options. 
4. In this pr, the clone message displayed while cloning from github was improved to be more clear.