### PR TITLE
fix: Add lockchain and status check to prevent sync flows race condition on function update

### DIFF
--- a/samcli/lib/sync/flows/function_sync_flow.py
+++ b/samcli/lib/sync/flows/function_sync_flow.py
@@ -118,11 +118,11 @@ class FunctionUpdateStatus(Enum):
 def wait_for_function_update_complete(lambda_client: BaseClient, physical_id: str) -> None:
     """
     Parameters
-        ----------
-        lambda_client : boto.core.BaseClient
-            Lambda client that performs get_function API call.
-        physical_id : str
-            Physical identifier of the function resource
+    ----------
+    lambda_client : boto.core.BaseClient
+        Lambda client that performs get_function API call.
+    physical_id : str
+        Physical identifier of the function resource
     """
 
     status = FunctionUpdateStatus.IN_PROGRESS.value

--- a/samcli/lib/sync/flows/function_sync_flow.py
+++ b/samcli/lib/sync/flows/function_sync_flow.py
@@ -127,7 +127,7 @@ def wait_for_function_update_complete(lambda_client: BaseClient, physical_id: st
 
     status = FunctionUpdateStatus.IN_PROGRESS.value
     while status == FunctionUpdateStatus.IN_PROGRESS.value:
-        response = lambda_client.get_function(FunctionName=physical_id)
+        response = lambda_client.get_function(FunctionName=physical_id)  # type: ignore
         status = response.get("Configuration", {}).get("LastUpdateStatus", "")
 
         if status == FunctionUpdateStatus.IN_PROGRESS.value:

--- a/samcli/lib/sync/flows/function_sync_flow.py
+++ b/samcli/lib/sync/flows/function_sync_flow.py
@@ -117,6 +117,8 @@ class FunctionUpdateStatus(Enum):
 
 def wait_for_function_update_complete(lambda_client: BaseClient, physical_id: str) -> None:
     """
+    Checks on cloud side to wait for the function update status to be complete
+
     Parameters
     ----------
     lambda_client : boto.core.BaseClient

--- a/samcli/lib/sync/flows/function_sync_flow.py
+++ b/samcli/lib/sync/flows/function_sync_flow.py
@@ -101,7 +101,7 @@ class FunctionSyncFlow(SyncFlow):
 
         return sync_flows
 
-    def _get_function_status(self) -> bool:
+    def _verify_function_status(self) -> bool:
         """
         return value:
         True if last function update was successful
@@ -110,11 +110,10 @@ class FunctionSyncFlow(SyncFlow):
         response = self._lambda_client.get_function(FunctionName=self.get_physical_id(self._function_identifier))
         if response.get("Configuration", {}).get("LastUpdateStatus", "") == FunctionUpdateStatus.IN_PROGRESS.value:
             time.sleep(FUNCTION_SLEEP)
-            return self._get_function_status()
+            return self._verify_function_status()
         if response.get("Configuration", {}).get("LastUpdateStatus", "") == FunctionUpdateStatus.SUCCESS.value:
             return True
-        else:
-            return False
+        return False
 
     def _equality_keys(self):
         return self._function_identifier
@@ -123,6 +122,6 @@ class FunctionSyncFlow(SyncFlow):
 class FunctionUpdateStatus(Enum):
     """Function update return types"""
 
-    SUCCESS = "Success"
+    SUCCESS = "Successful"
     FAILED = "Failed"
     IN_PROGRESS = "InProgress"

--- a/samcli/lib/sync/flows/layer_sync_flow.py
+++ b/samcli/lib/sync/flows/layer_sync_flow.py
@@ -327,9 +327,7 @@ class FunctionLayerReferenceSync(SyncFlow):
 
             self._lambda_client.update_function_configuration(FunctionName=function_physical_id, Layers=layer_arns)
 
-            lambda_client = self._lambda_client
-            physical_id = self.get_physical_id(self._function_identifier)
-            wait_for_function_update_complete(lambda_client, physical_id)
+            wait_for_function_update_complete(self._lambda_client, self.get_physical_id(self._function_identifier))
 
     def _get_resource_api_calls(self) -> List[ResourceAPICall]:
         return [

--- a/samcli/lib/sync/flows/layer_sync_flow.py
+++ b/samcli/lib/sync/flows/layer_sync_flow.py
@@ -327,9 +327,15 @@ class FunctionLayerReferenceSync(SyncFlow):
 
             self._lambda_client.update_function_configuration(FunctionName=function_physical_id, Layers=layer_arns)
 
+            # We need to wait for the cloud side update to finish
+            # Otherwise even if the call is finished and lockchain is released
+            # It is still possible that we have a race condition on cloud updating the same function
             wait_for_function_update_complete(self._lambda_client, self.get_physical_id(self._function_identifier))
 
     def _get_resource_api_calls(self) -> List[ResourceAPICall]:
+        # We need to acquire lock for both API calls since they would conflict on cloud
+        # Any UPDATE_FUNCTION_CODE and UPDATE_FUNCTION_CONFIGURATION on the same function
+        # Cannot take place in parallel
         return [
             ResourceAPICall(
                 self._function_identifier,

--- a/samcli/lib/sync/flows/layer_sync_flow.py
+++ b/samcli/lib/sync/flows/layer_sync_flow.py
@@ -328,8 +328,8 @@ class FunctionLayerReferenceSync(SyncFlow):
 
             self._lambda_client.update_function_configuration(FunctionName=function_physical_id, Layers=layer_arns)
 
-            if self._get_function_status():
-                LOG.debug("Function configuration update status is now successful on cloud.")
+            if self._verify_function_status():
+                LOG.debug(self._color.green("Function configuration update status is now successful on cloud."))
 
     def _get_resource_api_calls(self) -> List[ResourceAPICall]:
         return [
@@ -351,7 +351,7 @@ class FunctionLayerReferenceSync(SyncFlow):
     def _equality_keys(self) -> Any:
         return self._function_identifier, self._layer_arn, self._new_layer_version
 
-    def _get_function_status(self) -> bool:
+    def _verify_function_status(self) -> bool:
         """
         return value:
         True if last function update was successful
@@ -360,8 +360,7 @@ class FunctionLayerReferenceSync(SyncFlow):
         response = self._lambda_client.get_function(FunctionName=self.get_physical_id(self._function_identifier))
         if response.get("Configuration", {}).get("LastUpdateStatus", "") == FunctionUpdateStatus.IN_PROGRESS.value:
             time.sleep(FUNCTION_SLEEP)
-            return self._get_function_status()
+            return self._verify_function_status()
         if response.get("Configuration", {}).get("LastUpdateStatus", "") == FunctionUpdateStatus.SUCCESS.value:
             return True
-        else:
-            return False
+        return False

--- a/samcli/lib/sync/flows/zip_function_sync_flow.py
+++ b/samcli/lib/sync/flows/zip_function_sync_flow.py
@@ -128,9 +128,9 @@ class ZipFunctionSyncFlow(FunctionSyncFlow):
                         FunctionName=self.get_physical_id(self._function_identifier), ZipFile=data
                     )
 
-                    lambda_client = self._lambda_client
-                    physical_id = self.get_physical_id(self._function_identifier)
-                    wait_for_function_update_complete(lambda_client, physical_id)
+                    wait_for_function_update_complete(
+                        self._lambda_client, self.get_physical_id(self._function_identifier)
+                    )
 
         else:
             # Upload to S3 first for oversized ZIPs
@@ -156,9 +156,7 @@ class ZipFunctionSyncFlow(FunctionSyncFlow):
                     S3Key=s3_key,
                 )
 
-                lambda_client = self._lambda_client
-                physical_id = self.get_physical_id(self._function_identifier)
-                wait_for_function_update_complete(lambda_client, physical_id)
+                wait_for_function_update_complete(self._lambda_client, self.get_physical_id(self._function_identifier))
 
         if os.path.exists(self._zip_file):
             os.remove(self._zip_file)

--- a/samcli/lib/sync/flows/zip_function_sync_flow.py
+++ b/samcli/lib/sync/flows/zip_function_sync_flow.py
@@ -1,5 +1,4 @@
 """SyncFlow for ZIP based Lambda Functions"""
-from enum import Enum
 import hashlib
 import logging
 import os
@@ -10,7 +9,7 @@ from contextlib import ExitStack
 
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
 
-from samcli.lib.build.build_graph import FUNCTIONS_FIELD, BuildGraph
+from samcli.lib.build.build_graph import BuildGraph
 from samcli.lib.providers.provider import Stack
 
 from samcli.lib.sync.flows.function_sync_flow import FunctionSyncFlow
@@ -129,8 +128,8 @@ class ZipFunctionSyncFlow(FunctionSyncFlow):
                         FunctionName=self.get_physical_id(self._function_identifier), ZipFile=data
                     )
 
-                    if self._get_function_status():
-                        LOG.debug("Function update status is now successful on cloud.")
+                    if self._verify_function_status():
+                        LOG.debug(self._color.green("Function update status is now successful on cloud."))
 
         else:
             # Upload to S3 first for oversized ZIPs
@@ -156,8 +155,8 @@ class ZipFunctionSyncFlow(FunctionSyncFlow):
                     S3Key=s3_key,
                 )
 
-                if self._get_function_status():
-                    LOG.debug("Function update status is now successful on cloud.")
+                if self._verify_function_status():
+                    LOG.debug(self._color.green("Function update status is now successful on cloud."))
 
         if os.path.exists(self._zip_file):
             os.remove(self._zip_file)

--- a/samcli/lib/sync/sync_flow.py
+++ b/samcli/lib/sync/sync_flow.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from threading import Lock
-from typing import Any, Dict, List, NamedTuple, Optional, TYPE_CHECKING, cast
+from typing import Any, Dict, List, NamedTuple, Optional, TYPE_CHECKING, cast, Set
 from boto3.session import Session
 
 from samcli.lib.providers.provider import get_resource_by_id
@@ -28,6 +28,7 @@ class ApiCallTypes(Enum):
 
     BUILD = "Build"
     UPDATE_FUNCTION_CONFIGURATION = "UpdateFunctionConfiguration"
+    UPDATE_FUNCTION_CODE = "UpdateFunctionCode"
 
 
 class ResourceAPICall(NamedTuple):
@@ -148,18 +149,18 @@ class SyncFlow(ABC):
         """
         return bool(self._locks)
 
-    def get_lock_keys(self) -> List[str]:
+    def get_lock_keys(self) -> Set[str]:
         """Get a list of function + API calls that can be used as keys for LockDistributor
 
         Returns
         -------
-        List[str]
-            List of keys for all resources and their API calls
+        Set[str]
+            Set of keys for all resources and their API calls
         """
-        lock_keys = list()
+        lock_keys = set()
         for resource_api_calls in self._get_resource_api_calls():
             for api_call in resource_api_calls.api_calls:
-                lock_keys.append(SyncFlow._get_lock_key(resource_api_calls.shared_resource, api_call))
+                lock_keys.add(SyncFlow._get_lock_key(resource_api_calls.shared_resource, api_call))
         return lock_keys
 
     def set_locks_with_distributor(self, distributor: LockDistributor):

--- a/samcli/lib/sync/sync_flow_executor.py
+++ b/samcli/lib/sync/sync_flow_executor.py
@@ -145,37 +145,6 @@ class SyncFlowExecutor:
             task.sync_flow.set_locks_with_distributor(self._lock_distributor)
             self._flow_queue.put(task)
 
-    @staticmethod
-    def _check_racing_function_update(
-        sync_flow: SyncFlow, running_flows: List[SyncFlow], input_type: str, conflict_type: str
-    ) -> bool:
-        input_update = False
-        for class_type in type(sync_flow).__mro__:
-            if class_type.__name__ == input_type:
-                input_update = True
-        for running_flow in running_flows:
-            for class_type in type(running_flow).__mro__:
-                if class_type.__name__ == conflict_type:
-                    if input_update:
-                        return sync_flow._function_identifier == running_flow._function_identifier
-
-    def _wait_until_function_complete(self, sync_flow: SyncFlow, running_flows: List[SyncFlow]) -> None:
-        if self._check_racing_function_update(
-            sync_flow, running_flows, "FunctionLayerReferenceSync", "FunctionSyncFlow"
-        ) or self._check_racing_function_update(
-            sync_flow, running_flows, "FunctionSyncFlow", "FunctionLayerReferenceSync"
-        ):
-            time.sleep(0.5)
-            new_flows = [future.sync_flow for future in self._running_futures]
-            LOG.debug(self._color.red("Running wait function again"))
-            LOG.debug("Task for " + type(sync_flow).__name__ + "")
-            for flow in new_flows:
-                LOG.debug("Waiting on " + type(flow).__name__)
-            self._wait_until_function_complete(sync_flow, new_flows)
-        else:
-            LOG.debug(self._color.green("No blocker on function update"))
-            return
-
     def add_sync_flow(self, sync_flow: SyncFlow, dedup: bool = True) -> None:
         """Add a SyncFlow to queue to be executed
         Locks will be set with LockDistributor
@@ -257,11 +226,6 @@ class SyncFlowExecutor:
             # Go through all queued tasks and try to execute them
             while not self._flow_queue.empty():
                 sync_flow_task: SyncFlowTask = self._flow_queue.get()
-
-                sync_flow = sync_flow_task.sync_flow
-                running_flows = [future.sync_flow for future in self._running_futures]
-
-                self._wait_until_function_complete(sync_flow, running_flows)
 
                 sync_flow_future = self._submit_sync_flow_task(executor, sync_flow_task)
 

--- a/samcli/lib/sync/watch_manager.py
+++ b/samcli/lib/sync/watch_manager.py
@@ -132,7 +132,7 @@ class WatchManager:
             try:
                 template_trigger.validate_template()
             except InvalidTemplateFile:
-                LOG.warning(self._color.yellow("Template validation failed for %s in %s"), template, stack.location)
+                LOG.warning(self._color.yellow("Template validation failed for %s in %s"), template, stack.name)
 
             self._observer.schedule_handlers(template_trigger.get_path_handlers())
 

--- a/samcli/lib/utils/lock_distributor.py
+++ b/samcli/lib/utils/lock_distributor.py
@@ -2,7 +2,7 @@
 import threading
 import multiprocessing
 import multiprocessing.managers
-from typing import Dict, List, Optional, cast
+from typing import Dict, Set, Optional, cast
 from enum import Enum, auto
 
 
@@ -108,13 +108,13 @@ class LockDistributor:
                 self._locks[key] = self._create_new_lock()
             return self._locks[key]
 
-    def get_locks(self, keys: List[str]) -> Dict[str, threading.Lock]:
+    def get_locks(self, keys: Set[str]) -> Dict[str, threading.Lock]:
         """Retrieve a list of locks associating with keys
 
         Parameters
         ----------
-        keys : List[str]
-            List of keys for retrieving the locks
+        keys : Set[str]
+            Set of keys for retrieving the locks
 
         Returns
         -------
@@ -126,13 +126,13 @@ class LockDistributor:
             lock_mapping[key] = self.get_lock(key)
         return lock_mapping
 
-    def get_lock_chain(self, keys: List[str]) -> LockChain:
+    def get_lock_chain(self, keys: Set[str]) -> LockChain:
         """Similar to get_locks, but retrieves a LockChain object instead of a dictionary
 
         Parameters
         ----------
-        keys : List[str]
-            List of keys for retrieving the locks
+        keys : Set[str]
+            Set of keys for retrieving the locks
 
         Returns
         -------

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -189,7 +189,6 @@ class TestSyncCode(TestSyncCodeBase):
                 self.assertIn("extra_message", lambda_response)
                 self.assertEqual(lambda_response.get("message"), "7")
 
-
     def test_sync_code_rest_api(self):
         shutil.rmtree(TestSyncCode.temp_dir.joinpath("apigateway"), ignore_errors=True)
         shutil.copytree(

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -151,6 +151,45 @@ class TestSyncCode(TestSyncCodeBase):
                 self.assertIn("extra_message", lambda_response)
                 self.assertEqual(lambda_response.get("message"), "9")
 
+    def test_sync_function_layer_race_condition(self):
+        shutil.rmtree(TestSyncCode.temp_dir.joinpath("function"), ignore_errors=True)
+        shutil.copytree(
+            self.test_data_path.joinpath("code").joinpath("before").joinpath("function"),
+            TestSyncCode.temp_dir.joinpath("function"),
+        )
+        shutil.rmtree(TestSyncCode.temp_dir.joinpath("layer"), ignore_errors=True)
+        shutil.copytree(
+            self.test_data_path.joinpath("code").joinpath("before").joinpath("layer"),
+            TestSyncCode.temp_dir.joinpath("layer"),
+        )
+        # Run code sync
+        sync_command_list = self.get_sync_command_list(
+            template_file=TestSyncCode.template_path,
+            code=True,
+            watch=False,
+            resource="AWS::Serverless::Function",
+            dependency_layer=True,
+            stack_name=TestSyncCode.stack_name,
+            parameter_overrides="Parameter=Clarity",
+            image_repository=self.ecr_repo_name,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key,
+            tags="integ=true clarity=yes foo_bar=baz",
+        )
+        sync_process_execute = run_command_with_input(sync_command_list, "y\n".encode())
+        self.assertEqual(sync_process_execute.process.returncode, 0)
+
+        # CFN Api call here to collect all the stack resources
+        self.stack_resources = self._get_stacks(TestSyncCode.stack_name)
+        # Lambda Api call here, which tests both the python function and the layer
+        lambda_functions = self.stack_resources.get(AWS_LAMBDA_FUNCTION)
+        for lambda_function in lambda_functions:
+            if lambda_function == "HelloWorldFunction":
+                lambda_response = json.loads(self._get_lambda_response(lambda_function))
+                self.assertIn("extra_message", lambda_response)
+                self.assertEqual(lambda_response.get("message"), "7")
+
+
     def test_sync_code_rest_api(self):
         shutil.rmtree(TestSyncCode.temp_dir.joinpath("apigateway"), ignore_errors=True)
         shutil.copytree(

--- a/tests/unit/lib/sync/flows/test_layer_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_layer_sync_flow.py
@@ -380,7 +380,6 @@ class TestFunctionLayerReferenceSync(TestCase):
             )
             self.function_layer_sync._verify_function_status.assert_called_once()
             self.function_layer_sync._get_lock_chain.return_value.__exit__.assert_called_once()
-            
 
     def test_sync_with_existing_new_layer_version_arn(self):
         given_lambda_client = Mock()
@@ -393,7 +392,7 @@ class TestFunctionLayerReferenceSync(TestCase):
             self.function_layer_sync._get_lock_chain = MagicMock()
             self.function_layer_sync.has_locks = MagicMock()
             self.function_layer_sync._verify_function_status = Mock()
-            
+
             given_physical_id = Mock()
             patched_get_physical_id.return_value = given_physical_id
 
@@ -438,7 +437,7 @@ class TestFunctionLayerReferenceSync(TestCase):
             patched_get_physical_id.assert_called_with(self.function_identifier)
 
             given_lambda_client.get_function.assert_called_with(FunctionName=given_physical_id)
-            self.assertEqual( given_lambda_client.get_function.call_count, 3)
+            self.assertEqual(given_lambda_client.get_function.call_count, 3)
 
     def test_verify_function_status_failure(self):
         given_lambda_client = Mock()

--- a/tests/unit/lib/sync/flows/test_zip_function_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_zip_function_sync_flow.py
@@ -116,6 +116,7 @@ class TestZipFunctionSyncFlow(TestCase):
 
         sync_flow._get_lock_chain = MagicMock()
         sync_flow.has_locks = MagicMock()
+        sync_flow._verify_function_status = MagicMock()
         sync_flow.get_physical_id = MagicMock()
         sync_flow.get_physical_id.return_value = "PhysicalFunction1"
 
@@ -128,6 +129,7 @@ class TestZipFunctionSyncFlow(TestCase):
         sync_flow._lambda_client.update_function_code.assert_called_once_with(
             FunctionName="PhysicalFunction1", ZipFile=b"zip_content"
         )
+        sync_flow._verify_function_status.assert_called_once()
         sync_flow._get_lock_chain.return_value.__exit__.assert_called_once()
         remove_mock.assert_called_once_with("zip_file")
 
@@ -147,6 +149,7 @@ class TestZipFunctionSyncFlow(TestCase):
 
         sync_flow._get_lock_chain = MagicMock()
         sync_flow.has_locks = MagicMock()
+        sync_flow._verify_function_status = MagicMock()
         sync_flow.get_physical_id = MagicMock()
         sync_flow.get_physical_id.return_value = "PhysicalFunction1"
 
@@ -161,6 +164,7 @@ class TestZipFunctionSyncFlow(TestCase):
         sync_flow._lambda_client.update_function_code.assert_called_once_with(
             FunctionName="PhysicalFunction1", S3Bucket="bucket_name", S3Key="bucket/key"
         )
+        sync_flow._verify_function_status.assert_called_once()
         sync_flow._get_lock_chain.return_value.__exit__.assert_called_once()
         remove_mock.assert_called_once_with("zip_file")
 

--- a/tests/unit/lib/sync/flows/test_zip_function_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_zip_function_sync_flow.py
@@ -213,7 +213,7 @@ class TestZipFunctionSyncFlow(TestCase):
         given_lambda_client.get_function.assert_called_with(FunctionName=given_physical_id)
         self.assertEqual(given_lambda_client.get_function.call_count, 3)
 
-    def test_verify_function_status_failure(self):
+    def test_wait_for_function_status_failure(self):
         given_lambda_client = MagicMock()
         given_physical_id = "function"
 

--- a/tests/unit/lib/sync/flows/test_zip_function_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_zip_function_sync_flow.py
@@ -214,11 +214,11 @@ class TestZipFunctionSyncFlow(TestCase):
             patched_get_physical_id.assert_called_with("Function1")
 
             given_lambda_client.get_function.assert_called_with(FunctionName=given_physical_id)
-            self.assertEqual( given_lambda_client.get_function.call_count, 3)
+            self.assertEqual(given_lambda_client.get_function.call_count, 3)
 
     def test_verify_function_status_failure(self):
         sync_flow = self.create_function_sync_flow()
-        
+
         given_lambda_client = MagicMock()
         sync_flow._lambda_client = given_lambda_client
 

--- a/tests/unit/lib/sync/test_sync_flow.py
+++ b/tests/unit/lib/sync/test_sync_flow.py
@@ -104,7 +104,7 @@ class TestSyncFlow(TestCase):
             ResourceAPICall("B", [ApiCallTypes.UPDATE_FUNCTION_CONFIGURATION]),
         ]
         result = sync_flow.get_lock_keys()
-        self.assertEqual(result, ["A_Build", "B_UpdateFunctionConfiguration"])
+        self.assertEqual(sorted(result), sorted(["A_Build", "B_UpdateFunctionConfiguration"]))
 
     @patch("samcli.lib.sync.sync_flow.LockChain")
     @patch("samcli.lib.sync.sync_flow.Session")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N.A.

#### Why is this change necessary?
To prevent sync race condition on function flows.

#### How does it address the issue?
Added a lockchain that both function config update and function code update need to grab.
Added a remote function status check to ensure function update was complete.

#### What side effects does this change have?
Not known.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
