### PR TITLE
feat: Add --resource option input validation for sync --code

### DIFF
--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -122,14 +122,14 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
 @click.option(
     "--resource",
     multiple=True,
-    type=click.Choice(SyncCodeResources.values(), case_sensitive=False),
-    help="Sync code for all types of the resource.",
+    type=click.Choice(SyncCodeResources.values(), case_sensitive=True),
+    help=f"Sync code for all resources of the give resource type. Accepted values are {SyncCodeResources.values()}",
 )
 @click.option(
     "--dependency-layer/--no-dependency-layer",
     default=True,
     is_flag=True,
-    help="This option separates the dependencies of individual function into another layer, for speeding up the sync"
+    help="This option separates the dependencies of individual function into another layer, for speeding up the sync."
     "process",
 )
 @stack_name_option(required=True)  # pylint: disable=E1120

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -123,7 +123,7 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
     "--resource",
     multiple=True,
     type=click.Choice(SyncCodeResources.values(), case_sensitive=True),
-    help=f"Sync code for all resources of the give resource type. Accepted values are {SyncCodeResources.values()}",
+    help=f"Sync code for all resources of the given resource type. Accepted values are {SyncCodeResources.values()}",
 )
 @click.option(
     "--dependency-layer/--no-dependency-layer",

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -122,6 +122,7 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
 @click.option(
     "--resource",
     multiple=True,
+    type=click.Choice(SyncCodeResources.values(), case_sensitive=False),
     help="Sync code for all types of the resource.",
 )
 @click.option(
@@ -392,23 +393,8 @@ def execute_code_sync(
     factory.load_physical_id_mapping()
     executor = SyncFlowExecutor()
 
-    if resource_types:
-        skipped_resources = ""
-        for resource_type in resource_types:
-            if resource_type not in SyncCodeResources.values():
-                skipped_resources += resource_type if skipped_resources == "" else (", " + resource_type)
-        if not skipped_resources == "":
-            LOG.warning(
-                "Skipping sync on invalid inputted resource type: %s. \
-Accepted --resource inputs for sync --code are: %s",
-                skipped_resources,
-                SyncCodeResources.__str__(),
-            )
-
-    accepted_resources = [item for item in resource_types if item not in skipped_resources]
-
     sync_flow_resource_ids: Set[ResourceIdentifier] = (
-        get_unique_resource_ids(stacks, resource_ids, accepted_resources)
+        get_unique_resource_ids(stacks, resource_ids, resource_types)
         if resource_ids or resource_types
         else set(get_all_resource_ids(stacks))
     )

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -24,7 +24,6 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 import botocore
-import click
 
 from samcli.lib.deploy.utils import DeployColor
 from samcli.commands.deploy.exceptions import (
@@ -597,7 +596,7 @@ class Deployer:
                 self.wait_for_execute(stack_name, "CREATE", False)
                 msg = "\nStack creation succeeded. Sync infra completed.\n"
 
-            click.secho(msg, fg="green")
+            LOG.info(self._colored.green(msg))
 
             return result
         except botocore.exceptions.ClientError as ex:

--- a/samcli/lib/sync/sync_flow_factory.py
+++ b/samcli/lib/sync/sync_flow_factory.py
@@ -57,19 +57,6 @@ class SyncCodeResources:
     ]
 
     @classmethod
-    def __str__(cls) -> str:
-        """
-        To string method for printing
-
-        Returns: str
-            A string that contains all supported resources, separated by commas
-        """
-        result = ""
-        for resource in cls._accepted_resources:
-            result += resource if result == "" else (", " + resource)
-        return result
-
-    @classmethod
     def values(cls) -> List[str]:
         """
         A class getter to retrieve the accepted resource list

--- a/samcli/lib/sync/sync_flow_factory.py
+++ b/samcli/lib/sync/sync_flow_factory.py
@@ -38,6 +38,48 @@ if TYPE_CHECKING:  # pragma: no cover
 LOG = logging.getLogger(__name__)
 
 
+class SyncCodeResources:
+    """
+    A class that records the supported resource types that can perform sync --code
+    """
+
+    _accepted_resources = [
+        AWS_SERVERLESS_FUNCTION,
+        AWS_LAMBDA_FUNCTION,
+        AWS_SERVERLESS_LAYERVERSION,
+        AWS_LAMBDA_LAYERVERSION,
+        AWS_SERVERLESS_API,
+        AWS_APIGATEWAY_RESTAPI,
+        AWS_SERVERLESS_HTTPAPI,
+        AWS_APIGATEWAY_V2_API,
+        AWS_SERVERLESS_STATEMACHINE,
+        AWS_STEPFUNCTIONS_STATEMACHINE,
+    ]
+
+    @classmethod
+    def __str__(cls) -> str:
+        """
+        To string method for printing
+
+        Returns: str
+            A string that contains all supported resources, separated by commas
+        """
+        result = ""
+        for resource in cls._accepted_resources:
+            result += resource if result == "" else (", " + resource)
+        return result
+
+    @classmethod
+    def values(cls) -> List[str]:
+        """
+        A class getter to retrieve the accepted resource list
+
+        Returns: List[str]
+            The accepted resources list
+        """
+        return cls._accepted_resources
+
+
 class SyncFlowFactory(ResourceTypeBasedFactory[SyncFlow]):  # pylint: disable=E1136
     """Factory class for SyncFlow
     Creates appropriate SyncFlow types based on stack resource types

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -119,7 +119,6 @@ class TestSyncCode(TestSyncCodeBase):
             s3_prefix=self.s3_prefix,
             kms_key_id=self.kms_key,
             tags="integ=true clarity=yes foo_bar=baz",
-            debug=True,
         )
         sync_process_execute = run_command_with_input(sync_command_list, "y\n".encode())
         self.assertEqual(sync_process_execute.process.returncode, 0)
@@ -279,7 +278,6 @@ class TestSyncCode(TestSyncCodeBase):
             s3_prefix=self.s3_prefix,
             kms_key_id=self.kms_key,
             tags="integ=true clarity=yes foo_bar=baz",
-            debug=True,
         )
         sync_process_execute = run_command_with_input(sync_command_list, "y\n".encode())
         self.assertEqual(sync_process_execute.process.returncode, 2)
@@ -607,7 +605,6 @@ class TestSyncCodeNestedWithIntrinsics(TestSyncCodeBase):
             s3_prefix=self.s3_prefix,
             kms_key_id=self.kms_key,
             tags="integ=true clarity=yes foo_bar=baz",
-            debug=True,
         )
         sync_process_execute = run_command_with_input(sync_command_list, "y\n".encode())
         self.assertEqual(sync_process_execute.process.returncode, 0)

--- a/tests/unit/commands/sync/test_command.py
+++ b/tests/unit/commands/sync/test_command.py
@@ -478,7 +478,7 @@ class TestSyncCode(TestCase):
     ):
 
         resource_identifier_strings = ["Function1", "Function2"]
-        resource_types = ["Type1"]
+        resource_types = ["AWS::Serverless::Function"]
         sync_flows = [MagicMock(), MagicMock(), MagicMock()]
         sync_flow_factory_mock.return_value.create_sync_flow.side_effect = sync_flows
         get_unique_resource_ids_mock.return_value = {
@@ -508,7 +508,7 @@ class TestSyncCode(TestCase):
         self.assertEqual(sync_flow_executor_mock.return_value.add_sync_flow.call_count, 3)
 
         get_unique_resource_ids_mock.assert_called_once_with(
-            get_stacks_mock.return_value[0], resource_identifier_strings, ["Type1"]
+            get_stacks_mock.return_value[0], resource_identifier_strings, ["AWS::Serverless::Function"]
         )
 
     @patch("samcli.commands.sync.command.click")
@@ -517,6 +517,59 @@ class TestSyncCode(TestCase):
     @patch("samcli.commands.sync.command.SyncFlowExecutor")
     @patch("samcli.commands.sync.command.get_unique_resource_ids")
     def test_execute_code_sync_multiple_type_resource(
+        self,
+        get_unique_resource_ids_mock,
+        sync_flow_executor_mock,
+        sync_flow_factory_mock,
+        get_stacks_mock,
+        click_mock,
+    ):
+        resource_identifier_strings = ["Function1", "Function2"]
+        resource_types = ["AWS::Serverless::Function", "AWS::Serverless::LayerVersion"]
+        sync_flows = [MagicMock(), MagicMock(), MagicMock(), MagicMock()]
+        sync_flow_factory_mock.return_value.create_sync_flow.side_effect = sync_flows
+        get_unique_resource_ids_mock.return_value = {
+            ResourceIdentifier("Function1"),
+            ResourceIdentifier("Function2"),
+            ResourceIdentifier("Function3"),
+            ResourceIdentifier("Function4"),
+        }
+        execute_code_sync(
+            self.template_file,
+            self.build_context,
+            self.deploy_context,
+            resource_identifier_strings,
+            resource_types,
+            True,
+        )
+
+        sync_flow_factory_mock.return_value.create_sync_flow.assert_any_call(ResourceIdentifier("Function1"))
+        sync_flow_executor_mock.return_value.add_sync_flow.assert_any_call(sync_flows[0])
+
+        sync_flow_factory_mock.return_value.create_sync_flow.assert_any_call(ResourceIdentifier("Function2"))
+        sync_flow_executor_mock.return_value.add_sync_flow.assert_any_call(sync_flows[1])
+
+        sync_flow_factory_mock.return_value.create_sync_flow.assert_any_call(ResourceIdentifier("Function3"))
+        sync_flow_executor_mock.return_value.add_sync_flow.assert_any_call(sync_flows[2])
+
+        sync_flow_factory_mock.return_value.create_sync_flow.assert_any_call(ResourceIdentifier("Function4"))
+        sync_flow_executor_mock.return_value.add_sync_flow.assert_any_call(sync_flows[3])
+
+        self.assertEqual(sync_flow_factory_mock.return_value.create_sync_flow.call_count, 4)
+        self.assertEqual(sync_flow_executor_mock.return_value.add_sync_flow.call_count, 4)
+
+        get_unique_resource_ids_mock.assert_any_call(
+            get_stacks_mock.return_value[0],
+            resource_identifier_strings,
+            ["AWS::Serverless::Function", "AWS::Serverless::LayerVersion"],
+        )
+
+    @patch("samcli.commands.sync.command.click")
+    @patch("samcli.commands.sync.command.SamLocalStackProvider.get_stacks")
+    @patch("samcli.commands.sync.command.SyncFlowFactory")
+    @patch("samcli.commands.sync.command.SyncFlowExecutor")
+    @patch("samcli.commands.sync.command.get_unique_resource_ids")
+    def test_execute_code_sync_invalid_type_resource(
         self,
         get_unique_resource_ids_mock,
         sync_flow_executor_mock,
@@ -558,9 +611,7 @@ class TestSyncCode(TestCase):
         self.assertEqual(sync_flow_factory_mock.return_value.create_sync_flow.call_count, 4)
         self.assertEqual(sync_flow_executor_mock.return_value.add_sync_flow.call_count, 4)
 
-        get_unique_resource_ids_mock.assert_any_call(
-            get_stacks_mock.return_value[0], resource_identifier_strings, ["Type1", "Type2"]
-        )
+        get_unique_resource_ids_mock.assert_any_call(get_stacks_mock.return_value[0], resource_identifier_strings, [])
 
     @patch("samcli.commands.sync.command.click")
     @patch("samcli.commands.sync.command.SamLocalStackProvider.get_stacks")

--- a/tests/unit/commands/sync/test_command.py
+++ b/tests/unit/commands/sync/test_command.py
@@ -568,55 +568,6 @@ class TestSyncCode(TestCase):
     @patch("samcli.commands.sync.command.SamLocalStackProvider.get_stacks")
     @patch("samcli.commands.sync.command.SyncFlowFactory")
     @patch("samcli.commands.sync.command.SyncFlowExecutor")
-    @patch("samcli.commands.sync.command.get_unique_resource_ids")
-    def test_execute_code_sync_invalid_type_resource(
-        self,
-        get_unique_resource_ids_mock,
-        sync_flow_executor_mock,
-        sync_flow_factory_mock,
-        get_stacks_mock,
-        click_mock,
-    ):
-        resource_identifier_strings = ["Function1", "Function2"]
-        resource_types = ["Type1", "Type2"]
-        sync_flows = [MagicMock(), MagicMock(), MagicMock(), MagicMock()]
-        sync_flow_factory_mock.return_value.create_sync_flow.side_effect = sync_flows
-        get_unique_resource_ids_mock.return_value = {
-            ResourceIdentifier("Function1"),
-            ResourceIdentifier("Function2"),
-            ResourceIdentifier("Function3"),
-            ResourceIdentifier("Function4"),
-        }
-        execute_code_sync(
-            self.template_file,
-            self.build_context,
-            self.deploy_context,
-            resource_identifier_strings,
-            resource_types,
-            True,
-        )
-
-        sync_flow_factory_mock.return_value.create_sync_flow.assert_any_call(ResourceIdentifier("Function1"))
-        sync_flow_executor_mock.return_value.add_sync_flow.assert_any_call(sync_flows[0])
-
-        sync_flow_factory_mock.return_value.create_sync_flow.assert_any_call(ResourceIdentifier("Function2"))
-        sync_flow_executor_mock.return_value.add_sync_flow.assert_any_call(sync_flows[1])
-
-        sync_flow_factory_mock.return_value.create_sync_flow.assert_any_call(ResourceIdentifier("Function3"))
-        sync_flow_executor_mock.return_value.add_sync_flow.assert_any_call(sync_flows[2])
-
-        sync_flow_factory_mock.return_value.create_sync_flow.assert_any_call(ResourceIdentifier("Function4"))
-        sync_flow_executor_mock.return_value.add_sync_flow.assert_any_call(sync_flows[3])
-
-        self.assertEqual(sync_flow_factory_mock.return_value.create_sync_flow.call_count, 4)
-        self.assertEqual(sync_flow_executor_mock.return_value.add_sync_flow.call_count, 4)
-
-        get_unique_resource_ids_mock.assert_any_call(get_stacks_mock.return_value[0], resource_identifier_strings, [])
-
-    @patch("samcli.commands.sync.command.click")
-    @patch("samcli.commands.sync.command.SamLocalStackProvider.get_stacks")
-    @patch("samcli.commands.sync.command.SyncFlowFactory")
-    @patch("samcli.commands.sync.command.SyncFlowExecutor")
     @patch("samcli.commands.sync.command.get_all_resource_ids")
     def test_execute_code_sync_default_all_resources(
         self,

--- a/tests/unit/lib/sync/test_sync_flow_factory.py
+++ b/tests/unit/lib/sync/test_sync_flow_factory.py
@@ -191,10 +191,3 @@ class TestSyncCodeResources(TestCase):
             AWS_STEPFUNCTIONS_STATEMACHINE,
         ]
         self.assertEqual(expected, output)
-
-    def test_print_code_resource(self):
-        output = SyncCodeResources.__str__()
-        expected = f"{AWS_SERVERLESS_FUNCTION}, {AWS_LAMBDA_FUNCTION}, {AWS_SERVERLESS_LAYERVERSION}, \
-{AWS_LAMBDA_LAYERVERSION}, {AWS_SERVERLESS_API}, {AWS_APIGATEWAY_RESTAPI}, {AWS_SERVERLESS_HTTPAPI}, \
-{AWS_APIGATEWAY_V2_API}, {AWS_SERVERLESS_STATEMACHINE}, {AWS_STEPFUNCTIONS_STATEMACHINE}"
-        self.assertEqual(expected, output)

--- a/tests/unit/lib/sync/test_sync_flow_factory.py
+++ b/tests/unit/lib/sync/test_sync_flow_factory.py
@@ -1,8 +1,20 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch, Mock
 
-from samcli.lib.sync.sync_flow_factory import SyncFlowFactory
+from samcli.lib.sync.sync_flow_factory import SyncCodeResources, SyncFlowFactory
 from samcli.lib.utils.cloudformation import CloudFormationResourceSummary
+from samcli.lib.utils.resources import (
+    AWS_SERVERLESS_FUNCTION,
+    AWS_LAMBDA_FUNCTION,
+    AWS_SERVERLESS_LAYERVERSION,
+    AWS_LAMBDA_LAYERVERSION,
+    AWS_SERVERLESS_API,
+    AWS_APIGATEWAY_RESTAPI,
+    AWS_SERVERLESS_HTTPAPI,
+    AWS_APIGATEWAY_V2_API,
+    AWS_SERVERLESS_STATEMACHINE,
+    AWS_STEPFUNCTIONS_STATEMACHINE,
+)
 
 
 class TestSyncFlowFactory(TestCase):
@@ -161,3 +173,28 @@ class TestSyncFlowFactory(TestCase):
         factory._get_generator_function = get_generator_function_mock
 
         self.assertIsNone(factory.create_sync_flow(resource_identifier))
+
+
+class TestSyncCodeResources(TestCase):
+    def test_values(self):
+        output = SyncCodeResources.values()
+        expected = [
+            AWS_SERVERLESS_FUNCTION,
+            AWS_LAMBDA_FUNCTION,
+            AWS_SERVERLESS_LAYERVERSION,
+            AWS_LAMBDA_LAYERVERSION,
+            AWS_SERVERLESS_API,
+            AWS_APIGATEWAY_RESTAPI,
+            AWS_SERVERLESS_HTTPAPI,
+            AWS_APIGATEWAY_V2_API,
+            AWS_SERVERLESS_STATEMACHINE,
+            AWS_STEPFUNCTIONS_STATEMACHINE,
+        ]
+        self.assertEqual(expected, output)
+
+    def test_print_code_resource(self):
+        output = SyncCodeResources.__str__()
+        expected = f"{AWS_SERVERLESS_FUNCTION}, {AWS_LAMBDA_FUNCTION}, {AWS_SERVERLESS_LAYERVERSION}, \
+{AWS_LAMBDA_LAYERVERSION}, {AWS_SERVERLESS_API}, {AWS_APIGATEWAY_RESTAPI}, {AWS_SERVERLESS_HTTPAPI}, \
+{AWS_APIGATEWAY_V2_API}, {AWS_SERVERLESS_STATEMACHINE}, {AWS_STEPFUNCTIONS_STATEMACHINE}"
+        self.assertEqual(expected, output)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N.A.

#### Why is this change necessary?
When running sync --code, users can use --resource flag to run sync on specific resource types, for example --resource AWS::Serverless::Function means code sync on all serverless function resources. However if an invalid resource type is provided, the sync is skipped without letting the customer to be aware. This adds resource type validation and fail the command in that scenario.

#### How does it address the issue?
By having a class that stores all supported resource types for sync code.

#### What side effects does this change have?
Not known

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
