### PR TITLE
Add BuildRuntime event and trackers

### DIFF
--- a/build_dir/MyFunctionbf3066d1DepLayer/AWS_SAM_CLI_README
+++ b/build_dir/MyFunctionbf3066d1DepLayer/AWS_SAM_CLI_README
@@ -1,0 +1,1 @@
+This layer contains dependencies of function MyFunction and automatically added by AWS SAM CLI command 'sam sync'

--- a/build_dir/MyFunctionbf3066d1DepLayer/AWS_SAM_CLI_README
+++ b/build_dir/MyFunctionbf3066d1DepLayer/AWS_SAM_CLI_README
@@ -1,1 +1,0 @@
-This layer contains dependencies of function MyFunction and automatically added by AWS SAM CLI command 'sam sync'

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -25,6 +25,7 @@ from samcli.lib.build.build_strategy import (
     ParallelBuildStrategy,
     BuildStrategy,
 )
+from samcli.lib.telemetry.event import EventTracker
 from samcli.lib.utils.resources import (
     AWS_CLOUDFORMATION_STACK,
     AWS_LAMBDA_FUNCTION,
@@ -756,6 +757,7 @@ class ApplicationBuilder:
                 is_building_layer=is_building_layer,
                 experimental_flags=get_enabled_experimental_flags(),
             )
+            EventTracker.track_event("BuildRuntime", runtime)
         except LambdaBuilderError as ex:
             raise BuildError(wrapped_from=ex.__class__.__name__, msg=str(ex)) from ex
 
@@ -841,6 +843,7 @@ class ApplicationBuilder:
         finally:
             self._container_manager.stop(container)
 
+        EventTracker.track_event("BuildRuntime", runtime)
         LOG.debug("Build inside container succeeded")
         return artifacts_dir
 

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -5,6 +5,8 @@ Represents Events and their values.
 from enum import Enum
 from typing import List
 
+from samcli.local.common.runtime_template import INIT_RUNTIMES
+
 
 class EventName(Enum):
     """Enum for the names of available events to track."""
@@ -30,6 +32,7 @@ class EventType:
             "CreateChangeSetFailed",
             "CreateChangeSetSuccess",
         ],
+        EventName.BUILD_RUNTIME: INIT_RUNTIMES,
     }
 
     @staticmethod

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -25,7 +25,7 @@ from samcli.lib.build.app_builder import (
     DockerConnectionError,
 )
 from samcli.commands.local.cli_common.user_exceptions import InvalidFunctionPropertyType
-from samcli.lib.telemetry.event import EventName
+from samcli.lib.telemetry.event import EventName, EventTracker
 from samcli.lib.utils.architecture import X86_64, ARM64
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.stream_writer import StreamWriter
@@ -1477,6 +1477,9 @@ class TestApplicationBuilder_build_function_in_process(TestCase):
             Mock(), "/build/dir", "/base/dir", "/cache/dir", mode="mode", stream_writer=StreamWriter(sys.stderr)
         )
 
+    def tearDown(self):
+        EventTracker.clear_trackers()
+
     @parameterized.expand([([],), (["ExpFlag1", "ExpFlag2"],)])
     @patch("samcli.lib.telemetry.event.EventType.get_accepted_values")
     @patch("samcli.lib.build.app_builder.LambdaBuilder")
@@ -1608,6 +1611,9 @@ class TestApplicationBuilder_build_function_on_container(TestCase):
             stream_writer=StreamWriter(sys.stderr),
         )
         self.builder._parse_builder_response = Mock()
+
+    def tearDown(self):
+        EventTracker.clear_trackers()
 
     @patch("samcli.lib.telemetry.event.EventType.get_accepted_values")
     @patch("samcli.lib.build.app_builder.LambdaBuildContainer")

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -25,6 +25,7 @@ from samcli.lib.build.app_builder import (
     DockerConnectionError,
 )
 from samcli.commands.local.cli_common.user_exceptions import InvalidFunctionPropertyType
+from samcli.lib.telemetry.event import EventName
 from samcli.lib.utils.architecture import X86_64, ARM64
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.stream_writer import StreamWriter
@@ -1477,12 +1478,16 @@ class TestApplicationBuilder_build_function_in_process(TestCase):
         )
 
     @parameterized.expand([([],), (["ExpFlag1", "ExpFlag2"],)])
+    @patch("samcli.lib.telemetry.event.EventType.get_accepted_values")
     @patch("samcli.lib.build.app_builder.LambdaBuilder")
     @patch("samcli.lib.build.app_builder.get_enabled_experimental_flags")
-    def test_must_use_lambda_builder(self, experimental_flags, experimental_flags_mock, lambda_builder_mock):
+    def test_must_use_lambda_builder(
+        self, experimental_flags, experimental_flags_mock, lambda_builder_mock, event_mock
+    ):
         experimental_flags_mock.return_value = experimental_flags
         config_mock = Mock()
         builder_instance_mock = lambda_builder_mock.return_value = Mock()
+        event_mock.return_value = ["runtime"]
 
         result = self.builder._build_function_in_process(
             config_mock,
@@ -1545,10 +1550,14 @@ class TestApplicationBuilder_build_function_in_process(TestCase):
                 True,
             )
 
+    @patch("samcli.lib.telemetry.event.EventType.get_accepted_values")
     @patch("samcli.lib.build.app_builder.LambdaBuilder")
     @patch("samcli.lib.build.app_builder.get_enabled_experimental_flags")
-    def test_building_with_experimental_flags(self, get_enabled_experimental_flags_mock, lambda_builder_mock):
+    def test_building_with_experimental_flags(
+        self, get_enabled_experimental_flags_mock, lambda_builder_mock, event_mock
+    ):
         get_enabled_experimental_flags_mock.return_value = ["A", "B", "C"]
+        event_mock.return_value = ["runtime"]
         config_mock = Mock()
         self.builder._build_function_in_process(
             config_mock,
@@ -1600,11 +1609,15 @@ class TestApplicationBuilder_build_function_on_container(TestCase):
         )
         self.builder._parse_builder_response = Mock()
 
+    @patch("samcli.lib.telemetry.event.EventType.get_accepted_values")
     @patch("samcli.lib.build.app_builder.LambdaBuildContainer")
     @patch("samcli.lib.build.app_builder.lambda_builders_protocol_version")
     @patch("samcli.lib.build.app_builder.LOG")
     @patch("samcli.lib.build.app_builder.osutils")
-    def test_must_build_in_container(self, osutils_mock, LOGMock, protocol_version_mock, LambdaBuildContainerMock):
+    def test_must_build_in_container(
+        self, osutils_mock, LOGMock, protocol_version_mock, LambdaBuildContainerMock, event_mock
+    ):
+        event_mock.return_value = "runtime"
         config = Mock()
         log_level = LOGMock.getEffectiveLevel.return_value = "foo"
         stdout_data = "container stdout response data"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
This addition allows us to see the runtimes of any Lambda functions that are built. The Event currently tracks all supported Lambda runtimes.

#### How does it address the issue?
Whenever a function is built, its runtime is captured and sent to the `EventTracker` via the `track_event` method, which is currently set to allow for all supported Lambda runtimes to be created.

#### What side effects does this change have?
Any time a function is built, the `EventTracker` method is called, and its information will be stored until the trackers are cleared, which occurs when Telemetry metrics are captured.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
