### PR TITLE
feat: Update build graph to include handler for esbuild comparison

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -678,6 +678,8 @@ class ApplicationBuilder:
         """
 
         if metadata and dependency_manager and dependency_manager == "npm-esbuild":
+            # Make a copy of the metadata so that we don't force an updated build definition
+            # when we add the entry points
             build_props = deepcopy(metadata.get(BUILD_PROPERTIES, {}))
             # Esbuild takes an array of entry points from which to start bundling
             # as a required argument. This corresponds to the lambda function handler.

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -6,7 +6,6 @@ import io
 import json
 import logging
 import pathlib
-from copy import deepcopy
 from typing import List, Optional, Dict, cast, Union, NamedTuple
 
 import docker
@@ -678,15 +677,14 @@ class ApplicationBuilder:
         """
 
         if metadata and dependency_manager and dependency_manager == "npm-esbuild":
-            # Make a copy of the metadata so that we don't force an updated build definition
-            # when we add the entry points
-            build_props = deepcopy(metadata.get(BUILD_PROPERTIES, {}))
+            build_props = metadata.get(BUILD_PROPERTIES, {})
             # Esbuild takes an array of entry points from which to start bundling
             # as a required argument. This corresponds to the lambda function handler.
+            normalized_build_props = ResourceMetadataNormalizer.normalize_build_properties(build_props)
             if handler and not build_props.get("EntryPoints"):
                 entry_points = [handler.split(".")[0]]
-                build_props["entry_points"] = entry_points
-            return ResourceMetadataNormalizer.normalize_build_properties(build_props)
+                normalized_build_props["entry_points"] = entry_points
+            return normalized_build_props
 
         _build_options: Dict = {
             "go": {"artifact_executable_name": handler},

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import pathlib
+from copy import deepcopy
 from typing import List, Optional, Dict, cast, Union, NamedTuple
 
 import docker
@@ -230,6 +231,7 @@ class ApplicationBuilder:
                 function.packagetype,
                 function.architecture,
                 function.metadata,
+                function.handler,
                 env_vars=container_env_vars,
             )
             build_graph.put_function_build_definition(function_build_details, function)
@@ -676,7 +678,7 @@ class ApplicationBuilder:
         """
 
         if metadata and dependency_manager and dependency_manager == "npm-esbuild":
-            build_props = metadata.get(BUILD_PROPERTIES, {})
+            build_props = deepcopy(metadata.get(BUILD_PROPERTIES, {}))
             # Esbuild takes an array of entry points from which to start bundling
             # as a required argument. This corresponds to the lambda function handler.
             if handler and not build_props.get("EntryPoints"):

--- a/samcli/lib/build/build_graph.py
+++ b/samcli/lib/build/build_graph.py
@@ -43,7 +43,7 @@ BUILD_METHOD_FIELD = "build_method"
 COMPATIBLE_RUNTIMES_FIELD = "compatible_runtimes"
 LAYER_FIELD = "layer"
 ARCHITECTURE_FIELD = "architecture"
-INDEPENDENT_BUILD_DEFINITIONS = ["esbuild"]
+HANDLER_FIELD = "handler"
 
 
 def _function_build_definition_to_toml_table(
@@ -67,6 +67,7 @@ def _function_build_definition_to_toml_table(
         toml_table[CODE_URI_FIELD] = function_build_definition.codeuri
         toml_table[RUNTIME_FIELD] = function_build_definition.runtime
         toml_table[ARCHITECTURE_FIELD] = function_build_definition.architecture
+        toml_table[HANDLER_FIELD] = function_build_definition.handler
         if function_build_definition.source_hash:
             toml_table[SOURCE_HASH_FIELD] = function_build_definition.source_hash
         toml_table[MANIFEST_HASH_FIELD] = function_build_definition.manifest_hash
@@ -103,6 +104,7 @@ def _toml_table_to_function_build_definition(uuid: str, toml_table: tomlkit.api.
         toml_table.get(PACKAGETYPE_FIELD, ZIP),
         toml_table.get(ARCHITECTURE_FIELD, X86_64),
         dict(toml_table.get(METADATA_FIELD, {})),
+        toml_table.get(HANDLER_FIELD, ""),
         toml_table.get(SOURCE_HASH_FIELD, ""),
         toml_table.get(MANIFEST_HASH_FIELD, ""),
         dict(toml_table.get(ENV_VARS_FIELD, {})),
@@ -245,14 +247,7 @@ class BuildGraph:
         function: Function
             function details for this function build definition
         """
-
-        # Check for builders that require all lambda functions to be built separately
-        function_build_method = ""
-        if function.metadata:
-            function_build_method = function.metadata.get("BuildMethod", "")
-        is_independent_build_def = function_build_method in INDEPENDENT_BUILD_DEFINITIONS
-
-        if function_build_definition in self._function_build_definitions and not is_independent_build_def:
+        if function_build_definition in self._function_build_definitions:
             previous_build_definition = self._function_build_definitions[
                 self._function_build_definitions.index(function_build_definition)
             ]
@@ -572,6 +567,7 @@ class FunctionBuildDefinition(AbstractBuildDefinition):
         packagetype: str,
         architecture: str,
         metadata: Optional[Dict],
+        handler: Optional[str],
         source_hash: str = "",
         manifest_hash: str = "",
         env_vars: Optional[Dict] = None,
@@ -580,6 +576,7 @@ class FunctionBuildDefinition(AbstractBuildDefinition):
         self.runtime = runtime
         self.codeuri = codeuri
         self.packagetype = packagetype
+        self.handler = handler
 
         # Skip SAM Added metadata properties
         metadata_copied = deepcopy(metadata) if metadata else {}
@@ -646,6 +643,12 @@ class FunctionBuildDefinition(AbstractBuildDefinition):
         # each build with custom Makefile definition should be handled separately
         if self.metadata and self.metadata.get("BuildMethod", None) == "makefile":
             return False
+
+        if self.metadata and self.metadata.get("BuildMethod", None) == "esbuild":
+            # For esbuild, we need to check if handlers within the same CodeUri are the same
+            # if they are different, it should create a separate build definition
+            if self.handler != other.handler:
+                return False
 
         return (
             self.runtime == other.runtime

--- a/tests/unit/lib/build_module/test_build_graph.py
+++ b/tests/unit/lib/build_module/test_build_graph.py
@@ -31,6 +31,7 @@ from samcli.lib.build.build_graph import (
     LayerBuildDefinition,
     MANIFEST_HASH_FIELD,
     BuildHashingInformation,
+    HANDLER_FIELD,
 )
 from samcli.lib.providers.provider import Function, LayerVersion
 from samcli.lib.utils import osutils
@@ -204,7 +205,7 @@ class TestConversionFunctions(TestCase):
         self.assertEqual(build_definition.architecture, toml_table[ARCHITECTURE_FIELD])
 
     def test_minimal_function_build_definition_to_toml_table(self):
-        build_definition = FunctionBuildDefinition("runtime", "codeuri", ZIP, X86_64, {"key": "value"})
+        build_definition = FunctionBuildDefinition("runtime", "codeuri", ZIP, X86_64, {"key": "value"}, "handler")
         build_definition.add_function(generate_function())
 
         toml_table = _function_build_definition_to_toml_table(build_definition)
@@ -212,6 +213,7 @@ class TestConversionFunctions(TestCase):
         self.assertEqual(toml_table[PACKAGETYPE_FIELD], build_definition.packagetype)
         self.assertEqual(toml_table[RUNTIME_FIELD], build_definition.runtime)
         self.assertEqual(toml_table[METADATA_FIELD], build_definition.metadata)
+        self.assertEqual(toml_table[HANDLER_FIELD], build_definition.handler)
         self.assertEqual(toml_table[FUNCTIONS_FIELD], [f.name for f in build_definition.functions])
         if build_definition.source_hash:
             self.assertEqual(toml_table[SOURCE_HASH_FIELD], build_definition.source_hash)
@@ -291,6 +293,7 @@ class TestBuildGraph(TestCase):
     ENV_VARS = {"env_vars": "value"}
     ARCHITECTURE_FIELD = ARM64
     LAYER_ARCHITECTURE = X86_64
+    HANDLER = "app.handler"
 
     BUILD_GRAPH_CONTENTS = f"""
     [function_build_definitions]
@@ -301,6 +304,7 @@ class TestBuildGraph(TestCase):
     manifest_hash = "{MANIFEST_HASH}"
     packagetype = "{ZIP}"
     architecture = "{ARCHITECTURE_FIELD}"
+    handler = "{HANDLER}"
     functions = ["HelloWorldPython", "HelloWorldPython2"]
     [function_build_definitions.{UUID}.metadata]
     Test = "{METADATA['Test']}"
@@ -349,6 +353,7 @@ class TestBuildGraph(TestCase):
                 TestBuildGraph.ZIP,
                 TestBuildGraph.ARCHITECTURE_FIELD,
                 TestBuildGraph.METADATA,
+                TestBuildGraph.HANDLER,
                 TestBuildGraph.SOURCE_HASH,
                 TestBuildGraph.MANIFEST_HASH,
                 TestBuildGraph.ENV_VARS,
@@ -436,6 +441,7 @@ class TestBuildGraph(TestCase):
                 TestBuildGraph.ZIP,
                 TestBuildGraph.ARCHITECTURE_FIELD,
                 TestBuildGraph.METADATA,
+                TestBuildGraph.HANDLER,
                 TestBuildGraph.SOURCE_HASH,
                 TestBuildGraph.MANIFEST_HASH,
                 TestBuildGraph.ENV_VARS,
@@ -459,6 +465,7 @@ class TestBuildGraph(TestCase):
                 TestBuildGraph.ZIP,
                 ARM64,
                 None,
+                "app.handler",
                 "another_source_hash",
                 "another_manifest_hash",
                 {"env_vars": "value2"},
@@ -550,6 +557,7 @@ class TestBuildGraph(TestCase):
                 TestBuildGraph.ZIP,
                 TestBuildGraph.ARCHITECTURE_FIELD,
                 TestBuildGraph.METADATA,
+                TestBuildGraph.HANDLER,
                 TestBuildGraph.SOURCE_HASH,
                 TestBuildGraph.MANIFEST_HASH,
                 TestBuildGraph.ENV_VARS,
@@ -560,6 +568,7 @@ class TestBuildGraph(TestCase):
                 TestBuildGraph.ZIP,
                 TestBuildGraph.ARCHITECTURE_FIELD,
                 TestBuildGraph.METADATA,
+                TestBuildGraph.HANDLER,
                 "new_value",
                 "new_manifest_value",
                 TestBuildGraph.ENV_VARS,
@@ -607,8 +616,12 @@ class TestBuildGraph(TestCase):
     def test_compare_hash_changes_should_preserve_download_dependencies(
         self, old_manifest, new_manifest, download_dependencies
     ):
-        updated_definition = FunctionBuildDefinition("runtime", "codeuri", ZIP, X86_64, {}, manifest_hash=old_manifest)
-        existing_definition = FunctionBuildDefinition("runtime", "codeuri", ZIP, X86_64, {}, manifest_hash=new_manifest)
+        updated_definition = FunctionBuildDefinition(
+            "runtime", "codeuri", ZIP, X86_64, {}, "app.handler", manifest_hash=old_manifest
+        )
+        existing_definition = FunctionBuildDefinition(
+            "runtime", "codeuri", ZIP, X86_64, {}, "app.handler", manifest_hash=new_manifest
+        )
         BuildGraph._compare_hash_changes([updated_definition], [existing_definition])
         self.assertEqual(existing_definition.download_dependencies, download_dependencies)
 
@@ -664,7 +677,7 @@ class TestBuildGraph(TestCase):
 class TestBuildDefinition(TestCase):
     def test_single_function_should_return_function_and_handler_name(self):
         build_definition = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, X86_64, {}, "source_hash", "manifest_hash", {"env_vars": "value"}
+            "runtime", "codeuri", ZIP, X86_64, {}, "handler", "source_hash", "manifest_hash", {"env_vars": "value"}
         )
         build_definition.add_function(generate_function())
         self.assertEqual(build_definition.get_handler_name(), "handler")
@@ -672,7 +685,7 @@ class TestBuildDefinition(TestCase):
 
     def test_no_function_should_raise_exception(self):
         build_definition = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, X86_64, {}, "source_hash", "manifest_hash", {"env_vars": "value"}
+            "runtime", "codeuri", ZIP, X86_64, {}, "handler", "source_hash", "manifest_hash", {"env_vars": "value"}
         )
 
         self.assertRaises(InvalidBuildGraphException, build_definition.get_handler_name)
@@ -680,10 +693,10 @@ class TestBuildDefinition(TestCase):
 
     def test_same_runtime_codeuri_metadata_should_reflect_as_same_object(self):
         build_definition1 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, {"key": "value"}, "source_hash", "manifest_hash"
+            "runtime", "codeuri", ZIP, ARM64, {"key": "value"}, "handler", "source_hash", "manifest_hash"
         )
         build_definition2 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, {"key": "value"}, "source_hash", "manifest_hash"
+            "runtime", "codeuri", ZIP, ARM64, {"key": "value"}, "handler", "source_hash", "manifest_hash"
         )
 
         self.assertEqual(build_definition1, build_definition2)
@@ -695,6 +708,7 @@ class TestBuildDefinition(TestCase):
             ZIP,
             ARM64,
             {"key": "value", "SamResourceId": "resourceId1", "SamNormalized": True},
+            "handler",
             "source_hash",
             "manifest_hash",
         )
@@ -704,6 +718,7 @@ class TestBuildDefinition(TestCase):
             ZIP,
             ARM64,
             {"key": "value", "SamResourceId": "resourceId2", "SamNormalized": True},
+            "handler",
             "source_hash",
             "manifest_hash",
         )
@@ -712,10 +727,26 @@ class TestBuildDefinition(TestCase):
 
     def test_same_env_vars_reflect_as_same_object(self):
         build_definition1 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, X86_64, {"key": "value"}, "source_hash", "manifest_hash", {"env_vars": "value"}
+            "runtime",
+            "codeuri",
+            ZIP,
+            X86_64,
+            {"key": "value"},
+            "handler",
+            "source_hash",
+            "manifest_hash",
+            {"env_vars": "value"},
         )
         build_definition2 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, X86_64, {"key": "value"}, "source_hash", "manifest_hash", {"env_vars": "value"}
+            "runtime",
+            "codeuri",
+            ZIP,
+            X86_64,
+            {"key": "value"},
+            "handler",
+            "source_hash",
+            "manifest_hash",
+            {"env_vars": "value"},
         )
 
         self.assertEqual(build_definition1, build_definition2)
@@ -775,20 +806,36 @@ class TestBuildDefinition(TestCase):
 
     def test_different_architecture_should_not_reflect_as_same_object(self):
         build_definition1 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, X86_64, {"key": "value"}, "source_md5", {"env_vars": "value"}
+            "runtime", "codeuri", ZIP, X86_64, {"key": "value"}, "handler", "source_md5", {"env_vars": "value"}
         )
         build_definition2 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, {"key": "value"}, "source_md5", {"env_vars": "value"}
+            "runtime", "codeuri", ZIP, ARM64, {"key": "value"}, "handler", "source_md5", {"env_vars": "value"}
         )
 
         self.assertNotEqual(build_definition1, build_definition2)
 
     def test_different_env_vars_should_not_reflect_as_same_object(self):
         build_definition1 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, {"key": "value"}, "source_hash", "manifest_hash", {"env_vars": "value1"}
+            "runtime",
+            "codeuri",
+            ZIP,
+            ARM64,
+            {"key": "value"},
+            "handler",
+            "source_hash",
+            "manifest_hash",
+            {"env_vars": "value1"},
         )
         build_definition2 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, {"key": "value"}, "source_hash", "manifest_hash", {"env_vars": "value2"}
+            "runtime",
+            "codeuri",
+            ZIP,
+            ARM64,
+            {"key": "value"},
+            "handler",
+            "source_hash",
+            "manifest_hash",
+            {"env_vars": "value2"},
         )
 
         self.assertNotEqual(build_definition1, build_definition2)
@@ -801,24 +848,24 @@ class TestBuildDefinition(TestCase):
 
     def test_str_representation(self):
         build_definition = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, None, "source_hash", "manifest_hash"
+            "runtime", "codeuri", ZIP, ARM64, None, "handler", "source_hash", "manifest_hash"
         )
         self.assertEqual(
             str(build_definition),
             f"BuildDefinition(runtime, codeuri, Zip, source_hash, {build_definition.uuid}, {{}}, {{}}, arm64, [])",
         )
 
-    def test_independent_build_definitions_equal_objects_independent_build_method(self):
+    def test_esbuild_definitions_equal_objects_independent_build_method(self):
         build_graph = BuildGraph("build/path")
         metadata = {"BuildMethod": "esbuild"}
         build_definition1 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, metadata, "source_hash", "manifest_hash"
+            "runtime", "codeuri", ZIP, ARM64, metadata, "handler", "source_hash", "manifest_hash"
         )
         function1 = generate_function(
             runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler-1"
         )
         build_definition2 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, metadata, "source_hash", "manifest_hash"
+            "runtime", "codeuri", ZIP, ARM64, metadata, "app.handler", "source_hash", "manifest_hash"
         )
         function2 = generate_function(
             runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler-2"
@@ -828,22 +875,22 @@ class TestBuildDefinition(TestCase):
 
         build_definitions = build_graph.get_function_build_definitions()
 
-        self.assertEqual(build_definition1, build_definition2)
+        self.assertNotEqual(build_definition1, build_definition2)
         self.assertEqual(len(build_definitions), 2)
         self.assertEqual(len(build_definition1.functions), 1)
         self.assertEqual(len(build_definition2.functions), 1)
 
-    def test_independent_build_definitions_equal_objects_one_independent_build_method(self):
+    def test_independent_build_definitions_equal_objects_one_esbuild_build_method(self):
         build_graph = BuildGraph("build/path")
         metadata = {"BuildMethod": "esbuild"}
         build_definition1 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, metadata, "source_hash", "manifest_hash"
+            "runtime", "codeuri", ZIP, ARM64, metadata, "handler", "source_hash", "manifest_hash"
         )
         function1 = generate_function(
             runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler-1"
         )
         build_definition2 = FunctionBuildDefinition(
-            "runtime", "codeuri", ZIP, ARM64, {}, "source_hash", "manifest_hash"
+            "runtime", "codeuri", ZIP, ARM64, {}, "handler", "source_hash", "manifest_hash"
         )
         function2 = generate_function(
             runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata={}, handler="handler-2"
@@ -857,3 +904,27 @@ class TestBuildDefinition(TestCase):
         self.assertEqual(len(build_definitions), 2)
         self.assertEqual(len(build_definition1.functions), 1)
         self.assertEqual(len(build_definition2.functions), 1)
+
+    def test_two_esbuild_methods_same_handler(self):
+        build_graph = BuildGraph("build/path")
+        metadata = {"BuildMethod": "esbuild"}
+        build_definition1 = FunctionBuildDefinition(
+            "runtime", "codeuri", ZIP, ARM64, metadata, "handler", "source_hash", "manifest_hash"
+        )
+        function1 = generate_function(
+            runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler"
+        )
+        build_definition2 = FunctionBuildDefinition(
+            "runtime", "codeuri", ZIP, ARM64, metadata, "handler", "source_hash", "manifest_hash"
+        )
+        function2 = generate_function(
+            runtime=TestBuildGraph.RUNTIME, codeuri=TestBuildGraph.CODEURI, metadata={}, handler="handler"
+        )
+        build_graph.put_function_build_definition(build_definition1, function1)
+        build_graph.put_function_build_definition(build_definition2, function2)
+
+        build_definitions = build_graph.get_function_build_definitions()
+
+        self.assertEqual(build_definition1, build_definition2)
+        self.assertEqual(len(build_definitions), 1)
+        self.assertEqual(len(build_definition1.functions), 2)

--- a/tests/unit/lib/build_module/test_build_strategy.py
+++ b/tests/unit/lib/build_module/test_build_strategy.py
@@ -42,8 +42,8 @@ class BuildStrategyBaseTest(TestCase):
         self.function2.get_build_dir = Mock()
         self.function2.full_path = Mock()
 
-        self.function_build_definition1 = FunctionBuildDefinition("runtime", "codeuri", ZIP, X86_64, {})
-        self.function_build_definition2 = FunctionBuildDefinition("runtime2", "codeuri", ZIP, X86_64, {})
+        self.function_build_definition1 = FunctionBuildDefinition("runtime", "codeuri", ZIP, X86_64, {}, "handler")
+        self.function_build_definition2 = FunctionBuildDefinition("runtime2", "codeuri", ZIP, X86_64, {}, "handler")
         self.build_graph.put_function_build_definition(self.function_build_definition1, self.function1_1)
         self.build_graph.put_function_build_definition(self.function_build_definition1, self.function1_2)
         self.build_graph.put_function_build_definition(self.function_build_definition2, self.function2)
@@ -237,7 +237,9 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
         function2.name = "Function2"
         function2.full_path = "Function2"
         function2.packagetype = IMAGE
-        build_definition = FunctionBuildDefinition("3.7", "codeuri", IMAGE, X86_64, {}, env_vars={"FOO": "BAR"})
+        build_definition = FunctionBuildDefinition(
+            "3.7", "codeuri", IMAGE, X86_64, {}, "handler", env_vars={"FOO": "BAR"}
+        )
         # since they have the same metadata, they are put into the same build_definition.
         build_definition.functions = [function1, function2]
 
@@ -560,7 +562,7 @@ class TestCachedOrIncrementalBuildStrategyWrapper(TestCase):
         self, mocked_read, mocked_write, runtime, experimental_enabled, patched_experimental
     ):
         patched_experimental.return_value = experimental_enabled
-        build_definition = FunctionBuildDefinition(runtime, "codeuri", "packate_type", X86_64, {})
+        build_definition = FunctionBuildDefinition(runtime, "codeuri", "packate_type", X86_64, {}, "handler")
         self.build_graph.put_function_build_definition(build_definition, Mock())
         with patch.object(
             self.build_strategy, "_incremental_build_strategy"
@@ -584,7 +586,7 @@ class TestCachedOrIncrementalBuildStrategyWrapper(TestCase):
         ]
     )
     def test_will_call_cached_build_strategy(self, mocked_read, mocked_write, runtime):
-        build_definition = FunctionBuildDefinition(runtime, "codeuri", "packate_type", X86_64, {})
+        build_definition = FunctionBuildDefinition(runtime, "codeuri", "packate_type", X86_64, {}, "handler")
         self.build_graph.put_function_build_definition(build_definition, Mock())
         with patch.object(
             self.build_strategy, "_incremental_build_strategy"


### PR DESCRIPTION
Update the build definition comparison to handle esbuild needing a separate build for each handler.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
