### PR TITLE
fix: use correct entry file for node 16 debugging

### DIFF
--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -134,7 +134,7 @@ class LambdaDebugSettings:
                 + ["/var/lang/bin/node"]
                 + debug_args_list
                 + ["--no-lazy", "--expose-gc"]
-                + ["/var/runtime/index.js"],
+                + ["/var/runtime/index.mjs"],
                 container_env_vars={
                     "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node16/node_modules:/var/runtime/node_modules:"
                     "/var/runtime:/var/task",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
See https://github.com/aws/aws-sam-cli/issues/3886

Node16 lambdas use an ES module entry point, not CJS.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
