### PR TITLE
Add thread lock to EventTracker

### DIFF
--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -123,12 +123,14 @@ class EventTracker:
 
     @staticmethod
     def get_tracked_events() -> List[Event]:
-        return EventTracker._events
+        with EventTracker._event_lock:
+            return EventTracker._events
 
     @staticmethod
     def clear_trackers():
         """Clear the current list of tracked Events before the next session."""
-        EventTracker._events = []
+        with EventTracker._event_lock:
+            EventTracker._events = []
 
 
 class EventCreationError(Exception):

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -4,6 +4,7 @@ Represents Events and their values.
 
 from enum import Enum
 import logging
+import threading
 from typing import List
 
 from samcli.local.common.runtime_template import INIT_RUNTIMES
@@ -84,6 +85,7 @@ class EventTracker:
     """Class to track and recreate Events as they occur."""
 
     _events: List[Event] = []
+    _event_lock = threading.Lock()
 
     @staticmethod
     def track_event(event_name: str, event_value: str):
@@ -114,7 +116,8 @@ class EventTracker:
                 return some_value
         """
         try:
-            EventTracker._events.append(Event(event_name, event_value))
+            with EventTracker._event_lock:
+                EventTracker._events.append(Event(event_name, event_value))
         except EventCreationError as e:
             LOG.debug("Error occurred while trying to track an event: %s", e)
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
Previously, a race condition existed if two threads tried tracking events at the same time, as they would both try to be added to the list. This change works to fix that.

#### How does it address the issue?
With the introduction of a thread lock, threads will need to wait for the read and write processes of the Event list to finish before performing their own operations.

#### What side effects does this change have?
Due to the nature of `threading.Lock()`, there should be no notable side effects in any other section of the code.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
