### PR TITLE
feat: improve new PR and issue labeling for triaging

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create an Issue to report a bug
-title: ''
-labels: ''
+title: "Bug: TITLE"
+labels: ['type/bug', 'stage/needs-triage']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea/feature/enhancement
-title: ''
-labels: ''
+title: "Feature request: TITLE"
+labels: ['type/feature', 'stage/needs-triage']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/anything_else.md
+++ b/.github/ISSUE_TEMPLATE/anything_else.md
@@ -1,0 +1,8 @@
+---
+name: Anything else
+about: Choose if your issue doesn't apply to the other templates
+title: ''
+labels: ['stage/needs-triage']
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,5 +1,5 @@
 ---
-name: Anything else
+name: Other
 about: Choose if your issue doesn't apply to the other templates
 title: ''
 labels: ['stage/needs-triage']

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -34,6 +34,6 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                labels: ['pr/external']
+                labels: ['pr/external', 'stage/needs-triage']
               })
             }


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Will help triage which new issues and PRs haven't been looked at by the team, as querying by no comments or no labels can sometimes be misleading.

#### How does it address the issue?
New label `stage/needs-triage` automatically assigned on new issues and PRs.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
