### PR TITLE
test: Add ADL tests for nested and non-nested stacks

### DIFF
--- a/samcli/runtime_config.json
+++ b/samcli/runtime_config.json
@@ -1,3 +1,3 @@
 {
-    "app_template_repo_commit": "663f90c5ea51fbc5264924b51311934e1af1403b"
+    "app_template_repo_commit": "6cbf1e1f858aaa2e7d02402c33e11271c3156cc0"
 }

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -12,6 +12,7 @@ from unittest import skipIf
 
 import pytest
 import boto3
+from parameterized import parameterized_class
 
 from samcli.lib.utils.resources import (
     AWS_APIGATEWAY_RESTAPI,
@@ -50,14 +51,13 @@ class TestSyncCodeBase(SyncIntegBase):
 
             TestSyncCode.template_path = TestSyncCode.temp_dir.joinpath(self.template)
             TestSyncCode.stack_name = self._method_to_stack_name(self.id())
-
             # Run infra sync
             sync_command_list = self.get_sync_command_list(
                 template_file=TestSyncCode.template_path,
                 code=False,
                 watch=False,
                 base_dir=TestSyncCode.temp_dir,
-                dependency_layer=True,
+                dependency_layer=self.dependency_layer,
                 stack_name=TestSyncCode.stack_name,
                 parameter_overrides="Parameter=Clarity",
                 image_repository=self.ecr_repo_name,
@@ -88,6 +88,7 @@ class TestSyncCodeBase(SyncIntegBase):
 
 
 @skipIf(SKIP_SYNC_TESTS, "Skip sync tests in CI/CD only")
+@parameterized_class([{"dependency_layer": True}, {"dependency_layer": False}])
 class TestSyncCode(TestSyncCodeBase):
     template = "template-python.yaml"
 
@@ -103,7 +104,7 @@ class TestSyncCode(TestSyncCodeBase):
             code=True,
             watch=False,
             resource="AWS::Serverless::Function",
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             stack_name=TestSyncCode.stack_name,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,
@@ -136,7 +137,7 @@ class TestSyncCode(TestSyncCodeBase):
             code=True,
             watch=False,
             resource="AWS::Serverless::LayerVersion",
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             stack_name=TestSyncCode.stack_name,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,
@@ -174,7 +175,7 @@ class TestSyncCode(TestSyncCodeBase):
             code=True,
             watch=False,
             resource="AWS::Serverless::Function",
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             stack_name=TestSyncCode.stack_name,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,
@@ -259,6 +260,7 @@ class TestSyncCode(TestSyncCodeBase):
 @skipIf(SKIP_SYNC_TESTS, "Skip sync tests in CI/CD only")
 class TestSyncCodeDotnetFunctionTemplate(TestSyncCodeBase):
     template = "template-dotnet.yaml"
+    dependency_layer = False
 
     def test_sync_code_shared_codeuri(self):
         shutil.rmtree(Path(TestSyncCode.temp_dir).joinpath("dotnet_function"), ignore_errors=True)
@@ -273,7 +275,7 @@ class TestSyncCodeDotnetFunctionTemplate(TestSyncCodeBase):
             code=True,
             watch=False,
             resource="AWS::Serverless::Function",
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             stack_name=TestSyncCode.stack_name,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -325,7 +325,9 @@ class TestSyncCodeNodejsFunctionTemplate(TestSyncCodeBase):
         self.stack_resources = self._get_stacks(TestSyncCode.stack_name)
         if self.dependency_layer:
             # Test update manifest
-            layer_contents = self.get_dependency_layer_contents_from_arn(self.stack_resources, "nodejs/node_modules", 1)
+            layer_contents = self.get_dependency_layer_contents_from_arn(
+                self.stack_resources, str(Path("nodejs", "node_modules")), 1
+            )
             self.assertNotIn("@faker-js", layer_contents)
 
         # Run code sync
@@ -356,7 +358,9 @@ class TestSyncCodeNodejsFunctionTemplate(TestSyncCodeBase):
                 self.assertEqual(lambda_response.get("message"), "Hello world!")
 
         if self.dependency_layer:
-            layer_contents = self.get_dependency_layer_contents_from_arn(self.stack_resources, "nodejs/node_modules", 2)
+            layer_contents = self.get_dependency_layer_contents_from_arn(
+                self.stack_resources, str(Path("nodejs", "node_modules")), 2
+            )
             self.assertIn("@faker-js", layer_contents)
 
 

--- a/tests/integration/sync/test_sync_infra.py
+++ b/tests/integration/sync/test_sync_infra.py
@@ -194,6 +194,7 @@ Requires capabilities : [CAPABILITY_AUTO_EXPAND]",
         )
 
 
+@skipIf(SKIP_SYNC_TESTS, "Skip sync tests in CI/CD only")
 class TestSyncInfraCDKTemplates(SyncIntegBase):
     dependency_layer = None
 

--- a/tests/integration/sync/test_sync_infra.py
+++ b/tests/integration/sync/test_sync_infra.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest import skipIf
 
 import pytest
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 
 from samcli.lib.utils.resources import (
     AWS_APIGATEWAY_RESTAPI,
@@ -34,6 +34,7 @@ LOG = logging.getLogger(__name__)
 
 
 @skipIf(SKIP_SYNC_TESTS, "Skip sync tests in CI/CD only")
+@parameterized_class([{"dependency_layer": True}, {"dependency_layer": False}])
 class TestSyncInfra(SyncIntegBase):
     @skipIf(
         IS_WINDOWS,
@@ -52,7 +53,7 @@ class TestSyncInfra(SyncIntegBase):
             template_file=template_path,
             code=False,
             watch=False,
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             stack_name=stack_name,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,
@@ -89,7 +90,7 @@ class TestSyncInfra(SyncIntegBase):
             template_file=template_path,
             code=False,
             watch=False,
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             stack_name=stack_name,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,
@@ -129,7 +130,7 @@ class TestSyncInfra(SyncIntegBase):
             template_file=template_path,
             code=False,
             watch=False,
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             stack_name=stack_name,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,
@@ -151,7 +152,7 @@ class TestSyncInfra(SyncIntegBase):
             template_file=template_path,
             code=False,
             watch=False,
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,
             s3_prefix=self.s3_prefix,
@@ -174,7 +175,7 @@ class TestSyncInfra(SyncIntegBase):
             template_file=template_path,
             code=False,
             watch=False,
-            dependency_layer=True,
+            dependency_layer=self.dependency_layer,
             stack_name=stack_name,
             parameter_overrides="Parameter=Clarity",
             image_repository=self.ecr_repo_name,
@@ -191,6 +192,10 @@ class TestSyncInfra(SyncIntegBase):
 Requires capabilities : [CAPABILITY_AUTO_EXPAND]",
             str(sync_process_execute.stderr),
         )
+
+
+class TestSyncInfraCDKTemplates(SyncIntegBase):
+    dependency_layer = None
 
     @parameterized.expand(
         [

--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -272,6 +272,23 @@ class TestSyncCodeWatchNestedStacks(TestSyncWatchBase):
     def test_sync_watch_code_nested_stack(self):
         self.stack_resources = self._get_stacks(self.stack_name)
 
+        if self.dependency_layer:
+            # Test update manifest
+            layer_contents = self.get_dependency_layer_contents_from_arn(self.stack_resources, "python", 1)
+            self.assertNotIn("requests", layer_contents)
+            self.update_file(
+                self.test_dir.joinpath("code/after/function/requirements.txt"),
+                self.test_dir.joinpath("code/before/function/requirements.txt"),
+            )
+            read_until_string(
+                self.watch_process,
+                "\x1b[32mFinished syncing Function Layer Reference Sync "
+                "LocalNestedChildStack/HelloWorldFunction.\x1b[0m\n",
+                timeout=45,
+            )
+            layer_contents = self.get_dependency_layer_contents_from_arn(self.stack_resources, "python", 2)
+            self.assertIn("requests", layer_contents)
+
         # Test Lambda Function
         self.update_file(
             self.test_dir.joinpath("code/after/function/app.py"),

--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -174,7 +174,7 @@ class TestSyncCodeInfra(TestSyncWatchBase):
 
 @parameterized_class([{"dependency_layer": True}, {"dependency_layer": False}])
 class TestSyncWatchCode(TestSyncWatchBase):
-    template_before = f"code/before/template-python.yaml"
+    template_before = str(Path("code", "before", "template-python.yaml"))
 
     def test_sync_watch_code(self):
         self.stack_resources = self._get_stacks(self.stack_name)
@@ -184,8 +184,8 @@ class TestSyncWatchCode(TestSyncWatchBase):
             layer_contents = self.get_dependency_layer_contents_from_arn(self.stack_resources, "python", 1)
             self.assertNotIn("requests", layer_contents)
             self.update_file(
-                self.test_dir.joinpath("code/after/function/requirements.txt"),
-                self.test_dir.joinpath("code/before/function/requirements.txt"),
+                self.test_dir.joinpath("code", "after", "function", "requirements.txt"),
+                self.test_dir.joinpath("code", "before", "function", "requirements.txt"),
             )
             read_until_string(
                 self.watch_process,
@@ -197,8 +197,8 @@ class TestSyncWatchCode(TestSyncWatchBase):
 
         # Test Lambda Function
         self.update_file(
-            self.test_dir.joinpath("code/after/function/app.py"),
-            self.test_dir.joinpath("code/before/function/app.py"),
+            self.test_dir.joinpath("code", "after", "function", "app.py"),
+            self.test_dir.joinpath("code", "before", "function", "app.py"),
         )
         read_until_string(
             self.watch_process, "\x1b[32mFinished syncing Lambda Function HelloWorldFunction.\x1b[0m\n", timeout=30
@@ -211,8 +211,8 @@ class TestSyncWatchCode(TestSyncWatchBase):
 
         # Test Lambda Layer
         self.update_file(
-            self.test_dir.joinpath("code/after/layer/layer_method.py"),
-            self.test_dir.joinpath("code/before/layer/layer_method.py"),
+            self.test_dir.joinpath("code", "after", "layer", "layer_method.py"),
+            self.test_dir.joinpath("code", "before", "layer", "layer_method.py"),
         )
         read_until_string(
             self.watch_process,
@@ -227,8 +227,8 @@ class TestSyncWatchCode(TestSyncWatchBase):
 
         # Test APIGW
         self.update_file(
-            self.test_dir.joinpath("code/after/apigateway/definition.json"),
-            self.test_dir.joinpath("code/before/apigateway/definition.json"),
+            self.test_dir.joinpath("code", "after", "apigateway", "definition.json"),
+            self.test_dir.joinpath("code", "before", "apigateway", "definition.json"),
         )
         read_until_string(self.watch_process, "\x1b[32mFinished syncing RestApi HelloWorldApi.\x1b[0m\n", timeout=20)
         time.sleep(API_SLEEP)
@@ -237,8 +237,8 @@ class TestSyncWatchCode(TestSyncWatchBase):
 
         # Test SFN
         self.update_file(
-            self.test_dir.joinpath("code/after/statemachine/function.asl.json"),
-            self.test_dir.joinpath("code/before/statemachine/function.asl.json"),
+            self.test_dir.joinpath("code", "after", "statemachine", "function.asl.json"),
+            self.test_dir.joinpath("code", "before", "statemachine", "function.asl.json"),
         )
         read_until_string(
             self.watch_process, "\x1b[32mFinished syncing StepFunctions HelloStepFunction.\x1b[0m\n", timeout=20

--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -248,12 +248,11 @@ class TestSyncWatchCode(TestSyncWatchBase):
         self.assertEqual(self._get_sfn_response(state_machine), '"World 2"')
 
 
+@parameterized_class([{"dependency_layer": True}, {"dependency_layer": False}])
 class TestSyncInfraNestedStacks(TestSyncWatchBase):
     @classmethod
     def setUpClass(cls):
         cls.template_before = f"infra/parent-stack.yaml"
-        cls.dependency_layer = False
-        # cls.parameter_overrides = "EnableNestedStack=true"
         super(TestSyncInfraNestedStacks, cls).setUpClass()
 
     def setup(self):
@@ -275,6 +274,7 @@ class TestSyncInfraNestedStacks(TestSyncWatchBase):
         self._verify_infra_changes(self.stack_resources)
 
 
+@parameterized_class([{"dependency_layer": True}, {"dependency_layer": False}])
 class TestSyncCodeWatchNestedStacks(TestSyncWatchBase):
     @classmethod
     def setUpClass(cls):

--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -250,12 +250,12 @@ class TestSyncWatchCode(TestSyncWatchBase):
 
 @parameterized_class([{"dependency_layer": True}, {"dependency_layer": False}])
 class TestSyncInfraNestedStacks(TestSyncWatchBase):
-    template_before = f"infra/parent-stack.yaml"
+    template_before = str(Path("infra", "parent-stack.yaml"))
 
     def test_sync_watch_infra_nested_stack(self):
         self.update_file(
-            self.test_dir.joinpath(f"infra/template-python-after.yaml"),
-            self.test_dir.joinpath(f"infra/template-python-before.yaml"),
+            self.test_dir.joinpath("infra", "template-python-after.yaml"),
+            self.test_dir.joinpath("infra", "template-python-before.yaml"),
         )
 
         read_until_string(self.watch_process, "\x1b[32mInfra sync completed.\x1b[0m\n", timeout=600)
@@ -267,7 +267,7 @@ class TestSyncInfraNestedStacks(TestSyncWatchBase):
 
 @parameterized_class([{"dependency_layer": True}, {"dependency_layer": False}])
 class TestSyncCodeWatchNestedStacks(TestSyncWatchBase):
-    template_before = f"code/before/parent-stack.yaml"
+    template_before = str(Path("code", "before", "parent-stack.yaml"))
 
     def test_sync_watch_code_nested_stack(self):
         self.stack_resources = self._get_stacks(self.stack_name)
@@ -277,8 +277,8 @@ class TestSyncCodeWatchNestedStacks(TestSyncWatchBase):
             layer_contents = self.get_dependency_layer_contents_from_arn(self.stack_resources, "python", 1)
             self.assertNotIn("requests", layer_contents)
             self.update_file(
-                self.test_dir.joinpath("code/after/function/requirements.txt"),
-                self.test_dir.joinpath("code/before/function/requirements.txt"),
+                self.test_dir.joinpath("code", "after", "function", "requirements.txt"),
+                self.test_dir.joinpath("code", "before", "function", "requirements.txt"),
             )
             read_until_string(
                 self.watch_process,
@@ -291,8 +291,8 @@ class TestSyncCodeWatchNestedStacks(TestSyncWatchBase):
 
         # Test Lambda Function
         self.update_file(
-            self.test_dir.joinpath("code/after/function/app.py"),
-            self.test_dir.joinpath("code/before/function/app.py"),
+            self.test_dir.joinpath("code", "after", "function", "app.py"),
+            self.test_dir.joinpath("code", "before", "function", "app.py"),
         )
         read_until_string(
             self.watch_process,
@@ -307,8 +307,8 @@ class TestSyncCodeWatchNestedStacks(TestSyncWatchBase):
 
         # Test Lambda Layer
         self.update_file(
-            self.test_dir.joinpath("code/after/layer/layer_method.py"),
-            self.test_dir.joinpath("code/before/layer/layer_method.py"),
+            self.test_dir.joinpath("code", "after", "layer", "layer_method.py"),
+            self.test_dir.joinpath("code", "before", "layer", "layer_method.py"),
         )
         read_until_string(
             self.watch_process,
@@ -323,8 +323,8 @@ class TestSyncCodeWatchNestedStacks(TestSyncWatchBase):
 
         # Test APIGW
         self.update_file(
-            self.test_dir.joinpath("code/after/apigateway/definition.json"),
-            self.test_dir.joinpath("code/before/apigateway/definition.json"),
+            self.test_dir.joinpath("code", "after", "apigateway", "definition.json"),
+            self.test_dir.joinpath("code", "before", "apigateway", "definition.json"),
         )
         read_until_string(
             self.watch_process,
@@ -337,8 +337,8 @@ class TestSyncCodeWatchNestedStacks(TestSyncWatchBase):
 
         # Test SFN
         self.update_file(
-            self.test_dir.joinpath("code/after/statemachine/function.asl.json"),
-            self.test_dir.joinpath("code/before/statemachine/function.asl.json"),
+            self.test_dir.joinpath("code", "after", "statemachine", "function.asl.json"),
+            self.test_dir.joinpath("code", "before", "statemachine", "function.asl.json"),
         )
         read_until_string(
             self.watch_process,

--- a/tests/integration/testdata/sync/code/after/function/requirements.txt
+++ b/tests/integration/testdata/sync/code/after/function/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+requests

--- a/tests/integration/testdata/sync/code/after/nodejs_function/app.js
+++ b/tests/integration/testdata/sync/code/after/nodejs_function/app.js
@@ -1,0 +1,21 @@
+import * as faker from '@faker-js/faker';
+
+const name = faker.faker.name.firstName();
+let response;
+
+exports.lambdaHandler = async (event, context) => {
+    try {
+        response = {
+            'statusCode': 200,
+            'body': JSON.stringify({
+                message: 'Hello world!',
+                extra_message: name
+            })
+        }
+    } catch (err) {
+        console.log(err);
+        return err;
+    }
+
+    return response
+};

--- a/tests/integration/testdata/sync/code/after/nodejs_function/package.json
+++ b/tests/integration/testdata/sync/code/after/nodejs_function/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hello_world",
+  "version": "1.0.0",
+  "description": "hello world sample for NodeJS",
+  "main": "app.js",
+  "author": "SAM CLI",
+  "license": "MIT",
+  "dependencies": {
+    "axios": ">=0.21.1",
+    "@faker-js/faker": "7.1.0"
+  }
+}

--- a/tests/integration/testdata/sync/code/before/nodejs_function/app.js
+++ b/tests/integration/testdata/sync/code/before/nodejs_function/app.js
@@ -1,0 +1,18 @@
+let response;
+
+exports.lambdaHandler = async (event, context) => {
+    try {
+        const ret = await axios(url);
+        response = {
+            'statusCode': 200,
+            'body': JSON.stringify({
+                message: 'hello world',
+            })
+        }
+    } catch (err) {
+        console.log(err);
+        return err;
+    }
+
+    return response
+};

--- a/tests/integration/testdata/sync/code/before/nodejs_function/package.json
+++ b/tests/integration/testdata/sync/code/before/nodejs_function/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hello_world",
+  "version": "1.0.0",
+  "description": "hello world sample for NodeJS",
+  "main": "app.js",
+  "author": "SAM CLI",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.27.2"
+  }
+}

--- a/tests/integration/testdata/sync/code/before/template-nodejs.yaml
+++ b/tests/integration/testdata/sync/code/before/template-nodejs.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 10
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: nodejs_function/
+      Handler: app.lambdaHandler
+      Runtime: nodejs16.x
+      Tracing: Active
+
+  HelloWorldApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      DefinitionUri: apigateway/definition.json


### PR DESCRIPTION
#### Why is this change necessary?
Add integration tests for auto dependency layer.

#### How does it address the issue?
- Adds checks to ensure ADL contains the expected dependencies
- Parameterizes existing accelerate integration tests to run both with ADL and without
- Add checks to existing tests to verify ADL contents
- Adds a Nodejs code test to verify that runtime with ADL

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
