### PR TITLE
Upgrade encryption algorithm from SHA-1 to SHA-256

### DIFF
--- a/samcli/lib/telemetry/project_metadata.py
+++ b/samcli/lib/telemetry/project_metadata.py
@@ -11,14 +11,14 @@ from typing import List, Optional
 from samcli.cli.global_config import GlobalConfig
 
 
-def get_git_remote_origin_url() -> Optional[bytes]:
+def get_git_remote_origin_url() -> Optional[str]:
     """
     Retrieve an encrypted version of the project's git remote origin url, if it exists.
 
     Returns
     -------
-    bytes | None
-        A SHA256 byte string of the git remote origin url, formatted such that the
+    str | None
+        A SHA256 hexdigest string of the git remote origin url, formatted such that the
         encrypted value follows the pattern <hostname>/<owner>/<project_name>.git.
         If telemetry is opted out of by the user, or the `.git` folder is not found
         (the directory is not a git repository), returns None
@@ -39,14 +39,14 @@ def get_git_remote_origin_url() -> Optional[bytes]:
     return _encrypt_value(git_url)
 
 
-def get_project_name() -> Optional[bytes]:
+def get_project_name() -> Optional[str]:
     """
     Retrieve an encrypted version of the project's name, as defined by the .git folder (or directory name if no .git).
 
     Returns
     -------
-    bytes | None
-        A SHA256 byte string of either the name of the project, or the name of the
+    str | None
+        A SHA256 hexdigest string of either the name of the project, or the name of the
         current working directory that the command is running in.
         If telemetry is opted out of by the user, returns None
     """
@@ -65,14 +65,14 @@ def get_project_name() -> Optional[bytes]:
     return _encrypt_value(project_name)
 
 
-def get_initial_commit_hash() -> Optional[bytes]:
+def get_initial_commit_hash() -> Optional[str]:
     """
     Retrieve an encrypted version of the project's initial commit hash, if it exists.
 
     Returns
     -------
-    bytes | None
-        A SHA256 byte string of the git project's initial commit hash.
+    str | None
+        A SHA256 hexdigest string of the git project's initial commit hash.
         If telemetry is opted out of by the user, or the `.git` folder is not found
         (the directory is not a git repository), returns None.
     """
@@ -104,8 +104,8 @@ def _parse_remote_origin_url(url: str) -> List[str]:
     return [str(item) for item in pattern.findall(url)[0]]
 
 
-def _encrypt_value(value: str) -> bytes:
+def _encrypt_value(value: str) -> str:
     """Encrypt a string, and then return the encrypted value as a byte string."""
     h = hashlib.sha256()
     h.update(value.encode("utf-8"))
-    return h.digest()
+    return h.hexdigest()

--- a/samcli/lib/telemetry/project_metadata.py
+++ b/samcli/lib/telemetry/project_metadata.py
@@ -2,23 +2,23 @@
 Creates and encrypts metadata regarding SAM CLI projects.
 """
 
+import hashlib
 from os import getcwd
 import re
 import subprocess
 from typing import List, Optional
-from uuid import uuid5, NAMESPACE_URL
 
 from samcli.cli.global_config import GlobalConfig
 
 
-def get_git_remote_origin_url() -> Optional[str]:
+def get_git_remote_origin_url() -> Optional[bytes]:
     """
     Retrieve an encrypted version of the project's git remote origin url, if it exists.
 
     Returns
     -------
-    str | None
-        A UUID5 encrypted string of the git remote origin url, formatted such that the
+    bytes | None
+        A SHA256 byte string of the git remote origin url, formatted such that the
         encrypted value follows the pattern <hostname>/<owner>/<project_name>.git.
         If telemetry is opted out of by the user, or the `.git` folder is not found
         (the directory is not a git repository), returns None
@@ -39,14 +39,14 @@ def get_git_remote_origin_url() -> Optional[str]:
     return _encrypt_value(git_url)
 
 
-def get_project_name() -> Optional[str]:
+def get_project_name() -> Optional[bytes]:
     """
     Retrieve an encrypted version of the project's name, as defined by the .git folder (or directory name if no .git).
 
     Returns
     -------
-    str | None
-        A UUID5 encrypted string of either the name of the project, or the name of the
+    bytes | None
+        A SHA256 byte string of either the name of the project, or the name of the
         current working directory that the command is running in.
         If telemetry is opted out of by the user, returns None
     """
@@ -65,14 +65,14 @@ def get_project_name() -> Optional[str]:
     return _encrypt_value(project_name)
 
 
-def get_initial_commit_hash() -> Optional[str]:
+def get_initial_commit_hash() -> Optional[bytes]:
     """
     Retrieve an encrypted version of the project's initial commit hash, if it exists.
 
     Returns
     -------
-    str | None
-        A UUID5 encrypted string of the git project's initial commit hash.
+    bytes | None
+        A SHA256 byte string of the git project's initial commit hash.
         If telemetry is opted out of by the user, or the `.git` folder is not found
         (the directory is not a git repository), returns None.
     """
@@ -104,6 +104,8 @@ def _parse_remote_origin_url(url: str) -> List[str]:
     return [str(item) for item in pattern.findall(url)[0]]
 
 
-def _encrypt_value(value: str) -> str:
-    """Encrypt a string, and then return the encrypted value as a string."""
-    return str(uuid5(NAMESPACE_URL, value))
+def _encrypt_value(value: str) -> bytes:
+    """Encrypt a string, and then return the encrypted value as a byte string."""
+    h = hashlib.sha256()
+    h.update(value.encode("utf-8"))
+    return h.digest()

--- a/tests/unit/lib/telemetry/test_project_metadata.py
+++ b/tests/unit/lib/telemetry/test_project_metadata.py
@@ -2,8 +2,8 @@
 Module for testing the project_metadata.py methods.
 """
 
+import hashlib
 from subprocess import CompletedProcess, CalledProcessError
-from uuid import uuid5, NAMESPACE_URL
 from unittest.mock import patch, Mock
 from unittest import TestCase
 
@@ -49,7 +49,9 @@ class TestProjectMetadata(TestCase):
         sp_mock.return_value = CompletedProcess(["git", "config", "--get", "remote.origin.url"], 0, stdout=origin)
 
         git_origin = get_git_remote_origin_url()
-        self.assertEqual(git_origin, str(uuid5(NAMESPACE_URL, expected)))
+        expected_hash = hashlib.sha256()
+        expected_hash.update(expected.encode("utf-8"))
+        self.assertEqual(git_origin, expected_hash.digest())
 
     @patch("samcli.lib.telemetry.project_metadata.subprocess.run")
     def test_retrieve_git_origin_when_not_a_repo(self, sp_mock):
@@ -73,7 +75,9 @@ class TestProjectMetadata(TestCase):
         sp_mock.return_value = CompletedProcess(["git", "config", "--get", "remote.origin.url"], 0, stdout=origin)
 
         project_name = get_project_name()
-        self.assertEqual(project_name, str(uuid5(NAMESPACE_URL, expected)))
+        expected_hash = hashlib.sha256()
+        expected_hash.update(expected.encode("utf-8"))
+        self.assertEqual(project_name, expected_hash.digest())
 
     @parameterized.expand(
         [
@@ -94,7 +98,9 @@ class TestProjectMetadata(TestCase):
         cwd_mock.return_value = cwd
 
         project_name = get_project_name()
-        self.assertEqual(project_name, str(uuid5(NAMESPACE_URL, cwd.replace("\\", "/"))))
+        expected_hash = hashlib.sha256()
+        expected_hash.update(cwd.replace("\\", "/").encode("utf-8"))
+        self.assertEqual(project_name, expected_hash.digest())
 
     @parameterized.expand(
         [
@@ -108,4 +114,6 @@ class TestProjectMetadata(TestCase):
         sp_mock.return_value = CompletedProcess(["git", "rev-list", "--max-parents=0", "HEAD"], 0, stdout=git_hash)
 
         initial_commit = get_initial_commit_hash()
-        self.assertEqual(initial_commit, str(uuid5(NAMESPACE_URL, git_hash)))
+        expected_hash = hashlib.sha256()
+        expected_hash.update(git_hash.encode("utf-8"))
+        self.assertEqual(initial_commit, expected_hash.digest())

--- a/tests/unit/lib/telemetry/test_project_metadata.py
+++ b/tests/unit/lib/telemetry/test_project_metadata.py
@@ -51,7 +51,7 @@ class TestProjectMetadata(TestCase):
         git_origin = get_git_remote_origin_url()
         expected_hash = hashlib.sha256()
         expected_hash.update(expected.encode("utf-8"))
-        self.assertEqual(git_origin, expected_hash.digest())
+        self.assertEqual(git_origin, expected_hash.hexdigest())
 
     @patch("samcli.lib.telemetry.project_metadata.subprocess.run")
     def test_retrieve_git_origin_when_not_a_repo(self, sp_mock):
@@ -77,7 +77,7 @@ class TestProjectMetadata(TestCase):
         project_name = get_project_name()
         expected_hash = hashlib.sha256()
         expected_hash.update(expected.encode("utf-8"))
-        self.assertEqual(project_name, expected_hash.digest())
+        self.assertEqual(project_name, expected_hash.hexdigest())
 
     @parameterized.expand(
         [
@@ -100,7 +100,7 @@ class TestProjectMetadata(TestCase):
         project_name = get_project_name()
         expected_hash = hashlib.sha256()
         expected_hash.update(cwd.replace("\\", "/").encode("utf-8"))
-        self.assertEqual(project_name, expected_hash.digest())
+        self.assertEqual(project_name, expected_hash.hexdigest())
 
     @parameterized.expand(
         [
@@ -116,4 +116,4 @@ class TestProjectMetadata(TestCase):
         initial_commit = get_initial_commit_hash()
         expected_hash = hashlib.sha256()
         expected_hash.update(git_hash.encode("utf-8"))
-        self.assertEqual(initial_commit, expected_hash.digest())
+        self.assertEqual(initial_commit, expected_hash.hexdigest())


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
As discussed, the current SHA-1 hashing of project metadata info has proven not cryptographically secure enough, and thus should be upgraded to SHA-256.

#### How does it address the issue?
Any and all prior uses of the `uuid.uuid5()` method, which uses SHA-1, have been replaced by `hashlib.sha256()` and its relevant encryption methods.

#### What side effects does this change have?
Rather than sending a string, the encryption methods will return bytes. This shouldn't have significant impact on existing structures and frameworks in the codebase.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
