### PR TITLE
feat: Add in support for nested stack's code sync with Api's and StepFunctions

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -409,6 +409,10 @@ Commands you can use next
         return self._mode
 
     @property
+    def use_base_dir(self) -> bool:
+        return self._use_raw_codeuri
+
+    @property
     def resources_to_build(self) -> ResourcesToBuildCollector:
         """
         Function return resources that should be build by current build command. This function considers

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -603,22 +603,22 @@ class Stack:
         return None
 
     @staticmethod
-    def get_stack_by_logical_id(logical_id: str, stacks: List["Stack"]) -> Optional["Stack"]:
+    def get_stack_by_full_path(full_path: str, stacks: List["Stack"]) -> Optional["Stack"]:
         """
-        Return the stack with given logical id
+        Return the stack with given full path
         Parameters
         ----------
-        logical_id str
-            logical_id of the stack
+        full_path str
+            full path of the stack like ChildStack/ChildChildStack
         stacks : List[Stack]
             a list of stack for searching
         Returns
         -------
         Stack
-            The stack with the given logical id
+            The stack with the given full path
         """
         for stack in stacks:
-            if stack.name == logical_id:
+            if stack.stack_path == full_path:
                 return stack
         return None
 

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -616,7 +616,9 @@ class SamFunctionProvider(SamBaseProvider):
             LOG.debug("Search layer %s in child stack", layer_reference)
 
             child_stacks = Stack.get_child_stacks(stack, stacks)
-            child_stack = Stack.get_stack_by_logical_id(layer_stack_reference, child_stacks)
+            stack_prefix = stack.stack_path + "/" if stack.stack_path else ""
+            stack_path = stack_prefix + layer_stack_reference
+            child_stack = Stack.get_stack_by_full_path(stack_path, child_stacks)
             if not child_stack:
                 LOG.debug("Child stack not found, layer can not be located in templates")
                 return None

--- a/samcli/lib/sync/flows/generic_api_sync_flow.py
+++ b/samcli/lib/sync/flows/generic_api_sync_flow.py
@@ -75,13 +75,13 @@ class GenericApiSyncFlow(SyncFlow):
             return None
         properties = api_resource.get("Properties", {})
         definition_file = properties.get("DefinitionUri")
+        definition_path = None
         if definition_file:
-            if self._build_context.use_base_dir:
-                definition_file = Path(self._build_context.base_dir).joinpath(definition_file)
-            else:
+            definition_path = Path(self._build_context.base_dir).joinpath(definition_file)
+            if not self._build_context.use_base_dir:
                 child_stack = Stack.get_stack_by_full_path(ResourceIdentifier(api_identifier).stack_path, self._stacks)
-                definition_file = Path(child_stack.location).parent.joinpath(definition_file)
-        return cast(Optional[Path], definition_file)
+                definition_path = Path(child_stack.location).parent.joinpath(definition_file)
+        return cast(Optional[Path], definition_path)
 
     def compare_remote(self) -> bool:
         return False

--- a/samcli/lib/sync/flows/generic_api_sync_flow.py
+++ b/samcli/lib/sync/flows/generic_api_sync_flow.py
@@ -20,7 +20,7 @@ class GenericApiSyncFlow(SyncFlow):
 
     _api_client: Any
     _api_identifier: str
-    _definition_uri: Optional[str]
+    _definition_uri: Optional[Path]
     _stacks: List[Stack]
     _swagger_body: Optional[bytes]
 
@@ -65,7 +65,7 @@ class GenericApiSyncFlow(SyncFlow):
     def _process_definition_file(self) -> Optional[bytes]:
         if self._definition_uri is None:
             return None
-        with open(self._definition_uri, "rb") as swagger_file:
+        with open(str(self._definition_uri), "rb") as swagger_file:
             swagger_body = swagger_file.read()
             return swagger_body
 
@@ -77,7 +77,7 @@ class GenericApiSyncFlow(SyncFlow):
         definition_file = properties.get("DefinitionUri")
         if definition_file:
             if self._build_context.use_base_dir:
-                definition_file = str(Path(self._build_context.base_dir).joinpath(definition_file))
+                definition_file = Path(self._build_context.base_dir).joinpath(definition_file)
             else:
                 child_stack = Stack.get_stack_by_full_path(ResourceIdentifier(api_identifier).stack_path, self._stacks)
                 definition_file = Path(child_stack.location).parent.joinpath(definition_file)

--- a/samcli/lib/sync/flows/generic_api_sync_flow.py
+++ b/samcli/lib/sync/flows/generic_api_sync_flow.py
@@ -76,7 +76,7 @@ class GenericApiSyncFlow(SyncFlow):
         properties = api_resource.get("Properties", {})
         definition_file = properties.get("DefinitionUri")
         if definition_file:
-            if self._build_context._use_raw_codeuri:
+            if self._build_context.use_base_dir:
                 definition_file = str(Path(self._build_context.base_dir).joinpath(definition_file))
             else:
                 child_stack = Stack.get_stack_by_full_path(ResourceIdentifier(api_identifier).stack_path, self._stacks)

--- a/samcli/lib/sync/flows/generic_api_sync_flow.py
+++ b/samcli/lib/sync/flows/generic_api_sync_flow.py
@@ -1,7 +1,7 @@
 """SyncFlow interface for HttpApi and RestApi"""
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from samcli.lib.sync.sync_flow import SyncFlow, ResourceAPICall
 from samcli.lib.providers.provider import Stack, get_resource_by_id, ResourceIdentifier

--- a/samcli/lib/sync/flows/generic_api_sync_flow.py
+++ b/samcli/lib/sync/flows/generic_api_sync_flow.py
@@ -80,8 +80,9 @@ class GenericApiSyncFlow(SyncFlow):
             definition_path = Path(self._build_context.base_dir).joinpath(definition_file)
             if not self._build_context.use_base_dir:
                 child_stack = Stack.get_stack_by_full_path(ResourceIdentifier(api_identifier).stack_path, self._stacks)
-                definition_path = Path(child_stack.location).parent.joinpath(definition_file)
-        return cast(Optional[Path], definition_path)
+                if child_stack:
+                    definition_path = Path(child_stack.location).parent.joinpath(definition_file)
+        return definition_path
 
     def compare_remote(self) -> bool:
         return False

--- a/samcli/lib/sync/flows/stepfunctions_sync_flow.py
+++ b/samcli/lib/sync/flows/stepfunctions_sync_flow.py
@@ -84,15 +84,16 @@ class StepFunctionsSyncFlow(SyncFlow):
             return None
         properties = self._resource.get("Properties", {})
         definition_file = properties.get("DefinitionUri")
+        definition_path = None
         if definition_file:
-            if self._build_context.use_base_dir:
-                definition_file = Path(self._build_context.base_dir).joinpath(definition_file)
-            else:
+            definition_path = Path(self._build_context.base_dir).joinpath(definition_file)
+            if not self._build_context.use_base_dir:
                 child_stack = Stack.get_stack_by_full_path(
                     ResourceIdentifier(state_machine_identifier).stack_path, self._stacks
                 )
-                definition_file = Path(child_stack.location).parent.joinpath(definition_file)
-        return cast(Optional[Path], definition_file)
+                if child_stack:
+                    definition_path = Path(child_stack.location).parent.joinpath(definition_file)
+        return cast(Optional[Path], definition_path)
 
     def compare_remote(self) -> bool:
         # Not comparing with remote right now, instead only making update api calls

--- a/samcli/lib/sync/flows/stepfunctions_sync_flow.py
+++ b/samcli/lib/sync/flows/stepfunctions_sync_flow.py
@@ -93,7 +93,7 @@ class StepFunctionsSyncFlow(SyncFlow):
                 )
                 if child_stack:
                     definition_path = Path(child_stack.location).parent.joinpath(definition_file)
-        return cast(Optional[Path], definition_path)
+        return definition_path
 
     def compare_remote(self) -> bool:
         # Not comparing with remote right now, instead only making update api calls

--- a/samcli/lib/sync/flows/stepfunctions_sync_flow.py
+++ b/samcli/lib/sync/flows/stepfunctions_sync_flow.py
@@ -21,7 +21,7 @@ class StepFunctionsSyncFlow(SyncFlow):
     _state_machine_identifier: str
     _stepfunctions_client: Any
     _stacks: List[Stack]
-    _definition_uri: Optional[str]
+    _definition_uri: Optional[Path]
     _states_definition: Optional[str]
 
     def __init__(
@@ -75,7 +75,7 @@ class StepFunctionsSyncFlow(SyncFlow):
     def _process_definition_file(self) -> Optional[str]:
         if self._definition_uri is None:
             return None
-        with open(self._definition_uri, "r", encoding="utf-8") as states_file:
+        with open(str(self._definition_uri), "r", encoding="utf-8") as states_file:
             states_data = states_file.read()
             return states_data
 
@@ -86,7 +86,7 @@ class StepFunctionsSyncFlow(SyncFlow):
         definition_file = properties.get("DefinitionUri")
         if definition_file:
             if self._build_context.use_base_dir:
-                definition_file = str(Path(self._build_context.base_dir).joinpath(definition_file))
+                definition_file = Path(self._build_context.base_dir).joinpath(definition_file)
             else:
                 child_stack = Stack.get_stack_by_full_path(
                     ResourceIdentifier(state_machine_identifier).stack_path, self._stacks

--- a/samcli/lib/sync/flows/stepfunctions_sync_flow.py
+++ b/samcli/lib/sync/flows/stepfunctions_sync_flow.py
@@ -1,7 +1,7 @@
 """Base SyncFlow for StepFunctions"""
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, TYPE_CHECKING, cast, Optional
+from typing import Any, Dict, List, TYPE_CHECKING, Optional
 
 
 from samcli.lib.providers.provider import Stack, get_resource_by_id, ResourceIdentifier

--- a/samcli/lib/sync/flows/stepfunctions_sync_flow.py
+++ b/samcli/lib/sync/flows/stepfunctions_sync_flow.py
@@ -85,7 +85,7 @@ class StepFunctionsSyncFlow(SyncFlow):
         properties = self._resource.get("Properties", {})
         definition_file = properties.get("DefinitionUri")
         if definition_file:
-            if self._build_context._use_raw_codeuri:
+            if self._build_context.use_base_dir:
                 definition_file = str(Path(self._build_context.base_dir).joinpath(definition_file))
             else:
                 child_stack = Stack.get_stack_by_full_path(

--- a/samcli/lib/sync/sync_flow.py
+++ b/samcli/lib/sync/sync_flow.py
@@ -318,9 +318,31 @@ class SyncFlow(ABC):
         return dependencies
 
 
-# A helper method used by non-function sync flows to resolve definition file path
-# that are relative to the child stack to absolute path for nested stacks
-def get_definition_path(resource: Dict, identifier: str, use_base_dir: bool, base_dir, stacks) -> Optional[Path]:
+def get_definition_path(
+    resource: Dict, identifier: str, use_base_dir: bool, base_dir: str, stacks: List[Stack]
+) -> Optional[Path]:
+    """
+    A helper method used by non-function sync flows to resolve definition file path
+    that are relative to the child stack to absolute path for nested stacks
+
+    Parameters
+    -------
+    resource: Dict
+        The resource's template dict
+    identifier: str
+        The logical ID identifier of the resource
+    use_base_dir: bool
+        Whether or not the base_dir option was used
+    base_dir: str
+        Base directory if provided, otherwise the root template directory
+    stacks: List[Stack]
+        The list of stacks for the application
+
+    Returns
+    -------
+    Optional[Path]
+        A resolved absolute path for the definition file
+    """
     properties = resource.get("Properties", {})
     definition_file = properties.get("DefinitionUri")
     definition_path = None

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -410,7 +410,6 @@ class TestSyncCodeNested(TestSyncCodeBase):
                 self.assertIn("extra_message", lambda_response)
                 self.assertEqual(lambda_response.get("message"), "10")
 
-    @pytest.mark.skip(reason="Currently not properly supported")
     def test_sync_code_nested_rest_api(self):
         shutil.rmtree(
             TestSyncCodeBase.temp_dir.joinpath("child_stack").joinpath("child_child_stack").joinpath("apigateway"),
@@ -447,7 +446,6 @@ class TestSyncCodeNested(TestSyncCodeBase):
         rest_api = self.stack_resources.get(AWS_APIGATEWAY_RESTAPI)[0]
         self.assertEqual(self._get_api_message(rest_api), '{"message": "hello 2"}')
 
-    @pytest.mark.skip(reason="Currently not properly supported")
     def test_sync_code_nested_state_machine(self):
         shutil.rmtree(
             TestSyncCodeBase.temp_dir.joinpath("child_stack").joinpath("child_child_stack").joinpath("statemachine"),

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -467,6 +467,7 @@ class TestBuildContext__enter__(TestCase):
         self.assertEqual(context.stacks, [stack])
         self.assertEqual(context.manifest_path_override, os.path.abspath("manifest_path"))
         self.assertEqual(context.mode, "buildmode")
+        self.assertFalse(context.use_base_dir)
         self.assertFalse(context.is_building_specific_resource)
         resources_to_build = context.resources_to_build
         self.assertEqual(resources_to_build.functions, [func1, func2, func6])

--- a/tests/unit/commands/local/lib/test_provider.py
+++ b/tests/unit/commands/local/lib/test_provider.py
@@ -802,26 +802,39 @@ class TestGetResourceFullPathByID(TestCase):
 
 
 class TestGetStack(TestCase):
-    root_stack = Stack("", "", "template.yaml", None, {})
-    child_stack = Stack("", "child", "template.yaml", None, {})
+    root_stack = Stack("", "Root", "template.yaml", None, {})
+    child_stack = Stack("Root", "Child", "root_stack/template.yaml", None, {})
+    child_child_stack = Stack("Root/Child", "ChildChild", "root_stack/child_stack/template.yaml", None, {})
 
     def test_get_parent_stack(self):
-        stack = Stack.get_parent_stack(self.child_stack, [self.root_stack, self.child_stack])
+        stack = Stack.get_parent_stack(self.child_stack, [self.root_stack, self.child_stack, self.child_child_stack])
         self.assertEqual(stack, self.root_stack)
 
-        stack = Stack.get_parent_stack(self.root_stack, [self.root_stack, self.child_stack])
+        stack = Stack.get_parent_stack(self.root_stack, [self.root_stack, self.child_stack, self.child_child_stack])
         self.assertIsNone(stack)
 
-    def test_get_stack_by_logical_id(self):
-        stack = Stack.get_stack_by_logical_id("child", [self.root_stack, self.child_stack])
+    def test_get_stack_by_full_path(self):
+        stack = Stack.get_stack_by_full_path("Root/Child", [self.root_stack, self.child_stack, self.child_child_stack])
         self.assertEqual(stack, self.child_stack)
 
-        stack = Stack.get_stack_by_logical_id("not_exist", [self.root_stack, self.child_stack])
+        stack = Stack.get_stack_by_full_path("Root", [self.root_stack, self.child_stack, self.child_child_stack])
+        self.assertEqual(stack, self.root_stack)
+
+        stack = Stack.get_stack_by_full_path("Child/Child", [self.root_stack, self.child_stack, self.child_child_stack])
         self.assertIsNone(stack)
 
     def test_get_child_stacks(self):
-        stack_list = Stack.get_child_stacks(self.root_stack, [self.root_stack, self.child_stack])
+        stack_list = Stack.get_child_stacks(
+            self.root_stack, [self.root_stack, self.child_stack, self.child_child_stack]
+        )
         self.assertEqual(stack_list, [self.child_stack])
 
-        stack_list = Stack.get_child_stacks(self.child_stack, [self.root_stack, self.child_stack])
+        stack_list = Stack.get_child_stacks(
+            self.child_stack, [self.root_stack, self.child_stack, self.child_child_stack]
+        )
+        self.assertEqual(stack_list, [self.child_child_stack])
+
+        stack_list = Stack.get_child_stacks(
+            self.child_child_stack, [self.root_stack, self.child_stack, self.child_child_stack]
+        )
         self.assertEqual(stack_list, [])

--- a/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
@@ -50,7 +50,7 @@ class TestHttpApiSyncFlow(TestCase):
     def test_get_definition_file(self, get_resource_mock, get_stack_mock):
         sync_flow = self.create_sync_flow()
 
-        sync_flow._build_context._use_raw_codeuri = False
+        sync_flow._build_context.use_base_dir = False
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
 
@@ -67,7 +67,7 @@ class TestHttpApiSyncFlow(TestCase):
     def test_get_definition_file_with_base_dir(self, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
-        sync_flow._build_context._use_raw_codeuri = True
+        sync_flow._build_context.use_base_dir = True
         sync_flow._build_context.base_dir = "base_dir"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")

--- a/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
@@ -72,7 +72,7 @@ class TestHttpApiSyncFlow(TestCase):
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 
-        self.assertEqual(result_uri, str(Path("base_dir").joinpath("test_uri")))
+        self.assertEqual(result_uri, Path("base_dir").joinpath("test_uri"))
 
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()

--- a/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, mock_open, patch
 from pathlib import Path
+from samcli.lib.providers.provider import Stack
 
 from samcli.lib.sync.flows.http_api_sync_flow import HttpApiSyncFlow
 from samcli.lib.providers.exceptions import MissingLocalDefinition
@@ -44,17 +45,18 @@ class TestHttpApiSyncFlow(TestCase):
 
         sync_flow._api_client.reimport_api.assert_called_once_with(ApiId="PhysicalApi1", Body='{"key": "value"}')
 
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Stack.get_stack_by_full_path")
     @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_resource_by_id")
-    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Path.joinpath")
-    def test_get_definition_file(self, join_path_mock, get_resource_mock):
+    def test_get_definition_file(self, get_resource_mock, get_stack_mock):
         sync_flow = self.create_sync_flow()
 
-        sync_flow._build_context.base_dir = None
-        join_path_mock.return_value = "test_uri"
+        sync_flow._build_context._use_raw_codeuri = False
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
+        get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
+
         result_uri = sync_flow._get_definition_file("test")
 
-        self.assertEqual(result_uri, "test_uri")
+        self.assertEqual(result_uri, Path("location").joinpath("test_uri"))
 
         get_resource_mock.return_value = {"Properties": {}}
         result_uri = sync_flow._get_definition_file("test")
@@ -65,6 +67,7 @@ class TestHttpApiSyncFlow(TestCase):
     def test_get_definition_file_with_base_dir(self, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
+        sync_flow._build_context._use_raw_codeuri = True
         sync_flow._build_context.base_dir = "base_dir"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")

--- a/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
@@ -45,34 +45,51 @@ class TestHttpApiSyncFlow(TestCase):
 
         sync_flow._api_client.reimport_api.assert_called_once_with(ApiId="PhysicalApi1", Body='{"key": "value"}')
 
-    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Stack.get_stack_by_full_path")
     @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_resource_by_id")
-    def test_get_definition_file(self, get_resource_mock, get_stack_mock):
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_definition_path")
+    def test_get_definition_file(self, get_path_mock, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
         sync_flow._build_context.use_base_dir = False
         sync_flow._build_context.base_dir = "base_dir"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
-        get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
+        get_path_mock.return_value = Path("base_dir").joinpath("test_uri")
 
-        result_uri = sync_flow._get_definition_file("test")
+        result_uri = sync_flow._get_definition_file(sync_flow._api_identifier)
 
-        self.assertEqual(result_uri, Path("location").joinpath("test_uri"))
+        get_path_mock.assert_called_with(
+            {"Properties": {"DefinitionUri": "test_uri"}},
+            sync_flow._api_identifier,
+            False,
+            "base_dir",
+            sync_flow._stacks,
+        )
+        self.assertEqual(result_uri, Path("base_dir").joinpath("test_uri"))
 
-        get_resource_mock.return_value = {"Properties": {}}
-        result_uri = sync_flow._get_definition_file("test")
+        get_resource_mock.return_value = {}
+        result_uri = sync_flow._get_definition_file(sync_flow._api_identifier)
 
         self.assertEqual(result_uri, None)
 
     @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_resource_by_id")
-    def test_get_definition_file_with_base_dir(self, get_resource_mock):
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.get_definition_path")
+    def test_get_definition_file_with_base_dir(self, get_path_mock, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
         sync_flow._build_context.use_base_dir = True
         sync_flow._build_context.base_dir = "base_dir"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
-        result_uri = sync_flow._get_definition_file("test")
+        get_path_mock.return_value = Path("base_dir").joinpath("test_uri")
 
+        result_uri = sync_flow._get_definition_file(sync_flow._api_identifier)
+
+        get_path_mock.assert_called_with(
+            {"Properties": {"DefinitionUri": "test_uri"}},
+            sync_flow._api_identifier,
+            True,
+            "base_dir",
+            sync_flow._stacks,
+        )
         self.assertEqual(result_uri, Path("base_dir").joinpath("test_uri"))
 
     def test_process_definition_file(self):

--- a/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_http_api_sync_flow.py
@@ -51,6 +51,7 @@ class TestHttpApiSyncFlow(TestCase):
         sync_flow = self.create_sync_flow()
 
         sync_flow._build_context.use_base_dir = False
+        sync_flow._build_context.base_dir = "base_dir"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
 

--- a/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
@@ -289,7 +289,7 @@ please check the console to see if you have other stages that needs to be update
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 
-        self.assertEqual(result_uri, str(Path("base_dir").joinpath("test_uri")))
+        self.assertEqual(result_uri, Path("base_dir").joinpath("test_uri"))
 
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()

--- a/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
@@ -268,6 +268,7 @@ please check the console to see if you have other stages that needs to be update
         sync_flow = self.create_sync_flow()
 
         sync_flow._build_context.use_base_dir = False
+        sync_flow._build_context.base_dir = "base_dir"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
 

--- a/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
@@ -1,4 +1,3 @@
-from os import sync
 from unittest import TestCase
 from unittest.mock import MagicMock, mock_open, patch, call
 from pathlib import Path

--- a/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
@@ -268,7 +268,7 @@ please check the console to see if you have other stages that needs to be update
     def test_get_definition_file(self, get_resource_mock, get_stack_mock):
         sync_flow = self.create_sync_flow()
 
-        sync_flow._build_context._use_raw_codeuri = False
+        sync_flow._build_context.use_base_dir = False
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
 
@@ -285,7 +285,7 @@ please check the console to see if you have other stages that needs to be update
     def test_get_definition_file_with_base_dir(self, get_resource_mock):
         sync_flow = self.create_sync_flow()
 
-        sync_flow._build_context._use_raw_codeuri = True
+        sync_flow._build_context.use_base_dir = True
         sync_flow._build_context.base_dir = "base_dir"
         get_resource_mock.return_value = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import ANY, MagicMock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 from pathlib import Path
 from samcli.lib.providers.provider import Stack
 

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -59,7 +59,7 @@ class TestStepFunctionsSyncFlow(TestCase):
     def test_get_definition_file(self, get_stack_mock):
         sync_flow = self.create_sync_flow()
 
-        sync_flow._build_context._use_raw_codeuri = False
+        sync_flow._build_context.use_base_dir = False
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
         get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
 
@@ -76,7 +76,7 @@ class TestStepFunctionsSyncFlow(TestCase):
     def test_get_definition_file_with_base_dir(self, get_stack_mock):
         sync_flow = self.create_sync_flow()
 
-        sync_flow._build_context._use_raw_codeuri = True
+        sync_flow._build_context.use_base_dir = True
         sync_flow._build_context.base_dir = "base_dir"
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -60,6 +60,7 @@ class TestStepFunctionsSyncFlow(TestCase):
         sync_flow = self.create_sync_flow()
 
         sync_flow._build_context.use_base_dir = False
+        sync_flow._build_context.base_dir = "base_dir"
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
         get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
 

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -81,7 +81,7 @@ class TestStepFunctionsSyncFlow(TestCase):
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")
 
-        self.assertEqual(result_uri, str(Path("base_dir").joinpath("test_uri")))
+        self.assertEqual(result_uri, Path("base_dir").joinpath("test_uri"))
 
     def test_process_definition_file(self):
         sync_flow = self.create_sync_flow()

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from unittest.mock import ANY, MagicMock, mock_open, patch
 from pathlib import Path
+from samcli.lib.providers.provider import Stack
 
 from samcli.lib.sync.flows.stepfunctions_sync_flow import StepFunctionsSyncFlow
 from samcli.lib.sync.exceptions import InfraSyncRequiredError
@@ -54,27 +55,28 @@ class TestStepFunctionsSyncFlow(TestCase):
             stateMachineArn="PhysicalId1", definition='{"key": "value"}'
         )
 
-    @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.get_resource_by_id")
-    @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.Path.joinpath")
-    def test_get_definition_file(self, join_path_mock, get_resource_mock):
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Stack.get_stack_by_full_path")
+    def test_get_definition_file(self, get_stack_mock):
         sync_flow = self.create_sync_flow()
 
-        sync_flow._build_context.base_dir = None
-        join_path_mock.return_value = "test_uri"
+        sync_flow._build_context._use_raw_codeuri = False
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
+        get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
+
         result_uri = sync_flow._get_definition_file("test")
 
-        self.assertEqual(result_uri, "test_uri")
+        self.assertEqual(result_uri, Path("location").joinpath("test_uri"))
 
         sync_flow._resource = {"Properties": {}}
         result_uri = sync_flow._get_definition_file("test")
 
         self.assertEqual(result_uri, None)
 
-    @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.get_resource_by_id")
-    def test_get_definition_file_with_base_dir(self, get_resource_mock):
+    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Stack.get_stack_by_full_path")
+    def test_get_definition_file_with_base_dir(self, get_stack_mock):
         sync_flow = self.create_sync_flow()
 
+        sync_flow._build_context._use_raw_codeuri = True
         sync_flow._build_context.base_dir = "base_dir"
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
         result_uri = sync_flow._get_definition_file("test")

--- a/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_stepfunctions_sync_flow.py
@@ -55,33 +55,49 @@ class TestStepFunctionsSyncFlow(TestCase):
             stateMachineArn="PhysicalId1", definition='{"key": "value"}'
         )
 
-    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Stack.get_stack_by_full_path")
-    def test_get_definition_file(self, get_stack_mock):
+    @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.get_definition_path")
+    def test_get_definition_file(self, get_path_mock):
         sync_flow = self.create_sync_flow()
 
         sync_flow._build_context.use_base_dir = False
         sync_flow._build_context.base_dir = "base_dir"
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
-        get_stack_mock.return_value = Stack("parent_path", "stack_name", "location/template.yaml", None, {})
+        get_path_mock.return_value = Path("base_dir").joinpath("test_uri")
 
-        result_uri = sync_flow._get_definition_file("test")
+        result_uri = sync_flow._get_definition_file(sync_flow._state_machine_identifier)
 
-        self.assertEqual(result_uri, Path("location").joinpath("test_uri"))
+        get_path_mock.assert_called_with(
+            {"Properties": {"DefinitionUri": "test_uri"}},
+            sync_flow._state_machine_identifier,
+            False,
+            "base_dir",
+            sync_flow._stacks,
+        )
+        self.assertEqual(result_uri, Path("base_dir").joinpath("test_uri"))
 
-        sync_flow._resource = {"Properties": {}}
-        result_uri = sync_flow._get_definition_file("test")
+        sync_flow._resource = {}
+        result_uri = sync_flow._get_definition_file(sync_flow._state_machine_identifier)
 
         self.assertEqual(result_uri, None)
 
-    @patch("samcli.lib.sync.flows.generic_api_sync_flow.Stack.get_stack_by_full_path")
-    def test_get_definition_file_with_base_dir(self, get_stack_mock):
+    @patch("samcli.lib.sync.flows.stepfunctions_sync_flow.get_definition_path")
+    def test_get_definition_file_with_base_dir(self, get_path_mock):
         sync_flow = self.create_sync_flow()
 
         sync_flow._build_context.use_base_dir = True
         sync_flow._build_context.base_dir = "base_dir"
         sync_flow._resource = {"Properties": {"DefinitionUri": "test_uri"}}
-        result_uri = sync_flow._get_definition_file("test")
+        get_path_mock.return_value = Path("base_dir").joinpath("test_uri")
 
+        result_uri = sync_flow._get_definition_file(sync_flow._state_machine_identifier)
+
+        get_path_mock.assert_called_with(
+            {"Properties": {"DefinitionUri": "test_uri"}},
+            sync_flow._state_machine_identifier,
+            True,
+            "base_dir",
+            sync_flow._stacks,
+        )
         self.assertEqual(result_uri, Path("base_dir").joinpath("test_uri"))
 
     def test_process_definition_file(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N.A.

#### Why is this change necessary?
Since currently we are implementing code sync support for nested stack, this will make Api and StepFunction resources within child stacks also syncable through sam sync --code.

#### How does it address the issue?
It resolves the definition files from path relative to child template, to path relative to root template. For base_dir use cases, this will still be base_dir based.

#### What side effects does this change have?
Not known.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
