### PR TITLE
fix: clean build folder before starting sync operation

### DIFF
--- a/samcli/lib/sync/flows/layer_sync_flow.py
+++ b/samcli/lib/sync/flows/layer_sync_flow.py
@@ -20,6 +20,7 @@ from samcli.lib.sync.sync_flow_executor import HELP_TEXT_FOR_SYNC_INFRA
 from samcli.lib.utils.colors import Colored
 from samcli.lib.utils.hash import file_checksum
 from samcli.lib.sync.flows.function_sync_flow import wait_for_function_update_complete
+from samcli.lib.utils.osutils import rmtree_if_exists
 
 if TYPE_CHECKING:  # pragma: no cover
     from samcli.commands.build.build_context import BuildContext
@@ -205,6 +206,8 @@ class LayerSyncFlow(AbstractLayerSyncFlow):
     def gather_resources(self) -> None:
         """Build layer and ZIP it into a temp file in self._zip_file"""
         with self._get_lock_chain():
+
+            rmtree_if_exists(self._build_context.build_dir)
             builder = ApplicationBuilder(
                 self._build_context.collect_build_resources(self._layer_identifier),
                 self._build_context.build_dir,

--- a/samcli/lib/sync/flows/zip_function_sync_flow.py
+++ b/samcli/lib/sync/flows/zip_function_sync_flow.py
@@ -20,6 +20,7 @@ from samcli.lib.package.utils import make_zip
 
 from samcli.lib.build.app_builder import ApplicationBuilder
 from samcli.lib.sync.sync_flow import ResourceAPICall, ApiCallTypes
+from samcli.lib.utils.osutils import rmtree_if_exists
 
 if TYPE_CHECKING:  # pragma: no cover
     from samcli.commands.deploy.deploy_context import DeployContext
@@ -79,6 +80,7 @@ class ZipFunctionSyncFlow(FunctionSyncFlow):
             if self.has_locks():
                 exit_stack.enter_context(self._get_lock_chain())
 
+            rmtree_if_exists(self._build_context.build_dir)
             builder = ApplicationBuilder(
                 self._build_context.collect_build_resources(self._function_identifier),
                 self._build_context.build_dir,

--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -8,7 +8,8 @@ import stat
 import sys
 import tempfile
 from contextlib import contextmanager
-from typing import List, Optional
+from pathlib import Path
+from typing import List, Optional, Union
 
 LOG = logging.getLogger(__name__)
 
@@ -67,6 +68,14 @@ def rmtree_callback(function, path, excinfo):
         os.remove(path)
     except OSError:
         LOG.debug("rmtree failed in %s for %s, details: %s", function, path, excinfo)
+
+
+def rmtree_if_exists(path: Union[str, Path]):
+    """Removes given path if the path exists"""
+    path_obj = Path(str(path))
+    if path_obj.exists():
+        LOG.debug("Cleaning up path %s", str(path))
+        shutil.rmtree(path_obj)
 
 
 def stdout():

--- a/tests/unit/lib/sync/flows/test_layer_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_layer_sync_flow.py
@@ -60,8 +60,15 @@ class TestLayerSyncFlow(TestCase):
     @patch("samcli.lib.sync.flows.layer_sync_flow.make_zip")
     @patch("samcli.lib.sync.flows.layer_sync_flow.file_checksum")
     @patch("samcli.lib.sync.flows.layer_sync_flow.os")
+    @patch("samcli.lib.sync.flows.layer_sync_flow.rmtree_if_exists")
     def test_setup_gather_resources(
-        self, patched_os, patched_file_checksum, patched_make_zip, patched_tempfile, patched_app_builder
+        self,
+        patched_rmtree_if_exists,
+        patched_os,
+        patched_file_checksum,
+        patched_make_zip,
+        patched_tempfile,
+        patched_app_builder
     ):
         given_collect_build_resources = Mock()
         self.build_context_mock.collect_build_resources.return_value = given_collect_build_resources
@@ -81,6 +88,7 @@ class TestLayerSyncFlow(TestCase):
 
         self.layer_sync_flow.gather_resources()
 
+        patched_rmtree_if_exists.assert_called_with(self.build_context_mock.build_dir)
         self.build_context_mock.collect_build_resources.assert_called_with(self.layer_identifier)
 
         patched_app_builder.assert_called_with(

--- a/tests/unit/lib/sync/flows/test_zip_function_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_zip_function_sync_flow.py
@@ -10,9 +10,10 @@ from samcli.lib.sync.flows.zip_function_sync_flow import ZipFunctionSyncFlow
 
 class TestZipFunctionSyncFlow(TestCase):
     def create_function_sync_flow(self):
+        self.build_context_mock = MagicMock()
         sync_flow = ZipFunctionSyncFlow(
             "Function1",
-            build_context=MagicMock(),
+            build_context=self.build_context_mock,
             deploy_context=MagicMock(),
             physical_id_mapping={},
             stacks=[MagicMock()],
@@ -34,9 +35,18 @@ class TestZipFunctionSyncFlow(TestCase):
     @patch("samcli.lib.sync.flows.zip_function_sync_flow.make_zip")
     @patch("samcli.lib.sync.flows.zip_function_sync_flow.tempfile.gettempdir")
     @patch("samcli.lib.sync.flows.zip_function_sync_flow.ApplicationBuilder")
+    @patch("samcli.lib.sync.flows.zip_function_sync_flow.rmtree_if_exists")
     @patch("samcli.lib.sync.sync_flow.Session")
     def test_gather_resources(
-        self, session_mock, builder_mock, gettempdir_mock, make_zip_mock, file_checksum_mock, uuid4_mock, sha256_mock
+        self,
+        session_mock,
+        rmtree_if_exists_mock,
+        builder_mock,
+        gettempdir_mock,
+        make_zip_mock,
+        file_checksum_mock,
+        uuid4_mock,
+        sha256_mock
     ):
         get_mock = MagicMock()
         get_mock.return_value = "ArtifactFolder1"
@@ -53,6 +63,7 @@ class TestZipFunctionSyncFlow(TestCase):
         sync_flow.set_up()
         sync_flow.gather_resources()
 
+        rmtree_if_exists_mock.assert_called_once_with(self.build_context_mock.build_dir)
         get_mock.assert_called_once_with("Function1")
         self.assertEqual(sync_flow._artifact_folder, "ArtifactFolder1")
         make_zip_mock.assert_called_once_with("temp_folder" + os.sep + "data-uuid_value", "ArtifactFolder1")

--- a/tests/unit/lib/utils/test_osutils.py
+++ b/tests/unit/lib/utils/test_osutils.py
@@ -6,8 +6,9 @@ import os
 import sys
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from samcli.lib.utils import osutils
+from samcli.lib.utils.osutils import rmtree_if_exists
 
 
 class Test_mkdir_temp(TestCase):
@@ -77,3 +78,26 @@ class Test_convert_files_to_unix_line_endings:
         patched_open.assert_any_call(os.path.join("b", target_file), "rb")
         patched_open.assert_any_call(os.path.join("a", target_file), "wb")
         patched_open.assert_any_call(os.path.join("b", target_file), "wb")
+
+
+class Test_rmtree_if_exists(TestCase):
+
+    @patch("samcli.lib.utils.osutils.Path")
+    @patch("samcli.lib.utils.osutils.shutil.rmtree")
+    def test_must_skip_if_path_doesnt_exist(self, patched_rmtree, patched_path):
+        mock_path_obj = Mock()
+        mock_path_obj.exists.return_value = False
+        patched_path.return_value = mock_path_obj
+
+        rmtree_if_exists(Mock())
+        patched_rmtree.assert_not_called()
+
+    @patch("samcli.lib.utils.osutils.Path")
+    @patch("samcli.lib.utils.osutils.shutil.rmtree")
+    def test_must_skip_if_path_doesnt_exist(self, patched_rmtree, patched_path):
+        mock_path_obj = Mock()
+        mock_path_obj.exists.return_value = True
+        patched_path.return_value = mock_path_obj
+
+        rmtree_if_exists(Mock())
+        patched_rmtree.assert_called_with(mock_path_obj)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Ruby bundler in aws-lambda-builders uses `artifact_folder` as the root folder of build operation. Any change in dependencies will cause issue since `ZipFunctionSyncFlow` and `LayerSyncFlow` doesn't clean-up build folder as `sam build` does.

#### How does it address the issue?
Clean build folder of the function/layer before starting sync flow.

#### What side effects does this change have?
Since build works with cached/incremental enabled, this should not include any performance issues.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
