### PR TITLE
fix: auto dependency layer issue when there are no dependencies with existing lambda function

### DIFF
--- a/samcli/lib/bootstrap/nested_stack/nested_stack_manager.py
+++ b/samcli/lib/bootstrap/nested_stack/nested_stack_manager.py
@@ -201,7 +201,8 @@ class NestedStackManager:
         if not function_build_definition or not function_build_definition.dependencies_dir:
             return None
 
-        if not os.path.isdir(function_build_definition.dependencies_dir):
+        if not os.path.isdir(function_build_definition.dependencies_dir) \
+                or not os.listdir(function_build_definition.dependencies_dir):
             return None
 
         return function_build_definition.dependencies_dir

--- a/samcli/lib/bootstrap/nested_stack/nested_stack_manager.py
+++ b/samcli/lib/bootstrap/nested_stack/nested_stack_manager.py
@@ -201,8 +201,9 @@ class NestedStackManager:
         if not function_build_definition or not function_build_definition.dependencies_dir:
             return None
 
-        if not os.path.isdir(function_build_definition.dependencies_dir) \
-                or not os.listdir(function_build_definition.dependencies_dir):
+        if not os.path.isdir(function_build_definition.dependencies_dir) or not os.listdir(
+            function_build_definition.dependencies_dir
+        ):
             return None
 
         return function_build_definition.dependencies_dir

--- a/samcli/lib/sync/flows/layer_sync_flow.py
+++ b/samcli/lib/sync/flows/layer_sync_flow.py
@@ -315,7 +315,7 @@ class FunctionLayerReferenceSync(SyncFlow):
                 self._layer_arn,
                 HELP_TEXT_FOR_SYNC_INFRA,
             )
-            return
+            raise MissingPhysicalResourceError(self._layer_arn)
 
         # remove the old layer version arn and add the new one
         layer_arns.remove(old_layer_arn)

--- a/tests/unit/lib/sync/flows/test_auto_dependency_layer_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_auto_dependency_layer_sync_flow.py
@@ -6,7 +6,7 @@ from samcli.lib.build.build_graph import BuildGraph
 from samcli.lib.sync.exceptions import (
     MissingFunctionBuildDefinition,
     InvalidRuntimeDefinitionForFunction,
-    NoLayerVersionsFoundError,
+    NoLayerVersionsFoundError, MissingPhysicalResourceError,
 )
 from samcli.lib.sync.flows.auto_dependency_layer_sync_flow import (
     AutoDependencyLayerParentSyncFlow,
@@ -97,6 +97,13 @@ class TestAutoDependencyLayerSyncFlow(TestCase):
         patched_make_zip.return_value = zipfile
         self.build_graph.get_function_build_definitions.return_value = [Mock(dependencies_dir=dependencies_dir)]
 
+        lambda_client_mock = Mock()
+        given_layer_arn = "aws:lambda:layer:arn"
+        lambda_client_mock.list_layer_versions.return_value = {
+            "LayerVersions": [{"LayerVersionArn": f"{given_layer_arn}:1"}]
+        }
+        self.sync_flow._lambda_client = lambda_client_mock
+
         with patch.object(self.sync_flow, "_get_compatible_runtimes") as patched_comp_runtimes:
             patched_comp_runtimes.return_value = [runtime]
             self.sync_flow.gather_resources()
@@ -109,6 +116,45 @@ class TestAutoDependencyLayerSyncFlow(TestCase):
                 os.path.join(tmpdir, f"data-{uuid_hex}"), self.sync_flow._artifact_folder
             )
             patched_file_checksum.assert_called_with(zipfile, ANY)
+            lambda_client_mock.list_layer_versions.assert_called_with(LayerName=ANY)
+            self.assertEqual(self.sync_flow._layer_arn, given_layer_arn)
+
+    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.uuid")
+    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.file_checksum")
+    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.make_zip")
+    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.tempfile")
+    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.NestedStackManager")
+    def test_gather_resources_with_no_layer_version(
+            self,
+            patched_nested_stack_manager,
+            patched_tempfile,
+            patched_make_zip,
+            patched_file_checksum,
+            patched_uuid,
+    ):
+        layer_root_folder = "layer_root_folder"
+        dependencies_dir = "dependencies_dir"
+        tmpdir = "tmpdir"
+        uuid_hex = "uuid_hex"
+        runtime = "runtime"
+        zipfile = "zipfile"
+
+        patched_nested_stack_manager.update_layer_folder.return_value = layer_root_folder
+        patched_tempfile.gettempdir.return_value = tmpdir
+        patched_uuid.uuid4.return_value = Mock(hex=uuid_hex)
+        patched_make_zip.return_value = zipfile
+        self.build_graph.get_function_build_definitions.return_value = [Mock(dependencies_dir=dependencies_dir)]
+
+        lambda_client_mock = Mock()
+        lambda_client_mock.list_layer_versions.return_value = {
+            "LayerVersions": []
+        }
+        self.sync_flow._lambda_client = lambda_client_mock
+
+        with patch.object(self.sync_flow, "_get_compatible_runtimes") as patched_comp_runtimes:
+            patched_comp_runtimes.return_value = [runtime]
+            with self.assertRaises(MissingPhysicalResourceError):
+                self.sync_flow.gather_resources()
 
     def test_empty_gather_dependencies(self):
         with patch.object(self.sync_flow, "_get_dependent_functions") as patched_get_dependent_functions:
@@ -140,37 +186,3 @@ class TestAutoDependencyLayerSyncFlow(TestCase):
         patched_function_provider.return_value.get.return_value = given_function_in_template
 
         self.assertEqual(self.sync_flow._get_compatible_runtimes(), [given_runtime])
-
-    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.NestedStackBuilder")
-    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.super")
-    def test_setup(self, patched_super, patched_nested_stack_builder):
-        layer_name = "layer_name"
-        patched_nested_stack_builder.get_layer_name.return_value = layer_name
-
-        patched_lambda_client = Mock()
-        self.sync_flow._lambda_client = patched_lambda_client
-        layer_physical_name = "layer_physical_name"
-        patched_lambda_client.list_layer_versions.return_value = {
-            "LayerVersions": [{"LayerVersionArn": f"{layer_physical_name}:0"}]
-        }
-
-        self.sync_flow.set_up()
-
-        self.assertEqual(self.sync_flow._layer_arn, layer_physical_name)
-        patched_nested_stack_builder.get_layer_name.assert_called_with(
-            self.sync_flow._deploy_context.stack_name, self.sync_flow._function_identifier
-        )
-        patched_lambda_client.list_layer_versions.assert_called_with(LayerName=layer_name)
-
-    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.NestedStackBuilder")
-    @patch("samcli.lib.sync.flows.auto_dependency_layer_sync_flow.super")
-    def test_setup_with_no_layer_version(self, patched_super, patched_nested_stack_builder):
-        layer_name = "layer_name"
-        patched_nested_stack_builder.get_layer_name.return_value = layer_name
-
-        patched_lambda_client = Mock()
-        self.sync_flow._lambda_client = patched_lambda_client
-        patched_lambda_client.list_layer_versions.return_value = {"LayerVersions": []}
-
-        with self.assertRaises(NoLayerVersionsFoundError):
-            self.sync_flow.set_up()


### PR DESCRIPTION
TODO: Update integration tests to cover this use case.

#### Which issue(s) does this change fix?
#3945

#### Why is this change necessary?
We recently introduced a fix; `sam sync` will not create dependency layers for functions which doesn't any dependency defined in them. This feature works during initial infra sync but it fails subsequent sync flow executions.

#### How does it address the issue?
- We've added additional checks for dependency folders (list files in folder and skip if there are no files)
- If subsequent ADL sync flow fails due to missing layer, it will trigger infra sync which should update with layer information and bring deployed stack up to date with local.

Test following cases;
- Run `sam sync --stack-name {stack-name}` with a function with no dependencies
- Run `sam sync --stack-name {stack-name} --code --resource-id {LogicalId}` and confirmed function is updated
- Edited manifest file and then run the sam sync --stack-name {stack-name} --code --resource-id {LogicalId}` and confirmed infra sync ran with new layer information
- Run `sam sync --stack-name {stack-name} --watch` with a function with no dependencies
  - Make a change to function and confirm it is updated
  - Make a change to dependency and confirm infra sync is triggered and function is updated

#### What side effects does this change have?
This change might trigger infra sync if user adds a dependency for a function which didn't have any before.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
