### PR TITLE
bug: make sure all pullers in child combine puller also get stopped

### DIFF
--- a/samcli/lib/observability/observability_info_puller.py
+++ b/samcli/lib/observability/observability_info_puller.py
@@ -223,5 +223,7 @@ class ObservabilityCombinedPuller(ObservabilityPuller):
         async_context.run_async()
 
     def stop_tailing(self):
+        # if ObservabilityCombinedPuller A is a child puller in other ObservabilityCombinedPuller B, make sure A's child
+        # pullers stop as well when B stops.
         for puller in self._pullers:
             puller.stop_tailing()

--- a/samcli/lib/observability/observability_info_puller.py
+++ b/samcli/lib/observability/observability_info_puller.py
@@ -88,6 +88,9 @@ class ObservabilityPuller(ABC):
             List of event ids that will be pulled
         """
 
+    def stop_tailing(self):
+        self.cancelled = True
+
 
 # pylint: disable=fixme
 # fixme add ABC parent class back once we bump the pylint to a version 2.8.2 or higher
@@ -188,7 +191,7 @@ class ObservabilityCombinedPuller(ObservabilityPuller):
         except KeyboardInterrupt:
             LOG.info(" CTRL+C received, cancelling...")
             for puller in self._pullers:
-                puller.cancelled = True
+                puller.stop_tailing()
 
     def load_time_period(
         self,
@@ -218,3 +221,7 @@ class ObservabilityCombinedPuller(ObservabilityPuller):
             async_context.add_async_task(puller.load_events, event_ids)
         LOG.debug("Running all 'load_time_period' tasks in parallel")
         async_context.run_async()
+
+    def stop_tailing(self):
+        for puller in self._pullers:
+            puller.stop_tailing()

--- a/samcli/lib/observability/observability_info_puller.py
+++ b/samcli/lib/observability/observability_info_puller.py
@@ -190,8 +190,7 @@ class ObservabilityCombinedPuller(ObservabilityPuller):
             async_context.run_async()
         except KeyboardInterrupt:
             LOG.info(" CTRL+C received, cancelling...")
-            for puller in self._pullers:
-                puller.stop_tailing()
+            self.stop_tailing()
 
     def load_time_period(
         self,

--- a/tests/unit/lib/observability/test_observability_info_puller.py
+++ b/tests/unit/lib/observability/test_observability_info_puller.py
@@ -85,8 +85,11 @@ class TestObservabilityCombinedPuller(TestCase):
 
         mock_puller_1 = Mock()
         mock_puller_2 = Mock()
+        mock_puller_3 = Mock()
 
-        combined_puller = ObservabilityCombinedPuller([mock_puller_1, mock_puller_2])
+        child_combined_puller = ObservabilityCombinedPuller([mock_puller_3])
+
+        combined_puller = ObservabilityCombinedPuller([mock_puller_1, mock_puller_2, child_combined_puller])
 
         given_start_time = Mock()
         given_filter_pattern = Mock()
@@ -97,12 +100,14 @@ class TestObservabilityCombinedPuller(TestCase):
             [
                 call.add_async_task(mock_puller_1.tail, given_start_time, given_filter_pattern),
                 call.add_async_task(mock_puller_2.tail, given_start_time, given_filter_pattern),
+                call.add_async_task(child_combined_puller.tail, given_start_time, given_filter_pattern),
                 call.run_async(),
             ]
         )
 
-        self.assertTrue(mock_puller_1.cancelled)
-        self.assertTrue(mock_puller_2.cancelled)
+        self.assertTrue(mock_puller_1.stop_tailing.called)
+        self.assertTrue(mock_puller_2.stop_tailing.called)
+        self.assertTrue(mock_puller_3.stop_tailing.called)
 
     @patch("samcli.lib.observability.observability_info_puller.AsyncContext")
     def test_load_time_period(self, patched_async_context):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
ctrl+c to sam log command with --include-traces option currently doesn't kill the traces' combine puller, with this fix now it should works correctly

#### How does it address the issue?
overwrite the combine puller's `stop_tailing()` method to make sure it call `stop_tailing() `in all its children pullers.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
