### PR TITLE
fix: Don't use deps dir for non-cached builds

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -186,7 +186,7 @@ class ApplicationBuilder:
         """
         build_graph = self._get_build_graph(self._container_env_var, self._container_env_var_file)
         build_strategy: BuildStrategy = DefaultBuildStrategy(
-            build_graph, self._build_dir, self._build_function, self._build_layer
+            build_graph, self._build_dir, self._build_function, self._build_layer, self._cached
         )
 
         if self._parallel:

--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -126,11 +126,13 @@ class DefaultBuildStrategy(BuildStrategy):
         build_dir: str,
         build_function: Callable[[str, str, str, str, str, Optional[str], str, dict, dict, Optional[str], bool], str],
         build_layer: Callable[[str, str, str, List[str], str, str, dict, Optional[str], bool], str],
+        using_dependencies_dir: bool = True,
     ) -> None:
         super().__init__(build_graph)
         self._build_dir = build_dir
         self._build_function = build_function
         self._build_layer = build_layer
+        self._using_dependencies_dir = using_dependencies_dir
 
     def build_single_function_definition(self, build_definition: FunctionBuildDefinition) -> Dict[str, str]:
         """
@@ -167,7 +169,7 @@ class DefaultBuildStrategy(BuildStrategy):
             single_build_dir,
             build_definition.metadata,
             container_env_vars,
-            build_definition.dependencies_dir,
+            build_definition.dependencies_dir if self._using_dependencies_dir else None,
             build_definition.download_dependencies,
         )
         function_build_results[single_full_path] = result
@@ -214,7 +216,7 @@ class DefaultBuildStrategy(BuildStrategy):
                 layer.build_architecture,
                 single_build_dir,
                 layer_definition.env_vars,
-                layer_definition.dependencies_dir,
+                layer_definition.dependencies_dir if self._using_dependencies_dir else None,
                 layer_definition.download_dependencies,
             )
         }

--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -126,7 +126,7 @@ class DefaultBuildStrategy(BuildStrategy):
         build_dir: str,
         build_function: Callable[[str, str, str, str, str, Optional[str], str, dict, dict, Optional[str], bool], str],
         build_layer: Callable[[str, str, str, List[str], str, str, dict, Optional[str], bool], str],
-        cached: bool = True,
+        cached: bool = False,
     ) -> None:
         super().__init__(build_graph)
         self._build_dir = build_dir

--- a/samcli/lib/build/build_strategy.py
+++ b/samcli/lib/build/build_strategy.py
@@ -126,13 +126,13 @@ class DefaultBuildStrategy(BuildStrategy):
         build_dir: str,
         build_function: Callable[[str, str, str, str, str, Optional[str], str, dict, dict, Optional[str], bool], str],
         build_layer: Callable[[str, str, str, List[str], str, str, dict, Optional[str], bool], str],
-        using_dependencies_dir: bool = True,
+        cached: bool = True,
     ) -> None:
         super().__init__(build_graph)
         self._build_dir = build_dir
         self._build_function = build_function
         self._build_layer = build_layer
-        self._using_dependencies_dir = using_dependencies_dir
+        self._cached = cached
 
     def build_single_function_definition(self, build_definition: FunctionBuildDefinition) -> Dict[str, str]:
         """
@@ -169,7 +169,7 @@ class DefaultBuildStrategy(BuildStrategy):
             single_build_dir,
             build_definition.metadata,
             container_env_vars,
-            build_definition.dependencies_dir if self._using_dependencies_dir else None,
+            build_definition.dependencies_dir if self._cached else None,
             build_definition.download_dependencies,
         )
         function_build_results[single_full_path] = result
@@ -216,7 +216,7 @@ class DefaultBuildStrategy(BuildStrategy):
                 layer.build_architecture,
                 single_build_dir,
                 layer_definition.env_vars,
-                layer_definition.dependencies_dir if self._using_dependencies_dir else None,
+                layer_definition.dependencies_dir if self._cached else None,
                 layer_definition.download_dependencies,
             )
         }

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -12,7 +12,7 @@ from pathlib import Path, WindowsPath
 from parameterized import parameterized
 
 from samcli.lib.build.workflow_config import UnsupportedRuntimeException
-from samcli.lib.providers.provider import ResourcesToBuildCollector, Function
+from samcli.lib.providers.provider import ResourcesToBuildCollector, Function, LayerVersion
 from samcli.lib.build.app_builder import (
     ApplicationBuilder,
     UnsupportedBuilderLibraryVersionError,
@@ -468,6 +468,48 @@ class TestApplicationBuilder_build(TestCase):
                 handler="handler",
                 artifact_dir="artifact_dir",
             )
+
+    def test_must_not_use_dep_layer_for_non_cached(self):
+        mocked_default_build_strategy = Mock()
+        mocked_default_build_strategy.return_value = mocked_default_build_strategy
+
+        function = Function(
+            function_id="name",
+            name="name",
+            functionname="function_name",
+            runtime="runtime",
+            memory="memory",
+            timeout="timeout",
+            handler="handler",
+            imageuri="imageuri",
+            packagetype=ZIP,
+            imageconfig="imageconfig",
+            codeuri="codeuri",
+            environment="environment",
+            rolearn="rolearn",
+            layers="layers",
+            events="events",
+            codesign_config_arn="codesign_config_arn",
+            metadata=None,
+            inlinecode=None,
+            architectures=[X86_64],
+            stack_path="",
+            function_url_config=None,
+        )
+
+        resources_to_build_collector = ResourcesToBuildCollector()
+        resources_to_build_collector.add_functions([function])
+
+        builder = ApplicationBuilder(
+            resources_to_build_collector, "builddir", "basedir", "cachedir", stream_writer=StreamWriter(sys.stderr)
+        )
+        builder._build_function = Mock()
+
+        builder.build()
+
+        builder._build_function.assert_called_with(
+            "name", "codeuri", ZIP, "runtime", X86_64, "handler", "builddir/name", {}, {}, None, True
+        )
 
 
 class PathValidator:

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -12,7 +12,7 @@ from pathlib import Path, WindowsPath
 from parameterized import parameterized
 
 from samcli.lib.build.workflow_config import UnsupportedRuntimeException
-from samcli.lib.providers.provider import ResourcesToBuildCollector, Function, LayerVersion
+from samcli.lib.providers.provider import ResourcesToBuildCollector, Function
 from samcli.lib.build.app_builder import (
     ApplicationBuilder,
     UnsupportedBuilderLibraryVersionError,

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -508,7 +508,7 @@ class TestApplicationBuilder_build(TestCase):
         builder.build()
 
         builder._build_function.assert_called_with(
-            "name", "codeuri", ZIP, "runtime", X86_64, "handler", "builddir/name", {}, {}, None, True
+            "name", "codeuri", ZIP, "runtime", X86_64, "handler", str(Path("builddir/name")), {}, {}, None, True
         )
 
 

--- a/tests/unit/lib/build_module/test_build_strategy.py
+++ b/tests/unit/lib/build_module/test_build_strategy.py
@@ -155,7 +155,7 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
         )
 
         default_build_strategy.build()
-        print("HERE!!!!!" + str(self.function_build_definition1))
+
         # assert that build function has been called
         given_build_function.assert_has_calls(
             [

--- a/tests/unit/lib/build_module/test_build_strategy.py
+++ b/tests/unit/lib/build_module/test_build_strategy.py
@@ -146,7 +146,7 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
         given_build_layer = Mock()
         given_build_dir = "build_dir"
         default_build_strategy = DefaultBuildStrategy(
-            self.build_graph, given_build_dir, given_build_function, given_build_layer
+            self.build_graph, given_build_dir, given_build_function, given_build_layer, cached=True
         )
 
         default_build_strategy.build()
@@ -476,7 +476,7 @@ class TestIncrementalBuildStrategy(TestCase):
         self.build_layer = Mock()
         self.build_graph = Mock()
         self.delegate_build_strategy = DefaultBuildStrategy(
-            self.build_graph, Mock(), self.build_function, self.build_layer
+            self.build_graph, Mock(), self.build_function, self.build_layer, cached=True
         )
         self.build_strategy = IncrementalBuildStrategy(
             self.build_graph,

--- a/tests/unit/lib/build_module/test_build_strategy.py
+++ b/tests/unit/lib/build_module/test_build_strategy.py
@@ -45,6 +45,11 @@ class BuildStrategyBaseTest(TestCase):
 
         self.function_build_definition1 = FunctionBuildDefinition("runtime", "codeuri", ZIP, X86_64, {}, "handler")
         self.function_build_definition2 = FunctionBuildDefinition("runtime2", "codeuri", ZIP, X86_64, {}, "handler")
+
+        self.function_build_definition1.add_function(self.function1_1)
+        self.function_build_definition1.add_function(self.function1_2)
+        self.function_build_definition2.add_function(self.function2)
+
         self.build_graph.put_function_build_definition(self.function_build_definition1, self.function1_1)
         self.build_graph.put_function_build_definition(self.function_build_definition1, self.function1_2)
         self.build_graph.put_function_build_definition(self.function_build_definition2, self.function2)
@@ -146,11 +151,11 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
         given_build_layer = Mock()
         given_build_dir = "build_dir"
         default_build_strategy = DefaultBuildStrategy(
-            self.build_graph, given_build_dir, given_build_function, given_build_layer, cached=True
+            self.build_graph, given_build_dir, given_build_function, given_build_layer
         )
 
         default_build_strategy.build()
-
+        print("HERE!!!!!" + str(self.function_build_definition1))
         # assert that build function has been called
         given_build_function.assert_has_calls(
             [
@@ -164,7 +169,7 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
                     self.function_build_definition1.get_build_dir(given_build_dir),
                     self.function_build_definition1.metadata,
                     self.function_build_definition1.env_vars,
-                    self.function_build_definition1.dependencies_dir,
+                    None,
                     True,
                 ),
                 call(
@@ -177,7 +182,7 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
                     self.function_build_definition2.get_build_dir(given_build_dir),
                     self.function_build_definition2.metadata,
                     self.function_build_definition2.env_vars,
-                    self.function_build_definition2.dependencies_dir,
+                    None,
                     True,
                 ),
             ]
@@ -194,7 +199,7 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
                     self.layer1.build_architecture,
                     self.layer1.get_build_dir(given_build_dir),
                     self.layer_build_definition1.env_vars,
-                    self.layer_build_definition1.dependencies_dir,
+                    None,
                     True,
                 ),
                 call(
@@ -205,7 +210,7 @@ class DefaultBuildStrategyTest(BuildStrategyBaseTest):
                     self.layer2.build_architecture,
                     self.layer2.get_build_dir(given_build_dir),
                     self.layer_build_definition2.env_vars,
-                    self.layer_build_definition2.dependencies_dir,
+                    None,
                     True,
                 ),
             ]


### PR DESCRIPTION
#### Why is this change necessary?
After accelerate GA, we stopped gating the creating of a dependencies dir with a feature flag which means that now a dependencies dir is used for all builds where applicable. This means that the downstream lambda builders workflow performs an accelerate-specific workflow even when it shouldn't. 

#### How does it address the issue?
Don't build with dependencies dir if cached is False.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
