### PR TITLE
fix: Warm containers break on non-local layers

### DIFF
--- a/samcli/lib/utils/file_observer.py
+++ b/samcli/lib/utils/file_observer.py
@@ -112,7 +112,8 @@ class LambdaFunctionObserver:
             """
             code_paths = [function_config.code_abs_path]
             if function_config.layers:
-                code_paths += [layer.codeuri for layer in function_config.layers]
+                # Non-local layers will not have a codeuri property and don't need to be observed
+                code_paths += [layer.codeuri for layer in function_config.layers if layer.codeuri]
             return code_paths
 
         def _get_image_lambda_function_image_names(function_config: FunctionConfig) -> List[str]:

--- a/tests/integration/local/start_api/start_api_integ_base.py
+++ b/tests/integration/local/start_api/start_api_integ_base.py
@@ -12,8 +12,8 @@ from pathlib import Path
 import docker
 from docker.errors import APIError
 
-from tests.testing_utils import kill_process, read_until_string
-from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS, run_command, start_persistent_process
+from tests.testing_utils import kill_process
+from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS, run_command
 
 LOG = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ class StartApiIntegBaseClass(TestCase):
     binary_data_file: Optional[str] = None
     integration_dir = str(Path(__file__).resolve().parents[2])
     invoke_image: Optional[List] = None
+    layer_cache_base_dir: Optional[str] = None
 
     build_before_invoke = False
     build_overrides: Optional[Dict[str, str]] = None
@@ -79,6 +80,9 @@ class StartApiIntegBaseClass(TestCase):
 
         if cls.parameter_overrides:
             command_list += ["--parameter-overrides", cls._make_parameter_override_arg(cls.parameter_overrides)]
+
+        if cls.layer_cache_base_dir:
+            command_list += ["--layer-cache-basedir", cls.layer_cache_base_dir]
 
         if cls.invoke_image:
             for image in cls.invoke_image:

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -2822,7 +2822,7 @@ class WarmContainersWithRemoteLayersBase(TestWarmContainersBaseClass):
         super().tearDownClass()
 
 
-class TestWarmContainersNonLocalLayers(WarmContainersWithRemoteLayersBase):
+class TestWarmContainersRemoteLayers(WarmContainersWithRemoteLayersBase):
     template_path = "/testdata/start_api/template-warm-containers-layers.yaml"
     container_mode = ContainersInitializationMode.EAGER.value
     mode_env_variable = str(uuid.uuid4())
@@ -2843,7 +2843,7 @@ class TestWarmContainersNonLocalLayers(WarmContainersWithRemoteLayersBase):
         self.assertEqual(response.content.decode("utf-8"), '"Layer1"')
 
 
-class TestWarmContainersNonLocalLayersLazyInvoke(WarmContainersWithRemoteLayersBase):
+class TestWarmContainersRemoteLayersLazyInvoke(WarmContainersWithRemoteLayersBase):
     template_path = "/testdata/start_api/template-warm-containers-layers.yaml"
     container_mode = ContainersInitializationMode.LAZY.value
     mode_env_variable = str(uuid.uuid4())

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -1,6 +1,9 @@
 import base64
+import shutil
 import uuid
 import random
+from pathlib import Path
+from typing import Dict
 
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -12,6 +15,7 @@ from parameterized import parameterized_class
 from samcli.commands.local.cli_common.invoke_context import ContainersInitializationMode
 from samcli.local.apigw.local_apigw_service import Route
 from .start_api_integ_base import StartApiIntegBaseClass, WatchWarmContainersIntegBaseClass
+from ..invoke.layer_utils import LayerUtils
 
 
 @parameterized_class(
@@ -2794,3 +2798,60 @@ class TestServiceWithCustomInvokeImages(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+
+
+class WarmContainersWithRemoteLayersBase(TestWarmContainersBaseClass):
+    region = "us-west-2"
+    layer_utils = LayerUtils(region=region)
+    layer_cache_base_dir = str(Path().home().joinpath("integ_layer_cache"))
+    parameter_overrides: Dict[str, str] = {}
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.layer_utils.upsert_layer(LayerUtils.generate_layer_name(), "LayerArn", "layer1.zip")
+        for key, val in cls.layer_utils.parameters_overrides.items():
+            cls.parameter_overrides[key] = val
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(self) -> None:
+        self.layer_utils.delete_layers()
+        integ_layer_cache_dir = Path().home().joinpath("integ_layer_cache")
+        if integ_layer_cache_dir.exists():
+            shutil.rmtree(str(integ_layer_cache_dir))
+        super().tearDownClass()
+
+
+class TestWarmContainersNonLocalLayers(WarmContainersWithRemoteLayersBase):
+    template_path = "/testdata/start_api/template-warm-containers-layers.yaml"
+    container_mode = ContainersInitializationMode.EAGER.value
+    mode_env_variable = str(uuid.uuid4())
+    parameter_overrides = {"ModeEnvVariable": mode_env_variable}
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_all_containers_are_initialized_before_any_invoke(self):
+        initiated_containers = self.count_running_containers()
+        # Ensure only one function has spun up, remote layer shouldn't create another container
+        self.assertEqual(initiated_containers, 1)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_can_invoke_lambda_layer_successfully(self):
+        response = requests.get(self.url + "/", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode("utf-8"), '"Layer1"')
+
+
+class TestWarmContainersNonLocalLayersLazyInvoke(WarmContainersWithRemoteLayersBase):
+    template_path = "/testdata/start_api/template-warm-containers-layers.yaml"
+    container_mode = ContainersInitializationMode.LAZY.value
+    mode_env_variable = str(uuid.uuid4())
+    parameter_overrides = {"ModeEnvVariable": mode_env_variable}
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_can_invoke_lambda_layer_successfully(self):
+        response = requests.get(self.url + "/", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode("utf-8"), '"Layer1"')

--- a/tests/integration/testdata/start_api/main-layers.py
+++ b/tests/integration/testdata/start_api/main-layers.py
@@ -1,0 +1,10 @@
+import json
+import sys
+import site
+
+sys.path.insert(0, "/opt")
+site.addsitedir("/opt")
+
+def custom_layer_handler(event, context):
+    from simple_python_module.simple_python import which_layer
+    return {"body": json.dumps(which_layer())}

--- a/tests/integration/testdata/start_api/template-warm-containers-layers.yaml
+++ b/tests/integration/testdata/start_api/template-warm-containers-layers.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  ModeEnvVariable:
+    Type: String
+  LayerArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:layer:1
+    Type: String
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main-layers.custom_layer_handler
+      Runtime: python3.6
+      FunctionName: customname
+      CodeUri: .
+      Timeout: 600
+      Environment:
+        Variables:
+          MODE: !Ref ModeEnvVariable
+      Layers:
+        # Test remote layers with warm containers.
+        - Ref: LayerArn
+      Events:
+        BasePath:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /

--- a/tests/unit/lib/utils/test_file_observer.py
+++ b/tests/unit/lib/utils/test_file_observer.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch, call
 
 from docker.errors import ImageNotFound
 
+from samcli.lib.providers.provider import LayerVersion
 from samcli.lib.utils.file_observer import (
     FileObserver,
     FileObserverException,
@@ -775,6 +776,33 @@ class LambdaFunctionObserver_watch(TestCase):
                 call("path1"),
                 call("layer1_path"),
                 call("layer2_path"),
+            ],
+        )
+
+    def test_watch_ZIP_lambda_function_with_non_local_layers(self):
+        lambda_function = Mock()
+        lambda_function.packagetype = ZIP
+        lambda_function.code_abs_path = "path1"
+        layer1_mock = LayerVersion(arn="arn", codeuri="layer1_path")
+        layer2_mock = LayerVersion(arn="arn2", codeuri=None)
+
+        lambda_function.layers = [layer1_mock, layer2_mock]
+        self.lambda_function_observer.watch(lambda_function)
+        self.assertEqual(
+            self.lambda_function_observer._observed_functions,
+            {
+                ZIP: {
+                    "path1": [lambda_function],
+                    "layer1_path": [lambda_function],
+                },
+                IMAGE: {},
+            },
+        )
+        self.assertEqual(
+            self.file_observer_mock.watch.call_args_list,
+            [
+                call("path1"),
+                call("layer1_path"),
             ],
         )
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#3683

#### Why is this change necessary?
Running start-api with warm containers and a downloaded layer will throw an exception ```"Lambda functions containers initialization failed because of expected str, bytes or os.PathLike object, not NoneType"```

#### How does it address the issue?
Check if layer codeuri exists before attempting to watch it

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
