### PR TITLE
chore: add gh action to update app templates hash

### DIFF
--- a/.github/workflows/update_app_templates_hash.yml
+++ b/.github/workflows/update_app_templates_hash.yml
@@ -1,0 +1,43 @@
+name: Update aws/aws-sam-cli with latest commit hash from aws/aws-sam-cli-app-templates
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  updateCommitHash:
+    permissions:
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout App Templates
+        uses: actions/checkout@v3
+        with:
+          repository: aws/aws-sam-cli-app-templates
+          path: aws-sam-cli-app-templates
+
+      - name: Checkout SAM CLI
+        uses: actions/checkout@v3
+        with:
+          repository: aws/aws-sam-cli
+          path: aws-sam-cli
+
+      - name: Update commit hash in SAM CLI from App Templates
+        run: |
+          cd aws-sam-cli-app-templates
+          export APP_TEMPLATES_COMMIT_HASH=$(git rev-parse HEAD)
+          cd ../aws-sam-cli
+          cat <<< $(jq --arg commit_hash "$APP_TEMPLATES_COMMIT_HASH" --indent 4 '.app_template_repo_commit =  $commit_hash' samcli/runtime_config.json) > samcli/runtime_config.json
+
+      - name: Raise PR for SAM CLI
+        uses: peter-evans/create-pull-request@v4
+        with:
+          path: aws-sam-cli
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update_app_templates_hash
+          delete-branch: true
+          title: 'feat: update SAM CLI with latest App Templates commit hash'
+          body:
+            This PR & commit is automatically created by GH action to update the aws/aws-sam-cli with latest hash of the aws/aws-sam-cli-app-templates.

--- a/.github/workflows/update_app_templates_hash.yml
+++ b/.github/workflows/update_app_templates_hash.yml
@@ -2,7 +2,7 @@ name: Update aws/aws-sam-cli with latest commit hash from aws/aws-sam-cli-app-te
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 * * * *" # run at the top of every hour
   workflow_dispatch: {}
 
 jobs:
@@ -24,20 +24,22 @@ jobs:
           repository: aws/aws-sam-cli
           path: aws-sam-cli
 
-      - name: Update commit hash in SAM CLI from App Templates
+      - name: Update hash & Raise PR for SAM CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
           cd aws-sam-cli-app-templates
-          export APP_TEMPLATES_COMMIT_HASH=$(git rev-parse HEAD)
+          APP_TEMPLATES_COMMIT_HASH=$(git rev-parse HEAD)
           cd ../aws-sam-cli
-          cat <<< $(jq --arg commit_hash "$APP_TEMPLATES_COMMIT_HASH" --indent 2 '.app_template_repo_commit =  $commit_hash' samcli/runtime_config.json) > samcli/runtime_config.json
-
-      - name: Raise PR for SAM CLI
-        uses: peter-evans/create-pull-request@v4
-        with:
-          path: aws-sam-cli
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: update_app_templates_hash
-          delete-branch: true
-          title: 'feat: update SAM CLI with latest App Templates commit hash'
-          body:
-            This PR & commit is automatically created by GH action to update the aws/aws-sam-cli with latest hash of the aws/aws-sam-cli-app-templates.
+          git checkout -b update_app_templates_hash
+          git reset --hard develop
+          cat <<< $(jq --arg commit_hash "$APP_TEMPLATES_COMMIT_HASH" --indent 4 '.app_template_repo_commit =  $commit_hash' samcli/runtime_config.json) > samcli/runtime_config.json
+          git status
+          git diff --quiet && exit 0 # exit if there is no change
+          git add -u
+          git commit -m "feat: updating app templates repo hash with ($APP_TEMPLATES_COMMIT_HASH)"
+          git push --force origin update_app_templates_hash
+          gh pr list --repo mndeveci/mock-cli --head update_app_templates_hash --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
+          gh pr create --base develop --head update_app_templates_hash --title "feat: update SAM CLI with latest App Templates commit hash" --body "This PR & commit is automatically created from App Templates repo to update the SAM CLI with latest hash of the App Templates."

--- a/.github/workflows/update_app_templates_hash.yml
+++ b/.github/workflows/update_app_templates_hash.yml
@@ -35,7 +35,7 @@ jobs:
           cd ../aws-sam-cli
           git checkout -b update_app_templates_hash
           git reset --hard develop
-          cat <<< $(jq --arg commit_hash "$APP_TEMPLATES_COMMIT_HASH" --indent 4 '.app_template_repo_commit =  $commit_hash' samcli/runtime_config.json) > samcli/runtime_config.json
+          cat <<< "$(jq --arg commit_hash "$APP_TEMPLATES_COMMIT_HASH" --indent 4 '.app_template_repo_commit =  $commit_hash' samcli/runtime_config.json)" > samcli/runtime_config.json
           git status
           git diff --quiet && exit 0 # exit if there is no change
           git add -u

--- a/.github/workflows/update_app_templates_hash.yml
+++ b/.github/workflows/update_app_templates_hash.yml
@@ -24,9 +24,7 @@ jobs:
           repository: aws/aws-sam-cli
           path: aws-sam-cli
 
-      - name: Update hash & Raise PR for SAM CLI
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update hash & commit
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
@@ -38,8 +36,16 @@ jobs:
           cat <<< "$(jq --arg commit_hash "$APP_TEMPLATES_COMMIT_HASH" --indent 4 '.app_template_repo_commit =  $commit_hash' samcli/runtime_config.json)" > samcli/runtime_config.json
           git status
           git diff --quiet && exit 0 # exit if there is no change
+          echo "is_hash_changed=1" >> $GITHUB_ENV # set env variable for next step run decision
           git add -u
           git commit -m "feat: updating app templates repo hash with ($APP_TEMPLATES_COMMIT_HASH)"
+
+      - name: Raise PR for SAM CLI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ env.is_hash_changed == 1 }} # run only if there was a change
+        run: |
+          cd aws-sam-cli
           git push --force origin update_app_templates_hash
           gh pr list --repo aws/aws-sam-cli --head update_app_templates_hash --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
           gh pr create --base develop --head update_app_templates_hash --title "feat: update SAM CLI with latest App Templates commit hash" --body "This PR & commit is automatically created from App Templates repo to update the SAM CLI with latest hash of the App Templates."

--- a/.github/workflows/update_app_templates_hash.yml
+++ b/.github/workflows/update_app_templates_hash.yml
@@ -41,5 +41,5 @@ jobs:
           git add -u
           git commit -m "feat: updating app templates repo hash with ($APP_TEMPLATES_COMMIT_HASH)"
           git push --force origin update_app_templates_hash
-          gh pr list --repo mndeveci/mock-cli --head update_app_templates_hash --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
+          gh pr list --repo aws/aws-sam-cli --head update_app_templates_hash --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
           gh pr create --base develop --head update_app_templates_hash --title "feat: update SAM CLI with latest App Templates commit hash" --body "This PR & commit is automatically created from App Templates repo to update the SAM CLI with latest hash of the App Templates."

--- a/.github/workflows/update_app_templates_hash.yml
+++ b/.github/workflows/update_app_templates_hash.yml
@@ -29,7 +29,7 @@ jobs:
           cd aws-sam-cli-app-templates
           export APP_TEMPLATES_COMMIT_HASH=$(git rev-parse HEAD)
           cd ../aws-sam-cli
-          cat <<< $(jq --arg commit_hash "$APP_TEMPLATES_COMMIT_HASH" --indent 4 '.app_template_repo_commit =  $commit_hash' samcli/runtime_config.json) > samcli/runtime_config.json
+          cat <<< $(jq --arg commit_hash "$APP_TEMPLATES_COMMIT_HASH" --indent 2 '.app_template_repo_commit =  $commit_hash' samcli/runtime_config.json) > samcli/runtime_config.json
 
       - name: Raise PR for SAM CLI
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
We recently added a configuration file which keeps the latest commit hash from aws/aws-sam-cli-app-templates repositorty. This GH action is updating that hash value in configuration by running it every hour (or manually).

Test run in fork: https://github.com/mndeveci/aws-sam-cli/actions/runs/2223773270
Result PR in fork: https://github.com/mndeveci/aws-sam-cli/pull/3

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
