### PR TITLE
fix: Pin MarkupSafe to 2.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,11 @@ aws_lambda_builders==1.11.0
 tomlkit==0.7.2
 watchdog==2.1.2
 
+# See https://github.com/pallets/markupsafe/issues/286 but breaking change in 
+# MarkupSafe causes jinja to break which caused flask to break (which we depend on)
+# This is a short term patch as we should be upgrading to new versions of Flask (and other dependencies)
+MarkupSafe==2.0.1
+
 # Needed for supporting Protocol in Python 3.6
 typing_extensions==3.10.0.0
 # Needed for supporting dataclasses decorator in Python3.6


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#3661

#### Why is this change necessary?

#### How does it address the issue?

#### What side effects does this change have?

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
