### PR TITLE
fix: Add Validation for Incompatible watch and code Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,42 @@
 <p align="center">
 </p>
 
-# AWS SAM
+# AWS SAM CLI
 
 ![Apache-2.0](https://img.shields.io/npm/l/aws-sam-local.svg)
 ![SAM CLI Version](https://img.shields.io/github/release/awslabs/aws-sam-cli.svg?label=CLI%20Version)
+![Install](https://img.shields.io/badge/brew-aws--sam--cli-orange)
+![pip](https://img.shields.io/badge/pip-aws--sam--cli-9cf)
 
-The AWS Serverless Application Model (SAM) is an open-source framework for building serverless applications. 
-It provides shorthand syntax to express functions, APIs, databases, and event source mappings. 
-With just a few lines of configuration, you can define the application you want and model it.
+[Installation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) | [Blogs](https://serverlessland.com/blog?tag=AWS%20SAM) | [Videos](https://serverlessland.com/video?tag=AWS%20SAM) | [AWS Docs](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) | [Roadmap](https://github.com/aws/aws-sam-cli/wiki/SAM-CLI-Roadmap)
 
-[![Getting Started with AWS SAM](./media/get-started-youtube.png)](https://www.youtube.com/watch?v=1dzihtC5LJ0)
+The AWS Serverless Application Model (SAM) CLI is an open-source CLI tool that helps you develop serverless applications containing [Lambda functions](https://aws.amazon.com/lambda/), [Step Functions](https://aws.amazon.com/step-functions/), [API Gateway](https://aws.amazon.com/api-gateway/), [EventBridge](https://aws.amazon.com/eventbridge/), [SQS](https://aws.amazon.com/sqs/), [SNS](https://aws.amazon.com/sns/) and more. Some of the features it provides are:
+- **Initialize serverless applications** in minutes with AWS provided infrastructure templates with `sam init`
+- **Compile, build, and package** Lambda functions with provided runtimes and with custom Makefile workflows, for zip and image types of Lambda functions with `sam build`
+- **Locally test** a Lambda function and API Gateway easily in a Docker container with `sam local` commands on SAM and CDK applications
+- **Sync and test your changes in the cloud** with `sam sync` in your developer environments
+- **Deploy** your SAM and CloudFormation templates using `sam deploy`
+- Quickly **create pipelines** with prebuilt templates with popular CI/CD systems using `sam pipeline init`
+- **Tail CloudWatch logs and X-Ray traces** with `sam log` and `sam trace`
 
-![AWS SAM CLI help menu](https://user-images.githubusercontent.com/3770774/87969094-59d05a80-ca76-11ea-9c23-76306fa8592b.png)
 
 ## Get Started
 
 To get started with building SAM-based applications, use the SAM CLI. SAM CLI provides a Lambda-like execution 
-environment that lets you locally build, test, debug, and deploy applications defined by SAM templates.
+environment that lets you locally build, test, debug, and deploy [AWS serverless](https://aws.amazon.com/serverless/) applications.
 
 * [Install SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
 * [Build & Deploy a "Hello World" Web App](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-quick-start.html)
-* [Install AWS Toolkit](https://aws.amazon.com/getting-started/tools-sdks/#IDE_and_IDE_Toolkits) to use SAM with your favorite IDEs.
+* [Install AWS Toolkit](https://aws.amazon.com/getting-started/tools-sdks/#IDE_and_IDE_Toolkits) to use SAM with your favorite IDEs
+* [Tutorials and Workshops](https://serverlessland.com/learn)
+* [Lambda Powertools](https://aws.amazon.com/blogs/opensource/simplifying-serverless-best-practices-with-lambda-powertools/) Utilities for building Lambda functions in [Python](https://awslabs.github.io/aws-lambda-powertools-python/latest/), [Java](https://github.com/awslabs/aws-lambda-powertools-java), and [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript)
 
 
 **Next Steps:** Learn to build a more complex serverless application.
 * [Extract text from images and store in a database](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-example-s3.html) using Amazon S3 and Amazon Rekognition services.
 * [Detect when records are added to a database](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-example-ddb.html) using Amazon DynamoDB database and asynchronous stream processing.
+* [Explore popular patterns](https://serverlessland.com/patterns)
 
-
-**Detailed References:** Explains SAM commands and usage in depth.
-* [CLI Commands](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-command-reference.html)
-* [SAM Template Specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md)
-* [Policy Templates](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html)
-
-## Why SAM
-
-+ **Single\-deployment configuration**\. SAM makes it easy to organize related components and resources, and operate on a single stack\. You can use SAM to share configuration \(such as memory and timeouts\) between resources, and deploy all related resources together as a single, versioned entity\.
-   
-+ **Local debugging and testing**\. Use SAM CLI to locally build, test, and debug SAM applications on a Lambda-like execution environment. It tightens the development loop by helping you find & troubleshoot issues locally that you might otherwise identify only after deploying to the cloud.
-
-+ **Deep integration with development tools**. You can use SAM with a suite of tools you love and use.
-    + IDEs: [PyCharm](https://aws.amazon.com/pycharm/), [IntelliJ](https://aws.amazon.com/intellij/), [Visual Studio Code](https://aws.amazon.com/visualstudiocode/), [Visual Studio](https://aws.amazon.com/visualstudio/), [AWS Cloud9](https://aws.amazon.com/cloud9/)
-    + Build: [CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/)
-    + Deploy: [CodeDeploy](https://docs.aws.amazon.com/codedeploy/latest/userguide/), [Jenkins](https://wiki.jenkins.io/display/JENKINS/AWS+SAM+Plugin)
-    + Continuous Delivery Pipelines: [CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/) 
-    + Discover Serverless Apps & Patterns: [AWS Serverless Application Repository](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/)
-
-+ **Built\-in best practices**\. You can use SAM to define and deploy your infrastructure as configuration. This makes it possible for you to use and enforce best practices through code reviews. Also, with a few lines of configuration, you can enable safe deployments through CodeDeploy, and can enable tracing using AWS X\-Ray\.
-
-+ **Extension of AWS CloudFormation**\. Because SAM is an extension of AWS CloudFormation, you get the reliable deployment capabilities of AWS CloudFormation\. You can define resources by using CloudFormation in your SAM template\. Also, you can use the full suite of resources, intrinsic functions, and other template features that are available in CloudFormation\.
 
 ## What is this Github repository? 💻
 This Github Repository contains source code for SAM CLI. Here is the development team talking about this code:
@@ -57,6 +44,14 @@ This Github Repository contains source code for SAM CLI. Here is the development
 > SAM CLI code is written in Python. Source code is well documented, very modular, with 95% unit test coverage. 
 It uses this awesome Python library called Click to manage the command line interaction and uses Docker to run Lambda functions locally.
 We think you'll like the code base. Clone it and run `make pr` or `./Make -pr` on Windows!
+
+
+## Related Repositories and Resources
++ **SAM Transform** [Open source template specification](https://github.com/awslabs/serverless-application-model/) that provides shorthand syntax for CloudFormation
++ **SAM CLI application templates** Get started quickly with [predefined application templates](https://github.com/aws/aws-sam-cli-app-templates/blob/master/README.md) for all supported runtimes and languages, used by `sam init`
++ **Lambda Builders** [Lambda builder tools](https://github.com/aws/aws-lambda-builders) for supported runtimes and custom build workflows, used by `sam build`
++ **Build and local emulation images for CI/CD tools** [Build container images](https://gallery.ecr.aws/sam/) to use with CI/CD tasks 
+
 
 ## Contribute to SAM
 
@@ -88,6 +83,4 @@ started.
 
 ### Join the SAM Community on Slack
 [Join the SAM developers channel (#samdev)](https://join.slack.com/t/awsdevelopers/shared_invite/zt-idww18e8-Z1kXhI7GNuDewkweCF3YjA) on Slack to collaborate with fellow community members and the AWS SAM team.
-
-
 

--- a/samcli/commands/_utils/click_mutex.py
+++ b/samcli/commands/_utils/click_mutex.py
@@ -80,7 +80,7 @@ class ClickMutex(click.Option):
 
                 msg += self.required_params_hint
                 raise click.UsageError(msg)
-            self.prompt = None
+            self.prompt = ""
 
         return super().handle_parse_result(ctx, opts, args)
 

--- a/samcli/commands/_utils/click_mutex.py
+++ b/samcli/commands/_utils/click_mutex.py
@@ -28,9 +28,9 @@ class ClickMutex(click.Option):
     """
 
     def __init__(self, *args, **kwargs):
-        self.required_param_lists: List = kwargs.pop("required_param_lists", [])
+        self.required_param_lists: List[List[str]] = kwargs.pop("required_param_lists", [])
         self.required_params_hint: str = kwargs.pop("required_params_hint", "")
-        self.incompatible_params: List = kwargs.pop("incompatible_params", [])
+        self.incompatible_params: List[str] = kwargs.pop("incompatible_params", [])
         self.incompatible_params_hint: str = kwargs.pop("incompatible_params_hint", "")
 
         super().__init__(*args, **kwargs)

--- a/samcli/commands/_utils/click_mutex.py
+++ b/samcli/commands/_utils/click_mutex.py
@@ -1,7 +1,7 @@
 """
 Module to check mutually exclusive cli parameters
 """
-from typing import List
+from typing import List, Dict
 
 import click
 
@@ -19,7 +19,7 @@ class Mutex(click.Option):
 
         super().__init__(*args, **kwargs)
 
-    def handle_parse_result(self, ctx, opts, args):
+    def handle_parse_result(self, ctx, opts: Dict, args):
         if self.name not in opts:
             return super().handle_parse_result(ctx, opts, args)
 

--- a/samcli/commands/_utils/click_mutex.py
+++ b/samcli/commands/_utils/click_mutex.py
@@ -1,7 +1,7 @@
 """
 Module to check mutually exclusive cli parameters
 """
-from typing import List, Dict
+from typing import Any, List, Dict, Tuple
 
 import click
 
@@ -19,7 +19,7 @@ class Mutex(click.Option):
 
         super().__init__(*args, **kwargs)
 
-    def handle_parse_result(self, ctx, opts: Dict, args):
+    def handle_parse_result(self, ctx: click.Context, opts: Dict[str, Any], args: List[str]) -> Tuple[Any, List[str]]:
         if self.name not in opts:
             return super().handle_parse_result(ctx, opts, args)
 

--- a/samcli/commands/_utils/click_mutex.py
+++ b/samcli/commands/_utils/click_mutex.py
@@ -36,6 +36,15 @@ class ClickMutex(click.Option):
         super().__init__(*args, **kwargs)
 
     def handle_parse_result(self, ctx: click.Context, opts: Dict[str, Any], args: List[str]) -> Tuple[Any, List[str]]:
+        """
+        Checks whether any option is in self.incompatible_params
+        If one is found, prompt and throw an UsageError
+
+        Then checks any combination in self.required_param_lists is satisfied.
+        With option = "a" and required_param_lists = [["b", "c"], ["c", "d"]]
+        It is valid to specify --a --b --c, --a --c --d, or --a --b --c --d
+        but not --a --b --d
+        """
         if self.name not in opts:
             return super().handle_parse_result(ctx, opts, args)
 

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -63,11 +63,10 @@ Common usage:
     $ sam init --location /path/to/template/folder
 """
 
-INCOMPATIBLE_PARAMS_HINT = """
-You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
-    --name, --runtime, --app-template, --dependency-manager, or
-    --name, --package-type, --base-image, or
-    --location
+INCOMPATIBLE_PARAMS_HINT = """You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
+\t--name, --location, or
+\t--name, --package-type, --base-image, or
+\t--name, --runtime, --app-template, --dependency-manager
 """
 
 REQUIRED_PARAMS_HINT = "You can also re-run without the --no-interactive flag to be prompted for required values."

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -63,6 +63,15 @@ Common usage:
     $ sam init --location /path/to/template/folder
 """
 
+INCOMPATIBLE_PARAMS_HINT = """
+You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
+    --name, --runtime, --app-template, --dependency-manager, or
+    --name, --package-type, --base-image, or
+    --location
+"""
+
+REQUIRED_PARAMS_HINT = "You can also re-run without the --no-interactive flag to be prompted for required values."
+
 
 class PackageType:
     """
@@ -128,12 +137,13 @@ def non_interactive_validation(func):
     default=False,
     help="Disable interactive prompting for init parameters, and fail if any required values are missing.",
     cls=Mutex,
-    required_params=[
+    required_param_lists=[
         ["name", "location"],
-        ["name", "runtime", "dependency_manager", "app_template"],
         ["name", "package_type", "base_image"],
+        ["name", "runtime", "dependency_manager", "app_template"],
         # check non_interactive_validation for additional validations
     ],
+    required_params_hint=REQUIRED_PARAMS_HINT,
 )
 @click.option(
     "-a",
@@ -147,7 +157,8 @@ def non_interactive_validation(func):
     "--location",
     help="Template location (git, mercurial, http(s), zip, path)",
     cls=Mutex,
-    not_required=["package_type", "runtime", "base_image", "dependency_manager", "app_template"],
+    incompatible_params=["package_type", "runtime", "base_image", "dependency_manager", "app_template"],
+    incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
 @click.option(
     "-r",
@@ -155,7 +166,8 @@ def non_interactive_validation(func):
     type=click.Choice(get_sorted_runtimes(RUNTIMES)),
     help="Lambda Runtime of your app",
     cls=Mutex,
-    not_required=["location", "base_image"],
+    incompatible_params=["location", "base_image"],
+    incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
 @click.option(
     "-p",
@@ -164,7 +176,8 @@ def non_interactive_validation(func):
     help="Package type for your app",
     cls=Mutex,
     callback=PackageType.pt_callback,
-    not_required=["location"],
+    incompatible_params=["location"],
+    incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
 @click.option(
     "-i",
@@ -173,7 +186,8 @@ def non_interactive_validation(func):
     default=None,
     help="Lambda Image of your app",
     cls=Mutex,
-    not_required=["location", "runtime"],
+    incompatible_params=["location", "runtime"],
+    incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
 @click.option(
     "-d",
@@ -183,7 +197,8 @@ def non_interactive_validation(func):
     help="Dependency manager of your Lambda runtime",
     required=False,
     cls=Mutex,
-    not_required=["location"],
+    incompatible_params=["location"],
+    incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
 @click.option("-o", "--output-dir", type=click.Path(), help="Where to output the initialized app into", default=".")
 @click.option("-n", "--name", help="Name of your project to be generated as a folder")
@@ -192,7 +207,8 @@ def non_interactive_validation(func):
     help="Identifier of the managed application template you want to use. "
     "If not sure, call 'sam init' without options for an interactive workflow.",
     cls=Mutex,
-    not_required=["location"],
+    incompatible_params=["location"],
+    incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
 @click.option(
     "--no-input",

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -14,7 +14,7 @@ from samcli.lib.utils.version_checker import check_newer_version
 from samcli.local.common.runtime_template import RUNTIMES, SUPPORTED_DEP_MANAGERS, LAMBDA_IMAGES_RUNTIMES
 from samcli.lib.telemetry.metric import track_command
 from samcli.commands.init.interactive_init_flow import _get_runtime_from_image, get_architectures, get_sorted_runtimes
-from samcli.commands.local.cli_common.click_mutex import Mutex
+from samcli.commands._utils.click_mutex import Mutex
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.architecture import X86_64, ARM64
 

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -14,7 +14,7 @@ from samcli.lib.utils.version_checker import check_newer_version
 from samcli.local.common.runtime_template import RUNTIMES, SUPPORTED_DEP_MANAGERS, LAMBDA_IMAGES_RUNTIMES
 from samcli.lib.telemetry.metric import track_command
 from samcli.commands.init.interactive_init_flow import _get_runtime_from_image, get_architectures, get_sorted_runtimes
-from samcli.commands._utils.click_mutex import Mutex
+from samcli.commands._utils.click_mutex import ClickMutex
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.architecture import X86_64, ARM64
 
@@ -136,7 +136,7 @@ def non_interactive_validation(func):
     is_flag=True,
     default=False,
     help="Disable interactive prompting for init parameters, and fail if any required values are missing.",
-    cls=Mutex,
+    cls=ClickMutex,
     required_param_lists=[
         ["name", "location"],
         ["name", "package_type", "base_image"],
@@ -150,13 +150,13 @@ def non_interactive_validation(func):
     "--architecture",
     type=click.Choice([ARM64, X86_64]),
     help="Architectures your Lambda function will run on",
-    cls=Mutex,
+    cls=ClickMutex,
 )
 @click.option(
     "-l",
     "--location",
     help="Template location (git, mercurial, http(s), zip, path)",
-    cls=Mutex,
+    cls=ClickMutex,
     incompatible_params=["package_type", "runtime", "base_image", "dependency_manager", "app_template"],
     incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
@@ -165,7 +165,7 @@ def non_interactive_validation(func):
     "--runtime",
     type=click.Choice(get_sorted_runtimes(RUNTIMES)),
     help="Lambda Runtime of your app",
-    cls=Mutex,
+    cls=ClickMutex,
     incompatible_params=["location", "base_image"],
     incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
@@ -174,7 +174,7 @@ def non_interactive_validation(func):
     "--package-type",
     type=click.Choice([ZIP, IMAGE]),
     help="Package type for your app",
-    cls=Mutex,
+    cls=ClickMutex,
     callback=PackageType.pt_callback,
     incompatible_params=["location"],
     incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
@@ -185,7 +185,7 @@ def non_interactive_validation(func):
     type=click.Choice(LAMBDA_IMAGES_RUNTIMES),
     default=None,
     help="Lambda Image of your app",
-    cls=Mutex,
+    cls=ClickMutex,
     incompatible_params=["location", "runtime"],
     incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
@@ -196,7 +196,7 @@ def non_interactive_validation(func):
     default=None,
     help="Dependency manager of your Lambda runtime",
     required=False,
-    cls=Mutex,
+    cls=ClickMutex,
     incompatible_params=["location"],
     incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )
@@ -206,7 +206,7 @@ def non_interactive_validation(func):
     "--app-template",
     help="Identifier of the managed application template you want to use. "
     "If not sure, call 'sam init' without options for an interactive workflow.",
-    cls=Mutex,
+    cls=ClickMutex,
     incompatible_params=["location"],
     incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,
 )

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -63,7 +63,8 @@ Common usage:
     $ sam init --location /path/to/template/folder
 """
 
-INCOMPATIBLE_PARAMS_HINT = """You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
+INCOMPATIBLE_PARAMS_HINT = """You can run 'sam init' without any options for an interactive initialization flow, \
+or you can provide one of the following required parameter combinations:
 \t--name, --location, or
 \t--name, --package-type, --base-image, or
 \t--name, --runtime, --app-template, --dependency-manager

--- a/samcli/commands/local/cli_common/click_mutex.py
+++ b/samcli/commands/local/cli_common/click_mutex.py
@@ -27,8 +27,8 @@ class Mutex(click.Option):
         for incompatible_param in self.incompatible_params or []:
             if incompatible_param in opts:
                 msg = (
-                    f"You must not provide both the {Mutex._to_param_name(self.name)} and ",
-                    f"{Mutex._to_param_name(incompatible_param)} parameters.\n",
+                    f"You must not provide both the {Mutex._to_param_name(self.name)} and "
+                    f"{Mutex._to_param_name(incompatible_param)} parameters.\n"
                 )
                 if self.incompatible_params_hint:
                     msg += self.incompatible_params_hint
@@ -36,23 +36,18 @@ class Mutex(click.Option):
 
         # Check for required parameters
         if self.required_param_lists:
-            missing_param_lists = list()
             for required_params in self.required_param_lists:
-                missing_params = list()
-                for required_param in required_params:
-                    if required_param not in opts:
-                        missing_params.append(required_param)
-                if missing_params:
-                    missing_param_lists.append(missing_params)
-
-            if missing_param_lists:
+                has_all_required_params = False not in [required_param in opts for required_param in required_params]
+                if has_all_required_params:
+                    break
+            else:
                 msg = (
-                    f"Missing required parameters, with --{self.name.replace('_', '-')} set.\n",
-                    "Must provide one of the following required parameter combinations:\n",
+                    f"Missing required parameters, with --{self.name.replace('_', '-')} set.\n"
+                    "Must provide one of the following required parameter combinations:\n"
                 )
-                for missing_params in missing_param_lists:
+                for required_params in self.required_param_lists:
                     msg += "\t"
-                    msg += ", ".join(Mutex._to_param_name(param) for param in missing_params)
+                    msg += ", ".join(Mutex._to_param_name(param) for param in required_params)
                     msg += "\n"
 
                 if self.required_params_hint:

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -26,7 +26,7 @@ from samcli.commands._utils.options import (
     DEFAULT_BUILD_DIR_WITH_AUTO_DEPENDENCY_LAYER,
 )
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
-from samcli.commands._utils.click_mutex import Mutex
+from samcli.commands._utils.click_mutex import ClickMutex
 from samcli.lib.utils.colors import Colored
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.lib.bootstrap.bootstrap import manage_stack
@@ -100,14 +100,14 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
     "--code",
     is_flag=True,
     help="Sync code resources. This includes Lambda Functions, API Gateway, and Step Functions.",
-    cls=Mutex,
+    cls=ClickMutex,
     incompatible_params=["watch"],
 )
 @click.option(
     "--watch",
     is_flag=True,
     help="Watch local files and automatically sync with remote.",
-    cls=Mutex,
+    cls=ClickMutex,
     incompatible_params=["code"],
 )
 @click.option(

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -26,6 +26,7 @@ from samcli.commands._utils.options import (
     DEFAULT_BUILD_DIR_WITH_AUTO_DEPENDENCY_LAYER,
 )
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
+from samcli.commands.local.cli_common.click_mutex import Mutex
 from samcli.lib.utils.colors import Colored
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.lib.bootstrap.bootstrap import manage_stack
@@ -99,11 +100,15 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
     "--code",
     is_flag=True,
     help="Sync code resources. This includes Lambda Functions, API Gateway, and Step Functions.",
+    cls=Mutex,
+    incompatible_params=["watch"],
 )
 @click.option(
     "--watch",
     is_flag=True,
     help="Watch local files and automatically sync with remote.",
+    cls=Mutex,
+    incompatible_params=["code"],
 )
 @click.option(
     "--resource-id",

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -26,7 +26,7 @@ from samcli.commands._utils.options import (
     DEFAULT_BUILD_DIR_WITH_AUTO_DEPENDENCY_LAYER,
 )
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
-from samcli.commands.local.cli_common.click_mutex import Mutex
+from samcli.commands._utils.click_mutex import Mutex
 from samcli.lib.utils.colors import Colored
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.lib.bootstrap.bootstrap import manage_stack

--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -280,6 +280,22 @@ class TestBasicInitCommand(TestCase):
             self.assertIn(capture_output, msg)
 
 
+MISSING_REQUIRED_PARAM_MESSAGE = """Error: Missing required parameters, with --no-interactive set.
+Must provide one of the following required parameter combinations:
+\t--name, --location
+\t--name, --package-type, --base-image
+\t--name, --runtime, --dependency-manager, --app-template
+You can also re-run without the --no-interactive flag to be prompted for required values.
+"""
+
+INCOMPATIBLE_PARAM_MESSAGE = """Error: You must not provide both the --{0} and --{1} parameters.
+You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
+\t--name, --location, or
+\t--name, --package-type, --base-image, or
+\t--name, --runtime, --app-template, --dependency-manager
+"""
+
+
 class TestInitForParametersCompatibility(TestCase):
     def test_init_command_no_interactive_missing_name(self):
         stderr = None
@@ -309,19 +325,8 @@ class TestInitForParametersCompatibility(TestCase):
                 raise
 
             self.assertEqual(process.returncode, 2)
-            errmsg = """
-            Error: 
-Missing required parameters, with --no-interactive set.
 
-Must provide one of the following required parameter combinations:
-    --name and --runtime and --dependency-manager and --app-template
-    --name and --package-type and --base-image and --dependency-manager
-    --location
-
-You can also re-run without the --no-interactive flag to be prompted for required values.
-            """
-
-            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_apptemplate_location(self):
         stderr = None
@@ -349,17 +354,11 @@ You can also re-run without the --no-interactive flag to be prompted for require
                 raise
 
             self.assertEqual(process.returncode, 2)
-            errmsg = """
-                        Error: 
-You must not provide both the --app-template and --location parameters.
 
-You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
-    --name and --runtime and --app-template and --dependency-manager
-    --name and --package-type and --base-image
-    --location
-                        """
-
-            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(
+                INCOMPATIBLE_PARAM_MESSAGE.strip().format("app-template", "location"),
+                "\n".join(stderr.strip().splitlines()),
+            )
 
     def test_init_command_no_interactive_runtime_location(self):
         stderr = None
@@ -387,17 +386,10 @@ You can run 'sam init' without any options for an interactive initialization flo
                 raise
 
             self.assertEqual(process.returncode, 2)
-            errmsg = """
-                        Error: 
-You must not provide both the --runtime and --location parameters.
 
-You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
-    --name and --runtime and --app-template and --dependency-manager
-    --name and --package-type and --base-image
-    --location
-                        """
-
-            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(
+                INCOMPATIBLE_PARAM_MESSAGE.strip().format("runtime", "location"), "\n".join(stderr.strip().splitlines())
+            )
 
     def test_init_command_no_interactive_base_image_location(self):
         stderr = None
@@ -425,17 +417,11 @@ You can run 'sam init' without any options for an interactive initialization flo
                 raise
 
             self.assertEqual(process.returncode, 2)
-            errmsg = """
-                        Error: 
-You must not provide both the --base-image and --location parameters.
 
-You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
-    --name and --runtime and --app-template and --dependency-manager
-    --name and --package-type and --base-image
-    --location
-                        """
-
-            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(
+                INCOMPATIBLE_PARAM_MESSAGE.strip().format("base-image", "location"),
+                "\n".join(stderr.strip().splitlines()),
+            )
 
     def test_init_command_no_interactive_base_image_no_dependency(self):
         stderr = None
@@ -463,19 +449,8 @@ You can run 'sam init' without any options for an interactive initialization flo
                 raise
 
             self.assertEqual(process.returncode, 2)
-            errmsg = """
-                        Error: 
-Missing required parameters, with --no-interactive set.
 
-Must provide one of the following required parameter combinations:
-    --name and --runtime and --dependency-manager and --app-template
-    --name and --package-type and --base-image and --dependency-manager
-    --location
-
-You can also re-run without the --no-interactive flag to be prompted for required values.
-                        """
-
-            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_packagetype_location(self):
         stderr = None
@@ -503,17 +478,11 @@ You can also re-run without the --no-interactive flag to be prompted for require
                 raise
 
             self.assertEqual(process.returncode, 2)
-            errmsg = """
-                        Error: 
-You must not provide both the --package-type and --location parameters.
 
-You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
-    --name and --runtime and --app-template and --dependency-manager
-    --name and --package-type and --base-image
-    --location
-                        """
-
-            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(
+                INCOMPATIBLE_PARAM_MESSAGE.strip().format("package-type", "location"),
+                "\n".join(stderr.strip().splitlines()),
+            )
 
     def test_init_command_no_interactive_base_image_no_packagetype(self):
         stderr = None
@@ -539,19 +508,8 @@ You can run 'sam init' without any options for an interactive initialization flo
                 raise
 
             self.assertEqual(process.returncode, 2)
-            errmsg = """
-                        Error: 
-Missing required parameters, with --no-interactive set.
 
-Must provide one of the following required parameter combinations:
-    --name and --runtime and --dependency-manager and --app-template
-    --name and --package-type and --base-image and --dependency-manager
-    --location
-
-You can also re-run without the --no-interactive flag to be prompted for required values.
-                        """
-
-            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertEqual(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_wrong_packagetype(self):
         stderr = None

--- a/tests/unit/commands/_utils/test_click_mutex.py
+++ b/tests/unit/commands/_utils/test_click_mutex.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
-from samcli.commands._utils.click_mutex import Mutex
+from samcli.commands._utils.click_mutex import ClickMutex
 
 
-class TestMutex(TestCase):
+class TestClickMutex(TestCase):
     class TestException(Exception):
         def __init__(self, message):
             self.message = message
@@ -20,7 +20,7 @@ class TestMutex(TestCase):
         self.click_mock = self.click_patch.start()
         self.addCleanup(self.click_patch.stop)
 
-        self.click_mock.UsageError = TestMutex.TestException
+        self.click_mock.UsageError = TestClickMutex.TestException
 
         self.super_patch = patch("samcli.commands._utils.click_mutex.super")
         self.super_mock = self.super_patch.start()
@@ -28,7 +28,7 @@ class TestMutex(TestCase):
 
         self.context = MagicMock()
 
-        self.mutex = Mutex(
+        self.mutex = ClickMutex(
             required_param_lists=[["r11", "r12"], ["r21", "r22", "r23"]],
             required_params_hint="required hint",
             incompatible_params=["i1", "i2"],

--- a/tests/unit/commands/_utils/test_click_mutex.py
+++ b/tests/unit/commands/_utils/test_click_mutex.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from samcli.commands._utils.click_mutex import Mutex
+
+
+class TestMutex(TestCase):
+    class TestException(Exception):
+        def __init__(self, message):
+            self.message = message
+
+    def setUp(self):
+
+        self.click_option_patch = patch("samcli.commands._utils.click_mutex.click.Option.__init__")
+        self.click_option_mock = self.click_option_patch.start()
+        self.addCleanup(self.click_option_patch.stop)
+
+        self.click_option_mock.return_value = None
+
+        self.click_patch = patch("samcli.commands._utils.click_mutex.click")
+        self.click_mock = self.click_patch.start()
+        self.addCleanup(self.click_patch.stop)
+
+        self.click_mock.UsageError = TestMutex.TestException
+
+        self.super_patch = patch("samcli.commands._utils.click_mutex.super")
+        self.super_mock = self.super_patch.start()
+        self.addCleanup(self.super_patch.stop)
+
+        self.context = MagicMock()
+
+        self.mutex = Mutex(
+            required_param_lists=[["r11", "r12"], ["r21", "r22", "r23"]],
+            required_params_hint="required hint",
+            incompatible_params=["i1", "i2"],
+            incompatible_params_hint="incompatible hint",
+        )
+        self.mutex.name = "o1"
+
+    def test_handle_parse_result_valid(self):
+        options = {"o1": None, "o2": 1, "r11": None, "r12": 2}
+        self.mutex.handle_parse_result(self.context, options, MagicMock())
+
+    def test_handle_parse_result_incompatible(self):
+        options = {"o1": None, "o2": None, "r11": 1, "r21": 2, "i1": 3}
+        with self.assertRaises(Exception) as context:
+            self.mutex.handle_parse_result(self.context, options, MagicMock())
+        self.assertIn("i1", context.exception.message)
+
+    def test_handle_parse_result_required(self):
+        options = {"o1": None, "o2": None, "r11": 1, "r21": 2, "r22": None}
+        with self.assertRaises(Exception) as context:
+            self.mutex.handle_parse_result(self.context, options, MagicMock())
+        self.assertIn("r11", context.exception.message)
+        self.assertIn("r12", context.exception.message)
+        self.assertIn("r21", context.exception.message)
+        self.assertIn("r22", context.exception.message)
+        self.assertIn("r23", context.exception.message)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
For sam sync, both --watch and --code can be specified at the same time, but this is not a valid workflow.
In such case --code is ignored and a normal --watch is started.

#### How does it address the issue?
Refactored click_mutex.py to be reusable outside of sam init.

#### What side effects does this change have?
Format of the sam init errors are changed but the content is the same.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
