### PR TITLE
Refactor Event data structure

### DIFF
--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -2,6 +2,7 @@
 Represents Events and their values.
 """
 
+from datetime import datetime
 from enum import Enum
 import logging
 import threading
@@ -52,6 +53,8 @@ class Event:
 
     event_name: EventName
     event_value: str  # Validated by EventType.get_accepted_values to never be an arbitrary string
+    thread_id = threading.get_ident()  # The thread ID; used to group Events from the same command run
+    timestamp = datetime.utcnow()
 
     def __init__(self, event_name: str, event_value: str):
         Event._verify_event(event_name, event_value)
@@ -62,10 +65,20 @@ class Event:
         return self.event_name == other.event_name and self.event_value == other.event_value
 
     def __repr__(self):
-        return f"Event(event_name={self.event_name.value}, event_value={self.event_value})"
+        return (
+            f"Event(event_name={self.event_name.value}, "
+            f"event_value={self.event_value}, "
+            f"thread_id={self.thread_id}, "
+            f"timestamp={self.timestamp})"
+        )
 
     def to_json(self):
-        return {"event_name": self.event_name.value, "event_value": self.event_value}
+        return {
+            "event_name": self.event_name.value,
+            "event_value": self.event_value,
+            "thread_id": self.thread_id,
+            "timestamp": self.timestamp,
+        }
 
     @staticmethod
     def _verify_event(event_name: str, event_value: str) -> None:

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -77,7 +77,7 @@ class Event:
             "event_name": self.event_name.value,
             "event_value": self.event_value,
             "thread_id": self.thread_id,
-            "timestamp": self.timestamp,
+            "timestamp": str(self.timestamp),
         }
 
     @staticmethod

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -77,7 +77,7 @@ class Event:
             "event_name": self.event_name.value,
             "event_value": self.event_value,
             "thread_id": self.thread_id,
-            "timestamp": str(self.timestamp),
+            "timestamp": str(self.timestamp)[:-3],
         }
 
     @staticmethod

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -77,7 +77,7 @@ class Event:
             "event_name": self.event_name.value,
             "event_value": self.event_value,
             "thread_id": self.thread_id,
-            "timestamp": str(self.timestamp)[:-3],
+            "timestamp": str(self.timestamp)[:-3],  # cut time's microseconds from 6 -> 3 figures to allow SQL casting
         }
 
     @staticmethod


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
With these added attributes, we can not only tell when Events occur, but also match Events to one command run via their `thread_id`, which is set to be the arbitrary ID of whatever thread is being used by the system.

#### How does it address the issue?
The new attributes allow for queries to be run to match groups of Events by thread, which may be useful for SAM commands that employ multithreading.

#### What side effects does this change have?
Since the [thread_id](https://docs.python.org/3/library/threading.html#threading.get_ident) method picks an arbitrary integer to represent the thread ID, it takes no customer-specific data, and is safe for raw use as such. Otherwise, this would have the impact of adding two new fields to the `Event` data structure: `thread_id: int` and `timestamp: datetime`.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
