### PR TITLE
feat: Add Entry Points for All Handlers in a CodeURI

### DIFF
--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 from typing import Callable, Dict, List, Any, Optional, cast, Set
 
 from samcli.commands._utils.experimental import is_experimental_enabled, ExperimentalFlag
+from samcli.lib.providers.provider import Function
 from samcli.lib.utils import osutils
 from samcli.lib.utils.async_utils import AsyncContext
 from samcli.lib.utils.hash import dir_checksum
@@ -120,7 +121,10 @@ class DefaultBuildStrategy(BuildStrategy):
         self,
         build_graph: BuildGraph,
         build_dir: str,
-        build_function: Callable[[str, str, str, str, str, Optional[str], str, dict, dict, Optional[str], bool], str],
+        build_function: Callable[
+            [str, str, str, str, str, Optional[str], str, dict, dict, Optional[str], bool, Optional[List[Function]]],
+            str,
+        ],
         build_layer: Callable[[str, str, str, List[str], str, str, dict, Optional[str], bool], str],
     ) -> None:
         super().__init__(build_graph)
@@ -165,6 +169,7 @@ class DefaultBuildStrategy(BuildStrategy):
             container_env_vars,
             build_definition.dependencies_dir if is_experimental_enabled(ExperimentalFlag.Accelerate) else None,
             build_definition.download_dependencies,
+            build_definition.functions,
         )
         function_build_results[single_full_path] = result
 

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -137,6 +137,7 @@ class TestApplicationBuilder_build(TestCase):
                     ANY,
                     ANY,
                     True,
+                    ANY,
                 ),
                 call(
                     self.func2.name,
@@ -150,6 +151,7 @@ class TestApplicationBuilder_build(TestCase):
                     ANY,
                     ANY,
                     True,
+                    ANY,
                 ),
                 call(
                     self.imageFunc1.name,
@@ -163,6 +165,7 @@ class TestApplicationBuilder_build(TestCase):
                     ANY,
                     ANY,
                     True,
+                    ANY,
                 ),
             ],
             any_order=False,
@@ -198,7 +201,7 @@ class TestApplicationBuilder_build(TestCase):
     @patch("samcli.lib.build.build_graph.BuildGraph._write")
     def test_should_use_function_or_layer_get_build_dir_to_determine_artifact_dir(self, persist_mock):
         def get_func_call_with_artifact_dir(artifact_dir):
-            return call(ANY, ANY, ANY, ANY, ANY, ANY, artifact_dir, ANY, ANY, ANY, True)
+            return call(ANY, ANY, ANY, ANY, ANY, ANY, artifact_dir, ANY, ANY, ANY, True, ANY)
 
         def get_layer_call_with_artifact_dir(artifact_dir):
             return call(ANY, ANY, ANY, ANY, ANY, artifact_dir, ANY, ANY, True)
@@ -300,6 +303,7 @@ class TestApplicationBuilder_build(TestCase):
                     ANY,
                     ANY,
                     True,
+                    ANY,
                 ),
                 call(
                     function2.name,
@@ -313,6 +317,7 @@ class TestApplicationBuilder_build(TestCase):
                     ANY,
                     ANY,
                     True,
+                    ANY,
                 ),
             ],
             any_order=True,
@@ -1748,13 +1753,88 @@ class TestApplicationBuilder_get_build_options(TestCase):
         self.assertEqual(options, expected_properties)
 
     def test_get_options_from_metadata_no_entry_points_defined(self):
+        function_a = Function(
+            function_id="name",
+            name="name",
+            functionname="function_name",
+            runtime="runtime",
+            memory="memory",
+            timeout="timeout",
+            handler="app.handler",
+            imageuri="imageuri",
+            packagetype=ZIP,
+            imageconfig="imageconfig",
+            codeuri="codeuri",
+            environment="environment",
+            rolearn="rolearn",
+            layers="layers",
+            events="events",
+            codesign_config_arn="codesign_config_arn",
+            metadata=None,
+            inlinecode=None,
+            architectures=[X86_64, ARM64],
+            stack_path="",
+        )
+        function_b = Function(
+            function_id="name",
+            name="name",
+            functionname="function_name",
+            runtime="runtime",
+            memory="memory",
+            timeout="timeout",
+            handler="post_function.handler",
+            imageuri="imageuri",
+            packagetype=ZIP,
+            imageconfig="imageconfig",
+            codeuri="codeuri",
+            environment="environment",
+            rolearn="rolearn",
+            layers="layers",
+            events="events",
+            codesign_config_arn="codesign_config_arn",
+            metadata=None,
+            inlinecode=None,
+            architectures=[X86_64, ARM64],
+            stack_path="",
+        )
+        functions = [function_a, function_b]
         build_properties = {"Minify": False, "Target": "es2017", "Sourcemap": False}
         metadata = {"BuildMethod": "esbuild", "BuildProperties": build_properties}
-        expected_properties = {"minify": False, "target": "es2017", "sourcemap": False, "entry_points": ["handler"]}
-        options = ApplicationBuilder._get_build_options("Function", "Node.js", "handler", "npm-esbuild", metadata)
+        expected_properties = {
+            "minify": False,
+            "target": "es2017",
+            "sourcemap": False,
+            "entry_points": ["app", "post_function"],
+        }
+        options = ApplicationBuilder._get_build_options(
+            "Function", "Node.js", "handler", "npm-esbuild", metadata, functions
+        )
         self.assertEqual(options, expected_properties)
 
     def test_get_options_from_metadata_correctly_separates_source_and_handler(self):
+        function = Function(
+            function_id="name",
+            name="name",
+            functionname="function_name",
+            runtime="runtime",
+            memory="memory",
+            timeout="timeout",
+            handler="src/handlers/post.handler",
+            imageuri="imageuri",
+            packagetype=ZIP,
+            imageconfig="imageconfig",
+            codeuri="codeuri",
+            environment="environment",
+            rolearn="rolearn",
+            layers="layers",
+            events="events",
+            codesign_config_arn="codesign_config_arn",
+            metadata=None,
+            inlinecode=None,
+            architectures=[X86_64, ARM64],
+            stack_path="",
+        )
+        functions = [function]
         build_properties = {"Minify": False, "Target": "es2017", "Sourcemap": False}
         metadata = {"BuildMethod": "esbuild", "BuildProperties": build_properties}
         expected_properties = {
@@ -1764,7 +1844,7 @@ class TestApplicationBuilder_get_build_options(TestCase):
             "entry_points": ["src/handlers/post"],
         }
         options = ApplicationBuilder._get_build_options(
-            "Function", "Node.js", "src/handlers/post.handler", "npm-esbuild", metadata
+            "Function", "Node.js", "src/handlers/post.handler", "npm-esbuild", metadata, functions
         )
         self.assertEqual(options, expected_properties)
 

--- a/tests/unit/lib/build_module/test_build_strategy.py
+++ b/tests/unit/lib/build_module/test_build_strategy.py
@@ -165,6 +165,7 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
                     self.function_build_definition1.env_vars,
                     self.function_build_definition1.dependencies_dir,
                     True,
+                    self.function_build_definition1.functions,
                 ),
                 call(
                     self.function_build_definition2.get_function_name(),
@@ -178,6 +179,7 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
                     self.function_build_definition2.env_vars,
                     self.function_build_definition2.dependencies_dir,
                     True,
+                    self.function_build_definition2.functions,
                 ),
             ]
         )
@@ -498,7 +500,7 @@ class TestIncrementalBuildStrategy(TestCase):
 
         self.build_strategy.build()
         self.build_function.assert_called_with(
-            ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, dependency_dir, download_dependencies
+            ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, dependency_dir, download_dependencies, ANY
         )
 
     @parameterized.expand(


### PR DESCRIPTION
SAM-CLI calls Lambda Builders only once for each CodeURI. This works for existing runtimes since everything in the CodeURI gets built. For esbuild, independent handlers within the same CodeURI are built separately, meaning that all of the handlers within a CodeURI need to be added as entry points.

#### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
