### PR TITLE
Implement lock tests for EventTracker

### DIFF
--- a/tests/unit/lib/telemetry/test_event.py
+++ b/tests/unit/lib/telemetry/test_event.py
@@ -68,8 +68,12 @@ class TestEventCreation(TestCase):
 
 
 class TestEventTracker(TestCase):
+    @patch("samcli.lib.telemetry.event.EventTracker._event_lock")
     @patch("samcli.lib.telemetry.event.Event")
-    def test_track_event(self, event_mock):
+    def test_track_event(self, event_mock, lock_mock):
+        lock_mock.__enter__ = Mock()
+        lock_mock.__exit__ = Mock()
+
         # Test that an event can be tracked
         dummy_event = Mock(event_name="Test", event_value="SomeValue", thread_id=threading.get_ident(), timestamp=ANY)
         event_mock.return_value = dummy_event
@@ -78,8 +82,14 @@ class TestEventTracker(TestCase):
 
         self.assertEqual(len(EventTracker._events), 1)
         self.assertEqual(EventTracker._events[0], dummy_event)
+        lock_mock.__enter__.assert_called()  # Lock should have been accessed
+        lock_mock.__exit__.assert_called()
+        lock_mock.__enter__.reset_mock()
+        lock_mock.__exit__.reset_mock()
 
         # Test that the Event list will be cleared
         EventTracker.clear_trackers()
 
         self.assertEqual(len(EventTracker._events), 0)
+        lock_mock.__enter__.assert_called()  # Lock should have been accessed
+        lock_mock.__exit__.assert_called()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
As brought up in a [previous PR](https://github.com/aws/aws-sam-cli/pull/4019#discussion_r911300281), it may be a good idea to verify that the thread lock in `EventTracker` is functioning as intended. 

#### How does it address the issue?
The `EventTracker._event_lock` is mocked in the unit test, which allows us to verify that its `__enter__` and `__exit__` methods are called, confirming that the lock is being used correctly.

#### What side effects does this change have?
This change only updates one unit test, and as such, has no noteworthy side effects.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
