### PR TITLE
Gating Unsupported runtime

### DIFF
--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -17,7 +17,7 @@ from samcli.commands.init.interactive_event_bridge_flow import (
 )
 from samcli.commands.exceptions import SchemasApiException, InvalidInitOptionException
 from samcli.lib.schemas.schemas_code_manager import do_download_source_code_binding, do_extract_and_merge_schemas_code
-from samcli.local.common.runtime_template import LAMBDA_IMAGES_RUNTIMES_MAP
+from samcli.local.common.runtime_template import INIT_RUNTIMES, LAMBDA_IMAGES_RUNTIMES_MAP
 from samcli.commands.init.init_generator import do_generate
 from samcli.commands.init.init_templates import InitTemplates, InvalidInitTemplateError
 from samcli.lib.utils.osutils import remove
@@ -338,12 +338,13 @@ def get_sorted_runtimes(runtime_option_list):
         sorted list of possible runtime to be selected
     """
     runtime_list = []
-    for runtime in runtime_option_list:
+    supported_runtime_list = [runtime for runtime in runtime_option_list if runtime in INIT_RUNTIMES]
+    for runtime in supported_runtime_list:
         extractLanguageFromRuntime = re.split(r"\d", runtime)[0]
         extractVersionFromRuntime = re.search(r"\d.*", runtime).group()
         runtime_list.append((extractLanguageFromRuntime, extractVersionFromRuntime))
 
-    runtime_list = sorted(runtime_option_list, key=functools.cmp_to_key(compare_runtimes))
+    runtime_list = sorted(supported_runtime_list, key=functools.cmp_to_key(compare_runtimes))
     sorted_runtime = ["".join(runtime_tuple) for runtime_tuple in runtime_list]
     return sorted_runtime
 

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -300,9 +300,7 @@ def _get_choice_from_options(chosen, options, question, msg):
     click_choices = []
 
     options_list = options if isinstance(options, list) else list(options.keys())
-    options_list = (
-        get_sorted_runtimes(options_list) if msg == "Runtime" and not isinstance(options, list) else options_list
-    )
+    options_list = get_sorted_runtimes(options_list) if msg == "Runtime" else options_list
 
     if not options_list:
         raise InvalidInitOptionException(f"There are no {msg} options available to be selected.")

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -351,14 +351,28 @@ def get_sorted_runtimes(runtime_option_list):
 
 
 def get_supported_runtime(runtime_list):
+    """
+    Returns a list of only runtimes supported by the current version of SAMCLI.
+    This is the list that is presented to the customer to select from.
+
+    Parameters
+    ----------
+    runtime_list : list
+        List of runtime
+
+    Returns
+    -------
+    list
+        List of supported runtime
+    """
     supported_runtime_list = []
     error_message = ""
     for runtime in runtime_list:
         if runtime not in INIT_RUNTIMES:
             if not error_message:
-                LOG.debug(
-                    "Additional runtimes may be available in the latest SAM CLI version. Upgrade your SAM CLI to see the full list."
-                )
+                error_message = "Additional runtimes may be available in the latest SAM CLI version. \
+                    Upgrade your SAM CLI to see the full list."
+                LOG.debug(error_message)
             continue
         supported_runtime_list.append(runtime)
     return supported_runtime_list

--- a/tests/functional/commands/init/test_interactive_init_flow.py
+++ b/tests/functional/commands/init/test_interactive_init_flow.py
@@ -43,7 +43,6 @@ class TestInteractiveFlow(TestCase):
 
         self.prompt_mock.side_effect = [
             "1",  # Which template source -> AWS
-            "1",  # Runtime -> unknown 1
             "unknown_runtime_app",  # Project name
         ]
         self.confirm_mock.side_effect = [False]
@@ -61,4 +60,6 @@ class TestInteractiveFlow(TestCase):
             no_input=False,
         )
         output_files = list(self.output_dir.rglob("*"))
-        self.assertEqual(len(output_files), 7)
+        self.assertEqual(len(output_files), 8)
+        unique_test_file_path = self.output_dir / "unknown_runtime_app" / "unique_test_file.txt"
+        self.assertIn(unique_test_file_path, output_files)

--- a/tests/functional/testdata/init/unknown_runtime/python3.8/cookiecutter-aws-sam-hello/{{cookiecutter.project_name}}/unique_test_file.txt
+++ b/tests/functional/testdata/init/unknown_runtime/python3.8/cookiecutter-aws-sam-hello/{{cookiecutter.project_name}}/unique_test_file.txt
@@ -1,0 +1,1 @@
+The file was provided to confirm that all unsupported runtime were eliminated and only supported runtime was provided to the customer to select

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -25,6 +25,7 @@ from samcli.commands.init.init_templates import (
     get_template_value,
     template_does_not_meet_filter_criteria,
 )
+from samcli.commands.init.interactive_init_flow import get_sorted_runtimes
 from samcli.lib.init import GenerateProjectFailedError
 from samcli.lib.utils import osutils
 from samcli.lib.utils import packagetype
@@ -2527,3 +2528,11 @@ test-project
             True,
             {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
         )
+
+    @patch("samcli.local.common.runtime_template.INIT_RUNTIMES")
+    def test_must_remove_unsupported_runtime(self, init_runtime_mock):
+        runtime_option_list = ["python3.7", "ruby2.7", "java11", "unsupported_runtime", "dotnetcore3.1"]
+        init_runtime_mock.return_value = ["dotnetcore3.1", "go1.x", "java11", "python3.7", "ruby2.7"]
+        expect_result = ["dotnetcore3.1", "java11", "python3.7", "ruby2.7"]
+        actual_result = get_sorted_runtimes(runtime_option_list)
+        self.assertEquals(actual_result, expect_result)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Help in gating runtimes SAMCLI is yet to supported to be accessed by customer.

#### How does it address the issue?
Removes runtime from list of runtimes generated from the manifest file in CLI template repo


#### What side effects does this change have?
None


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
