### PR TITLE
fix: provided makefile py36 tests

### DIFF
--- a/tests/integration/testdata/buildcmd/Provided/Makefile-container
+++ b/tests/integration/testdata/buildcmd/Provided/Makefile-container
@@ -1,7 +1,7 @@
 build-Function:
 	cp *.py $(ARTIFACTS_DIR)
 	cp requirements.txt $(ARTIFACTS_DIR)
-	curl https://bootstrap.pypa.io/get-pip.py > /tmp/get-pip.py
+	curl https://bootstrap.pypa.io/pip/3.6/get-pip.py > /tmp/get-pip.py
 	python3 /tmp/get-pip.py
 	python3 -m pip install -r requirements.txt -t $(ARTIFACTS_DIR)
 	rm -rf $(ARTIFACTS_DIR)/bin


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Fix provided Makefile build tests by downloading compatible `get-pip.py` file

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
