### PR TITLE
Fix tests to not depend on changeable value

### DIFF
--- a/tests/unit/lib/utils/test_configuration.py
+++ b/tests/unit/lib/utils/test_configuration.py
@@ -1,7 +1,25 @@
 from unittest.case import TestCase
+from unittest.mock import patch
+
+from click import ClickException
 from samcli.lib.utils import configuration
 
 
 class TestConfiguration(TestCase):
-    def test_return_correct_value(self):
-        self.assertEqual(configuration.get_app_template_repo_commit(), "09b7de41c32ee5f50ec8ceeec4a304534767844b")
+    def test_config_is_read(self):
+        self.assertIsInstance(configuration.config, dict)
+        self.assertIn("app_template_repo_commit", configuration.config)
+
+    @patch("samcli.lib.utils.configuration.config")
+    def test_get_app_template_repo_commit_return_correct_value(self, config_mock):
+        config_mock.get.return_value = "some_commit_hash"
+        commit_hash = configuration.get_app_template_repo_commit()
+        config_mock.get.assert_called_once_with("app_template_repo_commit", None)
+        self.assertEqual(commit_hash, "some_commit_hash")
+
+    @patch("samcli.lib.utils.configuration.config")
+    def test_get_app_template_repo_commit_error(self, config_mock):
+        config_mock.get.return_value = None
+        with self.assertRaises(ClickException):
+            configuration.get_app_template_repo_commit()
+            config_mock.get.assert_called_once_with("app_template_repo_commit", None)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
The test originally tested against the value set in `samcli/runtime_config.json`. However, since merging PR #3838, the value can change from time to time. This PR fixes the test and improves coverage.


#### How does it address the issue?
mock `config.get` to return a fake value for testing. Also add test to test `samcli/runtime_config.json` is read properly.


#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
