### PR TITLE
feat: remove the created intermediate containers while building the lambda functions of Image Type

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -414,7 +414,6 @@ class ApplicationBuilder:
             "decode": True,
             "platform": get_docker_platform(architecture),
             "rm": True,
-            "forcerm": True,
         }
         if docker_build_target:
             build_args["target"] = cast(str, docker_build_target)

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -413,6 +413,8 @@ class ApplicationBuilder:
             "buildargs": docker_build_args,
             "decode": True,
             "platform": get_docker_platform(architecture),
+            "rm": True,
+            "forcerm": True,
         }
         if docker_build_target:
             build_args["target"] = cast(str, docker_build_target)

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -136,6 +136,13 @@ class BuildIntegBase(TestCase):
         )
         self.assertFalse(bool(samcli_containers), "Build containers have not been removed")
 
+    def get_number_of_created_containers(self):
+        if IS_WINDOWS:
+            time.sleep(1)
+        docker_client = docker.from_env()
+        containers = docker_client.containers.list(all=True)
+        return len(containers)
+
     def verify_pulled_image(self, runtime, architecture=X86_64):
         docker_client = docker.from_env()
         image_name = f"{LambdaBuildContainer._IMAGE_URI_PREFIX}-{runtime}"

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -46,11 +46,7 @@ LOG = logging.getLogger(__name__)
 SKIP_SAR_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_BY_CANARY
 
 
-@skipIf(
-    # Hits public ECR pull limitation, move it to canary tests
-    ((not RUN_BY_CANARY) or (IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
-    "Skip build tests on windows when running in CI unless overridden",
-)
+
 class TestBuildCommand_PythonFunctions_Images(BuildIntegBase):
     template = "template_image.yaml"
 
@@ -85,6 +81,40 @@ class TestBuildCommand_PythonFunctions_Images(BuildIntegBase):
         self._verify_invoke_built_function(
             self.built_template, self.FUNCTION_LOGICAL_ID_IMAGE, self._make_parameter_override_arg(overrides), expected
         )
+
+
+    @pytest.mark.flaky(reruns=3)
+    def test_intermediate_container_deleted(self):
+        _tag = f"{random.randint(1, 100)}"
+        overrides = {
+            "Runtime": "3.9",
+            "Handler": "main.handler",
+            "DockerFile": "Dockerfile",
+            "Tag": _tag,
+        }
+        cmdlist = self.get_command_list(use_container=False, parameter_overrides=overrides)
+
+        LOG.info("Running Command: ")
+        LOG.info(cmdlist)
+
+        _num_of_containers_before_build = self.get_number_of_created_containers()
+        run_command(cmdlist, cwd=self.working_dir)
+        _num_of_containers_after_build = self.get_number_of_created_containers()
+
+        self._verify_image_build_artifact(
+            self.built_template,
+            self.FUNCTION_LOGICAL_ID_IMAGE,
+            "ImageUri",
+            f"{self.FUNCTION_LOGICAL_ID_IMAGE.lower()}:{_tag}",
+        )
+
+        expected = {"pi": "3.14"}
+        self._verify_invoke_built_function(
+            self.built_template, self.FUNCTION_LOGICAL_ID_IMAGE, self._make_parameter_override_arg(overrides), expected
+        )
+
+        self.assertEqual(_num_of_containers_before_build, _num_of_containers_after_build,
+                         "Intermediate containers are not removed")
 
 
 @skipIf(

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -46,6 +46,11 @@ LOG = logging.getLogger(__name__)
 SKIP_SAR_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_BY_CANARY
 
 
+@skipIf(
+    # Hits public ECR pull limitation, move it to canary tests
+    ((not RUN_BY_CANARY) or (IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
 class TestBuildCommand_PythonFunctions_Images(BuildIntegBase):
     template = "template_image.yaml"
 

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -46,7 +46,6 @@ LOG = logging.getLogger(__name__)
 SKIP_SAR_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_BY_CANARY
 
 
-
 class TestBuildCommand_PythonFunctions_Images(BuildIntegBase):
     template = "template_image.yaml"
 
@@ -82,7 +81,6 @@ class TestBuildCommand_PythonFunctions_Images(BuildIntegBase):
             self.built_template, self.FUNCTION_LOGICAL_ID_IMAGE, self._make_parameter_override_arg(overrides), expected
         )
 
-
     @pytest.mark.flaky(reruns=3)
     def test_intermediate_container_deleted(self):
         _tag = f"{random.randint(1, 100)}"
@@ -113,8 +111,9 @@ class TestBuildCommand_PythonFunctions_Images(BuildIntegBase):
             self.built_template, self.FUNCTION_LOGICAL_ID_IMAGE, self._make_parameter_override_arg(overrides), expected
         )
 
-        self.assertEqual(_num_of_containers_before_build, _num_of_containers_after_build,
-                         "Intermediate containers are not removed")
+        self.assertEqual(
+            _num_of_containers_before_build, _num_of_containers_after_build, "Intermediate containers are not removed"
+        )
 
 
 @skipIf(

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -1143,6 +1143,8 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
                 buildargs={"a": "b", "SAM_BUILD_MODE": "debug"},
                 decode=True,
                 platform="linux/amd64",
+                rm=True,
+                forcerm=True,
             ),
         )
 
@@ -1171,6 +1173,8 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
                 decode=True,
                 target="stage",
                 platform="linux/amd64",
+                rm=True,
+                forcerm=True,
             ),
         )
 

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -1146,7 +1146,6 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
                 decode=True,
                 platform="linux/amd64",
                 rm=True,
-                forcerm=True,
             ),
         )
 
@@ -1176,7 +1175,6 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
                 target="stage",
                 platform="linux/amd64",
                 rm=True,
-                forcerm=True,
             ),
         )
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
The default behaviour of [docker image create API](https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.build) is to keep the intermediate containers created. So, when customer execute `sam build` for an Image type Lambda Function, the customer will find some created containers exist after `sam build` command finish. This PR is to clean these intermediate containers, and let the docker API delete these containers after the image built process finish.


By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
