### PR TITLE
chore: skip TestSyncAdlWithWatchStartWithNoDependencies on windows

### DIFF
--- a/tests/integration/sync/test_sync_adl.py
+++ b/tests/integration/sync/test_sync_adl.py
@@ -5,7 +5,7 @@ from unittest import skipIf
 from samcli.lib.utils.resources import AWS_LAMBDA_FUNCTION
 from tests.integration.sync.test_sync_code import TestSyncCodeBase, SKIP_SYNC_TESTS, TestSyncCode
 from tests.integration.sync.test_sync_watch import TestSyncWatchBase
-from tests.testing_utils import run_command_with_input, read_until_string
+from tests.testing_utils import run_command_with_input, read_until_string, IS_WINDOWS
 
 
 @skipIf(SKIP_SYNC_TESTS, "Skip sync tests in CI/CD only")
@@ -105,7 +105,7 @@ class TestSyncAdlCasesWithCodeParameter(TestSyncCodeBase):
         self.assertIn("extra_message", lambda_response)
 
 
-@skipIf(SKIP_SYNC_TESTS, "Skip sync tests in CI/CD only")
+@skipIf(SKIP_SYNC_TESTS or IS_WINDOWS, "Skip sync tests in CI/CD only")
 class TestSyncAdlWithWatchStartWithNoDependencies(TestSyncWatchBase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
