### PR TITLE
Fix issue in cloning app templates repo in windows

### DIFF
--- a/samcli/__init__.py
+++ b/samcli/__init__.py
@@ -2,4 +2,4 @@
 SAM CLI version
 """
 
-__version__ = "1.51.0"
+__version__ = "1.52.0"

--- a/samcli/lib/utils/git_repo.py
+++ b/samcli/lib/utils/git_repo.py
@@ -129,8 +129,11 @@ class GitRepo:
                 temp_path = os.path.normpath(os.path.join(tempdir, clone_name))
                 git_executable: str = GitRepo._git_executable()
                 LOG.info("\nCloning from %s (process may take a moment)", self.url)
+                command = [git_executable, "clone", self.url, clone_name]
+                if platform.system().lower() == "windows":
+                    command += ["--config", "core.longpaths=true"]
                 check_output(
-                    [git_executable, "clone", self.url, clone_name],
+                    command,
                     cwd=tempdir,
                     stderr=subprocess.STDOUT,
                 )

--- a/samcli/lib/utils/git_repo.py
+++ b/samcli/lib/utils/git_repo.py
@@ -132,7 +132,8 @@ class GitRepo:
                 command = [git_executable, "clone", self.url, clone_name]
                 if platform.system().lower() == "windows":
                     LOG.debug(
-                        "Configure to core.longpaths=true in git clone. You might also need to enable long paths in Windows registry."
+                        "Configure core.longpaths=true in git clone. "
+                        "You might also need to enable long paths in Windows registry."
                     )
                     command += ["--config", "core.longpaths=true"]
                 check_output(

--- a/samcli/lib/utils/git_repo.py
+++ b/samcli/lib/utils/git_repo.py
@@ -131,6 +131,9 @@ class GitRepo:
                 LOG.info("\nCloning from %s (process may take a moment)", self.url)
                 command = [git_executable, "clone", self.url, clone_name]
                 if platform.system().lower() == "windows":
+                    LOG.debug(
+                        "Configure to core.longpaths=true in git clone. You might also need to enable long paths in Windows registry."
+                    )
                     command += ["--config", "core.longpaths=true"]
                 check_output(
                     command,

--- a/tests/unit/lib/utils/test_git_repo.py
+++ b/tests/unit/lib/utils/test_git_repo.py
@@ -53,6 +53,7 @@ class TestGitRepo(TestCase):
     @patch("samcli.lib.utils.git_repo.subprocess.Popen")
     @patch("samcli.lib.utils.git_repo.platform.system")
     def test_clone_happy_case(self, platform_mock, popen_mock, check_output_mock, shutil_mock, path_exist_mock):
+        platform_mock.return_value = "Not Windows"
         path_exist_mock.return_value = False
         self.repo.clone(clone_dir=self.local_clone_dir, clone_name=REPO_NAME)
         self.local_clone_dir.mkdir.assert_called_once_with(mode=0o700, parents=True, exist_ok=True)
@@ -207,6 +208,7 @@ class TestGitRepo(TestCase):
     @patch("samcli.lib.utils.git_repo.subprocess.Popen")
     @patch("samcli.lib.utils.git_repo.platform.system")
     def test_clone_with_commit(self, platform_mock, popen_mock, check_output_mock, shutil_mock, path_exist_mock):
+        platform_mock.return_value = "Not Windows"
         path_exist_mock.return_value = False
         self.repo.clone(clone_dir=self.local_clone_dir, clone_name=REPO_NAME, commit=COMMIT)
         self.local_clone_dir.mkdir.assert_called_once_with(mode=0o700, parents=True, exist_ok=True)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#3946 


#### Why is this change necessary?
App templates repo contains some very long paths in which Windows doesn't support them as it has a limitation of 260 chars. 

#### How does it address the issue?
This change modifies the `git clone` command by appending `--config core.longpaths=true` if the system is Windows. The config is only applied for the cloned repo (i.e. the app templates repo) and won't affect user's system settings. 

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
