### PR TITLE
chore: replace InvokeContextException with granular ones

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -9,12 +9,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, IO, cast, Tuple, Any, Type
 
+from samcli.commands.local.cli_common.user_exceptions import InvokeContextException, DebugContextException
 from samcli.lib.utils import osutils
 from samcli.lib.providers.provider import Stack, Function
 from samcli.lib.providers.sam_stack_provider import SamLocalStackProvider
 from samcli.lib.utils.async_utils import AsyncContext
 from samcli.lib.utils.stream_writer import StreamWriter
-from samcli.commands.exceptions import ContainersInitializationException, UserException
+from samcli.commands.exceptions import ContainersInitializationException
 from samcli.commands.local.lib.local_lambda import LocalLambdaRunner
 from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.local.lambdafn.runtime import LambdaRuntime, WarmLambdaRuntime
@@ -27,27 +28,21 @@ from samcli.lib.providers.sam_function_provider import SamFunctionProvider, Refr
 LOG = logging.getLogger(__name__)
 
 
-class DockerIsNotReachableException(UserException):
+class DockerIsNotReachableException(InvokeContextException):
     """
     Docker is not installed or not running at the moment
     """
 
 
-class InvalidEnvironmentVariablesFileException(UserException):
+class InvalidEnvironmentVariablesFileException(InvokeContextException):
     """
     User provided an environment variables file which couldn't be read by SAM CLI
     """
 
 
-class NoFunctionIdentifierProvidedException(UserException):
+class NoFunctionIdentifierProvidedException(InvokeContextException):
     """
     If template has more than one function defined and user didn't provide any function logical id
-    """
-
-
-class DebugContextException(UserException):
-    """
-    Something went wrong when creating the DebugContext
     """
 
 

--- a/samcli/commands/local/cli_common/user_exceptions.py
+++ b/samcli/commands/local/cli_common/user_exceptions.py
@@ -5,6 +5,12 @@ Class containing error conditions that are exposed to the user.
 from samcli.commands.exceptions import UserException
 
 
+class InvokeContextException(UserException):
+    """
+    Something went wrong invoking the function.
+    """
+
+
 class InvalidSamTemplateException(UserException):
     """
     The template provided was invalid and not able to transform into a Standard CloudFormation Template
@@ -14,6 +20,12 @@ class InvalidSamTemplateException(UserException):
 class SamTemplateNotFoundException(UserException):
     """
     The SAM Template provided could not be found
+    """
+
+
+class DebugContextException(UserException):
+    """
+    Something went wrong when creating the DebugContext
     """
 
 

--- a/samcli/commands/local/cli_common/user_exceptions.py
+++ b/samcli/commands/local/cli_common/user_exceptions.py
@@ -5,12 +5,6 @@ Class containing error conditions that are exposed to the user.
 from samcli.commands.exceptions import UserException
 
 
-class InvokeContextException(UserException):
-    """
-    Something went wrong invoking the function.
-    """
-
-
 class InvalidSamTemplateException(UserException):
     """
     The template provided was invalid and not able to transform into a Standard CloudFormation Template
@@ -20,12 +14,6 @@ class InvalidSamTemplateException(UserException):
 class SamTemplateNotFoundException(UserException):
     """
     The SAM Template provided could not be found
-    """
-
-
-class DebugContextException(UserException):
-    """
-    Something went wrong when creating the DebugContext
     """
 
 

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -5,8 +5,15 @@ import errno
 import os
 
 from samcli.commands._utils.template import TemplateFailedParsingException
-from samcli.commands.local.cli_common.user_exceptions import InvokeContextException, DebugContextException
-from samcli.commands.local.cli_common.invoke_context import InvokeContext, ContainersInitializationMode, ContainersMode
+from samcli.commands.local.cli_common.invoke_context import (
+    InvokeContext,
+    ContainersInitializationMode,
+    ContainersMode,
+    DebugContextException,
+    DockerIsNotReachableException,
+    NoFunctionIdentifierProvidedException,
+    InvalidEnvironmentVariablesFileException,
+)
 
 from unittest import TestCase
 from unittest.mock import Mock, PropertyMock, patch, ANY, mock_open, call
@@ -398,7 +405,7 @@ class TestInvokeContext__enter__(TestCase):
             invoke_context._get_container_manager = Mock()
             invoke_context._get_container_manager.return_value = container_manager_mock
 
-            with self.assertRaises(InvokeContextException) as ex_ctx:
+            with self.assertRaises(DockerIsNotReachableException) as ex_ctx:
                 invoke_context.__enter__()
 
                 self.assertEqual(
@@ -411,7 +418,7 @@ class TestInvokeContext__enter__(TestCase):
         invoke_context = InvokeContext("template-file")
 
         get_buildable_stacks_mock.side_effect = TemplateFailedParsingException("")
-        with self.assertRaises(InvokeContextException) as ex_ctx:
+        with self.assertRaises(TemplateFailedParsingException) as ex_ctx:
             invoke_context.__enter__()
 
 
@@ -489,7 +496,7 @@ class TestInvokeContext_function_name_property(TestCase):
         context._function_provider = Mock()
         context._function_provider.get_all.return_value = [Mock(), Mock(), Mock()]  # Provider returns three functions
 
-        with self.assertRaises(InvokeContextException):
+        with self.assertRaises(NoFunctionIdentifierProvidedException):
             context.function_identifier
 
 
@@ -1001,7 +1008,7 @@ class TestInvokeContext_get_env_vars_value(TestCase):
 
         with patch("samcli.commands.local.cli_common.invoke_context.open", m):
 
-            with self.assertRaises(InvokeContextException) as ex_ctx:
+            with self.assertRaises(InvalidEnvironmentVariablesFileException) as ex_ctx:
                 InvokeContext._get_env_vars_value(filename)
 
             msg = str(ex_ctx.exception)

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -3,14 +3,12 @@ Testing local lambda runner
 """
 import os
 import posixpath
-from platform import architecture
 from unittest import TestCase
 from unittest.mock import Mock, patch
 from parameterized import parameterized, param
 
 from samcli.lib.utils.architecture import X86_64, ARM64
 
-from samcli.commands.local.cli_common.user_exceptions import InvokeContextException
 from samcli.commands.local.lib.local_lambda import LocalLambdaRunner
 from samcli.lib.providers.provider import Function
 from samcli.lib.utils.packagetype import ZIP, IMAGE


### PR DESCRIPTION
#### Which issue(s) does this change fix?
`InvokeContextException` for `sam local` command is used for multiple different error cases. With this PR we are replacing each individual case with specific exception type.

#### Why is this change necessary?
To get more granular information about `InvokeContextException`'s.


#### How does it address the issue?
By replacing `InvokeContextException` with specific ones.


#### What side effects does this change have?
N/A, some notes;
- `InvokeContextException` or parent class `UserException` have not caught anywhere in the codebase.
- The newly created exceptions are also extending from `UserException` which should cause SAM CLI to fail gracefully without logging the entire trace stack.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
