### PR TITLE
feat: Enable source maps if either Sourcemap: true or --enable-source-maps is provided

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -313,7 +313,8 @@ class BuildContext:
 
     def _enable_source_maps(self):
         """
-        Appends the --enable-source-maps NODE_OPTIONS if Sourcemap is set to true and vice versa
+        Appends ``NODE_OPTIONS: --enable-source-maps``, if Sourcemap is set to true
+        and sets Sourcemap to true if ``NODE_OPTIONS: --enable-source-maps`` is provided.
         """
         using_source_maps = False
         incorrect_node_option = False
@@ -331,7 +332,7 @@ class BuildContext:
                 source_map = build_properties.get("Sourcemap", None)
 
                 if source_map and not node_option_set:
-                    LOG.debug("Sourcemap set without --enable-source-maps, adding")
+                    LOG.debug("Sourcemap set without --enable-source-maps, adding Sourcemap to Metadata BuildProperties")
 
                     resource.setdefault("Properties", {})
                     resource["Properties"].setdefault("Environment", {})

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -406,7 +406,7 @@ class BuildContext:
         click.secho(
             "\nYou are using source maps, note that this comes with a performance hit!"
             " Set Sourcemap to false, or remove"
-            " NODE_OPTIONS: --enable-source-maps to disable source maps.",
+            " NODE_OPTIONS: --enable-source-maps to disable source maps.\n",
             fg="yellow",
         )
 

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -405,7 +405,7 @@ class BuildContext:
     def _warn_using_source_maps():
         click.secho(
             "\nYou are using source maps, note that this comes with a performance hit!"
-            " Set Sourcemap to false, or remove"
+            " Set Sourcemap to false and remove"
             " NODE_OPTIONS: --enable-source-maps to disable source maps.\n",
             fg="yellow",
         )

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -332,7 +332,10 @@ class BuildContext:
                 source_map = build_properties.get("Sourcemap", None)
 
                 if source_map and not node_option_set:
-                    LOG.debug("Sourcemap set without --enable-source-maps, adding Sourcemap to Metadata BuildProperties")
+                    LOG.debug(
+                        "Sourcemap set without --enable-source-maps, adding"
+                        " --enable-source-maps to function's NODE_OPTIONS"
+                    )
 
                     resource.setdefault("Properties", {})
                     resource["Properties"].setdefault("Environment", {})
@@ -351,7 +354,9 @@ class BuildContext:
 
                 # check if --enable-source-map is provided and append Sourcemap: true if it is not set
                 if source_map is None and node_option_set:
-                    LOG.debug("--enable-source-maps set without Sourcemap, adding")
+                    LOG.debug(
+                        "--enable-source-maps set without Sourcemap, adding Sourcemap to Metadata BuildProperties"
+                    )
 
                     resource.setdefault("Metadata", {})
                     resource["Metadata"].setdefault("BuildProperties", {})

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -342,7 +342,7 @@ class BuildContext:
                     if not isinstance(existing_options, str):
                         incorrect_node_option = True
                     else:
-                        resource["Properties"]["Environment"]["Variables"]["NODE_OPTIONS"] = "".join(
+                        resource["Properties"]["Environment"]["Variables"]["NODE_OPTIONS"] = " ".join(
                             [existing_options, "--enable-source-maps"]
                         )
 

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -320,7 +320,7 @@ class BuildContext:
         invalid_node_option = False
 
         for stack in self.stacks:
-            for _, resource in stack.resources.items():
+            for name, resource in stack.resources.items():
                 metadata = resource.get("Metadata", {})
                 if metadata.get("BuildMethod", "") != "esbuild":
                     continue
@@ -332,9 +332,10 @@ class BuildContext:
                 source_map = build_properties.get("Sourcemap", None)
 
                 if source_map and not node_option_set:
-                    LOG.debug(
-                        "Sourcemap set without --enable-source-maps, adding"
-                        " --enable-source-maps to function's NODE_OPTIONS"
+                    LOG.info(
+                        "\nSourcemap set without --enable-source-maps, adding"
+                        " --enable-source-maps to function %s NODE_OPTIONS",
+                        name,
                     )
 
                     resource.setdefault("Properties", {})
@@ -354,8 +355,10 @@ class BuildContext:
 
                 # check if --enable-source-map is provided and append Sourcemap: true if it is not set
                 if source_map is None and node_option_set:
-                    LOG.debug(
-                        "--enable-source-maps set without Sourcemap, adding Sourcemap to Metadata BuildProperties"
+                    LOG.info(
+                        "\n--enable-source-maps set without Sourcemap, adding Sourcemap to"
+                        " Metadata BuildProperties for %s",
+                        name,
                     )
 
                     resource.setdefault("Metadata", {})

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -317,7 +317,7 @@ class BuildContext:
         and sets Sourcemap to true if ``NODE_OPTIONS: --enable-source-maps`` is provided.
         """
         using_source_maps = False
-        incorrect_node_option = False
+        invalid_node_option = False
 
         for stack in self.stacks:
             for _, resource in stack.resources.items():
@@ -341,7 +341,7 @@ class BuildContext:
 
                     # make sure the NODE_OPTIONS is a string
                     if not isinstance(existing_options, str):
-                        incorrect_node_option = True
+                        invalid_node_option = True
                     else:
                         resource["Properties"]["Environment"]["Variables"]["NODE_OPTIONS"] = " ".join(
                             [existing_options, "--enable-source-maps"]
@@ -362,7 +362,7 @@ class BuildContext:
         if using_source_maps:
             self._warn_using_source_maps()
 
-        if incorrect_node_option:
+        if invalid_node_option:
             self._warn_invalid_node_options()
 
     @staticmethod

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -1461,3 +1461,33 @@ class TestBuildContext_enable_source_maps(TestCase):
             self.assertNotEqual(template, result_template)
         else:
             self.assertEqual(template, result_template)
+
+    @patch("samcli.commands.build.build_context.BuildContext._is_enable_source_map_set")
+    @patch("samcli.commands.build.build_context.click.secho")
+    def test_non_string_node_options(self, click_mock, is_enable_sm_set_mock):
+        build_context = BuildContext(
+            resource_identifier="resource_id",
+            template_file="template_file",
+            base_dir="base_dir",
+            build_dir="build_dir",
+            cache_dir="cache_dir",
+            cached=False,
+            parallel=False,
+            mode="mode",
+        )
+
+        template = {
+            "Resources": {
+                "a": {
+                    "Properties": {
+                        "Environment": {"Variables": {"NODE_OPTIONS": ["--something"]}},
+                    },
+                    "Metadata": {"BuildMethod": "esbuild", "BuildProperties": {"Sourcemap": True}},
+                }
+            },
+        }
+
+        is_enable_sm_set_mock.return_value = False
+        result_template = build_context._enable_source_maps(template)
+
+        self.assertEqual(click_mock.call_count, 2)

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -636,8 +636,10 @@ class TestBuildContext__enter__(TestCase):
     @patch("samcli.commands.build.build_context.move_template")
     @patch("samcli.commands.build.build_context.get_template_data")
     @patch("samcli.commands.build.build_context.os")
+    @patch("samcli.commands.build.build_context.BuildContext._enable_source_maps")
     def test_run_sync_build_context(
         self,
+        source_maps_mock,
         os_mock,
         get_template_data_mock,
         move_template_mock,
@@ -892,9 +894,11 @@ class TestBuildContext_run(TestCase):
     @patch("samcli.commands.build.build_context.move_template")
     @patch("samcli.commands.build.build_context.get_template_data")
     @patch("samcli.commands.build.build_context.os")
+    @patch("samcli.commands.build.build_context.BuildContext._enable_source_maps")
     def test_run_build_context(
         self,
         auto_dependency_layer,
+        source_map_mock,
         os_mock,
         get_template_data_mock,
         move_template_mock,
@@ -946,6 +950,8 @@ class TestBuildContext_run(TestCase):
             modified_template_child,
         ]
         nested_stack_manager_mock.return_value = given_nested_stack_manager
+
+        source_map_mock.side_effect = [modified_template_root, modified_template_child]
 
         with BuildContext(
             resource_identifier="function_identifier",


### PR DESCRIPTION
Related to lambda builders change: https://github.com/aws/aws-lambda-builders/pull/375

#### Why is this change necessary?
Previously, both `Sourcemap: true` and `NODE_OPTIONS: --enable-source-maps` needed to be provided to enable source map usage. This is redundant since explicitly defining one would imply source map usage.

#### How does it address the issue?
This change allows users to specify either `NODE_OPTIONS: --enable-source-maps` under environment variables or `Sourcemap: true` under esbuild build properties and have source maps enabled and added to their functions.

`NODE_OPTIONS` can be defined at either the Globals level or the Function level.

#### What side effects does this change have?
This change will modify the final template file in `sam build` by adding either `Sourcemap` or `NODE_OPTIONS` at the function level.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
