### PR TITLE
feat: make java build scope changes default

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ docker~=4.2.0
 dateparser~=1.0
 requests==2.25.1
 serverlessrepo==0.1.10
-aws_lambda_builders==1.16.0
+aws_lambda_builders==1.17.0
 tomlkit==0.7.2
 watchdog==2.1.2
 

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -12,10 +12,10 @@ attrs==20.3.0 \
     --hash=sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6 \
     --hash=sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700
     # via jsonschema
-aws-lambda-builders==1.16.0 \
-    --hash=sha256:227977e143e626087638989957d3443e11a93837318cfb377c88c231d6950f66 \
-    --hash=sha256:417b7709d9941d38b4d6ba8615d1416acd50c3fa137b4a4e818609c7c7c5b4ab \
-    --hash=sha256:f81c5835cf49a904e3bf66343238a2b7e46ea5a00ee519234402388446be5fc4
+aws-lambda-builders==1.17.0 \
+    --hash=sha256:1d296dc521f3f3f356ffbe290ca204713b1e8a24612262cf1c9283ffe34dc443 \
+    --hash=sha256:3eb7ca5ab71761766586db080a8b80ab81346b307fa72d5cea64ccd69fb41efe \
+    --hash=sha256:abae4ccfc419fc5cd8eebd4cc81e335ec7610f53804ce1aa2b655159ce339610
     # via aws-sam-cli (setup.py)
 aws-sam-translator==1.45.0 \
     --hash=sha256:40a6dd5a0aba32c7b38b0f5c54470396acdcd75e4b64251b015abdf922a18b5f \

--- a/samcli/commands/_utils/experimental.py
+++ b/samcli/commands/_utils/experimental.py
@@ -44,9 +44,6 @@ class ExperimentalFlag:
 
     All = ExperimentalEntry("experimentalAll", EXPERIMENTAL_ENV_VAR_PREFIX + "FEATURES")
     Accelerate = ExperimentalEntry("experimentalAccelerate", EXPERIMENTAL_ENV_VAR_PREFIX + "ACCELERATE")
-    JavaMavenBuildScope = ExperimentalEntry(
-        "experimentalMavenScopeAndLayer", EXPERIMENTAL_ENV_VAR_PREFIX + "MAVEN_SCOPE_AND_LAYER"
-    )
     Esbuild = ExperimentalEntry("experimentalEsbuild", EXPERIMENTAL_ENV_VAR_PREFIX + "ESBUILD")
 
 

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -13,6 +13,7 @@ import docker
 import jmespath
 from pathlib import Path
 
+from samcli.lib.utils import osutils
 from samcli.lib.utils.architecture import X86_64, has_runtime_multi_arch_image
 from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 from samcli.yamlhelper import yaml_parse
@@ -499,7 +500,7 @@ class BuildIntegJavaBase(BuildIntegBase):
             osutils.convert_to_unix_line_ending(os.path.join(self.test_data_path, self.USING_GRADLEW_PATH, "gradlew"))
 
         LOG.info("Running Command: {}".format(cmdlist))
-        run_command(cmdlist, cwd=self.working_dir)
+        run_command(cmdlist, cwd=self.working_dir, timeout=900)
 
         self._verify_built_artifact(
             self.default_build_dir, self.FUNCTION_LOGICAL_ID, expected_files, expected_dependencies

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -55,7 +55,6 @@ class TestExperimentalMetric(IntegBase):
                             "metricSpecificAttributes": {
                                 "experimentalAccelerate": True,
                                 "experimentalAll": False,
-                                "experimentalMavenScopeAndLayer": False,
                                 "experimentalEsbuild": False,
                             },
                             "duration": ANY,
@@ -107,7 +106,6 @@ class TestExperimentalMetric(IntegBase):
                             "metricSpecificAttributes": {
                                 "experimentalAccelerate": True,
                                 "experimentalAll": True,
-                                "experimentalMavenScopeAndLayer": True,
                                 "experimentalEsbuild": True,
                             },
                             "duration": ANY,

--- a/tests/unit/commands/_utils/test_experimental.py
+++ b/tests/unit/commands/_utils/test_experimental.py
@@ -12,6 +12,8 @@ from samcli.commands._utils.experimental import (
     prompt_experimental,
     set_experimental,
     get_enabled_experimental_flags,
+    ExperimentalEntry,
+    ExperimentalFlag,
 )
 
 
@@ -56,13 +58,13 @@ class TestExperimental(TestCase):
         self.gc_mock.return_value.set_value.assert_called_once_with(config_entry, False, is_flag=True, flush=False)
 
     def test_get_all_experimental(self):
-        self.assertEqual(len(get_all_experimental()), 4)
+        self.assertEqual(len(get_all_experimental()), 3)
 
     def test_get_all_experimental_statues(self):
-        self.assertEqual(len(get_all_experimental_statues()), 4)
+        self.assertEqual(len(get_all_experimental_statues()), 3)
 
     def test_get_enabled_experimental_flags(self):
-        self.assertEqual(len(get_enabled_experimental_flags()), 4)
+        self.assertEqual(len(get_enabled_experimental_flags()), 3)
 
     @patch("samcli.commands._utils.experimental.set_experimental")
     @patch("samcli.commands._utils.experimental.get_all_experimental")

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -611,10 +611,9 @@ class TestBuildContext__enter__(TestCase):
             print_success_message=False,
         ) as build_context:
             with patch("samcli.commands.build.build_context.BuildContext.gen_success_msg") as mock_message:
-                with patch("samcli.commands.build.build_context.BuildContext._check_java_warning") as mock_java_warning:
-                    with patch("samcli.commands.build.build_context.BuildContext._check_esbuild_warning"):
-                        build_context.run()
-                        mock_message.assert_not_called()
+                with patch("samcli.commands.build.build_context.BuildContext._check_esbuild_warning"):
+                    build_context.run()
+                    mock_message.assert_not_called()
 
 
 class TestBuildContext_setup_build_dir(TestCase):
@@ -1079,45 +1078,6 @@ class TestBuildContext_run(TestCase):
                 build_context.run()
 
         self.assertEqual(str(ctx.exception), "Function Not Found")
-
-
-class TestBuildContext_java_warning(TestCase):
-    @parameterized.expand(
-        [
-            ([], [], False),
-            ([DummyFunction("NonJavaFunction", runtime="nodejs14.x")], [], False),
-            ([], [DummyLayer("NonJavaLayer", build_method="nodejs14.x")], False),
-            (
-                [DummyFunction("NonJavaFunction", runtime="nodejs14.x")],
-                [DummyLayer("NonJavaLayer", build_method="nodejs14.x")],
-                False,
-            ),
-            ([DummyFunction("JavaFunction", runtime="java8")], [], True),
-            ([], [DummyLayer("JavaLayer", build_method="java11")], True),
-            ([DummyFunction("JavaFunction", runtime="java11")], [DummyLayer("JavaLayer", build_method="java8")], True),
-        ]
-    )
-    @patch("samcli.commands.build.build_context.click.secho")
-    def test_check_java_warning(self, functions, layers, should_print, mocked_click):
-        build_context = BuildContext(
-            resource_identifier="function_identifier",
-            template_file="template_file",
-            base_dir="base_dir",
-            build_dir="build_dir",
-            cache_dir="cache_dir",
-            cached=False,
-            clean=False,
-            parallel=False,
-            mode="mode",
-        )
-        with patch.object(build_context, "get_resources_to_build") as mocked_resources_to_build:
-            mocked_resources_to_build.return_value = Mock(functions=functions, layers=layers)
-            build_context._check_java_warning()
-
-            if should_print:
-                mocked_click.assert_called_with(BuildContext._JAVA_BUILD_WARNING_MESSAGE, fg="yellow")
-            else:
-                mocked_click.assert_not_called()
 
 
 class TestBuildContext_esbuild_warning(TestCase):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/3639


#### Why is this change necessary?
To use correct scope for building maven projects & copy correct files during layer build or Java runtimes.


#### How does it address the issue?
Lambda Builders was using `compile` scope before for maven projects. With this change it will be using `runtime` scope which will only bundle dependencies that is needed during execution.

Also, it will be bundling `.jar` files for layer build since layer build doesn't support loading `.class` files.


#### What side effects does this change have?
Final package size might be affected since some dependencies will be dropped and some might be added to the final artifact. These changes were in Beta since Feb 2022.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
