### PR TITLE
Error out and exit when --config-file does not exist

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -129,12 +129,11 @@ def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx,
     param.default = None
     config_env_name = ctx.params.get("config_env") or DEFAULT_ENV
 
-    config_file = ctx.params.get("config_file")
+    config_file = ctx.params.get("config_file") or DEFAULT_CONFIG_FILE_NAME
     if config_file and config_file != DEFAULT_CONFIG_FILE_NAME and not Path(config_file).is_file():
         error_msg = f"Config file {config_file} does not exist or could not be read"
         LOG.debug(error_msg)
         raise ConfigException(error_msg)
-    config_file = config_file or DEFAULT_CONFIG_FILE_NAME
 
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
     # If --config-file is an absolute path, use it, if not, start from config_dir

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -128,7 +128,14 @@ def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx,
     cmd_name = cmd_name or ctx.info_name
     param.default = None
     config_env_name = ctx.params.get("config_env") or DEFAULT_ENV
-    config_file = ctx.params.get("config_file") or DEFAULT_CONFIG_FILE_NAME
+
+    config_file = ctx.params.get("config_file")
+    if config_file and config_file != DEFAULT_CONFIG_FILE_NAME and not Path(config_file).is_file():
+        error_msg = f"Config file {config_file} does not exist or could not be read"
+        LOG.debug(error_msg)
+        raise ConfigException(error_msg)
+    config_file = config_file or DEFAULT_CONFIG_FILE_NAME
+
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
     # If --config-file is an absolute path, use it, if not, start from config_dir
     config_file_name = config_file if os.path.isabs(config_file) else os.path.join(config_dir, config_file)

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -110,6 +110,25 @@ class TestCliConfiguration(TestCase):
             self.assertIn(arg, self.saved_callback.call_args[0])
         self.assertNotIn(self.value, self.saved_callback.call_args[0])
 
+    def test_callback_with_invalid_config_file(self):
+        mock_context1 = MockContext(info_name="sam", parent=None)
+        mock_context2 = MockContext(info_name="local", parent=mock_context1)
+        mock_context3 = MockContext(info_name="start-api", parent=mock_context2)
+        self.ctx.parent = mock_context3
+        self.ctx.info_name = "test_info"
+        self.ctx.params = {"config_file": "invalid_config_file"}
+        setattr(self.ctx, "samconfig_dir", None)
+        with self.assertRaises(ConfigException):
+            configuration_callback(
+                cmd_name=self.cmd_name,
+                option_name=self.option_name,
+                saved_callback=self.saved_callback,
+                provider=self.provider,
+                ctx=self.ctx,
+                param=self.param,
+                value=self.value,
+            )
+
     def test_configuration_option(self):
         toml_provider = TomlProvider()
         click_option = configuration_option(provider=toml_provider)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Throw error and exit when --config-file does not exist
Fixes: https://github.com/aws/aws-sam-cli/issues/3899
#### Why is this change necessary?

Currently it throws an irrelevant error making it hard to debug.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
