### PR TITLE
Fix deploy with long poll delay events order and stop condition

### DIFF
--- a/samcli/commands/_utils/table_print.py
+++ b/samcli/commands/_utils/table_print.py
@@ -11,7 +11,9 @@ import click
 MIN_OFFSET = 20
 
 
-def pprint_column_names(format_string, format_kwargs, margin=None, table_header=None, color="yellow"):
+def pprint_column_names(
+    format_string, format_kwargs, margin=None, table_header=None, color="yellow", display_sleep=False
+):
     """
 
     :param format_string: format string to be used that has the strings, minimum width to be replaced
@@ -19,6 +21,7 @@ def pprint_column_names(format_string, format_kwargs, margin=None, table_header=
     :param margin: margin that is to be reduced from column width for columnar text.
     :param table_header: Supplied table header
     :param color: color supplied for table headers and column names.
+    :param display_sleep: flag to format table_header to include deployer's client_sleep
     :return: boilerplate table string
     """
 
@@ -59,7 +62,7 @@ def pprint_column_names(format_string, format_kwargs, margin=None, table_header=
         def wrap(*args, **kwargs):
             # The table is setup with the column names, format_string contains the column names.
             if table_header:
-                click.secho("\n" + table_header)
+                click.secho("\n" + table_header.format(args[0].client_sleep) if display_sleep else table_header)
             click.secho("-" * usable_width, fg=color)
             click.secho(format_string.format(*format_args, **format_kwargs), fg=color)
             click.secho("-" * usable_width, fg=color)

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -53,7 +53,7 @@ DESCRIBE_STACK_EVENTS_DEFAULT_ARGS = OrderedDict(
     }
 )
 
-DESCRIBE_STACK_EVENTS_TABLE_HEADER_NAME = "CloudFormation events from stack operations"
+DESCRIBE_STACK_EVENTS_TABLE_HEADER_NAME = "CloudFormation events from stack operations (refresh every {} seconds)"
 
 DESCRIBE_CHANGESET_FORMAT_STRING = "{Operation:<{0}} {LogicalResourceId:<{1}} {ResourceType:<{2}} {Replacement:<{3}}"
 DESCRIBE_CHANGESET_DEFAULT_ARGS = OrderedDict(
@@ -360,6 +360,7 @@ class Deployer:
         format_string=DESCRIBE_STACK_EVENTS_FORMAT_STRING,
         format_kwargs=DESCRIBE_STACK_EVENTS_DEFAULT_ARGS,
         table_header=DESCRIBE_STACK_EVENTS_TABLE_HEADER_NAME,
+        display_sleep=True,
     )
     def describe_stack_events(self, stack_name, time_stamp_marker, **kwargs):
         """

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -17,7 +17,7 @@ Cloudformation deploy class which also streams events and changeset information
 
 import sys
 import math
-from collections import OrderedDict
+from collections import OrderedDict, deque
 import logging
 import time
 from datetime import datetime
@@ -377,45 +377,50 @@ class Deployer:
             try:
                 # Only sleep if there have been no retry_attempts
                 time.sleep(0 if retry_attempts else self.client_sleep)
-                describe_stacks_resp = self._client.describe_stacks(StackName=stack_name)
                 paginator = self._client.get_paginator("describe_stack_events")
                 response_iterator = paginator.paginate(StackName=stack_name)
-                stack_status = describe_stacks_resp["Stacks"][0]["StackStatus"]
-                latest_time_stamp_marker = time_stamp_marker
+                new_events = deque()  # event buffer
                 for event_items in response_iterator:
                     for event in event_items["StackEvents"]:
-                        if event["EventId"] not in events and utc_to_timestamp(event["Timestamp"]) > time_stamp_marker:
-                            events.add(event["EventId"])
-                            latest_time_stamp_marker = max(
-                                latest_time_stamp_marker, utc_to_timestamp(event["Timestamp"])
-                            )
-                            row_color = self.deploy_color.get_stack_events_status_color(status=event["ResourceStatus"])
-                            pprint_columns(
-                                columns=[
-                                    event["ResourceStatus"],
-                                    event["ResourceType"],
-                                    event["LogicalResourceId"],
-                                    event.get("ResourceStatusReason", "-"),
-                                ],
-                                width=kwargs["width"],
-                                margin=kwargs["margin"],
-                                format_string=DESCRIBE_STACK_EVENTS_FORMAT_STRING,
-                                format_args=kwargs["format_args"],
-                                columns_dict=DESCRIBE_STACK_EVENTS_DEFAULT_ARGS.copy(),
-                                color=row_color,
-                            )
-                        # Skip already shown old event entries
-                        elif utc_to_timestamp(event["Timestamp"]) <= time_stamp_marker:
-                            time_stamp_marker = latest_time_stamp_marker
+                        # Skip already shown old event entries or former deployments
+                        if utc_to_timestamp(event["Timestamp"]) <= time_stamp_marker:
                             break
-                    else:  # go to next loop if not break from inside loop
-                        time_stamp_marker = latest_time_stamp_marker  # update marker if all events are new
+                        if event["EventId"] not in events:
+                            events.add(event["EventId"])
+                            # Events are in reverse chronological order
+                            # Pushing in front reverse the order to display older events first
+                            new_events.appendleft(event)
+                    else:  # go to next loop (page of events) if not break from inside loop
                         continue
                     break  # reached here only if break from inner loop!
 
-                if self._check_stack_not_in_progress(stack_status):
-                    stack_change_in_progress = False
-                    break
+                # Override timestamp marker with latest event (last in deque)
+                if len(new_events) > 0:
+                    time_stamp_marker = utc_to_timestamp(new_events[-1]["Timestamp"])
+
+                for new_event in new_events:
+                    row_color = self.deploy_color.get_stack_events_status_color(status=new_event["ResourceStatus"])
+                    pprint_columns(
+                        columns=[
+                            new_event["ResourceStatus"],
+                            new_event["ResourceType"],
+                            new_event["LogicalResourceId"],
+                            new_event.get("ResourceStatusReason", "-"),
+                        ],
+                        width=kwargs["width"],
+                        margin=kwargs["margin"],
+                        format_string=DESCRIBE_STACK_EVENTS_FORMAT_STRING,
+                        format_args=kwargs["format_args"],
+                        columns_dict=DESCRIBE_STACK_EVENTS_DEFAULT_ARGS.copy(),
+                        color=row_color,
+                    )
+                    # Skip events from another consecutive deployment triggered during sleep by another process
+                    if self._is_root_stack_event(new_event) and self._check_stack_not_in_progress(
+                        new_event["ResourceStatus"]
+                    ):
+                        stack_change_in_progress = False
+                        break
+
                 # Reset retry attempts if iteration is a success to use client_sleep again
                 retry_attempts = 0
             except botocore.exceptions.ClientError as ex:
@@ -425,6 +430,14 @@ class Deployer:
                     return
                 # Sleep in exponential backoff mode
                 time.sleep(math.pow(self.backoff, retry_attempts))
+
+    @staticmethod
+    def _is_root_stack_event(event: Dict) -> bool:
+        return (
+            event["ResourceType"] == "AWS::CloudFormation::Stack"
+            and event["StackName"] == event["LogicalResourceId"]
+            and event["PhysicalResourceId"] == event["StackId"]
+        )
 
     @staticmethod
     def _check_stack_not_in_progress(status: str) -> bool:

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -434,7 +434,7 @@ class Deployer:
 
     @staticmethod
     def _is_root_stack_event(event: Dict) -> bool:
-        return (
+        return bool(
             event["ResourceType"] == "AWS::CloudFormation::Stack"
             and event["StackName"] == event["LogicalResourceId"]
             and event["PhysicalResourceId"] == event["StackId"]

--- a/tests/unit/lib/deploy/test_deployer.py
+++ b/tests/unit/lib/deploy/test_deployer.py
@@ -50,7 +50,7 @@ class MockCreateUpdateWaiter:
 
 
 class CustomTestCase(TestCase):
-    def assertListSubset(self, l1: Union[Iterable, Container], l2: Union[Iterable, Container], msg=None) -> None:
+    def assertListSubset(self, l1: Iterable, l2: Union[Iterable, Container], msg=None) -> None:
         """
         Assert l2 contains all items in l1.
         Just like calling self.assertIn(l1[x], l2) in a loop.
@@ -461,20 +461,20 @@ class TestDeployer(CustomTestCase):
         self.deployer.describe_stack_events("test", utc_to_timestamp(start_timestamp) - 1)
         self.assertEqual(patched_pprint_columns.call_count, 5)
         self.assertListSubset(
-            ["CREATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0].kwargs["columns"]
+            ["CREATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0][1]["columns"]
         )
         self.assertListSubset(
-            ["CREATE_IN_PROGRESS", "kms", "mykms"], patched_pprint_columns.call_args_list[1].kwargs["columns"]
+            ["CREATE_IN_PROGRESS", "kms", "mykms"], patched_pprint_columns.call_args_list[1][1]["columns"]
         )
         self.assertListSubset(
-            ["CREATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[2].kwargs["columns"]
+            ["CREATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[2][1]["columns"]
         )
         self.assertListSubset(
-            ["CREATE_COMPLETE", "kms", "mykms"], patched_pprint_columns.call_args_list[3].kwargs["columns"]
+            ["CREATE_COMPLETE", "kms", "mykms"], patched_pprint_columns.call_args_list[3][1]["columns"]
         )
         self.assertListSubset(
             ["CREATE_COMPLETE", "AWS::CloudFormation::Stack", "test"],
-            patched_pprint_columns.call_args_list[4].kwargs["columns"],
+            patched_pprint_columns.call_args_list[4][1]["columns"],
         )
 
     @patch("time.sleep")
@@ -567,20 +567,20 @@ class TestDeployer(CustomTestCase):
         self.deployer.describe_stack_events("test", utc_to_timestamp(last_event_timestamp))
         self.assertEqual(patched_pprint_columns.call_count, 5)
         self.assertListSubset(
-            ["UPDATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0].kwargs["columns"]
+            ["UPDATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0][1]["columns"]
         )
         self.assertListSubset(
-            ["UPDATE_IN_PROGRESS", "kms", "mykms"], patched_pprint_columns.call_args_list[1].kwargs["columns"]
+            ["UPDATE_IN_PROGRESS", "kms", "mykms"], patched_pprint_columns.call_args_list[1][1]["columns"]
         )
         self.assertListSubset(
-            ["UPDATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[2].kwargs["columns"]
+            ["UPDATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[2][1]["columns"]
         )
         self.assertListSubset(
-            ["UPDATE_COMPLETE", "kms", "mykms"], patched_pprint_columns.call_args_list[3].kwargs["columns"]
+            ["UPDATE_COMPLETE", "kms", "mykms"], patched_pprint_columns.call_args_list[3][1]["columns"]
         )
         self.assertListSubset(
             ["UPDATE_COMPLETE", "AWS::CloudFormation::Stack", "test"],
-            patched_pprint_columns.call_args_list[4].kwargs["columns"],
+            patched_pprint_columns.call_args_list[4][1]["columns"],
         )
 
     @patch("time.sleep")
@@ -687,11 +687,11 @@ class TestDeployer(CustomTestCase):
         self.assertEqual(patched_pprint_columns.call_count, 4)
         self.assertListSubset(
             ["UPDATE_IN_PROGRESS", "AWS::CloudFormation::Stack", "test"],
-            patched_pprint_columns.call_args_list[0].kwargs["columns"],
+            patched_pprint_columns.call_args_list[0][1]["columns"],
         )
         self.assertListSubset(
             ["UPDATE_COMPLETE", "AWS::CloudFormation::Stack", "test"],
-            patched_pprint_columns.call_args_list[3].kwargs["columns"],
+            patched_pprint_columns.call_args_list[3][1]["columns"],
         )
 
     @patch("time.sleep")
@@ -789,14 +789,14 @@ class TestDeployer(CustomTestCase):
         self.deployer.describe_stack_events("test", utc_to_timestamp(start_timestamp) - 1)
         self.assertEqual(patched_pprint_columns.call_count, 3)
         self.assertListSubset(
-            ["CREATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0].kwargs["columns"]
+            ["CREATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0][1]["columns"]
         )
         self.assertListSubset(
-            ["CREATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[1].kwargs["columns"]
+            ["CREATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[1][1]["columns"]
         )
         self.assertListSubset(
             ["CREATE_COMPLETE", "AWS::CloudFormation::Stack", "test"],
-            patched_pprint_columns.call_args_list[2].kwargs["columns"],
+            patched_pprint_columns.call_args_list[2][1]["columns"],
         )
 
     @patch("samcli.lib.deploy.deployer.math")

--- a/tests/unit/lib/deploy/test_deployer.py
+++ b/tests/unit/lib/deploy/test_deployer.py
@@ -1,8 +1,10 @@
 from logging import captureWarnings
+from operator import inv
+from typing import Container, Iterable, Union
 import uuid
 import time
 import math
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import TestCase
 from unittest.mock import patch, MagicMock, ANY, call
 
@@ -47,7 +49,17 @@ class MockCreateUpdateWaiter:
         return
 
 
-class TestDeployer(TestCase):
+class CustomTestCase(TestCase):
+    def assertListSubset(self, l1: Union[Iterable, Container], l2: Union[Iterable, Container], msg=None) -> None:
+        """
+        Assert l2 contains all items in l1.
+        Just like calling self.assertIn(l1[x], l2) in a loop.
+        """
+        for x in l1:
+            self.assertIn(x, l2, msg)
+
+
+class TestDeployer(CustomTestCase):
     def setUp(self):
         self.session = MagicMock()
         self.cloudformation_client = self.session.client("cloudformation")
@@ -376,28 +388,25 @@ class TestDeployer(TestCase):
         self.assertEqual(last_stack_event_timestamp.second, current_timestamp.second)
 
     @patch("time.sleep")
-    def test_describe_stack_events(self, patched_time):
-        current_timestamp = datetime.utcnow()
+    @patch("samcli.lib.deploy.deployer.pprint_columns")
+    def test_describe_stack_events_chronological_order(self, patched_pprint_columns, patched_time):
+        start_timestamp = datetime(2022, 1, 1, 16, 42, 0, 0, timezone.utc)
 
-        self.deployer._client.describe_stacks = MagicMock(
-            side_effect=[
-                {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_COMPLETE_CLEANUP_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_COMPLETE"}]},
-            ]
-        )
         self.deployer._client.get_paginator = MagicMock(
             return_value=MockPaginator(
+                # describe_stack_events is in reverse chronological order
                 [
                     {
                         "StackEvents": [
                             {
+                                "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
                                 "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_IN_PROGRESS",
-                                "ResourceType": "s3",
-                                "LogicalResourceId": "mybucket",
+                                "StackName": "test",
+                                "LogicalResourceId": "test",
+                                "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "ResourceType": "AWS::CloudFormation::Stack",
+                                "Timestamp": start_timestamp + timedelta(seconds=3),
+                                "ResourceStatus": "CREATE_COMPLETE",
                             }
                         ]
                     },
@@ -405,8 +414,8 @@ class TestDeployer(TestCase):
                         "StackEvents": [
                             {
                                 "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_IN_PROGRESS",
+                                "Timestamp": start_timestamp + timedelta(seconds=2),
+                                "ResourceStatus": "CREATE_COMPLETE",
                                 "ResourceType": "kms",
                                 "LogicalResourceId": "mykms",
                             }
@@ -416,7 +425,7 @@ class TestDeployer(TestCase):
                         "StackEvents": [
                             {
                                 "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
+                                "Timestamp": start_timestamp + timedelta(seconds=1),
                                 "ResourceStatus": "CREATE_COMPLETE",
                                 "ResourceType": "s3",
                                 "LogicalResourceId": "mybucket",
@@ -427,10 +436,21 @@ class TestDeployer(TestCase):
                         "StackEvents": [
                             {
                                 "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_COMPLETE",
+                                "Timestamp": start_timestamp,
+                                "ResourceStatus": "CREATE_IN_PROGRESS",
                                 "ResourceType": "kms",
                                 "LogicalResourceId": "mykms",
+                            }
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp,
+                                "ResourceStatus": "CREATE_IN_PROGRESS",
+                                "ResourceType": "s3",
+                                "LogicalResourceId": "mybucket",
                             }
                         ]
                     },
@@ -438,28 +458,188 @@ class TestDeployer(TestCase):
             )
         )
 
-        self.deployer.describe_stack_events("test", time.time() - 1)
+        self.deployer.describe_stack_events("test", utc_to_timestamp(start_timestamp) - 1)
+        self.assertEqual(patched_pprint_columns.call_count, 5)
+        self.assertListSubset(
+            ["CREATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["CREATE_IN_PROGRESS", "kms", "mykms"], patched_pprint_columns.call_args_list[1].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["CREATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[2].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["CREATE_COMPLETE", "kms", "mykms"], patched_pprint_columns.call_args_list[3].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["CREATE_COMPLETE", "AWS::CloudFormation::Stack", "test"],
+            patched_pprint_columns.call_args_list[4].kwargs["columns"],
+        )
+
+    @patch("time.sleep")
+    @patch("samcli.lib.deploy.deployer.pprint_columns")
+    def test_describe_stack_events_chronological_order_with_previous_event(self, patched_pprint_columns, patched_time):
+        start_timestamp = datetime(2022, 1, 1, 16, 42, 0, 0, timezone.utc)
+        last_event_timestamp = start_timestamp - timedelta(hours=6)
+
+        self.deployer._client.get_paginator = MagicMock(
+            return_value=MockPaginator(
+                # describe_stack_events is in reverse chronological order
+                [
+                    {
+                        "StackEvents": [
+                            {
+                                "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "EventId": str(uuid.uuid4()),
+                                "StackName": "test",
+                                "LogicalResourceId": "test",
+                                "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "ResourceType": "AWS::CloudFormation::Stack",
+                                "Timestamp": start_timestamp + timedelta(seconds=3),
+                                "ResourceStatus": "UPDATE_COMPLETE",
+                            }
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp + timedelta(seconds=2),
+                                "ResourceStatus": "UPDATE_COMPLETE",
+                                "ResourceType": "kms",
+                                "LogicalResourceId": "mykms",
+                            }
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp + timedelta(seconds=1),
+                                "ResourceStatus": "UPDATE_COMPLETE",
+                                "ResourceType": "s3",
+                                "LogicalResourceId": "mybucket",
+                            }
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp,
+                                "ResourceStatus": "UPDATE_IN_PROGRESS",
+                                "ResourceType": "kms",
+                                "LogicalResourceId": "mykms",
+                            }
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp,
+                                "ResourceStatus": "UPDATE_IN_PROGRESS",
+                                "ResourceType": "s3",
+                                "LogicalResourceId": "mybucket",
+                            }
+                        ]
+                    },
+                    # Last event (from a former deployment)
+                    {
+                        "StackEvents": [
+                            {
+                                "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "EventId": str(uuid.uuid4()),
+                                "StackName": "test",
+                                "LogicalResourceId": "test",
+                                "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "ResourceType": "AWS::CloudFormation::Stack",
+                                "Timestamp": last_event_timestamp,
+                                "ResourceStatus": "CREATE_COMPLETE",
+                            }
+                        ]
+                    },
+                ]
+            )
+        )
+
+        self.deployer.describe_stack_events("test", utc_to_timestamp(last_event_timestamp))
+        self.assertEqual(patched_pprint_columns.call_count, 5)
+        self.assertListSubset(
+            ["UPDATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["UPDATE_IN_PROGRESS", "kms", "mykms"], patched_pprint_columns.call_args_list[1].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["UPDATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[2].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["UPDATE_COMPLETE", "kms", "mykms"], patched_pprint_columns.call_args_list[3].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["UPDATE_COMPLETE", "AWS::CloudFormation::Stack", "test"],
+            patched_pprint_columns.call_args_list[4].kwargs["columns"],
+        )
 
     @patch("time.sleep")
     @patch("samcli.lib.deploy.deployer.pprint_columns")
     def test_describe_stack_events_skip_old_event(self, patched_pprint_columns, patched_time):
-        current_timestamp = datetime.utcnow()
+        start_timestamp = datetime(2022, 1, 1, 16, 42, 0, 0, timezone.utc)
+        last_event_timestamp = start_timestamp - timedelta(hours=6)
 
-        self.deployer._client.describe_stacks = MagicMock(
-            side_effect=[
-                {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_COMPLETE_CLEANUP_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_COMPLETE"}]},
-            ]
-        )
         sample_events = [
+            # old deployment
+            {
+                "StackEvents": [
+                    {
+                        "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                        "EventId": str(uuid.uuid4()),
+                        "StackName": "test",
+                        "LogicalResourceId": "test",
+                        "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                        "ResourceType": "AWS::CloudFormation::Stack",
+                        "Timestamp": last_event_timestamp - timedelta(seconds=10),
+                        "ResourceStatus": "CREATE_IN_PROGRESS",
+                    }
+                ]
+            },
+            {
+                "StackEvents": [
+                    {
+                        "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                        "EventId": str(uuid.uuid4()),
+                        "StackName": "test",
+                        "LogicalResourceId": "test",
+                        "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                        "ResourceType": "AWS::CloudFormation::Stack",
+                        "Timestamp": last_event_timestamp,
+                        "ResourceStatus": "CREATE_COMPLETE",
+                    }
+                ]
+            },
+            # new deployment
+            {
+                "StackEvents": [
+                    {
+                        "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                        "EventId": str(uuid.uuid4()),
+                        "StackName": "test",
+                        "LogicalResourceId": "test",
+                        "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                        "ResourceType": "AWS::CloudFormation::Stack",
+                        "Timestamp": start_timestamp,
+                        "ResourceStatus": "UPDATE_IN_PROGRESS",
+                    }
+                ]
+            },
             {
                 "StackEvents": [
                     {
                         "EventId": str(uuid.uuid4()),
-                        "Timestamp": current_timestamp,
-                        "ResourceStatus": "CREATE_IN_PROGRESS",
+                        "Timestamp": start_timestamp + timedelta(seconds=10),
+                        "ResourceStatus": "UPDATE_IN_PROGRESS",
                         "ResourceType": "s3",
                         "LogicalResourceId": "mybucket",
                     }
@@ -469,19 +649,8 @@ class TestDeployer(TestCase):
                 "StackEvents": [
                     {
                         "EventId": str(uuid.uuid4()),
-                        "Timestamp": current_timestamp + timedelta(seconds=10),
-                        "ResourceStatus": "CREATE_IN_PROGRESS",
-                        "ResourceType": "kms",
-                        "LogicalResourceId": "mykms",
-                    }
-                ]
-            },
-            {
-                "StackEvents": [
-                    {
-                        "EventId": str(uuid.uuid4()),
-                        "Timestamp": current_timestamp + timedelta(seconds=20),
-                        "ResourceStatus": "CREATE_COMPLETE",
+                        "Timestamp": start_timestamp + timedelta(seconds=20),
+                        "ResourceStatus": "UPDATE_COMPLETE",
                         "ResourceType": "s3",
                         "LogicalResourceId": "mybucket",
                     }
@@ -490,11 +659,14 @@ class TestDeployer(TestCase):
             {
                 "StackEvents": [
                     {
+                        "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
                         "EventId": str(uuid.uuid4()),
-                        "Timestamp": current_timestamp + timedelta(seconds=30),
-                        "ResourceStatus": "CREATE_COMPLETE",
-                        "ResourceType": "kms",
-                        "LogicalResourceId": "mykms",
+                        "StackName": "test",
+                        "LogicalResourceId": "test",
+                        "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                        "ResourceType": "AWS::CloudFormation::Stack",
+                        "Timestamp": start_timestamp + timedelta(seconds=30),
+                        "ResourceStatus": "UPDATE_COMPLETE",
                     }
                 ]
             },
@@ -502,21 +674,136 @@ class TestDeployer(TestCase):
         invalid_event = {"StackEvents": [{}]}  # if deployer() loop read this, KeyError would raise
         self.deployer._client.get_paginator = MagicMock(
             side_effect=[
-                MockPaginator([sample_events[0]]),
+                MockPaginator([sample_events[0], invalid_event]),
                 MockPaginator([sample_events[1], sample_events[0], invalid_event]),
                 MockPaginator([sample_events[2], sample_events[1], invalid_event]),
                 MockPaginator([sample_events[3], sample_events[2], invalid_event]),
+                MockPaginator([sample_events[4], sample_events[3], invalid_event]),
+                MockPaginator([sample_events[5], sample_events[4], invalid_event]),
             ]
         )
 
-        self.deployer.describe_stack_events("test", time.time() - 1)
+        self.deployer.describe_stack_events("test", utc_to_timestamp(last_event_timestamp))
         self.assertEqual(patched_pprint_columns.call_count, 4)
+        self.assertListSubset(
+            ["UPDATE_IN_PROGRESS", "AWS::CloudFormation::Stack", "test"],
+            patched_pprint_columns.call_args_list[0].kwargs["columns"],
+        )
+        self.assertListSubset(
+            ["UPDATE_COMPLETE", "AWS::CloudFormation::Stack", "test"],
+            patched_pprint_columns.call_args_list[3].kwargs["columns"],
+        )
+
+    @patch("time.sleep")
+    @patch("samcli.lib.deploy.deployer.pprint_columns")
+    def test_describe_stack_events_stop_at_first_not_in_progress(self, patched_pprint_columns, patched_time):
+        start_timestamp = datetime(2022, 1, 1, 16, 42, 0, 0, timezone.utc)
+
+        self.deployer._client.get_paginator = MagicMock(
+            return_value=MockPaginator(
+                # describe_stack_events is in reverse chronological order
+                [
+                    {
+                        "StackEvents": [
+                            {
+                                "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "EventId": str(uuid.uuid4()),
+                                "StackName": "test",
+                                "LogicalResourceId": "test",
+                                "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "ResourceType": "AWS::CloudFormation::Stack",
+                                "Timestamp": start_timestamp + timedelta(seconds=33),
+                                "ResourceStatus": "UPDATE_COMLPETE",
+                            },
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp + timedelta(seconds=32),
+                                "ResourceStatus": "UPDATE_COMPLETE",
+                                "ResourceType": "s3",
+                                "LogicalResourceId": "mybucket",
+                            },
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp + timedelta(seconds=31),
+                                "ResourceStatus": "UPDATE_IN_PROGRESS",
+                                "ResourceType": "s3",
+                                "LogicalResourceId": "mybucket",
+                            },
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "EventId": str(uuid.uuid4()),
+                                "StackName": "test",
+                                "LogicalResourceId": "test",
+                                "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "ResourceType": "AWS::CloudFormation::Stack",
+                                "Timestamp": start_timestamp + timedelta(seconds=30),
+                                "ResourceStatus": "UPDATE_IN_PROGRESS",
+                            },
+                            {
+                                # This event should stop the loop and ignore above events
+                                "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "EventId": str(uuid.uuid4()),
+                                "StackName": "test",
+                                "LogicalResourceId": "test",
+                                "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                "ResourceType": "AWS::CloudFormation::Stack",
+                                "Timestamp": start_timestamp + timedelta(seconds=3),
+                                "ResourceStatus": "CREATE_COMPLETE",
+                            },
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp + timedelta(seconds=1),
+                                "ResourceStatus": "CREATE_COMPLETE",
+                                "ResourceType": "s3",
+                                "LogicalResourceId": "mybucket",
+                            }
+                        ]
+                    },
+                    {
+                        "StackEvents": [
+                            {
+                                "EventId": str(uuid.uuid4()),
+                                "Timestamp": start_timestamp,
+                                "ResourceStatus": "CREATE_IN_PROGRESS",
+                                "ResourceType": "s3",
+                                "LogicalResourceId": "mybucket",
+                            }
+                        ]
+                    },
+                ]
+            )
+        )
+
+        self.deployer.describe_stack_events("test", utc_to_timestamp(start_timestamp) - 1)
+        self.assertEqual(patched_pprint_columns.call_count, 3)
+        self.assertListSubset(
+            ["CREATE_IN_PROGRESS", "s3", "mybucket"], patched_pprint_columns.call_args_list[0].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["CREATE_COMPLETE", "s3", "mybucket"], patched_pprint_columns.call_args_list[1].kwargs["columns"]
+        )
+        self.assertListSubset(
+            ["CREATE_COMPLETE", "AWS::CloudFormation::Stack", "test"],
+            patched_pprint_columns.call_args_list[2].kwargs["columns"],
+        )
 
     @patch("samcli.lib.deploy.deployer.math")
     @patch("time.sleep")
     def test_describe_stack_events_exceptions(self, patched_time, patched_math):
 
-        self.deployer._client.describe_stacks = MagicMock(
+        self.deployer._client.get_paginator = MagicMock(
             side_effect=[
                 ClientError(
                     error_response={"Error": {"Message": "Rate Exceeded"}}, operation_name="describe_stack_events"
@@ -541,9 +828,9 @@ class TestDeployer(TestCase):
     @patch("samcli.lib.deploy.deployer.math")
     @patch("time.sleep")
     def test_describe_stack_events_resume_after_exceptions(self, patched_time, patched_math):
-        current_timestamp = datetime.utcnow()
+        start_timestamp = datetime(2022, 1, 1, 16, 42, 0, 0, timezone.utc)
 
-        self.deployer._client.describe_stacks = MagicMock(
+        self.deployer._client.get_paginator = MagicMock(
             side_effect=[
                 ClientError(
                     error_response={"Error": {"Message": "Rate Exceeded"}}, operation_name="describe_stack_events"
@@ -554,131 +841,139 @@ class TestDeployer(TestCase):
                 ClientError(
                     error_response={"Error": {"Message": "Rate Exceeded"}}, operation_name="describe_stack_events"
                 ),
-                {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_COMPLETE_CLEANUP_IN_PROGRESS"}]},
-                {"Stacks": [{"StackStatus": "CREATE_COMPLETE"}]},
+                MockPaginator(
+                    [
+                        {
+                            "StackEvents": [
+                                {
+                                    "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                    "EventId": str(uuid.uuid4()),
+                                    "StackName": "test",
+                                    "LogicalResourceId": "test",
+                                    "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                    "ResourceType": "AWS::CloudFormation::Stack",
+                                    "Timestamp": start_timestamp,
+                                    "ResourceStatus": "CREATE_COMPLETE",
+                                },
+                                {
+                                    "EventId": str(uuid.uuid4()),
+                                    "Timestamp": start_timestamp,
+                                    "ResourceStatus": "CREATE_COMPLETE",
+                                    "ResourceType": "kms",
+                                    "LogicalResourceId": "mykms",
+                                },
+                            ]
+                        },
+                        {
+                            "StackEvents": [
+                                {
+                                    "EventId": str(uuid.uuid4()),
+                                    "Timestamp": start_timestamp,
+                                    "ResourceStatus": "CREATE_COMPLETE",
+                                    "ResourceType": "s3",
+                                    "LogicalResourceId": "mybucket",
+                                }
+                            ]
+                        },
+                        {
+                            "StackEvents": [
+                                {
+                                    "EventId": str(uuid.uuid4()),
+                                    "Timestamp": start_timestamp,
+                                    "ResourceStatus": "CREATE_IN_PROGRESS",
+                                    "ResourceType": "kms",
+                                    "LogicalResourceId": "mykms",
+                                }
+                            ]
+                        },
+                        {
+                            "StackEvents": [
+                                {
+                                    "EventId": str(uuid.uuid4()),
+                                    "Timestamp": start_timestamp,
+                                    "ResourceStatus": "CREATE_IN_PROGRESS",
+                                    "ResourceType": "s3",
+                                    "LogicalResourceId": "mybucket",
+                                }
+                            ]
+                        },
+                    ]
+                ),
             ]
         )
 
-        self.deployer._client.get_paginator = MagicMock(
-            return_value=MockPaginator(
-                [
-                    {
-                        "StackEvents": [
-                            {
-                                "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_IN_PROGRESS",
-                                "ResourceType": "s3",
-                                "LogicalResourceId": "mybucket",
-                            }
-                        ]
-                    },
-                    {
-                        "StackEvents": [
-                            {
-                                "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_IN_PROGRESS",
-                                "ResourceType": "kms",
-                                "LogicalResourceId": "mykms",
-                            }
-                        ]
-                    },
-                    {
-                        "StackEvents": [
-                            {
-                                "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_COMPLETE",
-                                "ResourceType": "s3",
-                                "LogicalResourceId": "mybucket",
-                            }
-                        ]
-                    },
-                    {
-                        "StackEvents": [
-                            {
-                                "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_COMPLETE",
-                                "ResourceType": "kms",
-                                "LogicalResourceId": "mykms",
-                            }
-                        ]
-                    },
-                ]
-            )
-        )
-
-        self.deployer.describe_stack_events("test", time.time())
+        self.deployer.describe_stack_events("test", utc_to_timestamp(start_timestamp) - 1)
         self.assertEqual(patched_math.pow.call_count, 3)
         self.assertEqual(patched_math.pow.call_args_list, [call(2, 1), call(2, 2), call(2, 3)])
 
     @patch("samcli.lib.deploy.deployer.math.pow", wraps=math.pow)
     @patch("time.sleep")
     def test_describe_stack_events_reset_retry_on_success_after_exceptions(self, patched_time, patched_pow):
-        current_timestamp = datetime.utcnow()
+        start_timestamp = datetime(2022, 1, 1, 16, 42, 0, 0, timezone.utc)
 
-        self.deployer._client.describe_stacks = MagicMock(
+        self.deployer._client.get_paginator = MagicMock(
             side_effect=[
-                {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},
-                ClientError(
-                    error_response={"Error": {"Message": "Rate Exceeded"}}, operation_name="describe_stack_events"
+                MockPaginator(
+                    [
+                        {
+                            "StackEvents": [
+                                {
+                                    "EventId": str(uuid.uuid4()),
+                                    "Timestamp": start_timestamp,
+                                    "ResourceStatus": "CREATE_IN_PROGRESS",
+                                    "ResourceType": "s3",
+                                    "LogicalResourceId": "mybucket",
+                                },
+                            ]
+                        },
+                    ]
                 ),
                 ClientError(
                     error_response={"Error": {"Message": "Rate Exceeded"}}, operation_name="describe_stack_events"
                 ),
-                {"Stacks": [{"StackStatus": "CREATE_IN_PROGRESS"}]},
                 ClientError(
                     error_response={"Error": {"Message": "Rate Exceeded"}}, operation_name="describe_stack_events"
                 ),
-                {"Stacks": [{"StackStatus": "CREATE_COMPLETE"}]},
+                MockPaginator(
+                    [
+                        {
+                            "StackEvents": [
+                                {
+                                    "EventId": str(uuid.uuid4()),
+                                    "Timestamp": start_timestamp + timedelta(seconds=10),
+                                    "ResourceStatus": "CREATE_COMPLETE",
+                                    "ResourceType": "s3",
+                                    "LogicalResourceId": "mybucket",
+                                }
+                            ]
+                        },
+                    ]
+                ),
+                ClientError(
+                    error_response={"Error": {"Message": "Rate Exceeded"}}, operation_name="describe_stack_events"
+                ),
+                MockPaginator(
+                    [
+                        {
+                            "StackEvents": [
+                                {
+                                    "StackId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                    "EventId": str(uuid.uuid4()),
+                                    "StackName": "test",
+                                    "LogicalResourceId": "test",
+                                    "PhysicalResourceId": "arn:aws:cloudformation:region:accountId:stack/test/uuid",
+                                    "ResourceType": "AWS::CloudFormation::Stack",
+                                    "Timestamp": start_timestamp + timedelta(seconds=20),
+                                    "ResourceStatus": "CREATE_COMPLETE",
+                                },
+                            ]
+                        },
+                    ]
+                ),
             ]
         )
 
-        self.deployer._client.get_paginator = MagicMock(
-            return_value=MockPaginator(
-                [
-                    {
-                        "StackEvents": [
-                            {
-                                "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_IN_PROGRESS",
-                                "ResourceType": "s3",
-                                "LogicalResourceId": "mybucket",
-                            }
-                        ]
-                    },
-                    {
-                        "StackEvents": [
-                            {
-                                "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_IN_PROGRESS",
-                                "ResourceType": "kms",
-                                "LogicalResourceId": "mykms",
-                            }
-                        ]
-                    },
-                    {
-                        "StackEvents": [
-                            {
-                                "EventId": str(uuid.uuid4()),
-                                "Timestamp": current_timestamp,
-                                "ResourceStatus": "CREATE_COMPLETE",
-                                "ResourceType": "s3",
-                                "LogicalResourceId": "mybucket",
-                            }
-                        ]
-                    },
-                ]
-            )
-        )
-
-        self.deployer.describe_stack_events("test", time.time())
+        self.deployer.describe_stack_events("test", utc_to_timestamp(start_timestamp) - 1)
 
         # There are 2 sleep call for exceptions (backoff + regular one at 0)
         self.assertEqual(patched_time.call_count, 9)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Fixes #3910
Fixes #3911

#### Why is this change necessary?
When using the feature from #3500 and deploy with a large `SAM_CLI_POLL_DELAY` events for each poll iterations are in reverse order. And if another process update the stack while sleeping the loop won't stop and catch events from another process.

#### How does it address the issue?
- Buffer events in a `deque` (push front) to print in chronological order
- Remove `DescribeStacks` request and rely on first `not_in_progress` event on the root stack to exit the loop
- In tests reverse mock events order to match `DescribeStackEvents` api reverse chronological order
- Test print order

#### What side effects does this change have?
- No more requests to `DescribeStack`
- Print refresh delay (`client_sleep`) in table header

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write/update unit tests
- [x] `make pr` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
