### PR TITLE
Clarify debug log message in build_context command

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -566,7 +566,7 @@ Commands you can use next
             docker_context = cast(str, metadata.get("DockerContext", ""))
             if not dockerfile or not docker_context:
                 LOG.debug(
-                    "Skip Building %s function, as it does not contain either Dockerfile or DockerContext "
+                    "Skip Building %s function, as it is missing either Dockerfile or DockerContext "
                     "metadata properties.",
                     function.full_path,
                 )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
Debug log messaging from `sam build --debug` was confusing when Lambda Functions in CloudFormation template lack Docker metadata properties

#### How does it address the issue?
Tweaks the wording. The original log message said "Skip Building %s function, as it does not contain either Dockerfile or DockerContext" which confused me, because my function _did_ contain a `DockerContext` property. It was unclear to me that this message was saying that a Function needs _both_ properties. The new wording feels like clearer English to me, but I can't really justify why...maybe because "is missing X or Y" is more affirmative than "does not contain X or Y".

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] ~Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods~
- [ ] ~Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))~
- [ ] ~Write/update unit tests~
- [ ] ~Write/update integration tests~
- [ ] ~Write/update functional tests if needed~
- [ ] ~`make pr` passes~
- [ ] ~`make update-reproducible-reqs` if dependencies were changed~
- [ ] ~Write documentation~

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
