### PR TITLE
feat: Allow Independent Build Definitions Based on Build Method

### DIFF
--- a/build_dir/MyFunctionbf3066d1DepLayer/AWS_SAM_CLI_README
+++ b/build_dir/MyFunctionbf3066d1DepLayer/AWS_SAM_CLI_README
@@ -1,0 +1,1 @@
+This layer contains dependencies of function MyFunction and automatically added by AWS SAM CLI command 'sam sync'

--- a/build_dir/MyFunctionbf3066d1DepLayer/AWS_SAM_CLI_README
+++ b/build_dir/MyFunctionbf3066d1DepLayer/AWS_SAM_CLI_README
@@ -1,1 +1,0 @@
-This layer contains dependencies of function MyFunction and automatically added by AWS SAM CLI command 'sam sync'

--- a/samcli/lib/build/build_graph.py
+++ b/samcli/lib/build/build_graph.py
@@ -43,6 +43,7 @@ BUILD_METHOD_FIELD = "build_method"
 COMPATIBLE_RUNTIMES_FIELD = "compatible_runtimes"
 LAYER_FIELD = "layer"
 ARCHITECTURE_FIELD = "architecture"
+INDEPENDENT_BUILD_DEFINITIONS = ["esbuild"]
 
 
 def _function_build_definition_to_toml_table(
@@ -244,7 +245,14 @@ class BuildGraph:
         function: Function
             function details for this function build definition
         """
-        if function_build_definition in self._function_build_definitions:
+
+        # Check for builders that require all lambda functions to be built separately
+        function_build_method = ""
+        if function.metadata:
+            function_build_method = function.metadata.get("BuildMethod", "")
+        is_independent_build_def = function_build_method in INDEPENDENT_BUILD_DEFINITIONS
+
+        if function_build_definition in self._function_build_definitions and not is_independent_build_def:
             previous_build_definition = self._function_build_definitions[
                 self._function_build_definitions.index(function_build_definition)
             ]

--- a/tests/unit/lib/build_module/test_build_graph.py
+++ b/tests/unit/lib/build_module/test_build_graph.py
@@ -807,3 +807,53 @@ class TestBuildDefinition(TestCase):
             str(build_definition),
             f"BuildDefinition(runtime, codeuri, Zip, source_hash, {build_definition.uuid}, {{}}, {{}}, arm64, [])",
         )
+
+    def test_independent_build_definitions_equal_objects_independent_build_method(self):
+        build_graph = BuildGraph("build/path")
+        metadata = {"BuildMethod": "esbuild"}
+        build_definition1 = FunctionBuildDefinition(
+            "runtime", "codeuri", ZIP, ARM64, metadata, "source_hash", "manifest_hash"
+        )
+        function1 = generate_function(
+            runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler-1"
+        )
+        build_definition2 = FunctionBuildDefinition(
+            "runtime", "codeuri", ZIP, ARM64, metadata, "source_hash", "manifest_hash"
+        )
+        function2 = generate_function(
+            runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler-2"
+        )
+        build_graph.put_function_build_definition(build_definition1, function1)
+        build_graph.put_function_build_definition(build_definition2, function2)
+
+        build_definitions = build_graph.get_function_build_definitions()
+
+        self.assertEqual(build_definition1, build_definition2)
+        self.assertEqual(len(build_definitions), 2)
+        self.assertEqual(len(build_definition1.functions), 1)
+        self.assertEqual(len(build_definition2.functions), 1)
+
+    def test_independent_build_definitions_equal_objects_one_independent_build_method(self):
+        build_graph = BuildGraph("build/path")
+        metadata = {"BuildMethod": "esbuild"}
+        build_definition1 = FunctionBuildDefinition(
+            "runtime", "codeuri", ZIP, ARM64, metadata, "source_hash", "manifest_hash"
+        )
+        function1 = generate_function(
+            runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler-1"
+        )
+        build_definition2 = FunctionBuildDefinition(
+            "runtime", "codeuri", ZIP, ARM64, {}, "source_hash", "manifest_hash"
+        )
+        function2 = generate_function(
+            runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata={}, handler="handler-2"
+        )
+        build_graph.put_function_build_definition(build_definition1, function1)
+        build_graph.put_function_build_definition(build_definition2, function2)
+
+        build_definitions = build_graph.get_function_build_definitions()
+
+        self.assertNotEqual(build_definition1, build_definition2)
+        self.assertEqual(len(build_definitions), 2)
+        self.assertEqual(len(build_definition1.functions), 1)
+        self.assertEqual(len(build_definition2.functions), 1)


### PR DESCRIPTION
SAM-CLI calls Lambda Builders only once for each CodeURI. This works for existing runtimes since everything in the CodeURI gets built. For esbuild, independent handlers within the same CodeURI are built separately, meaning that all of the handlers within a CodeURI need to be added as entry points.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
