### PR TITLE
fix: deploy and init integration tests

### DIFF
--- a/tests/integration/deploy/deploy_integ_base.py
+++ b/tests/integration/deploy/deploy_integ_base.py
@@ -169,7 +169,7 @@ class DeployIntegBase(TestCase):
         return command_list
 
     @staticmethod
-    def get_minimal_build_command_list(self, template_file=None, build_dir=None):
+    def get_minimal_build_command_list(template_file=None, build_dir=None):
         command_list = [get_sam_command(), "build"]
 
         if template_file:

--- a/tests/integration/init/schemas/test_init_with_schemas_command.py
+++ b/tests/integration/init/schemas/test_init_with_schemas_command.py
@@ -332,4 +332,3 @@ Y
             result = runner.invoke(init_cmd, ["--output-dir", temp], input=user_input)
             self.assertTrue(result.exception)
             self._tear_down_custom_config()
-

--- a/tests/integration/init/schemas/test_init_with_schemas_command.py
+++ b/tests/integration/init/schemas/test_init_with_schemas_command.py
@@ -1,12 +1,11 @@
 import os
 import tempfile
+from pathlib import Path
 from unittest import skipIf
 
 from click.testing import CliRunner
-from samcli.commands.init import cli as init_cmd
-from pathlib import Path
 
-from samcli.lib.utils.packagetype import ZIP
+from samcli.commands.init import cli as init_cmd
 from tests.integration.init.schemas.schemas_test_data_setup import SchemaTestDataSetup
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
 
@@ -23,6 +22,7 @@ class TestBasicInitWithEventBridgeCommand(SchemaTestDataSetup):
         # 2: Java Runtime (java11)
         # 2: Maven
         # 2: select event-bridge app from scratch
+        # N: disable adding xray tracing
         # test-project: response to name
         # Y: Use default aws configuration
         # 1: select schema from cli_paginator
@@ -35,6 +35,7 @@ class TestBasicInitWithEventBridgeCommand(SchemaTestDataSetup):
 2
 2
 2
+N
 eb-app-maven
 Y
 1
@@ -61,6 +62,7 @@ Y
         # 2: Java Runtime
         # 2: Maven
         # 2: select event-bridge app from scratch
+        # N: disable adding xray tracing
         # test-project: response to name
         # Y: Use default aws configuration
         # 3: partner registry
@@ -72,6 +74,7 @@ Y
 2
 2
 2
+N
 eb-app-maven
 Y
 3
@@ -108,6 +111,7 @@ Y
         # 2: Java Runtime
         # 2: Maven
         # 2: select event-bridge app from scratch
+        # N: disable adding xray tracing
         # eb-app-maven: response to name
         # Y: Use default aws configuration
         # 4: select pagination-registry as registries
@@ -121,6 +125,7 @@ Y
 2
 2
 2
+N
 eb-app-maven
 Y
 4
@@ -148,6 +153,7 @@ P
         # 2: Java Runtime
         # 2: Maven
         # 2: select event-bridge app from scratch
+        # N: disable adding xray tracing
         # eb-app-maven: response to name
         # Y: Use default aws configuration
         # 2: select 2p-schema other-schema
@@ -159,6 +165,7 @@ P
 2
 2
 2
+N
 eb-app-maven
 Y
 2
@@ -194,6 +201,7 @@ Y
         # 7: Infrastructure event management - Use case
         # 6: Python 3.8
         # 2: select event-bridge app from scratch
+        # N: disable adding xray tracing
         # eb-app-python38: response to name
         # Y: Use default aws configuration
         # 4: select aws.events as registries
@@ -204,6 +212,7 @@ Y
 7
 6
 2
+N
 eb-app-python38
 Y
 1
@@ -226,6 +235,7 @@ Y
         # 7: Infrastructure event management - Use case
         # 1: Go 1.x
         # 2: select event-bridge app from scratch
+        # N: disable adding xray tracing
         # eb-app-go: response to name
         # Y: Use default aws configuration
         # 4: select aws.events as registries
@@ -236,6 +246,7 @@ Y
 7
 1
 2
+N
 eb-app-go
 Y
 4
@@ -258,6 +269,7 @@ Y
         # 3: Infrastructure event management - Use case
         # 6: Python 3.8
         # 2: select event-bridge app from scratch
+        # N: disable adding xray tracing
         # eb-app-python38: response to name
         # N: Use default profile
         # 2: uses second profile from displayed one (myprofile)
@@ -270,6 +282,7 @@ Y
 7
 6
 2
+N
 eb-app-python38
 3
 N
@@ -297,6 +310,7 @@ us-east-1
         # 7: Infrastructure event management - Use case
         # 6: Python 3.8
         # 2: select event-bridge app from scratch
+        # N: disable adding xray tracing
         # eb-app-python38: response to name
         # Y: Use default profile
         # 1: select aws.events as registries
@@ -307,6 +321,7 @@ us-east-1
 7
 6
 2
+N
 eb-app-python38
 Y
 1
@@ -318,9 +333,3 @@ Y
             self.assertTrue(result.exception)
             self._tear_down_custom_config()
 
-
-def _get_command():
-    command = "sam"
-    if os.getenv("SAM_CLI_DEV"):
-        command = "samdev"
-    return command

--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -1,14 +1,18 @@
-from samcli.lib.utils.osutils import stderr
+from click.testing import CliRunner
+
+from samcli.commands.init import cli as init_cmd
 from unittest import TestCase
 
 from parameterized import parameterized
-from subprocess import STDOUT, Popen, TimeoutExpired, PIPE
+from subprocess import Popen, TimeoutExpired, PIPE
 import os
 import shutil
 import tempfile
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 
 from pathlib import Path
+
+from tests.testing_utils import get_sam_command
 
 TIMEOUT = 300
 
@@ -20,7 +24,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -54,7 +58,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--package-type",
                     IMAGE,
@@ -82,7 +86,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -114,7 +118,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "java8",
@@ -146,7 +150,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "java8",
@@ -178,7 +182,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "java8",
@@ -212,7 +216,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -246,7 +250,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -280,7 +284,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -313,7 +317,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -342,7 +346,7 @@ class TestBasicInitCommand(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -390,7 +394,7 @@ class TestInitForParametersCompatibility(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -421,7 +425,7 @@ class TestInitForParametersCompatibility(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--app-template",
                     "hello-world",
@@ -453,7 +457,7 @@ class TestInitForParametersCompatibility(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--runtime",
                     "nodejs14.x",
@@ -484,7 +488,7 @@ class TestInitForParametersCompatibility(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--base-image",
                     "amazon/nodejs14.x-base",
@@ -516,7 +520,7 @@ class TestInitForParametersCompatibility(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--package-type",
                     IMAGE,
@@ -545,7 +549,7 @@ class TestInitForParametersCompatibility(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--package-type",
                     ZIP,
@@ -577,7 +581,7 @@ class TestInitForParametersCompatibility(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--base-image",
                     "amazon/nodejs14.x-base",
@@ -604,7 +608,7 @@ class TestInitForParametersCompatibility(TestCase):
         with tempfile.TemporaryDirectory() as temp:
             process = Popen(
                 [
-                    _get_command(),
+                    get_sam_command(),
                     "init",
                     "--package-type",
                     "WrongPT",
@@ -628,7 +632,7 @@ Try '{0} init -h' for help.
 
 Error: Invalid value for '-p' / '--package-type': invalid choice: WrongPT. (choose from Zip, Image)
                         """.format(
-                _get_command()
+                get_sam_command()
             )
 
             self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
@@ -652,7 +656,7 @@ class TestInitWithArbitraryProject(TestCase):
     @parameterized.expand([(None,), ("project_name",)])
     def test_arbitrary_project(self, project_name):
         with tempfile.TemporaryDirectory() as temp:
-            args = [_get_command(), "init", "--location", self.zip_path, "-o", temp]
+            args = [get_sam_command(), "init", "--location", self.zip_path, "-o", temp]
             if project_name:
                 args.extend(["--name", project_name])
 
@@ -671,7 +675,7 @@ class TestInitWithArbitraryProject(TestCase):
 
     def test_zip_not_exists(self):
         with tempfile.TemporaryDirectory() as temp:
-            args = [_get_command(), "init", "--location", str(Path("invalid", "zip", "path")), "-o", temp]
+            args = [get_sam_command(), "init", "--location", str(Path("invalid", "zip", "path")), "-o", temp]
 
             process = Popen(args)
             try:
@@ -683,8 +687,53 @@ class TestInitWithArbitraryProject(TestCase):
             self.assertEqual(process.returncode, 1)
 
 
-def _get_command():
-    command = "sam"
-    if os.getenv("SAM_CLI_DEV"):
-        command = "samdev"
-    return command
+class TestInteractiveInit(TestCase):
+
+    def test_interactive_init(self):
+        user_input = """
+1
+1
+N
+8
+1
+1
+N
+sam-interactive-init-app
+        """
+        with tempfile.TemporaryDirectory() as temp:
+            runner = CliRunner()
+            result = runner.invoke(init_cmd, ["--output-dir", temp, "--debug"], input=user_input)
+
+            self.assertFalse(result.exception)
+            expected_output_folder = Path(temp, "sam-interactive-init-app")
+            self.assertTrue(expected_output_folder.exists)
+            self.assertTrue(expected_output_folder.is_dir())
+            self.assertTrue(
+                Path(expected_output_folder, "hello-world").is_dir()
+            )
+            self.assertTrue(
+                Path(expected_output_folder, "hello-world", "app.js").is_file()
+            )
+
+    def test_interactive_init_default_runtime(self):
+        user_input = """
+1
+1
+Y
+N
+sam-interactive-init-app-default-runtime
+        """
+        with tempfile.TemporaryDirectory() as temp:
+            runner = CliRunner()
+            result = runner.invoke(init_cmd, ["--output-dir", temp, "--debug"], input=user_input)
+
+            self.assertFalse(result.exception)
+            expected_output_folder = Path(temp, "sam-interactive-init-app-default-runtime")
+            self.assertTrue(expected_output_folder.exists)
+            self.assertTrue(expected_output_folder.is_dir())
+            self.assertTrue(
+                Path(expected_output_folder, "hello_world").is_dir()
+            )
+            self.assertTrue(
+                Path(expected_output_folder, "hello_world", "app.py").is_file()
+            )

--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -688,7 +688,6 @@ class TestInitWithArbitraryProject(TestCase):
 
 
 class TestInteractiveInit(TestCase):
-
     def test_interactive_init(self):
         user_input = """
 1
@@ -708,12 +707,8 @@ sam-interactive-init-app
             expected_output_folder = Path(temp, "sam-interactive-init-app")
             self.assertTrue(expected_output_folder.exists)
             self.assertTrue(expected_output_folder.is_dir())
-            self.assertTrue(
-                Path(expected_output_folder, "hello-world").is_dir()
-            )
-            self.assertTrue(
-                Path(expected_output_folder, "hello-world", "app.js").is_file()
-            )
+            self.assertTrue(Path(expected_output_folder, "hello-world").is_dir())
+            self.assertTrue(Path(expected_output_folder, "hello-world", "app.js").is_file())
 
     def test_interactive_init_default_runtime(self):
         user_input = """
@@ -731,9 +726,5 @@ sam-interactive-init-app-default-runtime
             expected_output_folder = Path(temp, "sam-interactive-init-app-default-runtime")
             self.assertTrue(expected_output_folder.exists)
             self.assertTrue(expected_output_folder.is_dir())
-            self.assertTrue(
-                Path(expected_output_folder, "hello_world").is_dir()
-            )
-            self.assertTrue(
-                Path(expected_output_folder, "hello_world", "app.py").is_file()
-            )
+            self.assertTrue(Path(expected_output_folder, "hello_world").is_dir())
+            self.assertTrue(Path(expected_output_folder, "hello_world", "app.py").is_file())


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
To fix the failing integration tests.


#### How does it address the issue?
Recent addition to `sam init` interactive workflow has affected some of the init integration tests. There was also misconfiguration from recent refactoring which affected one of the `sam deploy` integration tests.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
