### PR TITLE
add exporter for AWS::CloudFormation::StackSet resource

### DIFF
--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -25,6 +25,7 @@ from samcli.lib.samlib.resource_metadata_normalizer import ResourceMetadataNorma
 from samcli.lib.utils.resources import (
     AWS_SERVERLESS_FUNCTION,
     AWS_CLOUDFORMATION_STACK,
+    AWS_CLOUDFORMATION_STACKSET,
     RESOURCES_WITH_LOCAL_PATHS,
     AWS_SERVERLESS_APPLICATION,
 )
@@ -113,6 +114,41 @@ class ServerlessApplicationResource(CloudFormationStackResource):
     RESOURCE_TYPE = AWS_SERVERLESS_APPLICATION
     PROPERTY_NAME = RESOURCES_WITH_LOCAL_PATHS[AWS_SERVERLESS_APPLICATION][0]
 
+class CloudFormationStackSetResource(ResourceZip):
+    """
+    Represents CloudFormation::StackSet resource that can refer to a
+    stack template via TemplateURL property.
+    """
+
+    RESOURCE_TYPE = AWS_CLOUDFORMATION_STACKSET
+    PROPERTY_NAME = RESOURCES_WITH_LOCAL_PATHS[RESOURCE_TYPE][0]
+
+    def do_export(self, resource_id, resource_dict, parent_dir):
+        """
+        If the stack template is valid, this method will
+        upload the template to S3
+        and set property to URL of the uploaded S3 template
+        """
+
+        template_path = resource_dict.get(self.PROPERTY_NAME, None)
+
+        if template_path is None or is_s3_url(template_path):
+            # Nothing to do
+            return
+
+        abs_template_path = make_abs_path(parent_dir, template_path)
+        if not is_local_file(abs_template_path):
+            raise exceptions.InvalidTemplateUrlParameterError(
+                property_name=self.PROPERTY_NAME, resource_id=resource_id, template_path=abs_template_path
+            )
+
+        remote_path = get_uploaded_s3_object_name(file_path=template_path, extension="template")
+        url = self.uploader.upload(template_path, remote_path)
+
+        # TemplateUrl property requires S3 URL to be in path-style format
+        parts = S3Uploader.parse_s3_url(url, version_property="Version")
+        s3_path_url = self.uploader.to_path_style_s3_url(parts["Key"], parts.get("Version", None))
+        set_value_from_jmespath(resource_dict, self.PROPERTY_NAME, s3_path_url)
 
 class Template:
     """
@@ -133,7 +169,7 @@ class Template:
         uploaders: Uploaders,
         code_signer: CodeSigner,
         resources_to_export=frozenset(
-            RESOURCES_EXPORT_LIST + [CloudFormationStackResource, ServerlessApplicationResource]
+            RESOURCES_EXPORT_LIST + [CloudFormationStackResource, CloudFormationStackSetResource, ServerlessApplicationResource]
         ),
         metadata_to_export=frozenset(METADATA_EXPORT_LIST),
         template_str: Optional[str] = None,

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -22,6 +22,7 @@ from samcli.lib.package.artifact_exporter import (
     make_abs_path,
     Template,
     CloudFormationStackResource,
+    CloudFormationStackSetResource,
     ServerlessApplicationResource,
 )
 from samcli.lib.package.packageable_resources import (
@@ -931,6 +932,81 @@ class TestArtifactExporter(unittest.TestCase):
         s3_url = "s3://hello/world"
 
         # Case 3: Path is not a file
+        with self.make_temp_dir() as dirname:
+            resource_dict = {property_name: dirname}
+            with self.assertRaises(exceptions.ExportFailedError):
+                stack_resource.export(resource_id, resource_dict, "dir")
+                self.s3_uploader_mock.upload.assert_not_called()
+
+    def test_export_cloudformation_stack_set(self):
+        stack_resource = CloudFormationStackSetResource(self.uploaders_mock, self.code_signer_mock)
+
+        resource_id = "id"
+        property_name = stack_resource.PROPERTY_NAME
+        result_s3_url = "s3://hello/world"
+        result_path_style_s3_url = "http://s3.amazonws.com/hello/world"
+
+        self.s3_uploader_mock.upload.return_value = result_s3_url
+        self.s3_uploader_mock.to_path_style_s3_url.return_value = result_path_style_s3_url
+
+        with tempfile.NamedTemporaryFile() as handle:
+            template_path = handle.name
+            resource_dict = {property_name: template_path}
+            parent_dir = tempfile.gettempdir()
+
+            stack_resource.export(resource_id, resource_dict, parent_dir)
+            self.assertEqual(resource_dict[property_name], result_path_style_s3_url)
+
+            self.s3_uploader_mock.upload.assert_called_once_with(mock.ANY, mock.ANY)
+            self.s3_uploader_mock.to_path_style_s3_url.assert_called_once_with("world", None)
+
+    def test_export_cloudformation_stack_set_no_upload_path_is_s3url(self):
+        stack_resource = CloudFormationStackSetResource(self.uploaders_mock, self.code_signer_mock)
+        resource_id = "id"
+        property_name = stack_resource.PROPERTY_NAME
+        s3_url = "s3://hello/world"
+        resource_dict = {property_name: s3_url}
+        # Case 1: Path is already S3 url
+        stack_resource.export(resource_id, resource_dict, "dir")
+        self.assertEqual(resource_dict[property_name], s3_url)
+        self.s3_uploader_mock.upload.assert_not_called()
+
+    def test_export_cloudformation_stack_set_no_upload_path_is_httpsurl(self):
+        stack_resource = CloudFormationStackSetResource(self.uploaders_mock, self.code_signer_mock)
+        resource_id = "id"
+        property_name = stack_resource.PROPERTY_NAME
+        s3_url = "https://s3.amazonaws.com/hello/world"
+        resource_dict = {property_name: s3_url}
+        # Case 2: Path is already HTTPS S3 url
+        stack_resource.export(resource_id, resource_dict, "dir")
+        self.assertEqual(resource_dict[property_name], s3_url)
+        self.s3_uploader_mock.upload.assert_not_called()
+
+    def test_export_cloudformation_stack_set_no_upload_path_is_s3_region_httpsurl(self):
+        stack_resource = CloudFormationStackSetResource(self.uploaders_mock, self.code_signer_mock)
+        resource_id = "id"
+        property_name = stack_resource.PROPERTY_NAME
+        s3_url = "https://s3.some-valid-region.amazonaws.com/hello/world"
+        resource_dict = {property_name: s3_url}
+        # Case 3: Path is already HTTPS S3 Regional url
+        stack_resource.export(resource_id, resource_dict, "dir")
+        self.assertEqual(resource_dict[property_name], s3_url)
+        self.s3_uploader_mock.upload.assert_not_called()
+
+    def test_export_cloudformation_stack_set_no_upload_path_is_empty(self):
+        stack_resource = CloudFormationStackSetResource(self.uploaders_mock, self.code_signer_mock)
+        resource_id = "id"
+        # Case 4: Path is empty
+        resource_dict = {}
+        stack_resource.export(resource_id, resource_dict, "dir")
+        self.assertEqual(resource_dict, {})
+        self.s3_uploader_mock.upload.assert_not_called()
+
+    def test_export_cloudformation_stack_set_no_upload_path_not_file(self):
+        stack_resource = CloudFormationStackSetResource(self.uploaders_mock, self.code_signer_mock)
+        resource_id = "id"
+        property_name = stack_resource.PROPERTY_NAME
+        # Case 5: Path is not a file
         with self.make_temp_dir() as dirname:
             resource_dict = {property_name: dirname}
             with self.assertRaises(exceptions.ExportFailedError):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#2249

#### Why is this change necessary?
The PR #3249 was not complete

#### How does it address the issue?
And a custom exporter for StackSet resource

#### What side effects does this change have?
I think there are no side effects because is a new feature

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
