### PR TITLE
feat: nested stack support for sam logs

### DIFF
--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -41,7 +41,7 @@ $ sam logs -n HelloWorldFunction --stack-name mystack --filter "error" \n
 \b
 [Beta Features]
 \b
-You can now fetch logs from supported resource, by only providing --stack-name parameter
+You can now fetch logs from supported resources, by only providing --stack-name parameter
 $ sam logs --stack-name mystack \n
 \b
 You can also fetch logs from a resource which is defined in a nested stack.

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -38,6 +38,14 @@ $ sam logs -n HelloWorldFunction --stack-name mystack --tail \n
 \b
 Use the --filter option to quickly find logs that match terms, phrases or values in your log events.
 $ sam logs -n HelloWorldFunction --stack-name mystack --filter "error" \n
+\b
+[Beta Features]
+\b
+You can now fetch logs from supported resource, by only providing --stack-name parameter
+$ sam logs --stack-name mystack \n
+\b
+You can also fetch logs from a resource which is defined in a nested stack.
+$ sam logs --stack-name mystack -n MyNestedStack/HelloWorldFunction
 """
 
 
@@ -50,8 +58,10 @@ $ sam logs -n HelloWorldFunction --stack-name mystack --filter "error" \n
     help="Name(s) of your AWS Lambda function. If this function is a part of a CloudFormation stack, "
     "this can be the LogicalID of function resource in the CloudFormation/SAM template. "
     "[Beta Feature] Multiple names can be provided by repeating the parameter again. "
+    "If resource is in a nested stack, name can be prepended by nested stack name to pull logs "
+    "from that resource (NestedStackLogicalId/ResourceLogicalId). "
     "If it is not provided and no --cw-log-group have been given, it will scan "
-    "given stack and find all possible resources, and start pulling log information from them.",
+    "given stack and find all supported resources, and start pulling log information from them.",
 )
 @click.option("--stack-name", default=None, help="Name of the AWS CloudFormation stack that the function is a part of.")
 @click.option(

--- a/samcli/lib/observability/xray_traces/xray_events.py
+++ b/samcli/lib/observability/xray_traces/xray_events.py
@@ -23,8 +23,7 @@ class XRayTraceEvent(ObservabilityEvent[dict]):
         self.id = event.get("Id", "")
         # A revision number will be passed to link with the event
         # The same x-ray event will differ in information on different revisions
-        if revision:
-            self.revision = revision
+        self.revision = revision
         self.duration = event.get("Duration", 0.0)
         self.message = json.dumps(event)
         self.segments: List[XRayTraceSegment] = []

--- a/samcli/lib/utils/cloudformation.py
+++ b/samcli/lib/utils/cloudformation.py
@@ -2,7 +2,8 @@
 This utility file contains methods to read information from certain CFN stack
 """
 import logging
-from typing import List, Dict, Set, Optional
+import posixpath
+from typing import Dict, Set, Optional
 
 from attr import dataclass
 from botocore.exceptions import ClientError
@@ -22,7 +23,6 @@ class CloudFormationResourceSummary:
     resource_type: str
     logical_resource_id: str
     physical_resource_id: str
-    nested_stack_resources: List["CloudFormationResourceSummary"]
 
 
 def get_physical_id_mapping(
@@ -49,15 +49,18 @@ def get_physical_id_mapping(
     resource_summaries = get_resource_summaries(boto_resource_provider, stack_name, resource_types)
 
     resource_physical_id_map: Dict[str, str] = {}
-    for resource_summary in resource_summaries:
-        resource_physical_id_map[resource_summary.logical_resource_id] = resource_summary.physical_resource_id
+    for resource_key, resource_summary in resource_summaries.items():
+        resource_physical_id_map[resource_key] = resource_summary.physical_resource_id
 
     return resource_physical_id_map
 
 
 def get_resource_summaries(
-    boto_resource_provider: BotoProviderType, stack_name: str, resource_types: Optional[Set[str]] = None
-) -> List[CloudFormationResourceSummary]:
+    boto_resource_provider: BotoProviderType,
+    stack_name: str,
+    resource_types: Optional[Set[str]] = None,
+    nested_stack_prefix: Optional[str] = None,
+) -> Dict[str, CloudFormationResourceSummary]:
     """
     Collects information about CFN resources and return their summary as list
 
@@ -69,6 +72,9 @@ def get_resource_summaries(
         Name of the stack which is deployed to CFN
     resource_types : Optional[Set[str]]
         List of resource types, which will filter the results
+    nested_stack_prefix: Optional[str]
+        This will contain logical id of the parent stack. So that ChildStackA/GrandChildStackB so that resources
+        under GrandChildStackB can create their keys like ChildStackA/GrandChildStackB/MyFunction
 
     Returns
     -------
@@ -77,20 +83,26 @@ def get_resource_summaries(
     """
     LOG.debug("Fetching stack (%s) resources", stack_name)
     cfn_resource_summaries = boto_resource_provider("cloudformation").Stack(stack_name).resource_summaries.all()
-    resource_summaries: List[CloudFormationResourceSummary] = []
+    resource_summaries: Dict[str, CloudFormationResourceSummary] = {}
 
     for cfn_resource_summary in cfn_resource_summaries:
         resource_summary = CloudFormationResourceSummary(
             cfn_resource_summary.resource_type,
             cfn_resource_summary.logical_resource_id,
             cfn_resource_summary.physical_resource_id,
-            [],
         )
         if resource_summary.resource_type == AWS_CLOUDFORMATION_STACK:
-            resource_summary.nested_stack_resources.extend(
-                get_resource_summaries(boto_resource_provider, resource_summary.physical_resource_id, resource_types)
+            new_nested_stack_prefix = resource_summary.logical_resource_id
+            if nested_stack_prefix:
+                new_nested_stack_prefix = posixpath.join(nested_stack_prefix, new_nested_stack_prefix)
+            resource_summaries.update(
+                get_resource_summaries(
+                    boto_resource_provider,
+                    resource_summary.physical_resource_id,
+                    resource_types,
+                    new_nested_stack_prefix,
+                )
             )
-            resource_summaries.append(resource_summary)
         if resource_types and resource_summary.resource_type not in resource_types:
             LOG.debug(
                 "Skipping resource %s since its type %s is not supported. Supported types %s",
@@ -100,7 +112,10 @@ def get_resource_summaries(
             )
             continue
 
-        resource_summaries.append(resource_summary)
+        resource_key = resource_summary.logical_resource_id
+        if nested_stack_prefix:
+            resource_key = posixpath.join(nested_stack_prefix, resource_key)
+        resource_summaries[resource_key] = resource_summary
 
     return resource_summaries
 
@@ -129,7 +144,6 @@ def get_resource_summary(boto_resource_provider: BotoProviderType, stack_name: s
             cfn_resource_summary.resource_type,
             cfn_resource_summary.logical_resource_id,
             cfn_resource_summary.physical_resource_id,
-            [],
         )
     except ClientError as e:
         LOG.error(

--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -207,7 +207,7 @@ class TestLogsCommand(LogsIntegBase):
         cmd_list = self.get_logs_command_list(
             self.stack_name, name=function_name, include_traces=True, beta_features=True
         )
-        self._check_logs(cmd_list, ["New XRay Service Graph", "XRay Event at", expected_log_output])
+        self._check_logs(cmd_list, ["New XRay Service Graph", "XRay Event [revision ", expected_log_output])
 
     def _check_logs(self, cmd_list: List, log_strings: List[str], output: str = "text", retries=RETRY_COUNT):
         for _ in range(retries):

--- a/tests/integration/sync/test_sync_infra.py
+++ b/tests/integration/sync/test_sync_infra.py
@@ -114,10 +114,10 @@ class TestSyncInfra(SyncIntegBase):
         if runtime == "python":
             # ApiGateway Api call here, which tests the RestApi
             rest_api = self.stack_resources.get(AWS_APIGATEWAY_RESTAPI)[0]
-            self.assertEqual(self._get_api_message(rest_api), '{"message": "hello 1"}')
+            self.assertEqual(self._get_api_message(rest_api), '{"message": "hello 2"}')
             # SFN Api call here, which tests the StateMachine
             state_machine = self.stack_resources.get(AWS_STEPFUNCTIONS_STATEMACHINE)[0]
-            self.assertEqual(self._get_sfn_response(state_machine), '"World 1"')
+            self.assertEqual(self._get_sfn_response(state_machine), '"World 2"')
 
     @parameterized.expand(["infra/template-python-before.yaml"])
     def test_sync_infra_no_confirm(self, template_file):

--- a/tests/unit/commands/logs/test_logs_context.py
+++ b/tests/unit/commands/logs/test_logs_context.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 from samcli.commands.exceptions import UserException
 from samcli.commands.logs.logs_context import parse_time, ResourcePhysicalIdResolver
 from samcli.lib.utils.cloudformation import CloudFormationResourceSummary
+from samcli.lib.utils.resources import AWS_CLOUDFORMATION_STACK
 
 AWS_SOME_RESOURCE = "AWS::Some::Resource"
 AWS_LAMBDA_FUNCTION = "AWS::Lambda::Function"
@@ -87,43 +88,95 @@ class TestResourcePhysicalIdResolver(TestCase):
     def test_fetch_all_resources(self, patched_get_resources):
         resource_physical_id_resolver = ResourcePhysicalIdResolver(Mock(), "stack_name", [])
         mocked_return_value = [
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1"),
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2"),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_3", "physical_id_3"),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_4", "physical_id_4"),
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1", []),
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2", []),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_3", "physical_id_3", []),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_4", "physical_id_4", []),
+            CloudFormationResourceSummary(
+                AWS_CLOUDFORMATION_STACK,
+                "logical_id_5",
+                "physical_id_5",
+                [
+                    CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_6", "physical_id_6", []),
+                    CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_7", "physical_id_7", []),
+                ],
+            ),
         ]
         patched_get_resources.return_value = mocked_return_value
 
         actual_result = resource_physical_id_resolver._fetch_resources_from_stack()
-        self.assertEqual(len(actual_result), 4)
+        self.assertEqual(len(actual_result), 6)
 
         expected_results = [
-            item
-            for item in mocked_return_value
-            if item.resource_type in ResourcePhysicalIdResolver.DEFAULT_SUPPORTED_RESOURCES
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1", []),
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2", []),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_3", "physical_id_3", []),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_4", "physical_id_4", []),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_6", "physical_id_6", []),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_7", "physical_id_7", []),
         ]
         self.assertEqual(expected_results, actual_result)
 
     @patch("samcli.commands.logs.logs_context.get_resource_summaries")
     def test_fetch_given_resources(self, patched_get_resources):
-        given_resources = ["logical_id_1", "logical_id_2", "logical_id_3", "logical_id_5", "logical_id_6"]
+        given_resources = [
+            "logical_id_1",
+            "logical_id_2",
+            "logical_id_3",
+            "logical_id_5",
+            "logical_id_6",
+            "StackA/logical_id_7",
+            "StackA/StackB/logical_id_9",
+            "StackA/StackB/StackC/logical_id_11",
+        ]
         resource_physical_id_resolver = ResourcePhysicalIdResolver(Mock(), "stack_name", given_resources)
         mocked_return_value = [
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1"),
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2"),
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_3", "physical_id_3"),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_4", "physical_id_4"),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_5", "physical_id_5"),
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1", []),
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2", []),
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_3", "physical_id_3", []),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_4", "physical_id_4", []),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_5", "physical_id_5", []),
+            CloudFormationResourceSummary(
+                AWS_CLOUDFORMATION_STACK,
+                "StackA",
+                "physical_id_StackA",
+                [
+                    CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_7", "physical_id_7", []),
+                    CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_8", "physical_id_8", []),
+                    CloudFormationResourceSummary(
+                        AWS_CLOUDFORMATION_STACK,
+                        "StackB",
+                        "physical_id_StackB",
+                        [
+                            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_9", "physical_id_9", []),
+                            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_10", "physical_id_10", []),
+                            CloudFormationResourceSummary(
+                                AWS_CLOUDFORMATION_STACK,
+                                "StackC",
+                                "physical_id_StackC",
+                                [
+                                    CloudFormationResourceSummary(
+                                        AWS_LAMBDA_FUNCTION, "logical_id_11", "physical_id_11", []
+                                    ),
+                                    CloudFormationResourceSummary(
+                                        AWS_LAMBDA_FUNCTION, "logical_id_12", "physical_id_12", []
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
         ]
         patched_get_resources.return_value = mocked_return_value
 
         actual_result = resource_physical_id_resolver._fetch_resources_from_stack(set(given_resources))
-        self.assertEqual(len(actual_result), 4)
+        self.assertEqual(len(actual_result), 7)
 
         expected_results = [
             item
             for item in mocked_return_value
             if item.resource_type in ResourcePhysicalIdResolver.DEFAULT_SUPPORTED_RESOURCES
-            and item.logical_resource_id in given_resources
+            and item.logical_resource_id in [given_resource.split("/")[:1] for given_resource in given_resources]
         ]
-        self.assertEqual(expected_results, actual_result)
+        self.assertEqual(expected_results.sort(), actual_result.sort())

--- a/tests/unit/commands/logs/test_logs_context.py
+++ b/tests/unit/commands/logs/test_logs_context.py
@@ -87,33 +87,30 @@ class TestResourcePhysicalIdResolver(TestCase):
     @patch("samcli.commands.logs.logs_context.get_resource_summaries")
     def test_fetch_all_resources(self, patched_get_resources):
         resource_physical_id_resolver = ResourcePhysicalIdResolver(Mock(), "stack_name", [])
-        mocked_return_value = [
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1", []),
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2", []),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_3", "physical_id_3", []),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_4", "physical_id_4", []),
-            CloudFormationResourceSummary(
-                AWS_CLOUDFORMATION_STACK,
-                "logical_id_5",
-                "physical_id_5",
-                [
-                    CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_6", "physical_id_6", []),
-                    CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_7", "physical_id_7", []),
-                ],
+        mocked_return_value = {
+            "logical_id_1": CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1"),
+            "logical_id_2": CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2"),
+            "logical_id_3": CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_3", "physical_id_3"),
+            "logical_id_4": CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_4", "physical_id_4"),
+            "logical_id_5/logical_id_6": CloudFormationResourceSummary(
+                AWS_APIGATEWAY_RESTAPI, "logical_id_6", "physical_id_6"
             ),
-        ]
+            "logical_id_5/logical_id_7": CloudFormationResourceSummary(
+                AWS_APIGATEWAY_HTTPAPI, "logical_id_7", "physical_id_7"
+            ),
+        }
         patched_get_resources.return_value = mocked_return_value
 
         actual_result = resource_physical_id_resolver._fetch_resources_from_stack()
         self.assertEqual(len(actual_result), 6)
 
         expected_results = [
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1", []),
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2", []),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_3", "physical_id_3", []),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_4", "physical_id_4", []),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_6", "physical_id_6", []),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_7", "physical_id_7", []),
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1"),
+            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2"),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_3", "physical_id_3"),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_4", "physical_id_4"),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_6", "physical_id_6"),
+            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_7", "physical_id_7"),
         ]
         self.assertEqual(expected_results, actual_result)
 
@@ -130,44 +127,27 @@ class TestResourcePhysicalIdResolver(TestCase):
             "StackA/StackB/StackC/logical_id_11",
         ]
         resource_physical_id_resolver = ResourcePhysicalIdResolver(Mock(), "stack_name", given_resources)
-        mocked_return_value = [
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1", []),
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2", []),
-            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_3", "physical_id_3", []),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_4", "physical_id_4", []),
-            CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_5", "physical_id_5", []),
-            CloudFormationResourceSummary(
-                AWS_CLOUDFORMATION_STACK,
-                "StackA",
-                "physical_id_StackA",
-                [
-                    CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_7", "physical_id_7", []),
-                    CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_8", "physical_id_8", []),
-                    CloudFormationResourceSummary(
-                        AWS_CLOUDFORMATION_STACK,
-                        "StackB",
-                        "physical_id_StackB",
-                        [
-                            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_9", "physical_id_9", []),
-                            CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_10", "physical_id_10", []),
-                            CloudFormationResourceSummary(
-                                AWS_CLOUDFORMATION_STACK,
-                                "StackC",
-                                "physical_id_StackC",
-                                [
-                                    CloudFormationResourceSummary(
-                                        AWS_LAMBDA_FUNCTION, "logical_id_11", "physical_id_11", []
-                                    ),
-                                    CloudFormationResourceSummary(
-                                        AWS_LAMBDA_FUNCTION, "logical_id_12", "physical_id_12", []
-                                    ),
-                                ],
-                            ),
-                        ],
-                    ),
-                ],
+        mocked_return_value = {
+            "logical_id_1": CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_1", "physical_id_1"),
+            "logical_id_2": CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_2", "physical_id_2"),
+            "logical_id_3": CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_3", "physical_id_3"),
+            "logical_id_4": CloudFormationResourceSummary(AWS_APIGATEWAY_RESTAPI, "logical_id_4", "physical_id_4"),
+            "logical_id_5": CloudFormationResourceSummary(AWS_APIGATEWAY_HTTPAPI, "logical_id_5", "physical_id_5"),
+            "StackA/logical_id_7": CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_7", "physical_id_7"),
+            "StackA/logical_id_8": CloudFormationResourceSummary(AWS_LAMBDA_FUNCTION, "logical_id_8", "physical_id_8"),
+            "StackA/StackB/logical_id_9": CloudFormationResourceSummary(
+                AWS_LAMBDA_FUNCTION, "logical_id_9", "physical_id_9"
             ),
-        ]
+            "StackA/StackB/logical_id_10": CloudFormationResourceSummary(
+                AWS_LAMBDA_FUNCTION, "logical_id_10", "physical_id_10"
+            ),
+            "StackA/StackB/StackC/logical_id_11": CloudFormationResourceSummary(
+                AWS_LAMBDA_FUNCTION, "logical_id_11", "physical_id_11"
+            ),
+            "StackA/StackB/StackC/logical_id_12": CloudFormationResourceSummary(
+                AWS_LAMBDA_FUNCTION, "logical_id_12", "physical_id_12"
+            ),
+        }
         patched_get_resources.return_value = mocked_return_value
 
         actual_result = resource_physical_id_resolver._fetch_resources_from_stack(set(given_resources))
@@ -175,8 +155,7 @@ class TestResourcePhysicalIdResolver(TestCase):
 
         expected_results = [
             item
-            for item in mocked_return_value
-            if item.resource_type in ResourcePhysicalIdResolver.DEFAULT_SUPPORTED_RESOURCES
-            and item.logical_resource_id in [given_resource.split("/")[:1] for given_resource in given_resources]
+            for key, item in mocked_return_value.items()
+            if item.resource_type in ResourcePhysicalIdResolver.DEFAULT_SUPPORTED_RESOURCES and key in given_resources
         ]
         self.assertEqual(expected_results.sort(), actual_result.sort())

--- a/tests/unit/lib/utils/test_cloudformation.py
+++ b/tests/unit/lib/utils/test_cloudformation.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch, Mock, ANY
+from unittest.mock import patch, Mock, ANY, call
 
 from botocore.exceptions import ClientError
 
@@ -9,6 +9,7 @@ from samcli.lib.utils.cloudformation import (
     get_resource_summaries,
     get_resource_summary,
 )
+from samcli.lib.utils.resources import AWS_CLOUDFORMATION_STACK
 
 
 class TestCloudFormationResourceSummary(TestCase):
@@ -17,20 +18,39 @@ class TestCloudFormationResourceSummary(TestCase):
         given_logical_id = "logical_id"
         given_physical_id = "physical_id"
 
-        resource_summary = CloudFormationResourceSummary(given_type, given_logical_id, given_physical_id)
+        given_nested_resource_type = "nested_type"
+        given_nested_logical_id = "nested_type"
+        given_nested_physical_id = "nested_type"
+
+        resource_summary = CloudFormationResourceSummary(
+            given_type,
+            given_logical_id,
+            given_physical_id,
+            [
+                CloudFormationResourceSummary(
+                    given_nested_resource_type, given_nested_logical_id, given_nested_physical_id, []
+                )
+            ],
+        )
 
         self.assertEqual(given_type, resource_summary.resource_type)
         self.assertEqual(given_logical_id, resource_summary.logical_resource_id)
         self.assertEqual(given_physical_id, resource_summary.physical_resource_id)
+        self.assertEqual(len(resource_summary.nested_stack_resources), 1)
+
+        nested_resource_summary = resource_summary.nested_stack_resources[0]
+        self.assertEqual(nested_resource_summary.resource_type, given_nested_resource_type)
+        self.assertEqual(nested_resource_summary.logical_resource_id, given_nested_logical_id)
+        self.assertEqual(nested_resource_summary.physical_resource_id, given_nested_physical_id)
 
 
 class TestCloudformationUtils(TestCase):
     @patch("samcli.lib.utils.cloudformation.get_resource_summaries")
     def test_get_physical_id_mapping(self, patched_get_resource_summaries):
         patched_get_resource_summaries.return_value = [
-            CloudFormationResourceSummary("", "Logical1", "Physical1"),
-            CloudFormationResourceSummary("", "Logical2", "Physical2"),
-            CloudFormationResourceSummary("", "Logical3", "Physical3"),
+            CloudFormationResourceSummary("", "Logical1", "Physical1", []),
+            CloudFormationResourceSummary("", "Logical2", "Physical2", []),
+            CloudFormationResourceSummary("", "Logical3", "Physical3", []),
         ]
 
         given_resource_provider = Mock()
@@ -66,24 +86,59 @@ class TestCloudformationUtils(TestCase):
             Mock(
                 physical_resource_id="physical_id_3", logical_resource_id="logical_id_3", resource_type="ResourceType1"
             ),
+            Mock(
+                physical_resource_id="physical_id_4",
+                logical_resource_id="logical_id_4",
+                resource_type=AWS_CLOUDFORMATION_STACK,
+            ),
         ]
 
-        resource_provider_mock(ANY).Stack(ANY).resource_summaries.all.return_value = given_stack_resource_array
+        given_nested_stack_resource_array = [
+            Mock(
+                physical_resource_id="physical_id_5", logical_resource_id="logical_id_5", resource_type="ResourceType0"
+            ),
+            Mock(
+                physical_resource_id="physical_id_6", logical_resource_id="logical_id_6", resource_type="ResourceType0"
+            ),
+            Mock(
+                physical_resource_id="physical_id_7", logical_resource_id="logical_id_7", resource_type="ResourceType1"
+            ),
+        ]
+
+        resource_provider_mock(ANY).Stack(ANY).resource_summaries.all.side_effect = [
+            given_stack_resource_array,
+            given_nested_stack_resource_array,
+        ]
 
         resource_summaries = get_resource_summaries(resource_provider_mock, given_stack_name, given_resource_types)
 
-        self.assertEqual(len(resource_summaries), 2)
+        self.assertEqual(len(resource_summaries), 3)
         self.assertEqual(
             resource_summaries,
             [
-                CloudFormationResourceSummary("ResourceType0", "logical_id_1", "physical_id_1"),
-                CloudFormationResourceSummary("ResourceType0", "logical_id_2", "physical_id_2"),
+                CloudFormationResourceSummary("ResourceType0", "logical_id_1", "physical_id_1", []),
+                CloudFormationResourceSummary("ResourceType0", "logical_id_2", "physical_id_2", []),
+                CloudFormationResourceSummary(
+                    AWS_CLOUDFORMATION_STACK,
+                    "logical_id_4",
+                    "physical_id_4",
+                    [
+                        CloudFormationResourceSummary("ResourceType0", "logical_id_5", "physical_id_5", []),
+                        CloudFormationResourceSummary("ResourceType0", "logical_id_6", "physical_id_6", []),
+                    ],
+                ),
             ],
         )
 
         resource_provider_mock.assert_called_with("cloudformation")
-        resource_provider_mock(ANY).Stack.assert_called_with(given_stack_name)
-        resource_provider_mock(ANY).Stack(ANY).resource_summaries.all.assert_called_once()
+        resource_provider_mock(ANY).Stack.assert_has_calls(
+            [
+                call(given_stack_name),
+                call().resource_summaries.all(),
+                call("physical_id_4"),
+                call().resource_summaries.all(),
+            ]
+        )
 
     def test_get_resource_summary(self):
         resource_provider_mock = Mock()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Adding Nested Stack support for `sam logs` command


#### How does it address the issue?
As of now, `sam logs` only searches for `logicalId` -> `physicalId` mapping in the current stack. With this change, this search is expanded into nested stacks, and information returned as tree format.

Logs from nested stack resources can be pulled by prepending Nested Stack's logical id in the front (like `NestedStackLogicalId/ResourceLogicalId`)

#### What side effects does this change have?
With SAM Accelerate, customers were able to pull logs from all supported resources from the current stack, this feature is under Beta Flag at the moment. With this change, customers will be pulling logs from all supported resources across their nested stacks as well.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
