### PR TITLE
fix: Resolving symlinks when updating relative paths in template

### DIFF
--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -247,7 +247,9 @@ def _resolve_relative_to(path, original_root, new_root):
 
     # Value is definitely a relative path. Change it relative to the destination directory
     return os.path.relpath(
-        os.path.normpath(os.path.join(original_root, path)), new_root  # Absolute original path w.r.t ``original_root``
+        # Resolve the paths to take care of symlinks
+        os.path.normpath(os.path.join(pathlib.Path(original_root).resolve(), path)),
+        pathlib.Path(new_root).resolve(),  # Absolute original path w.r.t ``original_root``
     )  # Resolve the original path with respect to ``new_root``
 
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
No issue was created.

#### Why is this change necessary?
Running `sam build` against a template that is in a symlinked directory results in incorrect relative paths in the generated template. (See additional context below)

#### How does it address the issue?
This change resolves symlinks in the `original_root` and `new_root` before updating relative paths in the generated template at the end of a build.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).

#### Additional Context
Given the project structure:
```
.
├── .aws-sam
│   └── build
│       ├── LambdaFunction
│       └── template.yaml
├── build -> /some/other/directory/build
│   └── cdk.out
│       └── Application.template.json
└── lib
    └── app.ts
```
When the project is built via `sam build -t build/cdk.out/Application.template.json`, in `app_builder.py` absolute paths are constructed by resolving all symlinks and then made relative as seen [here](https://github.com/aws/aws-sam-cli/blob/develop/samcli/lib/build/app_builder.py#L332). Before the template is written, the relative file paths are updated to be relative to a `new_root`, however neither the `new_root` nor the `original_root` are resolved to accommodate symlinks. This results in an incorrect code path and `sam local invoke` fails to mount the source.