### PR TITLE
Add explicit --no-cached option 

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -551,8 +551,10 @@ def manifest_option(f):
 
 def cached_click_option():
     return click.option(
-        "--cached",
+        "--cached/--no-cached",
         "-c",
+        default=False,
+        required=False,
         is_flag=True,
         help="Enable cached builds. Use this flag to reuse build artifacts that have not changed from previous builds. "
         "AWS SAM evaluates whether you have made any changes to files in your project directory. \n\n"

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1560,6 +1560,38 @@ class TestBuildWithCacheBuilds(CachedBuildIntegBase):
                 expected_messages, command_result, self._make_parameter_override_arg(overrides)
             )
 
+    def test_no_cached_override_build(self):
+        overrides = {
+            "FunctionCodeUri": "Python",
+            "Function1Handler": "main.first_function_handler",
+            "Function2Handler": "main.second_function_handler",
+            "FunctionRuntime": "python3.8",
+        }
+        config_file_testdata = Path(__file__).resolve().parents[2].joinpath("integration", "testdata")
+        config_file_buildcmd = (config_file_testdata.joinpath("buildcmd"))
+        config_file = str(config_file_buildcmd.joinpath("samconfig_no_cached.toml"))
+        cmdlist = self.get_command_list(parameter_overrides=overrides, cached=True)
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+        self.assertTrue(self.default_build_dir.exists())
+        self.assertIn("samconfig_no_cached.toml", os.listdir(str(config_file_buildcmd)))
+        self.assertTrue("Running PythonPipBuilder:ResolveDependencies" in str(command_result.stderr) and
+                        "Running PythonPipBuilder:CopySource" in str(command_result.stderr),
+                        "Non-cached build should have been run")
+        cmdlist = self.get_command_list(parameter_overrides=overrides)
+        cmdlist.extend(['--config-file', config_file])
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+        self.assertTrue("Valid cache found, copying previously built resources from function build definition of"
+                        in str(command_result.stderr), "Should have built using cache")
+        cmdlist.extend(['--no-cached'])
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+        self.assertTrue("Running PythonPipBuilder:ResolveDependencies" in str(command_result.stderr) and
+                        "Running PythonPipBuilder:CopySource" in str(command_result.stderr),
+                        "Non-cached build should have been run")
+
+
+
+
+
     @skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
     def test_cached_build_with_env_vars(self):
         """

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1567,13 +1567,9 @@ class TestBuildWithCacheBuilds(CachedBuildIntegBase):
             "Function2Handler": "main.second_function_handler",
             "FunctionRuntime": "python3.8",
         }
-        config_file_testdata = Path(__file__).resolve().parents[2].joinpath("integration", "testdata")
-        config_file_buildcmd = config_file_testdata.joinpath("buildcmd")
-        config_file = str(config_file_buildcmd.joinpath("samconfig_no_cached.toml"))
+        config_file = str(Path(self.test_data_path).joinpath("samconfig_no_cached.toml"))
         cmdlist = self.get_command_list(parameter_overrides=overrides, cached=True)
         command_result = run_command(cmdlist, cwd=self.working_dir)
-        self.assertTrue(self.default_build_dir.exists())
-        self.assertIn("samconfig_no_cached.toml", os.listdir(str(config_file_buildcmd)))
         self.assertTrue(
             "Running PythonPipBuilder:ResolveDependencies" in str(command_result.stderr)
             and "Running PythonPipBuilder:CopySource" in str(command_result.stderr),

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1568,29 +1568,32 @@ class TestBuildWithCacheBuilds(CachedBuildIntegBase):
             "FunctionRuntime": "python3.8",
         }
         config_file_testdata = Path(__file__).resolve().parents[2].joinpath("integration", "testdata")
-        config_file_buildcmd = (config_file_testdata.joinpath("buildcmd"))
+        config_file_buildcmd = config_file_testdata.joinpath("buildcmd")
         config_file = str(config_file_buildcmd.joinpath("samconfig_no_cached.toml"))
         cmdlist = self.get_command_list(parameter_overrides=overrides, cached=True)
         command_result = run_command(cmdlist, cwd=self.working_dir)
         self.assertTrue(self.default_build_dir.exists())
         self.assertIn("samconfig_no_cached.toml", os.listdir(str(config_file_buildcmd)))
-        self.assertTrue("Running PythonPipBuilder:ResolveDependencies" in str(command_result.stderr) and
-                        "Running PythonPipBuilder:CopySource" in str(command_result.stderr),
-                        "Non-cached build should have been run")
+        self.assertTrue(
+            "Running PythonPipBuilder:ResolveDependencies" in str(command_result.stderr)
+            and "Running PythonPipBuilder:CopySource" in str(command_result.stderr),
+            "Non-cached build should have been run",
+        )
         cmdlist = self.get_command_list(parameter_overrides=overrides)
-        cmdlist.extend(['--config-file', config_file])
+        cmdlist.extend(["--config-file", config_file])
         command_result = run_command(cmdlist, cwd=self.working_dir)
-        self.assertTrue("Valid cache found, copying previously built resources from function build definition of"
-                        in str(command_result.stderr), "Should have built using cache")
-        cmdlist.extend(['--no-cached'])
+        self.assertTrue(
+            "Valid cache found, copying previously built resources from function build definition of"
+            in str(command_result.stderr),
+            "Should have built using cache",
+        )
+        cmdlist.extend(["--no-cached"])
         command_result = run_command(cmdlist, cwd=self.working_dir)
-        self.assertTrue("Running PythonPipBuilder:ResolveDependencies" in str(command_result.stderr) and
-                        "Running PythonPipBuilder:CopySource" in str(command_result.stderr),
-                        "Non-cached build should have been run")
-
-
-
-
+        self.assertTrue(
+            "Running PythonPipBuilder:ResolveDependencies" in str(command_result.stderr)
+            and "Running PythonPipBuilder:CopySource" in str(command_result.stderr),
+            "Non-cached build should have been run",
+        )
 
     @skipIf(SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE)
     def test_cached_build_with_env_vars(self):

--- a/tests/integration/testdata/buildcmd/samconfig_no_cached.toml
+++ b/tests/integration/testdata/buildcmd/samconfig_no_cached.toml
@@ -1,0 +1,5 @@
+version = 0.1
+[default]
+[default.build]
+[default.build.parameters]
+cached = true

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -158,6 +158,60 @@ class TestSamConfigForAllCommands(TestCase):
             )
 
     @patch("samcli.commands.build.command.do_cli")
+    def test_build_with_no_cached_override(self, do_cli_mock):
+        config_values = {
+            "resource_logical_id": "foo",
+            "template_file": "mytemplate.yaml",
+            "base_dir": "basedir",
+            "build_dir": "builddir",
+            "cache_dir": "cachedir",
+            "cache": False,
+            "cached": True,
+            "use_container": True,
+            "manifest": "requirements.txt",
+            "docker_network": "mynetwork",
+            "skip_pull_image": True,
+            "parameter_overrides": "ParameterKey=Key,ParameterValue=Value ParameterKey=Key2,ParameterValue=Value2",
+            "container_env_var": (""),
+            "container_env_var_file": "file",
+            "build_image": (""),
+        }
+
+        with samconfig_parameters(["build"], self.scratch_dir, **config_values) as config_path:
+            from samcli.commands.build.command import cli
+
+            LOG.debug(Path(config_path).read_text())
+            runner = CliRunner()
+            result = runner.invoke(cli, ["--no-cached"])
+
+            LOG.info(result.output)
+            LOG.info(result.exception)
+            if result.exception:
+                LOG.exception("Command failed", exc_info=result.exc_info)
+            self.assertIsNone(result.exception)
+
+            do_cli_mock.assert_called_with(
+                ANY,
+                "foo",
+                str(Path(os.getcwd(), "mytemplate.yaml")),
+                "basedir",
+                "builddir",
+                "cachedir",
+                True,
+                True,
+                False,
+                False,
+                "requirements.txt",
+                "mynetwork",
+                True,
+                {"Key": "Value", "Key2": "Value2"},
+                None,
+                (),
+                "file",
+                (),
+            )
+
+    @patch("samcli.commands.build.command.do_cli")
     def test_build_with_container_env_vars(self, do_cli_mock):
         config_values = {
             "resource_logical_id": "foo",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 --> #3828


#### Why is this change necessary?
To allow for samconfig.toml's cached = true setting to be overriden by a command line parameter 

#### How does it address the issue?
adding a  "--no-cached" option to overrides the cached = true setting in samconfig.toml


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
