### PR TITLE
Add send_events method to EventTracker

### DIFF
--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -166,7 +166,9 @@ class EventTracker:
 
         try:
             metric = Metric("events")
-            metric.add_data("metricSpecificAttributes", [e.to_json() for e in EventTracker.get_tracked_events()])
+            msa = {}
+            msa['events'] = [e.to_json() for e in EventTracker.get_tracked_events()]
+            metric.add_data("metricSpecificAttributes", msa)
             telemetry.emit(metric)
             EventTracker.clear_trackers()
         except RuntimeError:

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -167,7 +167,7 @@ class EventTracker:
         try:
             metric = Metric("events")
             msa = {}
-            msa['events'] = [e.to_json() for e in EventTracker.get_tracked_events()]
+            msa["events"] = [e.to_json() for e in EventTracker.get_tracked_events()]
             metric.add_data("metricSpecificAttributes", msa)
             telemetry.emit(metric)
             EventTracker.clear_trackers()

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -71,7 +71,7 @@ class Event:
             f"Event(event_name={self.event_name.value}, "
             f"event_value={self.event_value}, "
             f"thread_id={self.thread_id}, "
-            f"timestamp={self.time_stamp})"
+            f"time_stamp={self.time_stamp})"
         )
 
     def to_json(self):
@@ -79,7 +79,7 @@ class Event:
             "event_name": self.event_name.value,
             "event_value": self.event_value,
             "thread_id": self.thread_id,
-            "timestamp": self.time_stamp,
+            "time_stamp": self.time_stamp,
         }
 
     @staticmethod
@@ -157,10 +157,10 @@ class EventTracker:
     @staticmethod
     def send_events():
         """Sends the current list of events via Telemetry."""
+        from samcli.lib.telemetry.metric import Metric  # pylint: disable=cyclic-import
+
         if not EventTracker.get_tracked_events():  # Don't do anything if there are no events to send
             return
-
-        from samcli.lib.telemetry.metric import Metric  # creates circular import otherwise
 
         telemetry = Telemetry()
 

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -165,15 +165,12 @@ class EventTracker:
 
             telemetry = Telemetry()
 
-            try:
-                metric = Metric("events")
-                msa = {}
-                msa["events"] = [e.to_json() for e in EventTracker._events]
-                metric.add_data("metricSpecificAttributes", msa)
-                telemetry.emit(metric)
-                EventTracker._events = []  # Manual clear_trackers() since we're within the lock
-            except RuntimeError:
-                LOG.debug("Unable to find Click Context for getting session_id.")
+            metric = Metric("events")
+            msa = {}
+            msa["events"] = [e.to_json() for e in EventTracker._events]
+            metric.add_data("metricSpecificAttributes", msa)
+            telemetry.emit(metric)
+            EventTracker._events = []  # Manual clear_trackers() since we're within the lock
 
 
 class EventCreationError(Exception):

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -166,7 +166,7 @@ class EventTracker:
 
         try:
             metric = Metric("events")
-            metric.add_data("events", [e.to_json() for e in EventTracker.get_tracked_events()])
+            metric.add_data("metricSpecificAttributes", [e.to_json() for e in EventTracker.get_tracked_events()])
             telemetry.emit(metric)
             EventTracker.clear_trackers()
         except RuntimeError:

--- a/samcli/lib/telemetry/metric.py
+++ b/samcli/lib/telemetry/metric.py
@@ -161,14 +161,12 @@ def track_command(func):
             metric_specific_attributes["gitOrigin"] = get_git_remote_origin_url()
             metric_specific_attributes["projectName"] = get_project_name()
             metric_specific_attributes["initialCommit"] = get_initial_commit_hash()
-            # Event metrics
-            metric_specific_attributes["events"] = [e.to_json() for e in EventTracker.get_tracked_events()]
-            EventTracker.clear_trackers()
             metric.add_data("metricSpecificAttributes", metric_specific_attributes)
             # Metric about command's execution characteristics
             metric.add_data("duration", duration_fn())
             metric.add_data("exitReason", exit_reason)
             metric.add_data("exitCode", exit_code)
+            EventTracker.send_events()
             telemetry.emit(metric)
         except RuntimeError:
             LOG.debug("Unable to find Click Context for getting session_id.")

--- a/samcli/lib/telemetry/metric.py
+++ b/samcli/lib/telemetry/metric.py
@@ -166,7 +166,7 @@ def track_command(func):
             metric.add_data("duration", duration_fn())
             metric.add_data("exitReason", exit_reason)
             metric.add_data("exitCode", exit_code)
-            EventTracker.send_events()
+            EventTracker.send_events()  # Sends Event metrics to Telemetry before commandRun metrics
             telemetry.emit(metric)
         except RuntimeError:
             LOG.debug("Unable to find Click Context for getting session_id.")

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -151,10 +151,7 @@ class TestExperimentalMetric(IntegBase):
 
             all_requests = server.get_all_requests()
             self.assertGreaterEqual(len(all_requests), 1, "Command run metric must be sent")
-            request = None
-            for req in all_requests:
-                print(req["data"])
-                request = req if "commandRun" in req["data"]["metrics"][0].keys() else all_requests[-1]
+            request = all_requests[-1]  # commandRun metric is last bc of ordering 'send_events' vs 'telemetry.emit'
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")
 

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -59,7 +59,6 @@ class TestExperimentalMetric(IntegBase):
                                 "gitOrigin": ANY,
                                 "projectName": ANY,
                                 "initialCommit": ANY,
-                                "events": ANY,
                             },
                             "duration": ANY,
                             "exitReason": ANY,
@@ -114,7 +113,6 @@ class TestExperimentalMetric(IntegBase):
                                 "gitOrigin": ANY,
                                 "projectName": ANY,
                                 "initialCommit": ANY,
-                                "events": ANY,
                             },
                             "duration": ANY,
                             "exitReason": ANY,
@@ -152,7 +150,7 @@ class TestExperimentalMetric(IntegBase):
             process.communicate()
 
             all_requests = server.get_all_requests()
-            self.assertEqual(1, len(all_requests), "Command run metric must be sent")
+            self.assertGreaterEqual(1, len(all_requests), "Command run metric must be sent")
             request = all_requests[0]
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")
@@ -177,7 +175,6 @@ class TestExperimentalMetric(IntegBase):
                                 "gitOrigin": ANY,
                                 "projectName": ANY,
                                 "initialCommit": ANY,
-                                "events": ANY,
                             },
                             "duration": ANY,
                             "exitReason": ANY,

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -150,7 +150,7 @@ class TestExperimentalMetric(IntegBase):
             process.communicate()
 
             all_requests = server.get_all_requests()
-            self.assertGreaterEqual(1, len(all_requests), "Command run metric must be sent")
+            self.assertGreaterEqual(len(all_requests), 1, "Command run metric must be sent")
             request = all_requests[0]
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -153,7 +153,7 @@ class TestExperimentalMetric(IntegBase):
             self.assertGreaterEqual(len(all_requests), 1, "Command run metric must be sent")
             request = None
             for req in all_requests:
-                request = req if "commandRun" in req["data"]["metrics"] else None
+                request = req if "commandRun" in req["data"]["metrics"].keys() else all_requests[-1]
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")
 

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -153,7 +153,8 @@ class TestExperimentalMetric(IntegBase):
             self.assertGreaterEqual(len(all_requests), 1, "Command run metric must be sent")
             request = None
             for req in all_requests:
-                request = req if "commandRun" in req["data"]["metrics"].keys() else all_requests[-1]
+                print(req["data"])
+                request = req if "commandRun" in req["data"]["metrics"][0].keys() else all_requests[-1]
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")
 

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -151,7 +151,9 @@ class TestExperimentalMetric(IntegBase):
 
             all_requests = server.get_all_requests()
             self.assertGreaterEqual(len(all_requests), 1, "Command run metric must be sent")
-            request = all_requests[0]
+            request = None
+            for req in all_requests:
+                request = req if "commandRun" in req["data"]["metrics"] else None
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")
 

--- a/tests/unit/lib/telemetry/test_event.py
+++ b/tests/unit/lib/telemetry/test_event.py
@@ -3,7 +3,6 @@ Module for testing the event.py methods and classes.
 """
 
 from enum import Enum
-from re import X
 import threading
 from unittest import TestCase
 from unittest.mock import ANY, Mock, patch

--- a/tests/unit/lib/telemetry/test_event.py
+++ b/tests/unit/lib/telemetry/test_event.py
@@ -139,7 +139,7 @@ class TestEventTracker(TestCase):
                         "time_stamp": ANY,
                     }
                 ]
-            }
+            },
         }
         print(metric_data)
         self.assertEqual(len(metric_data["metricSpecificAttributes"]["events"]), 1)  # There is one event captured

--- a/tests/unit/lib/telemetry/test_event.py
+++ b/tests/unit/lib/telemetry/test_event.py
@@ -130,16 +130,19 @@ class TestEventTracker(TestCase):
             "ci": ANY,
             "pyversion": ANY,
             "samcliVersion": ANY,
-            "events": [
-                {
-                    "event_name": "Test",
-                    "event_value": "SomeValue",
-                    "thread_id": ANY,
-                    "time_stamp": ANY,
-                }
-            ],
+            "metricSpecificAttributes": {
+                "events": [
+                    {
+                        "event_name": "Test",
+                        "event_value": "SomeValue",
+                        "thread_id": ANY,
+                        "time_stamp": ANY,
+                    }
+                ]
+            }
         }
-        self.assertEqual(len(metric_data["events"]), 1)  # There is one metric captured
+        print(metric_data)
+        self.assertEqual(len(metric_data["metricSpecificAttributes"]["events"]), 1)  # There is one event captured
         self.assertEqual(metric_data, expected_data)
         self.assertEqual(len(EventTracker._events), 0)  # Events should have been sent and cleared
 

--- a/tests/unit/lib/telemetry/test_metric.py
+++ b/tests/unit/lib/telemetry/test_metric.py
@@ -9,6 +9,7 @@ import samcli
 
 from unittest import TestCase
 from unittest.mock import patch, Mock, ANY, call
+from samcli.lib.telemetry.event import EventTracker
 
 import samcli.lib.telemetry.metric
 from samcli.lib.telemetry.cicd import CICDPlatform
@@ -132,6 +133,7 @@ class TestTrackCommand(TestCase):
         GlobalConfigClassMock = Mock()
         self.telemetry_instance = TelemetryClassMock.return_value = Mock()
         self.gc_instance_mock = GlobalConfigClassMock.return_value = Mock()
+        EventTracker.clear_trackers()
 
         self.telemetry_class_patcher = patch("samcli.lib.telemetry.metric.Telemetry", TelemetryClassMock)
         self.gc_patcher = patch("samcli.lib.telemetry.metric.GlobalConfig", GlobalConfigClassMock)

--- a/tests/unit/lib/telemetry/test_metric.py
+++ b/tests/unit/lib/telemetry/test_metric.py
@@ -8,8 +8,7 @@ from parameterized import parameterized
 import samcli
 
 from unittest import TestCase
-from unittest.mock import MagicMock, patch, Mock, ANY, call
-from samcli.lib.telemetry.event import Event, EventTracker
+from unittest.mock import patch, Mock, ANY, call
 
 import samcli.lib.telemetry.metric
 from samcli.lib.telemetry.cicd import CICDPlatform

--- a/tests/unit/lib/telemetry/test_metric.py
+++ b/tests/unit/lib/telemetry/test_metric.py
@@ -339,6 +339,18 @@ class TestTrackCommand(TestCase):
             "The command metrics be emitted when used as a decorator",
         )
 
+    @patch("samcli.lib.telemetry.event.EventTracker.send_events", return_value=None)
+    @patch("samcli.lib.telemetry.metric.Context")
+    def test_must_send_events(self, ContextMock, send_mock):
+        ContextMock.get_current_context.return_value = self.context_mock
+
+        def real_fn():
+            pass
+
+        track_command(real_fn)()
+
+        send_mock.assert_called()
+
 
 class TestParameterCapture(TestCase):
     def setUp(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
Previously, Event information could only be sent through Metric's `track_command` decorator. This change looks to decouple the functionality, allowing Events to be sent to the backend of Telemetry independently of the decorator.

#### How does it address the issue?
With a new `send_events()` method, Events will be sent to the Telemetry backend whenever requested. This method is called in place of the existing format used in the `track_command` decorator. In addition, new functionality is given to the `track_event` method, and when there exceeds a certain number of tracked events, their information is sent automatically via Telemetry, and the existing Events are cleared from the list.

#### What side effects does this change have?
Now, `metricSpecificAttributes` for the `commandRun` metrics will no longer contain `events` as a field, as they will be sent under a different metric name. Additionally, the unit test for testing that the list of Events (in `..metric.py`) have been removed, as the functionality of `send_events` is checked separately, and is now decoupled from the decorator, thus its testing in this situation is no longer necessary.
In addition, the `Event.timestamp: datetime.datetime` attribute has been refactored, and is now `Event.time_stamp: str`, so as to not use the same keyword as the SQL backend, as well as allow for the correct cropping of the timestamp to allow for SQL casting.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
