### PR TITLE
fix: issues with parallel build when using compiled languages

### DIFF
--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -349,6 +349,10 @@ class ParallelBuildStrategy(BuildStrategy):
         super().__init__(build_graph)
         self._delegate_build_strategy = delegate_build_strategy
 
+    def build(self) -> Dict[str, str]:
+        with self._delegate_build_strategy:
+            return super().build()
+
     def _build_layers(self, build_graph: BuildGraph) -> Dict[str, str]:
         async_context = AsyncContext()
         for layer_definition in build_graph.get_layer_build_definitions():

--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -363,7 +363,7 @@ class ParallelBuildStrategy(BuildStrategy):
     def _build_functions(self, build_graph: BuildGraph) -> Dict[str, str]:
         async_context = AsyncContext()
         for function_definition in build_graph.get_function_build_definitions():
-            async_context.add_async_task(self.build_single_layer_definition, function_definition)
+            async_context.add_async_task(self.build_single_function_definition, function_definition)
         async_results = async_context.run_async()
 
         function_build_result: Dict[str, str] = dict()

--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -371,6 +371,12 @@ class ParallelBuildStrategy(BuildStrategy):
             function_build_result.update(async_result)
         return function_build_result
 
+    def build_single_layer_definition(self, layer_definition: LayerBuildDefinition) -> Dict[str, str]:
+        return self._delegate_build_strategy.build_single_layer_definition(layer_definition)
+
+    def build_single_function_definition(self, build_definition: FunctionBuildDefinition) -> Dict[str, str]:
+        return self._delegate_build_strategy.build_single_function_definition(build_definition)
+
 
 class IncrementalBuildStrategy(BuildStrategy):
     """

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1812,7 +1812,7 @@ class TestParallelBuilds(DedupBuildIntegBase):
 class TestParallelBuildsJavaWithLayers(DedupBuildIntegBase):
     template = "template-java-maven-with-layers.yaml"
 
-    # @pytest.mark.flaky(reruns=3)
+    @pytest.mark.flaky(reruns=3)
     def test_dedup_build(self):
         """
         Build template above and verify that each function call returns as expected

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -1809,6 +1809,35 @@ class TestParallelBuilds(DedupBuildIntegBase):
     ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
     "Skip build tests on windows when running in CI unless overridden",
 )
+class TestParallelBuildsJavaWithLayers(DedupBuildIntegBase):
+    template = "template-java-maven-with-layers.yaml"
+
+    # @pytest.mark.flaky(reruns=3)
+    def test_dedup_build(self):
+        """
+        Build template above and verify that each function call returns as expected
+        """
+
+        cmdlist = self.get_command_list(parallel=True)
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+
+        self.assertEqual(command_result.process.returncode, 0)
+        self._verify_build_artifact(self.default_build_dir, "HelloWorldFunction")
+        self._verify_build_artifact(self.default_build_dir, "HelloWorldLayer")
+
+        if not SKIP_DOCKER_TESTS:
+            self._verify_invoke_built_function(
+                self.built_template,
+                "HelloWorldFunction",
+                None,
+                "hello world. sum is 12.",
+            )
+
+
+@skipIf(
+    ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
 class TestBuildWithInlineCode(BuildIntegBase):
     template = "inline_template.yaml"
 

--- a/tests/integration/testdata/buildcmd/Java/maven-with-layer/HelloWorldFunction/pom.xml
+++ b/tests/integration/testdata/buildcmd/Java/maven-with-layer/HelloWorldFunction/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>helloworld</groupId>
+    <artifactId>HelloWorld</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>A sample Hello World created for SAM CLI.</name>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>helloworld</groupId>
+            <artifactId>HelloWorldLayer</artifactId>
+            <version>1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-lambda-java-events</artifactId>
+          <version>3.11.0</version>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.13.2</version>
+          <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.4</version>
+          <configuration>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/tests/integration/testdata/buildcmd/Java/maven-with-layer/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/tests/integration/testdata/buildcmd/Java/maven-with-layer/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -1,0 +1,17 @@
+package helloworld;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+
+import helloworldlayer.SimpleMath;
+
+/**
+ * Handler for requests to Lambda function.
+ */
+public class App {
+
+    public String handleRequest(Context context) {
+        int sumResult = SimpleMath.sum(7, 5);
+        return String.format("hello world. sum is %d.", sumResult);
+    }
+}

--- a/tests/integration/testdata/buildcmd/Java/maven-with-layer/HelloWorldLayer/pom.xml
+++ b/tests/integration/testdata/buildcmd/Java/maven-with-layer/HelloWorldLayer/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>helloworld</groupId>
+    <artifactId>HelloWorldLayer</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>A sample Hello World created for SAM CLI.</name>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+    </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.4</version>
+          <configuration>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/tests/integration/testdata/buildcmd/Java/maven-with-layer/HelloWorldLayer/src/main/java/helloworldlayer/SimpleMath.java
+++ b/tests/integration/testdata/buildcmd/Java/maven-with-layer/HelloWorldLayer/src/main/java/helloworldlayer/SimpleMath.java
@@ -1,0 +1,8 @@
+package helloworldlayer;
+
+public class SimpleMath {
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+}

--- a/tests/integration/testdata/buildcmd/template-java-maven-with-layers.yaml
+++ b/tests/integration/testdata/buildcmd/template-java-maven-with-layers.yaml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 30
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: Java/maven-with-layer/HelloWorldFunction
+      Handler: helloworld.App::handleRequest
+      Runtime: java8
+      MemorySize: 512
+      Layers:
+        - !Ref HelloWorldLayer
+
+  HelloWorldLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      ContentUri: Java/maven-with-layer/HelloWorldLayer
+      CompatibleRuntimes:
+        - java8
+    Metadata:
+      BuildMethod: java8
+      BuildArchitecture: x86_64

--- a/tests/unit/lib/build_module/test_build_strategy.py
+++ b/tests/unit/lib/build_module/test_build_strategy.py
@@ -379,7 +379,6 @@ class CachedBuildStrategyTest(BuildStrategyBaseTest):
 
 
 class ParallelBuildStrategyTest(BuildStrategyBaseTest):
-
     @patch("samcli.lib.build.build_strategy.AsyncContext")
     def test_given_async_context_should_call_expected_methods(self, patched_async_context):
         delegate_build_strategy = MagicMock(wraps=_TestBuildStrategy(self.build_graph))


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
If a function depends on a layer which should be build before it, running `sam build --use-container` might fail randomly since layers and functions are built in parallel.

#### How does it address the issue?
First builds layers in parallel and once it is completed it builds all functions in parallel.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
