### PR TITLE
chore: use ps prefix for windows integration tests to run pytest commands

### DIFF
--- a/appveyor-windows-build-dotnet.yml
+++ b/appveyor-windows-build-dotnet.yml
@@ -67,7 +67,7 @@ test_script:
     # Reactivate virtualenv before running tests
     - "venv\\Scripts\\activate"
     - "docker system prune -a -f"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_Dotnet_cli_package"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_Dotnet_cli_package"
 
 # Uncomment for RDP
 # on_finish:

--- a/appveyor-windows-build-go.yml
+++ b/appveyor-windows-build-go.yml
@@ -75,8 +75,8 @@ test_script:
     # Reactivate virtualenv before running tests
     - "venv\\Scripts\\activate"
     - "docker system prune -a -f"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_Go_Modules"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_Go_Modules_With_Specified_Architecture"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_Go_Modules"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_Go_Modules_With_Specified_Architecture"
 
 
 # Uncomment for RDP

--- a/appveyor-windows-build-java-container.yml
+++ b/appveyor-windows-build-java-container.yml
@@ -75,7 +75,7 @@ test_script:
     # Reactivate virtualenv before running tests
     - "venv\\Scripts\\activate"
     - "docker system prune -a -f"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java_in_container"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java_in_container"
 
 
 # Uncomment for RDP

--- a/appveyor-windows-build-java-ruby-inprocess.yml
+++ b/appveyor-windows-build-java-ruby-inprocess.yml
@@ -49,9 +49,9 @@ install:
 
 test_script:
     # Reactivate virtualenv before running tests
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java8_in_process"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java8_in_process"
     - "SET JAVA_HOME=C:\\Program Files\\Java\\jdk11"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java11_in_process"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java11_in_process"
 
     # Run Ruby in-process builds
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_ruby_in_process"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_ruby_in_process"

--- a/appveyor-windows-build-nodejs.yml
+++ b/appveyor-windows-build-nodejs.yml
@@ -70,8 +70,8 @@ test_script:
     # Reactivate virtualenv before running tests
     - "venv\\Scripts\\activate"
     - "docker system prune -a -f"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_NodeFunctions"
-    - "pytest -vv tests/integration/local/invoke/invoke_cdk_templates.py -k TestCDKSynthesizedTemplatesImageFunctions"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_NodeFunctions"
+    - ps: "pytest -vv tests/integration/local/invoke/invoke_cdk_templates.py -k TestCDKSynthesizedTemplatesImageFunctions"
 
 # Uncomment for RDP
 # on_finish:

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -81,9 +81,9 @@ test_script:
     # Reactivate virtualenv before running tests
     - "venv\\Scripts\\activate"
     - "docker system prune -a -f"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_PythonFunctions"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_SingleFunctionBuilds"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_ErrorCases"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_PythonFunctions"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_SingleFunctionBuilds"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_ErrorCases"
 
 # Uncomment for RDP
 # on_finish:

--- a/appveyor-windows-build-ruby.yml
+++ b/appveyor-windows-build-ruby.yml
@@ -75,7 +75,7 @@ test_script:
     # Reactivate virtualenv before running tests
     - "venv\\Scripts\\activate"
     - "docker system prune -a -f"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_ruby_in_container"
+    - ps: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_ruby_in_container"
 
 # Uncomment for RDP
 # on_finish:

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -100,7 +100,7 @@ for:
         - "git --version"
         - "venv\\Scripts\\activate"
         - "docker system prune -a -f"
-        - "pytest -vv tests/integration/buildcmd"
+        - ps: "pytest -vv tests/integration/buildcmd"
 
   #Integ testing deploy
   -
@@ -117,7 +117,7 @@ for:
         - "git --version"
         - "venv\\Scripts\\activate"
         - "docker system prune -a -f"
-        - "pytest -vv tests/integration/delete tests/integration/deploy tests/integration/package tests/integration/sync"
+        - ps: "pytest -vv tests/integration/delete tests/integration/deploy tests/integration/package tests/integration/sync"
 
   #Integ testing local
   -
@@ -134,7 +134,7 @@ for:
         - "git --version"
         - "venv\\Scripts\\activate"
         - "docker system prune -a -f"
-        - "pytest -vv tests/integration/local"
+        - ps: "pytest -vv tests/integration/local"
 
   #Other testing
   -
@@ -151,11 +151,11 @@ for:
         - "git --version"
         - "venv\\Scripts\\activate"
         - "docker system prune -a -f"
-        - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit"
+        - ps: "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit"
         - "mypy setup.py samcli tests"
-        - "pytest -n 4 tests/functional"
-        - "pytest -vv tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local"
-        - "pytest -vv tests/regression"
+        - ps: "pytest -n 4 tests/functional"
+        - ps: "pytest -vv tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local"
+        - ps: "pytest -vv tests/regression"
 
 # Uncomment for RDP
 # on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 image: 
   - Ubuntu
-  - Visual Studio 2019
+  - Previous Visual Studio 2019
 
 environment:
   AWS_DEFAULT_REGION: us-east-1
@@ -60,7 +60,7 @@ for:
   - 
     matrix:
       only:
-        - image: Visual Studio 2019
+        - image: Previous Visual Studio 2019
 
     install:
       - "SET PATH=%PYTHON_HOME%;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,6 @@ for:
         - image: Previous Visual Studio 2019
 
     install:
-      - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
       - "SET PATH=%PYTHON_HOME%;%PATH%"
       - "echo %PYTHON_HOME%"
       - "echo %PATH%"
@@ -120,6 +119,9 @@ for:
       - "mypy setup.py samcli tests"
       - "pytest -n 4 tests/functional"
       - "deactivate"
+    on_finish:
+      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 
   - 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,7 @@ for:
         - image: Previous Visual Studio 2019
 
     install:
+      - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
       - "SET PATH=%PYTHON_HOME%;%PATH%"
       - "echo %PYTHON_HOME%"
       - "echo %PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 image: 
   - Ubuntu
-  - Previous Visual Studio 2019
+  - Visual Studio 2019
 
 environment:
   AWS_DEFAULT_REGION: us-east-1
@@ -60,7 +60,7 @@ for:
   - 
     matrix:
       only:
-        - image: Previous Visual Studio 2019
+        - image: Visual Studio 2019
 
     install:
       - "SET PATH=%PYTHON_HOME%;%PATH%"
@@ -114,13 +114,11 @@ for:
 
       # Run tests with dev env
       - "venv\\Scripts\\activate"
-      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit"
-      - "pylint --rcfile .pylintrc samcli"
-      - "mypy setup.py samcli tests"
-      - "pytest -n 4 tests/functional"
+      - ps: "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit"
+      - ps: "pylint --rcfile .pylintrc samcli"
+      - ps: "mypy setup.py samcli tests"
+      - ps: "pytest -n 4 tests/functional"
       - "deactivate"
-    on_finish:
-      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 
   - 


### PR DESCRIPTION
Update all `pytest` commands to use `ps:` prefix to resolve issues with windows tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
