### PR TITLE
fix: Fixing the trace event class to support trace_id option

### DIFF
--- a/samcli/lib/observability/xray_traces/xray_event_mappers.py
+++ b/samcli/lib/observability/xray_traces/xray_event_mappers.py
@@ -24,8 +24,9 @@ class XRayTraceConsoleMapper(ObservabilityEventMapper[XRayTraceEvent]):
     def map(self, event: XRayTraceEvent) -> XRayTraceEvent:
         formatted_segments = self.format_segments(event.segments)
         iso_formatted_timestamp = datetime.fromtimestamp(event.timestamp).isoformat()
+        revision_info = f"[revision {event.revision}] " if event.revision else ""
         mapped_message = (
-            f"\nXRay Event [revision {event.revision}] at ({iso_formatted_timestamp}) with \
+            f"\nXRay Event {revision_info}at ({iso_formatted_timestamp}) with \
 id ({event.id}) and duration ({event.duration:.3f}s)"
             f"{formatted_segments}"
         )

--- a/samcli/lib/observability/xray_traces/xray_events.py
+++ b/samcli/lib/observability/xray_traces/xray_events.py
@@ -18,7 +18,7 @@ class XRayTraceEvent(ObservabilityEvent[dict]):
     See XRayTracePuller
     """
 
-    def __init__(self, event: dict, revision: Optional[int]):
+    def __init__(self, event: dict, revision: Optional[int] = None):
         super().__init__(event, 0)
         self.id = event.get("Id", "")
         # A revision number will be passed to link with the event


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N.A.

#### Why is this change necessary?
Our previous fix on traces that introduced revision number to trace events, which is incompatible with traces command's trace_id option.

#### How does it address the issue?
Made this revision change compatible with trace_id option.

#### What side effects does this change have?
Not known.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
