### PR TITLE
fix: Skip APIs with No DefinitionUri

### DIFF
--- a/samcli/lib/sync/flows/generic_api_sync_flow.py
+++ b/samcli/lib/sync/flows/generic_api_sync_flow.py
@@ -75,7 +75,7 @@ class GenericApiSyncFlow(SyncFlow):
             return None
         properties = api_resource.get("Properties", {})
         definition_file = properties.get("DefinitionUri")
-        if self._build_context.base_dir:
+        if self._build_context.base_dir and definition_file:
             definition_file = str(Path(self._build_context.base_dir).joinpath(definition_file))
         return cast(Optional[str], definition_file)
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Definition file can be None which will error out when called with .joinpath(..,)

#### How does it address the issue?
Added check for definition file.

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
