### PR TITLE
Support Bitbucket OIDC in pipeline bootstrap

### DIFF
--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -322,17 +322,10 @@ def do_cli(
             image_repository_arn=image_repository_arn,
             region=region,
             permissions_provider=permissions_provider,
-            oidc_provider_url=oidc_config.oidc_provider_url,
-            oidc_client_id=oidc_config.oidc_client_id,
-            oidc_provider=oidc_config.oidc_provider,
-            github_org=github_config.github_org,
-            github_repo=github_config.github_repo,
-            deployment_branch=github_config.deployment_branch
-            if github_config.deployment_branch
-            else gitlab_config.deployment_branch,
-            gitlab_group=gitlab_config.gitlab_group,
-            gitlab_project=gitlab_config.gitlab_project,
-            bitbucket_repo_uuid=bitbucket_config.bitbucket_repo_uuid,
+            oidc_config=oidc_config,
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
         )
         guided_context.run()
         stage_configuration_name = guided_context.stage_configuration_name
@@ -345,16 +338,6 @@ def do_cli(
         region = guided_context.region
         profile = guided_context.profile
         permissions_provider = guided_context.permissions_provider
-        oidc_config.oidc_client_id = guided_context.oidc_client_id
-        oidc_config.oidc_provider_url = guided_context.oidc_provider_url
-        oidc_config.oidc_provider = guided_context.oidc_provider
-        github_config.github_org = guided_context.github_org
-        github_config.github_repo = guided_context.github_repo
-        github_config.deployment_branch = guided_context.deployment_branch
-        gitlab_config.deployment_branch = guided_context.deployment_branch
-        gitlab_config.gitlab_project = guided_context.gitlab_project
-        gitlab_config.gitlab_group = guided_context.gitlab_group
-        bitbucket_config.bitbucket_repo_uuid = guided_context.bitbucket_repo_uuid
 
     subject_claim = None
     pipeline_oidc_provider: Optional[PipelineOidcProvider] = None

--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -115,7 +115,12 @@ LOG = logging.getLogger(__name__)
     help="Choose a permissions provider to assume the pipeline execution role. Default is to use an IAM User.",
 )
 @click.option(
-    "--oidc-provider-url", help="The URL of the OIDC provider. Example: https://server.example.com", required=False
+    "--oidc-provider-url",
+    help="The URL of the OIDC provider. "
+    "Github Actions: https://token.actions.githubusercontent.com "
+    "GitLab: https//:<GITLAB INSTANCE> "
+    "Bitbucket: https://bitbucket.org/<WORKSPACE>/<REPOSITORY>/admin/addon/admin/pipelines/openid-connect",
+    required=False,
 )
 @click.option("--oidc-client-id", help="The client ID configured to use with the OIDC provider.", required=False)
 @click.option(
@@ -155,7 +160,8 @@ LOG = logging.getLogger(__name__)
 )
 @click.option(
     "--bitbucket-repo-uuid",
-    help="The UUID of the Bitbucket Repository. Only used if using Bitbucket OIDC for permissions",
+    help="The UUID of the Bitbucket Repository. Only used if using Bitbucket OIDC for permissions. "
+    "Found at https://bitbucket.org/<WORKSPACE>/<REPOSITORY>/admin/addon/admin/pipelines/openid-connect",
     required=False,
 )
 @common_options

--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -291,7 +291,7 @@ def do_cli(
                 deployment_branch=config_parameters.get(DEPLOYMENT_BRANCH),
             )
             bitbucket_config.update_values(bitbucket_repo_uuid=config_parameters.get(BITBUCKET_REPO_UUID))
-        elif saved_provider == "IAM":
+        elif saved_provider == "AWS IAM":
             permissions_provider = IAM
 
     if interactive:

--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -117,10 +117,7 @@ LOG = logging.getLogger(__name__)
 )
 @click.option(
     "--oidc-provider-url",
-    help="The URL of the OIDC provider. "
-    "Github Actions: https://token.actions.githubusercontent.com "
-    "GitLab: https//:<GITLAB INSTANCE> "
-    "Bitbucket: https://bitbucket.org/<WORKSPACE>/<REPOSITORY>/admin/addon/admin/pipelines/openid-connect",
+    help="The URL of the OIDC provider.",
     required=False,
 )
 @click.option("--oidc-client-id", help="The client ID configured to use with the OIDC provider.", required=False)
@@ -161,7 +158,7 @@ LOG = logging.getLogger(__name__)
 )
 @click.option(
     "--bitbucket-repo-uuid",
-    help="The UUID of the Bitbucket Repository. Only used if using Bitbucket OIDC for permissions. "
+    help="The UUID of the Bitbucket repository. Only used if using Bitbucket OIDC for permissions. "
     "Found at https://bitbucket.org/<WORKSPACE>/<REPOSITORY>/admin/addon/admin/pipelines/openid-connect",
     required=False,
 )

--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -148,7 +148,8 @@ LOG = logging.getLogger(__name__)
 )
 @click.option(
     "--oidc-provider",
-    help="The name of the CI/CD system that will be used for OIDC permissions",
+    help="The name of the CI/CD system that will be used for OIDC permissions "
+    "we currently only support GitLab, GitHub, and Bitbucket",
     type=click.Choice([GITHUB_ACTIONS, GITLAB, BITBUCKET]),
     required=False,
 )

--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -413,17 +413,17 @@ def _get_pipeline_oidc_provider(
             GitHubOidcProvider.GITHUB_REPO_PARAMETER_NAME: github_repo,
             GitHubOidcProvider.DEPLOYMENT_BRANCH_PARAMETER_NAME: deployment_branch,
         }
-        return GitHubOidcProvider(github_oidc_params, common_oidc_params, GITHUB_ACTIONS)
+        return GitHubOidcProvider(github_oidc_params, common_oidc_params)
     if oidc_provider == GITLAB:
         gitlab_oidc_params: dict = {
             GitLabOidcProvider.GITLAB_PROJECT_PARAMETER_NAME: gitlab_project,
             GitLabOidcProvider.GITLAB_GROUP_PARAMETER_NAME: gitlab_group,
             GitLabOidcProvider.DEPLOYMENT_BRANCH_PARAMETER_NAME: deployment_branch,
         }
-        return GitLabOidcProvider(gitlab_oidc_params, common_oidc_params, GITLAB)
+        return GitLabOidcProvider(gitlab_oidc_params, common_oidc_params)
     if oidc_provider == BITBUCKET:
         bitbucket_oidc_params: dict = {BitbucketOidcProvider.BITBUCKET_REPO_UUID_PARAMETER_NAME: bitbucket_repo_uuid}
-        return BitbucketOidcProvider(bitbucket_oidc_params, common_oidc_params, BITBUCKET)
+        return BitbucketOidcProvider(bitbucket_oidc_params, common_oidc_params)
     raise click.UsageError("Missing required parameter '--oidc-provider'")
 
 

--- a/samcli/commands/pipeline/bootstrap/guided_context.py
+++ b/samcli/commands/pipeline/bootstrap/guided_context.py
@@ -11,6 +11,12 @@ import click
 from botocore.credentials import EnvProvider
 
 from samcli.commands.exceptions import CredentialsError
+from samcli.commands.pipeline.bootstrap.oidc_config import (
+    BitbucketOidcConfig,
+    GitHubOidcConfig,
+    GitLabOidcConfig,
+    OidcConfig,
+)
 from samcli.commands.pipeline.external_links import CONFIG_AWS_CRED_DOC_URL
 from samcli.lib.bootstrap.bootstrap import get_current_account_id
 from samcli.lib.utils.colors import Colored
@@ -40,6 +46,10 @@ class GuidedContext:
 
     def __init__(
         self,
+        oidc_config: OidcConfig,
+        github_config: GitHubOidcConfig,
+        gitlab_config: GitLabOidcConfig,
+        bitbucket_config: BitbucketOidcConfig,
         profile: Optional[str] = None,
         stage_configuration_name: Optional[str] = None,
         pipeline_user_arn: Optional[str] = None,
@@ -50,15 +60,6 @@ class GuidedContext:
         image_repository_arn: Optional[str] = None,
         region: Optional[str] = None,
         permissions_provider: Optional[str] = None,
-        oidc_client_id: Optional[str] = None,
-        oidc_provider_url: Optional[str] = None,
-        oidc_provider: Optional[str] = None,
-        github_org: Optional[str] = None,
-        github_repo: Optional[str] = None,
-        gitlab_group: Optional[str] = None,
-        gitlab_project: Optional[str] = None,
-        deployment_branch: Optional[str] = None,
-        bitbucket_repo_uuid: Optional[str] = None,
     ) -> None:
         self.profile = profile
         self.stage_configuration_name = stage_configuration_name
@@ -70,15 +71,10 @@ class GuidedContext:
         self.image_repository_arn = image_repository_arn
         self.region = region
         self.permissions_provider = permissions_provider
-        self.oidc_client_id = oidc_client_id
-        self.oidc_provider_url = oidc_provider_url
-        self.oidc_provider = oidc_provider
-        self.github_repo = github_repo
-        self.github_org = github_org
-        self.deployment_branch = deployment_branch
-        self.gitlab_group = gitlab_group
-        self.gitlab_project = gitlab_project
-        self.bitbucket_repo_uuid = bitbucket_repo_uuid
+        self.oidc_config = oidc_config
+        self.github_config = github_config
+        self.gitlab_config = gitlab_config
+        self.bitbucket_config = bitbucket_config
         self.color = Colored()
 
     def _prompt_account_id(self) -> None:
@@ -198,74 +194,78 @@ class GuidedContext:
             type=click.Choice((list(self.SUPPORTED_OIDC_PROVIDERS))),
             show_default=False,
         )
-        self.oidc_provider = self.SUPPORTED_OIDC_PROVIDERS[oidc_provider]
+        self.oidc_config.oidc_provider = self.SUPPORTED_OIDC_PROVIDERS[oidc_provider]
 
     def _prompt_oidc_provider_url(self) -> None:
-        self.oidc_provider_url = click.prompt(
+        self.oidc_config.oidc_provider_url = click.prompt(
             "Enter the URL of the OIDC provider",
             type=click.STRING,
-            default=self.DEFAULT_OIDC_URLS[self.oidc_provider] if self.oidc_provider else None,
+            default=self.DEFAULT_OIDC_URLS[self.oidc_config.oidc_provider] if self.oidc_config.oidc_provider else None,
         )
 
     def _prompt_oidc_client_id(self) -> None:
-        self.oidc_client_id = click.prompt(
+        self.oidc_config.oidc_client_id = click.prompt(
             "Enter the OIDC client ID (sometimes called audience)",
             type=click.STRING,
-            default=self.DEFAULT_CLIENT_IDS[self.oidc_provider] if self.oidc_provider else None,
+            default=self.DEFAULT_CLIENT_IDS[self.oidc_config.oidc_provider] if self.oidc_config.oidc_provider else None,
         )
 
     def _prompt_subject_claim(self) -> None:
-        if self.oidc_provider == GITHUB_ACTIONS:
-            if not self.github_org:
+        if self.oidc_config.oidc_provider == GITHUB_ACTIONS:
+            if not self.github_config.github_org:
                 self._prompt_github_org()
-            if not self.github_repo:
+            if not self.github_config.github_repo:
                 self._prompt_github_repo()
-            if not self.deployment_branch:
+            if not self.github_config.deployment_branch:
                 self._prompt_deployment_branch()
-        elif self.oidc_provider == GITLAB:
-            if not self.gitlab_group:
+        elif self.oidc_config.oidc_provider == GITLAB:
+            if not self.gitlab_config.gitlab_group:
                 self._prompt_gitlab_group()
-            if not self.gitlab_project:
+            if not self.gitlab_config.gitlab_project:
                 self._prompt_gitlab_project()
-            if not self.deployment_branch:
+            if not self.gitlab_config.deployment_branch:
                 self._prompt_deployment_branch()
-        elif self.oidc_provider == BITBUCKET:
-            if not self.bitbucket_repo_uuid:
+        elif self.oidc_config.oidc_provider == BITBUCKET:
+            if not self.bitbucket_config.bitbucket_repo_uuid:
                 self._prompt_bitbucket_repo_uuid()
 
     def _prompt_bitbucket_repo_uuid(self) -> None:
-        self.bitbucket_repo_uuid = click.prompt("Enter the Bitbucket repository UUID", type=click.STRING)
+        self.bitbucket_config.bitbucket_repo_uuid = click.prompt(
+            "Enter the Bitbucket repository UUID", type=click.STRING
+        )
 
     def _prompt_gitlab_group(self) -> None:
-        self.gitlab_group = click.prompt(
+        self.gitlab_config.gitlab_group = click.prompt(
             "Enter the GitLab group that the code repository belongs to."
             " If there is no group enter your username instead",
             type=click.STRING,
         )
 
     def _prompt_gitlab_project(self) -> None:
-        self.gitlab_project = click.prompt("Enter GitLab project name", type=click.STRING)
+        self.gitlab_config.gitlab_project = click.prompt("Enter GitLab project name", type=click.STRING)
 
     def _prompt_github_org(self) -> None:
-        self.github_org = click.prompt(
+        self.github_config.github_org = click.prompt(
             "Enter the GitHub organization that the code repository belongs to."
             " If there is no organization enter your username instead",
             type=click.STRING,
         )
 
     def _prompt_github_repo(self) -> None:
-        self.github_repo = click.prompt("Enter GitHub repository name", type=click.STRING)
+        self.github_config.github_repo = click.prompt("Enter GitHub repository name", type=click.STRING)
 
     def _prompt_deployment_branch(self) -> None:
-        self.deployment_branch = click.prompt(
+        deployment_branch = click.prompt(
             "Enter the name of the branch that deployments will occur from", type=click.STRING, default="main"
         )
+        self.github_config.deployment_branch = deployment_branch
+        self.gitlab_config.deployment_branch = deployment_branch
 
     def _validate_oidc_provider_url(self) -> None:
-        while not self.oidc_provider_url:
+        while not self.oidc_config.oidc_provider_url:
             click.echo("Please enter the URL of the OIDC provider")
             self._prompt_oidc_provider_url()
-        while self.oidc_provider_url.find("https://") == -1:
+        while self.oidc_config.oidc_provider_url.find("https://") == -1:
             click.echo("Please ensure the OIDC URL begins with 'https://'")
             self._prompt_oidc_provider_url()
 
@@ -279,30 +279,36 @@ class GuidedContext:
         if self.permissions_provider == OPEN_ID_CONNECT:
             inputs.extend(
                 [
-                    (f"OIDC identity provider URL: {self.oidc_provider_url}", self._prompt_oidc_provider_url),
-                    (f"OIDC client ID: {self.oidc_client_id}", self._prompt_oidc_client_id),
+                    (
+                        f"OIDC identity provider URL: {self.oidc_config.oidc_provider_url}",
+                        self._prompt_oidc_provider_url,
+                    ),
+                    (f"OIDC client ID: {self.oidc_config.oidc_client_id}", self._prompt_oidc_client_id),
                 ]
             )
-            if self.oidc_provider == GITHUB_ACTIONS:
+            if self.oidc_config.oidc_provider == GITHUB_ACTIONS:
                 inputs.extend(
                     [
-                        (f"GitHub organization: {self.github_org}", self._prompt_github_org),
-                        (f"GitHub repository: {self.github_repo}", self._prompt_github_repo),
-                        (f"Deployment branch:  {self.deployment_branch}", self._prompt_deployment_branch),
+                        (f"GitHub organization: {self.github_config.github_org}", self._prompt_github_org),
+                        (f"GitHub repository: {self.github_config.github_repo}", self._prompt_github_repo),
+                        (f"Deployment branch:  {self.github_config.deployment_branch}", self._prompt_deployment_branch),
                     ]
                 )
-            elif self.oidc_provider == GITLAB:
+            elif self.oidc_config.oidc_provider == GITLAB:
                 inputs.extend(
                     [
-                        (f"GitLab group: {self.gitlab_group}", self._prompt_gitlab_group),
-                        (f"GitLab project: {self.gitlab_project}", self._prompt_gitlab_project),
-                        (f"Deployment branch: {self.deployment_branch}", self._prompt_deployment_branch),
+                        (f"GitLab group: {self.gitlab_config.gitlab_group}", self._prompt_gitlab_group),
+                        (f"GitLab project: {self.gitlab_config.gitlab_project}", self._prompt_gitlab_project),
+                        (f"Deployment branch: {self.gitlab_config.deployment_branch}", self._prompt_deployment_branch),
                     ]
                 )
-            elif self.oidc_provider == BITBUCKET:
+            elif self.oidc_config.oidc_provider == BITBUCKET:
                 inputs.extend(
                     [
-                        (f"Bitbucket repository UUID: {self.bitbucket_repo_uuid}", self._prompt_bitbucket_repo_uuid),
+                        (
+                            f"Bitbucket repository UUID: {self.bitbucket_config.bitbucket_repo_uuid}",
+                            self._prompt_bitbucket_repo_uuid,
+                        ),
                     ]
                 )
         else:
@@ -371,12 +377,12 @@ class GuidedContext:
             self._prompt_permissions_provider()
 
         if self.permissions_provider == OPEN_ID_CONNECT:
-            if not self.oidc_provider:
+            if not self.oidc_config.oidc_provider:
                 self._prompt_oidc_provider()
-            if not self.oidc_provider_url:
+            if not self.oidc_config.oidc_provider_url:
                 self._prompt_oidc_provider_url()
             self._validate_oidc_provider_url()
-            if not self.oidc_client_id:
+            if not self.oidc_config.oidc_client_id:
                 self._prompt_oidc_client_id()
             self._prompt_subject_claim()
         elif self.pipeline_user_arn:

--- a/samcli/commands/pipeline/bootstrap/guided_context.py
+++ b/samcli/commands/pipeline/bootstrap/guided_context.py
@@ -29,6 +29,8 @@ class GuidedContext:
 
     SUPPORTED_OIDC_PROVIDERS = {"1": GITHUB_ACTIONS, "2": GITLAB, "3": BITBUCKET}
     OIDC_PROVIDER_NAME_MAPPINGS = {GITHUB_ACTIONS: "GitHub Actions", GITLAB: "GitLab", BITBUCKET: "Bitbucket"}
+    # GitHub defaults: https://tinyurl.com/github-defaults
+    # GitLab defaults: https://docs.gitlab.com/ee/ci/cloud_services/aws/#add-the-identity-provider
     DEFAULT_OIDC_URLS = {
         GITHUB_ACTIONS: "https://token.actions.githubusercontent.com",
         GITLAB: "https://gitlab.com",

--- a/samcli/commands/pipeline/bootstrap/guided_context.py
+++ b/samcli/commands/pipeline/bootstrap/guided_context.py
@@ -232,7 +232,7 @@ class GuidedContext:
                 self._prompt_bitbucket_repo_uuid()
 
     def _prompt_bitbucket_repo_uuid(self) -> None:
-        self.bitbucket_repo_uuid = click.prompt("Enter the Bitbucket Repository UUID", type=click.STRING)
+        self.bitbucket_repo_uuid = click.prompt("Enter the Bitbucket repository UUID", type=click.STRING)
 
     def _prompt_gitlab_group(self) -> None:
         self.gitlab_group = click.prompt(
@@ -300,7 +300,7 @@ class GuidedContext:
             elif self.oidc_provider == BITBUCKET:
                 inputs.extend(
                     [
-                        (f"Bitbucket Repo UUID: {self.bitbucket_repo_uuid}", self._prompt_bitbucket_repo_uuid),
+                        (f"Bitbucket repository UUID: {self.bitbucket_repo_uuid}", self._prompt_bitbucket_repo_uuid),
                     ]
                 )
         else:

--- a/samcli/commands/pipeline/bootstrap/oidc_config.py
+++ b/samcli/commands/pipeline/bootstrap/oidc_config.py
@@ -1,22 +1,21 @@
 """
 Represents a pipeline OIDC provider
 """
+from dataclasses import dataclass
 from typing import Optional
 
 
+@dataclass
 class OidcConfig:
-    def __init__(
-        self, oidc_provider: Optional[str], oidc_provider_url: Optional[str], oidc_client_id: Optional[str]
-    ) -> None:
-        self.oidc_provider = oidc_provider
-        self.oidc_provider_url = oidc_provider_url
-        self.oidc_client_id = oidc_client_id
+    oidc_provider_url: Optional[str]
+    oidc_client_id: Optional[str]
+    oidc_provider: Optional[str]
 
     def get_oidc_parameters(self) -> dict:
         return {
             "oidc-provider-url": self.oidc_provider_url,
-            "oidc-provider": self.oidc_provider,
             "oidc-client-id": self.oidc_client_id,
+            "oidc-provider": self.oidc_provider,
         }
 
     def update_values(
@@ -27,11 +26,11 @@ class OidcConfig:
         self.oidc_client_id = oidc_client_id if oidc_client_id else self.oidc_client_id
 
 
+@dataclass
 class GitHubOidcConfig:
-    def __init__(self, github_org: Optional[str], github_repo: Optional[str], deployment_branch: Optional[str]) -> None:
-        self.github_org = github_org
-        self.github_repo = github_repo
-        self.deployment_branch = deployment_branch
+    github_org: Optional[str]
+    github_repo: Optional[str]
+    deployment_branch: Optional[str]
 
     def get_oidc_parameters(self) -> dict:
         return {
@@ -48,13 +47,11 @@ class GitHubOidcConfig:
         self.deployment_branch = deployment_branch if deployment_branch else self.deployment_branch
 
 
+@dataclass
 class GitLabOidcConfig:
-    def __init__(
-        self, gitlab_group: Optional[str], gitlab_project: Optional[str], deployment_branch: Optional[str]
-    ) -> None:
-        self.gitlab_group = gitlab_group
-        self.gitlab_project = gitlab_project
-        self.deployment_branch = deployment_branch
+    gitlab_group: Optional[str]
+    gitlab_project: Optional[str]
+    deployment_branch: Optional[str]
 
     def get_oidc_parameters(self) -> dict:
         return {
@@ -71,9 +68,9 @@ class GitLabOidcConfig:
         self.deployment_branch = deployment_branch if deployment_branch else self.deployment_branch
 
 
+@dataclass
 class BitbucketOidcConfig:
-    def __init__(self, bitbucket_repo_uuid: Optional[str]) -> None:
-        self.bitbucket_repo_uuid = bitbucket_repo_uuid
+    bitbucket_repo_uuid: Optional[str]
 
     def get_oidc_parameters(self) -> dict:
         return {

--- a/samcli/commands/pipeline/bootstrap/oidc_config.py
+++ b/samcli/commands/pipeline/bootstrap/oidc_config.py
@@ -1,0 +1,84 @@
+"""
+Represents a pipeline OIDC provider
+"""
+from typing import Optional
+
+
+class OidcConfig:
+    def __init__(
+        self, oidc_provider: Optional[str], oidc_provider_url: Optional[str], oidc_client_id: Optional[str]
+    ) -> None:
+        self.oidc_provider = oidc_provider
+        self.oidc_provider_url = oidc_provider_url
+        self.oidc_client_id = oidc_client_id
+
+    def get_oidc_parameters(self) -> dict:
+        return {
+            "oidc-provider-url": self.oidc_provider_url,
+            "oidc-provider": self.oidc_provider,
+            "oidc-client-id": self.oidc_client_id,
+        }
+
+    def update_values(
+        self, oidc_provider: Optional[str], oidc_provider_url: Optional[str], oidc_client_id: Optional[str]
+    ) -> None:
+        self.oidc_provider = oidc_provider if oidc_provider else self.oidc_provider
+        self.oidc_provider_url = oidc_provider_url if oidc_provider_url else self.oidc_provider_url
+        self.oidc_client_id = oidc_client_id if oidc_client_id else self.oidc_client_id
+
+
+class GitHubOidcConfig:
+    def __init__(self, github_org: Optional[str], github_repo: Optional[str], deployment_branch: Optional[str]) -> None:
+        self.github_org = github_org
+        self.github_repo = github_repo
+        self.deployment_branch = deployment_branch
+
+    def get_oidc_parameters(self) -> dict:
+        return {
+            "github-org": self.github_org,
+            "github-repo": self.github_repo,
+            "deployment-branch": self.deployment_branch,
+        }
+
+    def update_values(
+        self, github_org: Optional[str], github_repo: Optional[str], deployment_branch: Optional[str]
+    ) -> None:
+        self.github_org = github_org if github_org else self.github_org
+        self.github_repo = github_repo if github_repo else self.github_repo
+        self.deployment_branch = deployment_branch if deployment_branch else self.deployment_branch
+
+
+class GitLabOidcConfig:
+    def __init__(
+        self, gitlab_group: Optional[str], gitlab_project: Optional[str], deployment_branch: Optional[str]
+    ) -> None:
+        self.gitlab_group = gitlab_group
+        self.gitlab_project = gitlab_project
+        self.deployment_branch = deployment_branch
+
+    def get_oidc_parameters(self) -> dict:
+        return {
+            "gitlab-group": self.gitlab_group,
+            "gitlab-project": self.gitlab_project,
+            "deployment-branch": self.deployment_branch,
+        }
+
+    def update_values(
+        self, gitlab_group: Optional[str], gitlab_project: Optional[str], deployment_branch: Optional[str]
+    ) -> None:
+        self.gitlab_group = gitlab_group if gitlab_group else self.gitlab_group
+        self.gitlab_project = gitlab_project if gitlab_project else self.gitlab_project
+        self.deployment_branch = deployment_branch if deployment_branch else self.deployment_branch
+
+
+class BitbucketOidcConfig:
+    def __init__(self, bitbucket_repo_uuid: Optional[str]) -> None:
+        self.bitbucket_repo_uuid = bitbucket_repo_uuid
+
+    def get_oidc_parameters(self) -> dict:
+        return {
+            "bitbucket-repo-uuid": self.bitbucket_repo_uuid,
+        }
+
+    def update_values(self, bitbucket_repo_uuid: Optional[str]) -> None:
+        self.bitbucket_repo_uuid = bitbucket_repo_uuid if bitbucket_repo_uuid else self.bitbucket_repo_uuid

--- a/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
+++ b/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
@@ -44,6 +44,7 @@ class PipelineOidcProvider:
                 value=self.oidc_parameters[parameter_name],
             )
         samconfig.put(cmd_names=cmd_names, section=section, key="oidc_provider", value=self.oidc_provider_name)
+        samconfig.put(cmd_names=cmd_names, section=section, key="permissions_provider", value="OpenID Connect")
 
     @abstractmethod
     def get_subject_claim(self) -> str:

--- a/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
+++ b/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
@@ -20,6 +20,10 @@ class PipelineOidcProvider:
         self.verify_parameters()
 
     def verify_parameters(self) -> None:
+        """
+        Makes sure that all required parameters have been provided
+        -------
+        """
         error_string = ""
         for parameter_name in self.oidc_parameter_names:
             if not self.oidc_parameters[parameter_name]:
@@ -28,6 +32,10 @@ class PipelineOidcProvider:
             raise click.UsageError("\n" + error_string)
 
     def save_values(self, samconfig: SamConfig, cmd_names: List[str], section: str) -> None:
+        """
+        Saves provided values into config file so they can be reused for future calls to bootstrap
+        -------
+        """
         for parameter_name in self.oidc_parameter_names:
             samconfig.put(
                 cmd_names=cmd_names,
@@ -43,6 +51,17 @@ class PipelineOidcProvider:
 
 
 class GitHubOidcProvider(PipelineOidcProvider):
+    """
+    Represents a GitHub Actions OIDC provider
+    https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
+    ----------
+    subject_claim_parameters: dict
+        Parameters specific to building the subject claim for this provider.
+    oidc_parameters: dict
+        Parameters common to all providers.
+    oidc_provider_name: str
+        Name of the oidc_provider to be saved in the config file
+    """
 
     GITHUB_ORG_PARAMETER_NAME = "github-org"
     GITHUB_REPO_PARAMETER_NAME = "github-repo"
@@ -73,6 +92,17 @@ class GitHubOidcProvider(PipelineOidcProvider):
 
 
 class GitLabOidcProvider(PipelineOidcProvider):
+    """
+    Represents a GitLab OIDC provider
+    https://docs.gitlab.com/ee/integration/openid_connect_provider.html
+    ----------
+    subject_claim_parameters: dict
+        Parameters specific to building the subject claim for this provider.
+    oidc_parameters: dict
+        Parameters common to all providers.
+    oidc_provider_name: str
+        Name of the oidc_provider to be saved in the config file
+    """
 
     GITLAB_PROJECT_PARAMETER_NAME = "gitlab-project"
     GITLAB_GROUP_PARAMETER_NAME = "gitlab-group"
@@ -103,6 +133,17 @@ class GitLabOidcProvider(PipelineOidcProvider):
 
 
 class BitbucketOidcProvider(PipelineOidcProvider):
+    """
+    Represents a Bitbucket OIDC provider
+    https://support.atlassian.com/bitbucket-cloud/docs/integrate-pipelines-with-resource-servers-using-oidc/
+    ----------
+    subject_claim_parameters: dict
+        Parameters specific to building the subject claim for this provider.
+    oidc_parameters: dict
+        Parameters common to all providers.
+    oidc_provider_name: str
+        Name of the oidc_provider to be saved in the config file
+    """
 
     BITBUCKET_REPO_UUID_PARAMETER_NAME = "bitbucket-repo-uuid"
 

--- a/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
+++ b/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
@@ -100,3 +100,26 @@ class GitLabOidcProvider(PipelineOidcProvider):
         project = self.oidc_parameters["gitlab-project"]
         branch = self.oidc_parameters["deployment-branch"]
         return f"project_path:{group}/{project}:ref_type:branch:ref:{branch}"
+
+
+class BitbucketOidcProvider(PipelineOidcProvider):
+
+    BITBUCKET_REPO_UUID_PARAMETER_NAME = "bitbucket-repo-uuid"
+
+    def __init__(self, subject_claim_parameters: dict, oidc_parameters: dict, oidc_provider_name: str) -> None:
+        all_oidc_parameters = {**oidc_parameters, **subject_claim_parameters}
+        all_oidc_parameter_names = [
+            self.BITBUCKET_REPO_UUID_PARAMETER_NAME,
+        ]
+        super().__init__(all_oidc_parameters, all_oidc_parameter_names, oidc_provider_name)
+
+    def get_subject_claim(self) -> str:
+        """
+        Returns the subject claim that will be used to establish trust between the OIDC provider and AWS.
+        To read more about OIDC claims see the following: https://openid.net/specs/openid-connect-core-1_0.html#Claims
+        To learn more about configuring a role to work with GitLab OIDC through claims see the following
+        tinyurl.com/bitbucket-oidc-claims
+        -------
+        """
+        repo_uuid = self.oidc_parameters[self.BITBUCKET_REPO_UUID_PARAMETER_NAME]
+        return f"{repo_uuid}:*"

--- a/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
+++ b/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
@@ -61,8 +61,6 @@ class GitHubOidcProvider(PipelineOidcProvider):
         Parameters specific to building the subject claim for this provider.
     oidc_parameters: dict
         Parameters common to all providers.
-    oidc_provider_name: str
-        Name of the oidc_provider to be saved in the config file
     """
 
     GITHUB_ORG_PARAMETER_NAME = "github-org"
@@ -102,8 +100,6 @@ class GitLabOidcProvider(PipelineOidcProvider):
         Parameters specific to building the subject claim for this provider.
     oidc_parameters: dict
         Parameters common to all providers.
-    oidc_provider_name: str
-        Name of the oidc_provider to be saved in the config file
     """
 
     GITLAB_PROJECT_PARAMETER_NAME = "gitlab-project"
@@ -143,8 +139,6 @@ class BitbucketOidcProvider(PipelineOidcProvider):
         Parameters specific to building the subject claim for this provider.
     oidc_parameters: dict
         Parameters common to all providers.
-    oidc_provider_name: str
-        Name of the oidc_provider to be saved in the config file
     """
 
     BITBUCKET_REPO_UUID_PARAMETER_NAME = "bitbucket-repo-uuid"

--- a/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
+++ b/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
@@ -4,6 +4,7 @@ Represents a pipeline OIDC provider
 from abc import abstractmethod
 from typing import List
 import click
+from samcli.commands.pipeline.bootstrap.guided_context import BITBUCKET, GITHUB_ACTIONS, GITLAB
 
 from samcli.lib.config.samconfig import SamConfig
 
@@ -68,14 +69,14 @@ class GitHubOidcProvider(PipelineOidcProvider):
     GITHUB_REPO_PARAMETER_NAME = "github-repo"
     DEPLOYMENT_BRANCH_PARAMETER_NAME = "deployment-branch"
 
-    def __init__(self, subject_claim_parameters: dict, oidc_parameters: dict, oidc_provider_name: str) -> None:
+    def __init__(self, subject_claim_parameters: dict, oidc_parameters: dict) -> None:
         all_oidc_parameters = {**oidc_parameters, **subject_claim_parameters}
         all_oidc_parameter_names = [
             self.GITHUB_ORG_PARAMETER_NAME,
             self.GITHUB_REPO_PARAMETER_NAME,
             self.DEPLOYMENT_BRANCH_PARAMETER_NAME,
         ]
-        super().__init__(all_oidc_parameters, all_oidc_parameter_names, oidc_provider_name)
+        super().__init__(all_oidc_parameters, all_oidc_parameter_names, GITHUB_ACTIONS)
 
     def get_subject_claim(self) -> str:
         """
@@ -109,14 +110,14 @@ class GitLabOidcProvider(PipelineOidcProvider):
     GITLAB_GROUP_PARAMETER_NAME = "gitlab-group"
     DEPLOYMENT_BRANCH_PARAMETER_NAME = "deployment-branch"
 
-    def __init__(self, subject_claim_parameters: dict, oidc_parameters: dict, oidc_provider_name: str) -> None:
+    def __init__(self, subject_claim_parameters: dict, oidc_parameters: dict) -> None:
         all_oidc_parameters = {**oidc_parameters, **subject_claim_parameters}
         all_oidc_parameter_names = [
             self.GITLAB_PROJECT_PARAMETER_NAME,
             self.GITLAB_GROUP_PARAMETER_NAME,
             self.DEPLOYMENT_BRANCH_PARAMETER_NAME,
         ]
-        super().__init__(all_oidc_parameters, all_oidc_parameter_names, oidc_provider_name)
+        super().__init__(all_oidc_parameters, all_oidc_parameter_names, GITLAB)
 
     def get_subject_claim(self) -> str:
         """
@@ -148,12 +149,12 @@ class BitbucketOidcProvider(PipelineOidcProvider):
 
     BITBUCKET_REPO_UUID_PARAMETER_NAME = "bitbucket-repo-uuid"
 
-    def __init__(self, subject_claim_parameters: dict, oidc_parameters: dict, oidc_provider_name: str) -> None:
+    def __init__(self, subject_claim_parameters: dict, oidc_parameters: dict) -> None:
         all_oidc_parameters = {**oidc_parameters, **subject_claim_parameters}
         all_oidc_parameter_names = [
             self.BITBUCKET_REPO_UUID_PARAMETER_NAME,
         ]
-        super().__init__(all_oidc_parameters, all_oidc_parameter_names, oidc_provider_name)
+        super().__init__(all_oidc_parameters, all_oidc_parameter_names, BITBUCKET)
 
     def get_subject_claim(self) -> str:
         """

--- a/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
+++ b/samcli/commands/pipeline/bootstrap/pipeline_oidc_provider.py
@@ -35,7 +35,6 @@ class PipelineOidcProvider:
     def save_values(self, samconfig: SamConfig, cmd_names: List[str], section: str) -> None:
         """
         Saves provided values into config file so they can be reused for future calls to bootstrap
-        -------
         """
         for parameter_name in self.oidc_parameter_names:
             samconfig.put(
@@ -45,7 +44,7 @@ class PipelineOidcProvider:
                 value=self.oidc_parameters[parameter_name],
             )
         samconfig.put(cmd_names=cmd_names, section=section, key="oidc_provider", value=self.oidc_provider_name)
-        samconfig.put(cmd_names=cmd_names, section=section, key="permissions_provider", value="OpenID Connect")
+        samconfig.put(cmd_names=cmd_names, section=section, key="permissions_provider", value="OpenID Connect (OIDC)")
 
     @abstractmethod
     def get_subject_claim(self) -> str:

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -184,6 +184,7 @@ class InteractiveInitFlow:
                     oidc_provider=None,
                     gitlab_group=None,
                     gitlab_project=None,
+                    bitbucket_repo_uuid=None,
                 )
                 return True
         else:

--- a/samcli/commands/pipeline/init/interactive_init_flow.py
+++ b/samcli/commands/pipeline/init/interactive_init_flow.py
@@ -256,6 +256,8 @@ def _load_pipeline_bootstrap_resources() -> Tuple[List[str], Dict[str, str]]:
             # create an index alias for each stage name
             # so that if customers type "1," it is equivalent to the first stage name
             context[str([str(index + 1), key])] = value
+    for key, value in config.get_all(_get_bootstrap_command_names(), section, "default").items():
+        context[str(["default", key])] = value
 
     # pre-load the list of stage names detected from pipelineconfig.toml
     stage_names_message = (

--- a/samcli/lib/cookiecutter/template.py
+++ b/samcli/lib/cookiecutter/template.py
@@ -121,6 +121,7 @@ class Template:
         """
         try:
             context = context if context else {}
+            context["shared_values"] = "default"
             for flow in self._interactive_flows:
                 context = flow.run(context)
             return context

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -39,6 +39,7 @@ GITHUB_REPO = "github_repo"
 GITLAB_GROUP = "gitlab_group"
 GITLAB_PROJECT = "gitlab_project"
 DEPLOYMENT_BRANCH = "deployment_branch"
+BITBUCKET_REPO_UUID = "bitbucket_repo_uuid"
 REGION = "region"
 
 

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -373,7 +373,7 @@ class Stage:
 
         if self.pipeline_user.arn:
             samconfig.put(cmd_names=cmd_names, section="parameters", key=PIPELINE_USER, value=self.pipeline_user.arn)
-            samconfig.put(cmd_names=cmd_names, section="parameters", key=PERMISSIONS_PROVIDER, value="IAM")
+            samconfig.put(cmd_names=cmd_names, section="parameters", key=PERMISSIONS_PROVIDER, value="AWS IAM")
         if self.use_oidc_provider and self.pipeline_oidc_provider:
             self.pipeline_oidc_provider.save_values(cmd_names=cmd_names, section="parameters", samconfig=samconfig)
 

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -40,6 +40,7 @@ GITLAB_GROUP = "gitlab_group"
 GITLAB_PROJECT = "gitlab_project"
 DEPLOYMENT_BRANCH = "deployment_branch"
 BITBUCKET_REPO_UUID = "bitbucket_repo_uuid"
+PERMISSIONS_PROVIDER = "permissions_provider"
 REGION = "region"
 
 
@@ -372,6 +373,7 @@ class Stage:
 
         if self.pipeline_user.arn:
             samconfig.put(cmd_names=cmd_names, section="parameters", key=PIPELINE_USER, value=self.pipeline_user.arn)
+            samconfig.put(cmd_names=cmd_names, section="parameters", key=PERMISSIONS_PROVIDER, value="IAM")
         if self.use_oidc_provider and self.pipeline_oidc_provider:
             self.pipeline_oidc_provider.save_values(cmd_names=cmd_names, section="parameters", samconfig=samconfig)
 

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -147,15 +147,21 @@ class Stage:
         )
 
     def _should_create_new_provider(self) -> bool:
+        """
+        Checks if there is an existing Identity Provider in the account already
+        whos ARN contains the URL provided by the user.
+
+        OIDC Provider arns are of the following format
+        arn:aws:iam:::oidc-provider/api.bitbucket.org/2.0/workspaces//pipelines-config/identity/oidc
+        we can check if the URL provided is already in an existing provider to see if a new one should be made
+        -------
+        """
         if not self.oidc_provider.provider_url:
             return False
         session = boto3.Session(profile_name=self.aws_profile, region_name=self.aws_region)
         iam_client = session.client("iam")
         providers = iam_client.list_open_id_connect_providers()
 
-        # OIDC Provider arns are of the following format
-        # arn:aws:iam:::oidc-provider/api.bitbucket.org/2.0/workspaces//pipelines-config/identity/oidc
-        # we can check if the URL provided is already in an existing provider to see if a new one should be made
         url_to_compare = self.oidc_provider.provider_url.replace("https://", "")
         for provider_resource in providers["OpenIDConnectProviderList"]:
             if url_to_compare in provider_resource["Arn"]:

--- a/tests/unit/commands/pipeline/bootstrap/test_cli.py
+++ b/tests/unit/commands/pipeline/bootstrap/test_cli.py
@@ -462,7 +462,7 @@ class TestCli(TestCase):
             "github_org": "saved_org",
             "github_repo": "saved_repo",
             "deployment_branch": "saved_branch",
-            "permissions_provider": "OpenID Connect",
+            "permissions_provider": "OpenID Connect (OIDC)",
         }
 
         # trigger
@@ -486,9 +486,9 @@ class TestCli(TestCase):
             create_image_repository=True,
             image_repository_arn=ANY_IMAGE_REPOSITORY_ARN,
             region=ANY_REGION,
-            gitlab_group=None,
-            gitlab_project=None,
-            bitbucket_repo_uuid=None,
+            gitlab_group=ANY_GITLAB_GROUP,
+            gitlab_project=ANY_GITLAB_PROJECT,
+            bitbucket_repo_uuid=ANY_BITBUCKET_REPO_UUID,
         )
 
     @patch("samcli.commands.pipeline.bootstrap.cli._get_bootstrap_command_names")

--- a/tests/unit/commands/pipeline/bootstrap/test_cli.py
+++ b/tests/unit/commands/pipeline/bootstrap/test_cli.py
@@ -33,6 +33,7 @@ ANY_GITHUB_REPO = "ANY_GITHUB_REPO"
 ANY_DEPLOYMENT_BRANCH = "ANY_DEPLOYMENT_BRANCH"
 ANY_GITLAB_PROJECT = "ANY_GITLAB_PROJECT"
 ANY_GITLAB_GROUP = "ANY_GITLAB_GROUP"
+ANY_BITBUCKET_REPO_UUID = "ANY_BITBUCKET_REPO_UUID"
 ANY_SUBJECT_CLAIM = "ANY_SUBJECT_CLAIM"
 ANY_BUILT_SUBJECT_CLAIM = "repo:ANY_GITHUB_ORG/ANY_GITHUB_REPO:ref:refs/heads/ANY_DEPLOYMENT_BRANCH"
 ANY_BUILT_GITLAB_SUBJECT_CLAIM = (
@@ -65,6 +66,7 @@ class TestCli(TestCase):
             "github_repo": ANY_GITHUB_REPO,
             "gitlab_project": ANY_GITLAB_PROJECT,
             "gitlab_group": ANY_GITLAB_GROUP,
+            "bitbucket_repo_uuid": ANY_BITBUCKET_REPO_UUID,
             "deployment_branch": ANY_DEPLOYMENT_BRANCH,
         }
 
@@ -100,6 +102,7 @@ class TestCli(TestCase):
             oidc_provider=None,
             gitlab_group=None,
             gitlab_project=None,
+            bitbucket_repo_uuid=None,
         )
 
     @patch("samcli.commands.pipeline.bootstrap.cli.do_cli")

--- a/tests/unit/commands/pipeline/bootstrap/test_guided_context.py
+++ b/tests/unit/commands/pipeline/bootstrap/test_guided_context.py
@@ -114,6 +114,32 @@ class TestGuidedContext(TestCase):
         prompt_account_id_mock.assert_called_once()
         click_mock.prompt.assert_called_once()
 
+    @patch("samcli.commands.pipeline.bootstrap.guided_context.GuidedContext._validate_oidc_provider_url")
+    @patch("samcli.commands.pipeline.bootstrap.guided_context.get_current_account_id")
+    @patch("samcli.commands.pipeline.bootstrap.guided_context.click")
+    @patch("samcli.commands.pipeline.bootstrap.guided_context.GuidedContext._prompt_account_id")
+    def test_guided_context_will_prompt_for_fields_that_are_not_provided_oidc_bitbucket(
+        self, prompt_account_id_mock, click_mock, account_id_mock, oidc_url_validate_mock
+    ):
+        account_id_mock.return_value = "1234567890"
+        click_mock.confirm.return_value = False
+        click_mock.prompt = Mock(return_value="0")
+        gc: GuidedContext = GuidedContext(
+            image_repository_arn=ANY_IMAGE_REPOSITORY_ARN,  # Exclude ECR repo, it has its own detailed test below
+            permissions_provider="oidc",
+            oidc_provider="bitbucket",
+        )
+        gc.run()
+        prompt_account_id_mock.assert_called_once()
+        self.assertTrue(self.did_prompt_text_like("Stage configuration Name", click_mock.prompt))
+        self.assertTrue(self.did_prompt_text_like("Pipeline execution role", click_mock.prompt))
+        self.assertTrue(self.did_prompt_text_like("CloudFormation execution role", click_mock.prompt))
+        self.assertTrue(self.did_prompt_text_like("Artifact bucket", click_mock.prompt))
+        self.assertTrue(self.did_prompt_text_like("region", click_mock.prompt))
+        self.assertTrue(self.did_prompt_text_like("URL of the OIDC provider", click_mock.prompt))
+        self.assertTrue(self.did_prompt_text_like("OIDC Client ID", click_mock.prompt))
+        self.assertTrue(self.did_prompt_text_like("Repository UUID", click_mock.prompt))
+
     @patch("samcli.commands.pipeline.bootstrap.guided_context.get_current_account_id")
     @patch("samcli.commands.pipeline.bootstrap.guided_context.click")
     @patch("samcli.commands.pipeline.bootstrap.guided_context.GuidedContext._prompt_account_id")

--- a/tests/unit/commands/pipeline/bootstrap/test_guided_context.py
+++ b/tests/unit/commands/pipeline/bootstrap/test_guided_context.py
@@ -4,6 +4,12 @@ from unittest.mock import patch, Mock, ANY
 from parameterized import parameterized
 
 from samcli.commands.pipeline.bootstrap.guided_context import GuidedContext, GITHUB_ACTIONS
+from samcli.commands.pipeline.bootstrap.oidc_config import (
+    GitHubOidcConfig,
+    BitbucketOidcConfig,
+    GitLabOidcConfig,
+    OidcConfig,
+)
 
 ANY_STAGE_CONFIGURATION_NAME = "ANY_STAGE_CONFIGURATION_NAME"
 ANY_PIPELINE_USER_ARN = "ANY_PIPELINE_USER_ARN"
@@ -21,6 +27,7 @@ ANY_GITHUB_REPO = "ANY_GITHUB_REPO"
 ANY_GITLAB_GROUP = "ANY_GITLAB_GROUP"
 ANY_GITLAB_PROJECT = "ANY_GITLAB_PROJECT"
 ANY_DEPLOYMENT_BRANCH = "ANY_DEPLOYMENT_BRANCH"
+ANY_BITBUCKET_REPO_UUID = "ANY_BITBUCKET_REPO_UUID"
 
 
 class TestGuidedContext(TestCase):
@@ -33,7 +40,21 @@ class TestGuidedContext(TestCase):
         account_id_mock.return_value = "1234567890"
         click_mock.confirm.return_value = False
         click_mock.prompt = Mock(return_value="0")
+        github_config = GitHubOidcConfig(
+            github_org=ANY_GITHUB_ORG, github_repo=ANY_GITHUB_REPO, deployment_branch=ANY_DEPLOYMENT_BRANCH
+        )
+        gitlab_config = GitLabOidcConfig(
+            gitlab_group=ANY_GITLAB_GROUP, gitlab_project=ANY_GITLAB_PROJECT, deployment_branch=ANY_DEPLOYMENT_BRANCH
+        )
+        bitbucket_config = BitbucketOidcConfig(ANY_BITBUCKET_REPO_UUID)
+        oidc_config = OidcConfig(
+            oidc_provider=ANY_OIDC_PROVIDER, oidc_provider_url=ANY_OIDC_PROVIDER_URL, oidc_client_id=ANY_OIDC_CLIENT_ID
+        )
         gc: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             stage_configuration_name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
@@ -59,15 +80,24 @@ class TestGuidedContext(TestCase):
         account_id_mock.return_value = "1234567890"
         click_mock.confirm.return_value = False
         click_mock.prompt = Mock(return_value="0")
+
+        github_config = GitHubOidcConfig(
+            github_org=ANY_GITHUB_ORG, github_repo=ANY_GITHUB_REPO, deployment_branch=ANY_DEPLOYMENT_BRANCH
+        )
+        gitlab_config = GitLabOidcConfig(
+            gitlab_group=ANY_GITLAB_GROUP, gitlab_project=ANY_GITLAB_PROJECT, deployment_branch=ANY_DEPLOYMENT_BRANCH
+        )
+        bitbucket_config = BitbucketOidcConfig(ANY_BITBUCKET_REPO_UUID)
+        oidc_config = OidcConfig(
+            oidc_provider=ANY_OIDC_PROVIDER, oidc_provider_url=ANY_OIDC_PROVIDER_URL, oidc_client_id=ANY_OIDC_CLIENT_ID
+        )
         gc: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             stage_configuration_name=ANY_STAGE_CONFIGURATION_NAME,
             permissions_provider="oidc",
-            oidc_provider_url=ANY_OIDC_PROVIDER_URL,
-            oidc_provider=ANY_OIDC_PROVIDER,
-            oidc_client_id=ANY_OIDC_CLIENT_ID,
-            github_org=ANY_GITHUB_ORG,
-            github_repo=ANY_GITHUB_REPO,
-            deployment_branch=ANY_DEPLOYMENT_BRANCH,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
             artifacts_bucket_arn=ANY_ARTIFACTS_BUCKET_ARN,
@@ -91,15 +121,22 @@ class TestGuidedContext(TestCase):
         account_id_mock.return_value = "1234567890"
         click_mock.confirm.return_value = False
         click_mock.prompt = Mock(return_value="0")
+
+        github_config = GitHubOidcConfig(github_org=None, github_repo=None, deployment_branch=None)
+        gitlab_config = GitLabOidcConfig(
+            gitlab_group=ANY_GITLAB_GROUP, gitlab_project=ANY_GITLAB_PROJECT, deployment_branch=ANY_DEPLOYMENT_BRANCH
+        )
+        bitbucket_config = BitbucketOidcConfig(ANY_BITBUCKET_REPO_UUID)
+        oidc_config = OidcConfig(
+            oidc_provider="gitlab", oidc_provider_url=ANY_OIDC_PROVIDER_URL, oidc_client_id=ANY_OIDC_CLIENT_ID
+        )
         gc: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             stage_configuration_name=ANY_STAGE_CONFIGURATION_NAME,
             permissions_provider="oidc",
-            oidc_provider_url=ANY_OIDC_PROVIDER_URL,
-            oidc_provider="gitlab",
-            oidc_client_id=ANY_OIDC_CLIENT_ID,
-            gitlab_group=ANY_GITLAB_GROUP,
-            gitlab_project=ANY_GITLAB_PROJECT,
-            deployment_branch=ANY_DEPLOYMENT_BRANCH,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,
             cloudformation_execution_role_arn=ANY_CLOUDFORMATION_EXECUTION_ROLE_ARN,
             artifacts_bucket_arn=ANY_ARTIFACTS_BUCKET_ARN,
@@ -124,10 +161,18 @@ class TestGuidedContext(TestCase):
         account_id_mock.return_value = "1234567890"
         click_mock.confirm.return_value = False
         click_mock.prompt = Mock(return_value="0")
+        github_config = GitHubOidcConfig(github_org=None, github_repo=None, deployment_branch=None)
+        gitlab_config = GitLabOidcConfig(gitlab_group=None, gitlab_project=None, deployment_branch=None)
+        bitbucket_config = BitbucketOidcConfig(None)
+        oidc_config = OidcConfig(oidc_provider="bitbucket", oidc_provider_url=None, oidc_client_id=None)
+
         gc: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             image_repository_arn=ANY_IMAGE_REPOSITORY_ARN,  # Exclude ECR repo, it has its own detailed test below
             permissions_provider="oidc",
-            oidc_provider="bitbucket",
         )
         gc.run()
         prompt_account_id_mock.assert_called_once()
@@ -149,8 +194,17 @@ class TestGuidedContext(TestCase):
         account_id_mock.return_value = "1234567890"
         click_mock.confirm.return_value = False
         click_mock.prompt = Mock(return_value="0")
+        github_config = GitHubOidcConfig(github_org=None, github_repo=None, deployment_branch=None)
+        gitlab_config = GitLabOidcConfig(gitlab_group=None, gitlab_project=None, deployment_branch=None)
+        bitbucket_config = BitbucketOidcConfig(None)
+        oidc_config = OidcConfig(oidc_provider=ANY_OIDC_PROVIDER, oidc_provider_url=None, oidc_client_id=None)
+
         gc: GuidedContext = GuidedContext(
-            image_repository_arn=ANY_IMAGE_REPOSITORY_ARN  # Exclude ECR repo, it has its own detailed test below
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
+            image_repository_arn=ANY_IMAGE_REPOSITORY_ARN,  # Exclude ECR repo, it has its own detailed test below
         )
         gc.run()
         prompt_account_id_mock.assert_called_once()
@@ -171,10 +225,18 @@ class TestGuidedContext(TestCase):
         account_id_mock.return_value = "1234567890"
         click_mock.confirm.return_value = False
         click_mock.prompt = Mock(return_value="0")
+        github_config = GitHubOidcConfig(github_org=None, github_repo=None, deployment_branch=None)
+        gitlab_config = GitLabOidcConfig(gitlab_group=None, gitlab_project=None, deployment_branch=None)
+        bitbucket_config = BitbucketOidcConfig(None)
+        oidc_config = OidcConfig(oidc_provider=ANY_OIDC_PROVIDER, oidc_provider_url=None, oidc_client_id=None)
+
         gc: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             image_repository_arn=ANY_IMAGE_REPOSITORY_ARN,  # Exclude ECR repo, it has its own detailed test below
             permissions_provider="oidc",
-            oidc_provider=ANY_OIDC_PROVIDER,
         )
         gc.run()
         prompt_account_id_mock.assert_called_once()
@@ -199,10 +261,18 @@ class TestGuidedContext(TestCase):
         account_id_mock.return_value = "1234567890"
         click_mock.confirm.return_value = False
         click_mock.prompt = Mock(return_value="0")
+        github_config = GitHubOidcConfig(github_org=None, github_repo=None, deployment_branch=None)
+        gitlab_config = GitLabOidcConfig(gitlab_group=None, gitlab_project=None, deployment_branch=None)
+        bitbucket_config = BitbucketOidcConfig(None)
+        oidc_config = OidcConfig(oidc_provider="gitlab", oidc_provider_url=None, oidc_client_id=None)
+
         gc: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             image_repository_arn=ANY_IMAGE_REPOSITORY_ARN,  # Exclude ECR repo, it has its own detailed test below
             permissions_provider="oidc",
-            oidc_provider="gitlab",
         )
         gc.run()
         prompt_account_id_mock.assert_called_once()
@@ -219,34 +289,51 @@ class TestGuidedContext(TestCase):
 
     @patch("samcli.commands.pipeline.bootstrap.guided_context.click")
     def test_guided_context_prompts_oidc_url_if_missing_or_invalid(self, click_mock):
+        github_config = GitHubOidcConfig(github_org=None, github_repo=None, deployment_branch=None)
+        gitlab_config = GitLabOidcConfig(gitlab_group=None, gitlab_project=None, deployment_branch=None)
+        bitbucket_config = BitbucketOidcConfig(None)
+        oidc_config = OidcConfig(oidc_provider=ANY_OIDC_PROVIDER, oidc_provider_url=None, oidc_client_id=None)
+
         gc: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             image_repository_arn=ANY_IMAGE_REPOSITORY_ARN,  # Exclude ECR repo, it has its own detailed test below
             permissions_provider="oidc",
-            oidc_provider=ANY_OIDC_PROVIDER,
         )
         click_mock.prompt = Mock(return_value=ANY_OIDC_PROVIDER_URL)
 
         gc._validate_oidc_provider_url()
         self.assertTrue(self.did_prompt_text_like("Please enter the URL of the OIDC provider", click_mock.echo))
 
-        gc.oidc_provider_url = "Missing_Https://_At_The_Start.com"
+        gc.oidc_config.oidc_provider_url = "Missing_Https://_At_The_Start.com"
 
         gc._validate_oidc_provider_url()
         self.assertTrue(self.did_prompt_text_like("Please ensure the OIDC URL begins with 'https://", click_mock.echo))
 
     @patch("samcli.commands.pipeline.bootstrap.guided_context.click")
     def test_guided_context_oidc_provider_prompt(self, click_mock):
+        github_config = GitHubOidcConfig(github_org=None, github_repo=None, deployment_branch=None)
+        gitlab_config = GitLabOidcConfig(gitlab_group=None, gitlab_project=None, deployment_branch=None)
+        bitbucket_config = BitbucketOidcConfig(None)
+        oidc_config = OidcConfig(oidc_provider=None, oidc_provider_url=None, oidc_client_id=None)
+
         gc: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             image_repository_arn=ANY_IMAGE_REPOSITORY_ARN,  # Exclude ECR repo, it has its own detailed test below
             permissions_provider="oidc",
         )
         click_mock.prompt = Mock(return_value="1")
 
-        self.assertTrue(gc.oidc_provider is None)
+        self.assertTrue(gc.oidc_config.oidc_provider is None)
         gc._prompt_oidc_provider()
         self.assertTrue(self.did_prompt_text_like("Select an OIDC Provider", click_mock.echo))
         self.assertTrue(self.did_prompt_text_like("1 - GitHub Actions", click_mock.echo))
-        self.assertTrue(gc.oidc_provider == GITHUB_ACTIONS)
+        self.assertTrue(gc.oidc_config.oidc_provider == GITHUB_ACTIONS)
 
     @patch("samcli.commands.pipeline.bootstrap.guided_context.get_current_account_id")
     @patch("samcli.commands.pipeline.bootstrap.guided_context.click")
@@ -255,11 +342,21 @@ class TestGuidedContext(TestCase):
         self, prompt_account_id_mock, click_mock, account_id_mock
     ):
         account_id_mock.return_value = "1234567890"
+        github_config = GitHubOidcConfig(github_org=None, github_repo=None, deployment_branch=None)
+        gitlab_config = GitLabOidcConfig(gitlab_group=None, gitlab_project=None, deployment_branch=None)
+        bitbucket_config = BitbucketOidcConfig(None)
+        oidc_config = OidcConfig(oidc_provider=ANY_OIDC_PROVIDER, oidc_provider_url=None, oidc_client_id=None)
+
         # ECR Image Repository choices:
         # 1 - No, My SAM Template won't include lambda functions of Image package-type
         # 2 - Yes, I need a help creating one
         # 3 - I already have an ECR image repository
+
         gc_without_ecr_info: GuidedContext = GuidedContext(
+            github_config=github_config,
+            gitlab_config=gitlab_config,
+            bitbucket_config=bitbucket_config,
+            oidc_config=oidc_config,
             stage_configuration_name=ANY_STAGE_CONFIGURATION_NAME,
             pipeline_user_arn=ANY_PIPELINE_USER_ARN,
             pipeline_execution_role_arn=ANY_PIPELINE_EXECUTION_ROLE_ARN,

--- a/tests/unit/commands/pipeline/bootstrap/test_oidc_config.py
+++ b/tests/unit/commands/pipeline/bootstrap/test_oidc_config.py
@@ -1,0 +1,65 @@
+from unittest import TestCase
+
+from samcli.commands.pipeline.bootstrap.oidc_config import (
+    OidcConfig,
+    GitHubOidcConfig,
+    GitLabOidcConfig,
+    BitbucketOidcConfig,
+)
+
+ANY_OIDC_PROVIDER = "ANY_PROVIDER"
+ANY_OIDC_PROVIDER_URL = "ANY_PROVIDER_URL"
+ANY_OIDC_CLIENT_ID = "ANY_CLIENT_ID"
+ANY_GITHUB_ORG = "ANY_GITHUB_ORG"
+ANY_GITHUB_REPO = "ANY_GITHUB_REPO"
+ANY_DEPLOYMENT_BRANCH = "ANY_DEPLOYMENT_BRANCH"
+ANY_GITLAB_PROJECT = "ANY_GITLAB_PROJECT"
+ANY_GITLAB_GROUP = "ANY_GITLAB_GROUP"
+ANY_BITBUCKET_REPO_UUID = "ANY_BITBUCKET_REPO_UUID"
+ANY_SUBJECT_CLAIM = "ANY_SUBJECT_CLAIM"
+
+
+class TestOidcConfig(TestCase):
+    def setUp(self) -> None:
+        self.oidc_config = OidcConfig(
+            oidc_provider=ANY_OIDC_PROVIDER, oidc_provider_url=ANY_OIDC_PROVIDER_URL, oidc_client_id=ANY_OIDC_CLIENT_ID
+        )
+        self.github_config = GitHubOidcConfig(
+            github_org=ANY_GITHUB_ORG, github_repo=ANY_GITHUB_REPO, deployment_branch=ANY_DEPLOYMENT_BRANCH
+        )
+        self.gitlab_config = GitLabOidcConfig(
+            gitlab_group=ANY_GITLAB_GROUP, gitlab_project=ANY_GITLAB_PROJECT, deployment_branch=ANY_DEPLOYMENT_BRANCH
+        )
+        self.bitbucket_config = BitbucketOidcConfig(bitbucket_repo_uuid=ANY_BITBUCKET_REPO_UUID)
+
+    def test_update_oidc_config(self):
+        self.oidc_config.update_values(
+            oidc_provider="updated_provider", oidc_client_id="updated_client_id", oidc_provider_url="updated_url"
+        )
+
+        self.assertEqual(self.oidc_config.oidc_provider, "updated_provider")
+        self.assertEqual(self.oidc_config.oidc_client_id, "updated_client_id")
+        self.assertEqual(self.oidc_config.oidc_provider_url, "updated_url")
+
+    def test_update_github_config(self):
+        self.github_config.update_values(
+            github_org="updated_org", github_repo="updated_repo", deployment_branch="updated_branch"
+        )
+
+        self.assertEqual(self.github_config.github_org, "updated_org")
+        self.assertEqual(self.github_config.github_repo, "updated_repo")
+        self.assertEqual(self.github_config.deployment_branch, "updated_branch")
+
+    def test_update_gitlab_config(self):
+        self.gitlab_config.update_values(
+            gitlab_group="updated_group", gitlab_project="updated_project", deployment_branch="updated_branch"
+        )
+
+        self.assertEqual(self.gitlab_config.gitlab_group, "updated_group")
+        self.assertEqual(self.gitlab_config.gitlab_project, "updated_project")
+        self.assertEqual(self.gitlab_config.deployment_branch, "updated_branch")
+
+    def test_update_bitbucket_config(self):
+        self.bitbucket_config.update_values(bitbucket_repo_uuid="updated_uuid")
+
+        self.assertEqual(self.bitbucket_config.bitbucket_repo_uuid, "updated_uuid")

--- a/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
+++ b/tests/unit/commands/pipeline/init/test_initeractive_init_flow.py
@@ -185,8 +185,10 @@ class TestInteractiveInitFlow(TestCase):
                 str(["1", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["prod", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["2", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
+                str(["default", "pipeline_execution_role"]): "arn:aws:iam::123456789012:role/execution-role",
                 str(["stage_names_message"]): "Here are the stage configuration names detected "
                 f'in {os.path.join(".aws-sam", "pipeline", "pipelineconfig.toml")}:\n\t1 - testing\n\t2 - prod',
+                "shared_values": "default",
             }
         )
         cookiecutter_mock.assert_called_once_with(

--- a/tests/unit/lib/cookiecutter/test_template.py
+++ b/tests/unit/lib/cookiecutter/test_template.py
@@ -73,7 +73,7 @@ class TestTemplate(TestCase):
         # Template with no interactive-flows neither direct nor through a plugin
         t = Template(location=self._ANY_LOCATION)
         context = t.run_interactive_flows()
-        self.assertEqual(context, {})
+        self.assertEqual(context, {"shared_values": "default"})
         # Template with direct interactive flow only
         mock_interactive_flow.run.return_value = self._ANY_INTERACTIVE_FLOW_CONTEXT
         mock_plugin.interactive_flow = None

--- a/tests/unit/lib/pipeline/bootstrap/test_environment.py
+++ b/tests/unit/lib/pipeline/bootstrap/test_environment.py
@@ -265,7 +265,9 @@ class TestStage(TestCase):
         expected_calls.append(
             call(cmd_names=cmd_names, section="parameters", key="pipeline_user", value=ANY_PIPELINE_USER_ARN)
         )
-        expected_calls.append(call(cmd_names=cmd_names, section="parameters", key="permissions_provider", value="IAM"))
+        expected_calls.append(
+            call(cmd_names=cmd_names, section="parameters", key="permissions_provider", value="AWS IAM")
+        )
         self.trigger_and_assert_save_config_calls(
             stage, cmd_names, expected_calls + [empty_ecr_call], samconfig_instance_mock.put
         )

--- a/tests/unit/lib/pipeline/bootstrap/test_environment.py
+++ b/tests/unit/lib/pipeline/bootstrap/test_environment.py
@@ -265,6 +265,7 @@ class TestStage(TestCase):
         expected_calls.append(
             call(cmd_names=cmd_names, section="parameters", key="pipeline_user", value=ANY_PIPELINE_USER_ARN)
         )
+        expected_calls.append(call(cmd_names=cmd_names, section="parameters", key="permissions_provider", value="IAM"))
         self.trigger_and_assert_save_config_calls(
             stage, cmd_names, expected_calls + [empty_ecr_call], samconfig_instance_mock.put
         )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Supports Bitbucket OIDC during pipelines bootstrap


#### Why is this change necessary?
GitHub, GitLab, and Bitbucket all support OIDC but the assume role policy conditions they use differ for each of the providers. This change builds the correct policy for Bitbucket

#### How does it address the issue?
Adding more click optoins/prompts so that the pipeline bootstrap command can build the correct values for the assume role policy

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
