### PR TITLE
fix(ci): Move to Ruby 2.7 over 1.9

### DIFF
--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -53,7 +53,7 @@ install:
 
   # Make sure the temp directory exists for Python to use.
   - ps: "mkdir -Force D:\\tmp"
-  - "SET PATH=%PYTHON_HOME%;%PATH%"
+  - "SET PATH=%PYTHON_HOME%;C:\\Ruby27-x64\\bin;%PATH%"
   - "echo %PYTHON_HOME%"
   - "echo %PATH%"
   - "python --version"


### PR DESCRIPTION
Appveyor defaults to 1.9 but we have sync tests that use Ruby 2.7.
This caused our integration tests that run within DeployIntegTesting
to fail.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
DeployIntegTesting in `appveyor-windows.yml` fails due to 1.9 being the Ruby version.

#### How does it address the issue?
Add Ruby 2.7 to the path which is what the sync tests use.

#### What side effects does this change have?
None

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
