### PR TITLE
fix: Update Python3.6 Debug Bootstrap Path

### DIFF
--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -130,7 +130,7 @@ class LambdaDebugSettings:
                 },
             ),
             Runtime.python36.value: lambda: DebugSettings(
-                entry + ["/var/lang/bin/python3.6"] + debug_args_list + ["/var/runtime/awslambda/bootstrap.py"],
+                entry + ["/var/lang/bin/python3.6"] + debug_args_list + ["/var/runtime/bootstrap.py"],
                 container_env_vars=_container_env_vars,
             ),
             Runtime.python37.value: lambda: DebugSettings(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Python3.6 emulation images now uses `/var/runtime/bootstrap.py` instead of `/var/runtime/awslambda/bootstrap.py`.
Although `/var/runtime/awslambda/bootstrap.py` is still a symlink to the new path, we want to update the path for the future.

#### How does it address the issue?
Changes the path to `/var/runtime/bootstrap.py`.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [ ] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
