### PR TITLE
chore: run app templates hash updated job only on aws/aws-sam-cli

### DIFF
--- a/.github/workflows/update_app_templates_hash.yml
+++ b/.github/workflows/update_app_templates_hash.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+    if: github.repository == 'aws/aws-sam-cli'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout App Templates


### PR DESCRIPTION
Limit `Update aws/aws-sam-cli with latest commit hash from aws/aws-sam-cli-app-templates` GH Action to only run on `aws/aws-sam-cli`.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
