### PR TITLE
fix: Updated get-pip.py for Python3.6

### DIFF
--- a/appveyor-iac-integration-ubuntu.yml
+++ b/appveyor-iac-integration-ubuntu.yml
@@ -81,13 +81,14 @@ install:
 
   - sh: "PATH=$PATH:/usr/bin/python3.9:/usr/bin/python3.8:/usr/bin/python3.7"
   - sh: "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
+  - sh: "curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip-36.py"
 
   - sh: "sudo apt-get -y install python3-distutils"
   - sh: "sudo apt-get -y install python3.9-distutils"
   - ps: "If ($env:INSTALL_PY_39_PIP) {python3.9 get-pip.py --user}"
   - ps: "If ($env:INSTALL_PY_38_PIP) {python3.8 get-pip.py --user}"
   - ps: "If ($env:INSTALL_PY_37_PIP) {python3.7 get-pip.py --user}"
-  - ps: "If ($env:INSTALL_PY_36_PIP) {python3.6 get-pip.py --user}"
+  - ps: "If ($env:INSTALL_PY_36_PIP) {python3.6 get-pip-36.py --user}"
 
   # required for RIE with arm64 in linux
   - sh: "docker run --rm --privileged multiarch/qemu-user-static --reset -p yes"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -102,13 +102,14 @@ install:
 
   - sh: "PATH=$PATH:/usr/bin/python3.9:/usr/bin/python3.8:/usr/bin/python3.7"
   - sh: "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
+  - sh: "curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip-36.py"
 
   - sh: "sudo apt-get -y install python3-distutils"
   - sh: "sudo apt-get -y install python3.9-distutils"
   - ps: "If ($env:INSTALL_PY_39_PIP) {python3.9 get-pip.py --user}"
   - ps: "If ($env:INSTALL_PY_38_PIP) {python3.8 get-pip.py --user}"
   - ps: "If ($env:INSTALL_PY_37_PIP) {python3.7 get-pip.py --user}"
-  - ps: "If ($env:INSTALL_PY_36_PIP) {python3.6 get-pip.py --user}"
+  - ps: "If ($env:INSTALL_PY_36_PIP) {python3.6 get-pip-36.py --user}"
 
   # required for RIE with arm64 in linux
   - sh: "docker run --rm --privileged multiarch/qemu-user-static --reset -p yes"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -165,13 +165,14 @@ for:
 
       - sh: "PATH=$PATH:/usr/bin/python3.9:/usr/bin/python3.8:/usr/bin/python3.7"
       - sh: "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
+      - sh: "curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip-36.py"
 
       - sh: "sudo apt-get -y install python3-distutils"
       - sh: "sudo apt-get -y install python3.9-distutils"
       - ps: "If ($env:INSTALL_PY_39_PIP) {python3.9 get-pip.py --user}"
       - ps: "If ($env:INSTALL_PY_38_PIP) {python3.8 get-pip.py --user}"
       - ps: "If ($env:INSTALL_PY_37_PIP) {python3.7 get-pip.py --user}"
-      - ps: "If ($env:INSTALL_PY_36_PIP) {python3.6 get-pip.py --user}"
+      - ps: "If ($env:INSTALL_PY_36_PIP) {python3.6 get-pip-36.py --user}"
 
       # required for RIE with arm64 in linux
       - sh: "docker run --rm --privileged multiarch/qemu-user-static --reset -p yes"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Our CI is broken due to trying to install pip for Python 3.6 which reached its EOL.
```
If ($env:INSTALL_PY_36_PIP) {python3.6 get-pip.py --user}
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
```

#### How does it address the issue?
Download a separate 3.6 script and install it instead.

#### What side effects does this change have?
N/A
#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
