### PR TITLE
Fix retrieval process for directory name

### DIFF
--- a/samcli/lib/telemetry/project_metadata.py
+++ b/samcli/lib/telemetry/project_metadata.py
@@ -3,7 +3,6 @@ Creates and encrypts metadata regarding SAM CLI projects.
 """
 
 from os import getcwd
-from os.path import basename
 import re
 import subprocess
 from typing import List, Optional
@@ -48,7 +47,7 @@ def get_project_name() -> Optional[str]:
     -------
     str | None
         A UUID5 encrypted string of either the name of the project, or the name of the
-        current directory that the command is running in.
+        current working directory that the command is running in.
         If telemetry is opted out of by the user, returns None
     """
     if not bool(GlobalConfig().telemetry_enabled):
@@ -61,7 +60,7 @@ def get_project_name() -> Optional[str]:
         )
         project_name = _parse_remote_origin_url(str(runcmd.stdout))[2]  # dir is git repo, get project name from URL
     except subprocess.CalledProcessError:
-        project_name = basename(getcwd().replace("\\", "/"))  # dir is not a git repo, get directory name
+        project_name = getcwd().replace("\\", "/")  # dir is not a git repo, get directory name
 
     return _encrypt_value(project_name)
 

--- a/tests/unit/lib/telemetry/test_project_metadata.py
+++ b/tests/unit/lib/telemetry/test_project_metadata.py
@@ -77,24 +77,24 @@ class TestProjectMetadata(TestCase):
 
     @parameterized.expand(
         [
-            ("C:/Users/aws/path/to/library/aws-sam-cli", "aws-sam-cli"),
-            ("C:\\Users\\aws\\Windows\\path\\aws-sam-cli", "aws-sam-cli"),
-            ("C:/", ""),
-            ("C:\\", ""),
-            ("E:/path/to/another/dir", "dir"),
-            ("This/one/doesn't/start/with/a/letter", "letter"),
-            ("/banana", "banana"),
-            ("D:/one/more/just/to/be/safe", "safe"),
+            ("C:/Users/aws/path/to/library/aws-sam-cli"),
+            ("C:\\Users\\aws\\Windows\\path\\aws-sam-cli"),
+            ("C:/"),
+            ("C:\\"),
+            ("E:/path/to/another/dir"),
+            ("This/one/doesn't/start/with/a/letter"),
+            ("/banana"),
+            ("D:/one/more/just/to/be/safe"),
         ]
     )
     @patch("samcli.lib.telemetry.project_metadata.getcwd")
     @patch("samcli.lib.telemetry.project_metadata.subprocess.run")
-    def test_retrieve_project_name_from_dir(self, cwd, expected, sp_mock, cwd_mock):
+    def test_retrieve_project_name_from_dir(self, cwd, sp_mock, cwd_mock):
         sp_mock.side_effect = CalledProcessError(128, ["git", "config", "--get", "remote.origin.url"])
         cwd_mock.return_value = cwd
 
         project_name = get_project_name()
-        self.assertEqual(project_name, str(uuid5(NAMESPACE_URL, expected)))
+        self.assertEqual(project_name, str(uuid5(NAMESPACE_URL, cwd.replace("\\", "/"))))
 
     @parameterized.expand(
         [


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Previously, the metadata attribute `projectName` would be retrieved as the name of the current folder the project is working in (in the event that a project is not also a git repository). This may present issues for projects that may take on identical names (i.e. multiple customers who use the default project name "sam-app"). In those situations, multiple different users would appear as one user. 

#### How does it address the issue?
If we parse the entire current working directory instead of simply the folder name, we are able to differentiate between different projects of the same name. If two users were to have projects named "sam-app", they would appear identical before this change. With this change, the only way for the two to be identical is for them to have identical file paths to their working directory, which is incredibly unlikely.

#### What side effects does this change have?
When tracking between the same project among the project creator, the team, and the CICD, this would likely break the chain connecting the team to the CICD. However, it is still possible to link the data together through joint queries, as the project creator and team share the same initial commit hash, and the project creator and CICD share the same git origin.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
