### PR TITLE
Bug fix: Runtime sorting bug fix

### DIFF
--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -11,7 +11,7 @@ import click
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
 from samcli.cli.main import pass_context, common_options, print_cmdline_args
 from samcli.lib.utils.version_checker import check_newer_version
-from samcli.local.common.runtime_template import RUNTIMES, SUPPORTED_DEP_MANAGERS, LAMBDA_IMAGES_RUNTIMES
+from samcli.local.common.runtime_template import INIT_RUNTIMES, SUPPORTED_DEP_MANAGERS, LAMBDA_IMAGES_RUNTIMES
 from samcli.lib.telemetry.metric import track_command
 from samcli.commands.init.interactive_init_flow import _get_runtime_from_image, get_architectures, get_sorted_runtimes
 from samcli.commands._utils.click_mutex import ClickMutex
@@ -169,7 +169,7 @@ def non_interactive_validation(func):
 @click.option(
     "-r",
     "--runtime",
-    type=click.Choice(get_sorted_runtimes(RUNTIMES)),
+    type=click.Choice(get_sorted_runtimes(INIT_RUNTIMES)),
     help="Lambda Runtime of your app",
     cls=ClickMutex,
     incompatible_params=["location", "base_image"],

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -21,7 +21,7 @@ from samcli.local.common.runtime_template import (
 )
 
 LOG = logging.getLogger(__name__)
-MANIFEST_URL = "https://raw.githubusercontent.com/aws/aws-sam-cli-app-templates/master/manifest.json"
+MANIFEST_URL = "https://raw.githubusercontent.com/aws/aws-sam-cli-app-templates/master/manifest-v2.json"
 APP_TEMPLATES_REPO_URL = "https://github.com/aws/aws-sam-cli-app-templates"
 APP_TEMPLATES_REPO_NAME = "aws-sam-cli-app-templates"
 
@@ -33,7 +33,7 @@ class InvalidInitTemplateError(UserException):
 class InitTemplates:
     def __init__(self):
         self._git_repo: GitRepo = GitRepo(url=APP_TEMPLATES_REPO_URL)
-        self.manifest_file_name = "manifest.json"
+        self.manifest_file_name = "manifest-v2.json"
 
     def location_from_app_template(self, package_type, runtime, base_image, dependency_manager, app_template):
         options = self.init_options(package_type, runtime, base_image, dependency_manager)

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -82,33 +82,11 @@ def get_local_lambda_images_location(mapping, runtime):
     return os.path.join(_lambda_images_templates, runtime, dir_name + "-lambda-image")
 
 
-RUNTIME_TO_DEPENDENCY_MANAGERS = {
-    "python3.9": ["pip"],
-    "python3.8": ["pip"],
-    "python3.7": ["pip"],
-    "python3.6": ["pip"],
-    "ruby2.7": ["bundler"],
-    "nodejs14.x": ["npm"],
-    "nodejs12.x": ["npm"],
-    "dotnetcore3.1": ["cli-package"],
-    "dotnet6": ["cli-package"],
-    "go1.x": ["mod"],
-    "java8": ["maven", "gradle"],
-    "java11": ["maven", "gradle"],
-    "java8.al2": ["maven", "gradle"],
-}
-
 SUPPORTED_DEP_MANAGERS: Set[str] = {
     c["dependency_manager"]  # type: ignore
     for c in list(itertools.chain(*(RUNTIME_DEP_TEMPLATE_MAPPING.values())))
     if c["dependency_manager"]
 }
-
-RUNTIMES: Set[str] = set(
-    itertools.chain(
-        *[c["runtimes"] for c in list(itertools.chain(*(RUNTIME_DEP_TEMPLATE_MAPPING.values())))]  # type: ignore
-    )
-)
 
 # When adding new Lambda runtimes, please update SAM_RUNTIME_TO_SCHEMAS_CODE_LANG_MAPPING
 # Runtimes are ordered in alphabetical fashion with reverse version order (latest versions first)

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -25,6 +25,7 @@ from samcli.commands.init.init_templates import (
     get_template_value,
     template_does_not_meet_filter_criteria,
 )
+from samcli.commands.init.interactive_init_flow import get_sorted_runtimes
 from samcli.lib.init import GenerateProjectFailedError
 from samcli.lib.utils import osutils
 from samcli.lib.utils import packagetype


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

#### Why is this change necessary?
This change essentially fixes the bugs that arises as a result of depending on a hardcoded runtimes list. 
Older versions of samcli fail when a new runtimes are added to cli template repo. Version affected are 1.37.0 to 1.40.0

#### How does it address the issue?
sorting the runtimes with making reference to the list of supported runtimes

#### What side effects does this change have?
INIT depends solely on the information in the cli template repo to create the interactive experience.

#### Checklist

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
