### PR TITLE
chore: Add safe teardown for accelerate integration test

### DIFF
--- a/tests/integration/testdata/logs/python-apigw-sfn/template.yaml
+++ b/tests/integration/testdata/logs/python-apigw-sfn/template.yaml
@@ -58,6 +58,8 @@ Resources:
 
   MyStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['-', ['/aws/vendedlogs/', !Select [2, !Split ['/', !Ref AWS::StackId]]]]
 
   ApiGwFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Sync watch and sync infra don't use fixture, so no change there.

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
