### PR TITLE
fix: command should not fail when global config fails to write

### DIFF
--- a/samcli/cli/global_config.py
+++ b/samcli/cli/global_config.py
@@ -307,7 +307,7 @@ class GlobalConfig(metaclass=Singleton):
             for key in json_body:
                 self._persistent_fields.append(key)
         except (OSError, ValueError) as ex:
-            LOG.debug(
+            LOG.warning(
                 "Error when loading global config file: %s",
                 self.config_path,
                 exc_info=ex,
@@ -325,7 +325,7 @@ class GlobalConfig(metaclass=Singleton):
                 self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
             self.config_path.write_text(json_str)
         except (OSError, ValueError) as ex:
-            LOG.debug(
+            LOG.warning(
                 "Error when writing global config file: %s",
                 self.config_path,
                 exc_info=ex,

--- a/samcli/cli/global_config.py
+++ b/samcli/cli/global_config.py
@@ -319,10 +319,17 @@ class GlobalConfig(metaclass=Singleton):
         if not self._config_data:
             return
         config_data = {key: value for (key, value) in self._config_data.items() if key in self._persistent_fields}
-        json_str = json.dumps(config_data, indent=4)
-        if not self.config_dir.exists():
-            self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-        self.config_path.write_text(json_str)
+        try:
+            json_str = json.dumps(config_data, indent=4)
+            if not self.config_dir.exists():
+                self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            self.config_path.write_text(json_str)
+        except (OSError, ValueError) as ex:
+            LOG.debug(
+                "Error when writing global config file: %s",
+                self.config_path,
+                exc_info=ex,
+            )
 
     @property
     def installation_id(self):

--- a/tests/functional/commands/cli/test_global_config.py
+++ b/tests/functional/commands/cli/test_global_config.py
@@ -4,7 +4,7 @@ import shutil
 import os
 from time import time
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, ANY
 from unittest import TestCase
 from samcli.cli.global_config import GlobalConfig
 from pathlib import Path
@@ -237,7 +237,8 @@ class TestGlobalConfig(TestCase):
         gc.telemetry_enabled = True
         self.assertTrue(gc.telemetry_enabled)
 
-    def test_setter_cannot_open_file(self):
+    @patch("samcli.cli.global_config.LOG")
+    def test_setter_cannot_open_file(self, patched_logger):
         path = Path(self._cfg_dir, "metadata.json")
         with open(str(path), "w") as f:
             cfg = {"telemetryEnabled": True}
@@ -247,5 +248,5 @@ class TestGlobalConfig(TestCase):
         gc = GlobalConfig()
         gc.config_dir = Path(self._cfg_dir)
         with patch("samcli.cli.global_config.Path.write_text", m):
-            with self.assertRaises(OSError):
-                gc.telemetry_enabled = True
+            gc.telemetry_enabled = True
+            patched_logger.warning.assert_called_with("Error when writing global config file: %s", ANY, exc_info=ANY)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#3855


#### Why is this change necessary?
SAM CLI writes its `GlobalConfig` object when getting or setting its persistent configuration values. If a folder is configured which user doesn't have write access, getting or setting these values might fail, which will also affect the running command.

#### How does it address the issue?
Move write into a try/except block so that failing while persisting a configuration won't affect running command.

#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
