### PR TITLE
Add option to 'deploy' and 'sync' commands to write stack outputs to machine readable (Yaml or JSON) file

### DIFF
--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -2,6 +2,7 @@
 CLI command for "deploy" command
 """
 import logging
+import pathlib
 
 import click
 
@@ -103,6 +104,12 @@ LOG = logging.getLogger(__name__)
     is_flag=True,
     help="Preserves the state of previously provisioned resources when an operation fails.",
 )
+@click.option(
+    "--stack-outputs-file",
+    "-so",
+    type=click.Path(),
+    help="Saves stack outputs as JSON with the file path/name provided",
+)
 @stack_name_option(callback=guided_deploy_stack_name)  # pylint: disable=E1120
 @s3_bucket_option(guided=True)  # pylint: disable=E1120
 @image_repository_option
@@ -157,6 +164,7 @@ def cli(
     config_file,
     config_env,
     disable_rollback,
+    stack_outputs_file,
 ):
     """
     `sam deploy` command entry point
@@ -191,6 +199,7 @@ def cli(
         config_env,
         resolve_image_repos,
         disable_rollback,
+        stack_outputs_file,
     )  # pragma: no cover
 
 
@@ -223,6 +232,7 @@ def do_cli(
     config_env,
     resolve_image_repos,
     disable_rollback,
+    stack_outputs_file,
 ):
     """
     Implementation of the ``cli`` method
@@ -315,5 +325,6 @@ def do_cli(
             signing_profiles=guided_context.signing_profiles if guided else signing_profiles,
             use_changeset=True,
             disable_rollback=guided_context.disable_rollback if guided else disable_rollback,
+            stack_outputs_file=pathlib.Path(stack_outputs_file),
         ) as deploy_context:
             deploy_context.run()

--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -17,6 +17,7 @@ Deploy a SAM stack
 
 import logging
 import os
+import pathlib
 from typing import Dict, List, Optional
 
 import boto3
@@ -72,6 +73,7 @@ class DeployContext:
         signing_profiles,
         use_changeset,
         disable_rollback,
+        stack_outputs_file: pathlib.Path,
     ):
         self.template_file = template_file
         self.stack_name = stack_name
@@ -101,6 +103,7 @@ class DeployContext:
         self.signing_profiles = signing_profiles
         self.use_changeset = use_changeset
         self.disable_rollback = disable_rollback
+        self.stack_outputs_file = stack_outputs_file
 
     def __enter__(self):
         return self
@@ -142,7 +145,7 @@ class DeployContext:
                 s3_client, self.s3_bucket, self.s3_prefix, self.kms_key_id, self.force_upload, self.no_progressbar
             )
 
-        self.deployer = Deployer(cloudformation_client)
+        self.deployer = Deployer(cloudformation_client, stack_outputs_file=self.stack_outputs_file)
 
         region = s3_client._client_config.region_name if s3_client else self.region  # pylint: disable=W0212
         display_parameter_overrides = hide_noecho_parameter_overrides(template_dict, self.parameter_overrides)
@@ -173,6 +176,7 @@ class DeployContext:
             self.confirm_changeset,
             self.use_changeset,
             self.disable_rollback,
+            self.stack_outputs_file,
         )
 
     def deploy(
@@ -191,6 +195,7 @@ class DeployContext:
         confirm_changeset=False,
         use_changeset=True,
         disable_rollback=False,
+        stack_outputs_file=None,
     ):
         """
         Deploy the stack to cloudformation.
@@ -227,6 +232,8 @@ class DeployContext:
             Involve creation of changesets, false when using sam sync
         disable_rollback : bool
             Preserves the state of previously provisioned resources when an operation fails
+        stack_outputs_file : pathlib.Path
+            If provided, write stack outputs as JSON to file
         """
         stacks, _ = SamLocalStackProvider.get_stacks(
             self.template_file,

--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -17,7 +17,6 @@ Deploy a SAM stack
 
 import logging
 import os
-import pathlib
 from typing import Dict, List, Optional
 
 import boto3
@@ -73,7 +72,7 @@ class DeployContext:
         signing_profiles,
         use_changeset,
         disable_rollback,
-        stack_outputs_file: pathlib.Path,
+        stack_outputs_file,
     ):
         self.template_file = template_file
         self.stack_name = stack_name
@@ -176,7 +175,6 @@ class DeployContext:
             self.confirm_changeset,
             self.use_changeset,
             self.disable_rollback,
-            self.stack_outputs_file,
         )
 
     def deploy(
@@ -195,7 +193,6 @@ class DeployContext:
         confirm_changeset=False,
         use_changeset=True,
         disable_rollback=False,
-        stack_outputs_file=None,
     ):
         """
         Deploy the stack to cloudformation.
@@ -232,8 +229,6 @@ class DeployContext:
             Involve creation of changesets, false when using sam sync
         disable_rollback : bool
             Preserves the state of previously provisioned resources when an operation fails
-        stack_outputs_file : pathlib.Path
-            If provided, write stack outputs as JSON to file
         """
         stacks, _ = SamLocalStackProvider.get_stacks(
             self.template_file,

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -319,6 +319,7 @@ def do_cli(
                     force_upload=True,
                     signing_profiles=None,
                     disable_rollback=False,
+                    stack_outputs_file=None,
                 ) as deploy_context:
                     if watch:
                         execute_watch(template_file, build_context, package_context, deploy_context, dependency_layer)

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -1,7 +1,7 @@
 """CLI command for "sync" command."""
 import os
 import logging
-from typing import List, Set, TYPE_CHECKING, Optional, Tuple
+from typing import List, Set, TYPE_CHECKING, Optional, Tuple, Union
 
 import click
 
@@ -127,6 +127,12 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
     help="This option separates the dependencies of individual function into another layer, for speeding up the sync"
     "process",
 )
+@click.option(
+    "--stack-outputs-file",
+    "-so",
+    type=click.Path(),
+    help="Saves stack outputs as JSON with the file path/name provided",
+)
 @stack_name_option(required=True)  # pylint: disable=E1120
 @base_dir_option
 @image_repository_option
@@ -157,6 +163,7 @@ def cli(
     resource_id: Optional[Tuple[str]],
     resource: Optional[Tuple[str]],
     dependency_layer: bool,
+    stack_outputs_file: Union[None, str, bytes],
     stack_name: str,
     base_dir: Optional[str],
     parameter_overrides: dict,
@@ -185,6 +192,7 @@ def cli(
         resource_id,
         resource,
         dependency_layer,
+        stack_outputs_file,
         stack_name,
         ctx.region,
         ctx.profile,
@@ -212,6 +220,7 @@ def do_cli(
     resource_id: Optional[Tuple[str]],
     resource: Optional[Tuple[str]],
     dependency_layer: bool,
+    stack_outputs_file: Union[None, str, bytes],
     stack_name: str,
     region: str,
     profile: str,
@@ -319,7 +328,7 @@ def do_cli(
                     force_upload=True,
                     signing_profiles=None,
                     disable_rollback=False,
-                    stack_outputs_file=None,
+                    stack_outputs_file=stack_outputs_file,
                 ) as deploy_context:
                     if watch:
                         execute_watch(template_file, build_context, package_context, deploy_context, dependency_layer)

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -618,8 +618,8 @@ class Deployer:
                 else:
                     out_io.write(yaml_dump(out_dict))
             return True
-        except OSError:
-            LOG.warning("Stack Outputs not written. Unable to open file '%s'.", file_path)
+        except OSError as err:
+            LOG.warning("Stack Outputs not written. Unable to write to file '%s':\n{err}", file_path)
         return False
 
     def get_stack_outputs(self, stack_name, echo=True):

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -77,9 +77,7 @@ OUTPUTS_TABLE_HEADER_NAME = "CloudFormation outputs from deployed stack"
 
 
 class Deployer:
-    def __init__(
-        self, cloudformation_client, changeset_prefix="samcli-deploy", stack_outputs_file: pathlib.Path = None
-    ):
+    def __init__(self, cloudformation_client, changeset_prefix="samcli-deploy", stack_outputs_file=None):
         self._client = cloudformation_client
         self.changeset_prefix = changeset_prefix
         # 500ms of sleep time between stack checks and describe stack events.
@@ -475,7 +473,7 @@ class Deployer:
         if outputs:
             if self.stack_outputs_file:
                 # write out outputs
-                self._write_stack_outputs_file(outputs, self.stack_outputs_file)
+                self._write_stack_outputs_file(outputs, pathlib.Path(self.stack_outputs_file))
 
             self._display_stack_outputs(outputs)
 

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -619,7 +619,7 @@ class Deployer:
                     out_io.write(yaml_dump(out_dict))
             return True
         except OSError as err:
-            LOG.warning("Stack Outputs not written. Unable to write to file '%s':\n{err}", file_path)
+            LOG.warning("Stack Outputs not written. Unable to write to file '%s':\n%s", file_path, err)
         return False
 
     def get_stack_outputs(self, stack_name, echo=True):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
When using `sam deploy` in a monorepo or ci pipeline, stack outputs containing resource identifiers may be needed as inputs to further build and deploy steps. Parsing the stdout of the `sam` command is awkward and brittle (the output may change) and running additional `aws cli` describe-stack command is unneccesary as `sam` already has the necessary data.

#### How does it address the issue?
Adds an optional argument to `deploy` and `sync` commands so save stack outputs into a local Yaml or JSON file.


#### What side effects does this change have?
Requires test suites to be updated to be aware of additional optional argument.

No other side effects:
- The argument is optional so does not change the CLI interface
- When used, the feature simple writes the same information currently provided to STDOUT to a file as well. No behavior is changed.
- Failure to write the file (e.g. attempting to write to a non-existent directory) results in a warning only.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
