### PR TITLE
FEAT: Test Runner - Kick Off Testsuite

### DIFF
--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -102,3 +102,9 @@ class TestRunnerTemplateGenerationException(UserException):
     """
     Exception class when the generation of a Test Runner CloudFormation Template fails during `sam test_runner init`
     """
+
+
+class ReservedEnvironmentVariableException(UserException):
+    """
+    Exception class when the user attempts to override a reserved environment variable during `sam test_runner run`
+    """

--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -108,3 +108,10 @@ class ReservedEnvironmentVariableException(UserException):
     """
     Exception class when the user attempts to override a reserved environment variable during `sam test_runner run`
     """
+
+
+class InvalidEnvironmentVariableNameException(UserException):
+    """
+    Exception class when the user attempts to specify environment variables that have invalid
+    identifier names in the ARN map file passed to `sam test_runner run`
+    """

--- a/samcli/lib/test_runner/invoke_testsuite.py
+++ b/samcli/lib/test_runner/invoke_testsuite.py
@@ -1,4 +1,4 @@
-from typing import *
+from typing import List
 import click
 from samcli.lib.utils.boto_utils import BotoProviderType
 from samcli.commands.exceptions import ReservedEnvironmentVariableException

--- a/samcli/lib/test_runner/invoke_testsuite.py
+++ b/samcli/lib/test_runner/invoke_testsuite.py
@@ -1,33 +1,7 @@
-from typing import List
 import click
-from samcli.lib.utils.boto_utils import BotoProviderType
+from typing import List
 from samcli.commands.exceptions import ReservedEnvironmentVariableException
-
-
-def get_subnets(boto_client_provider: BotoProviderType) -> List[str]:
-    """
-    Queries describe-subnets to get subnets associated with the customer account.
-
-    NOTE: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html
-
-    Parameters
-    ----------
-    boto_client_provider : BotoProviderType
-        Provides a boto3 client in order to query the describe-subnets API
-
-    Returns
-    -------
-    List[str]
-        A list of subnet ids associated with a customer account.
-
-    Raises
-    ------
-    botocore.ClientError
-        If the describe_subnets call fails
-    """
-    ec2_client = boto_client_provider("ec2")
-    subnets = ec2_client.describe_subnets().get("Subnets")
-    return [subnet["SubnetId"] for subnet in subnets]
+from samcli.lib.utils.boto_utils import BotoProviderType
 
 
 def invoke_testsuite(
@@ -39,6 +13,7 @@ def invoke_testsuite(
     task_definition_arn: str,
     other_env_vars: dict,
     test_command_options: str,
+    subnets: List[str],
     do_await: bool = False,
 ) -> None:
 
@@ -87,10 +62,6 @@ def invoke_testsuite(
     botocore.ClientError
         If get_subnets, run_task, or waiters fail
     """
-
-    # If the customer specifies their own subnet, use it, otherwise query describe-subnets.
-
-    subnets = other_env_vars.get("subnets") or get_subnets(boto_client_provider)
 
     container_env_vars = {
         "TEST_RUNNER_BUCKET": bucket,

--- a/samcli/lib/test_runner/invoke_testsuite.py
+++ b/samcli/lib/test_runner/invoke_testsuite.py
@@ -8,6 +8,7 @@ from samcli.lib.utils.colors import Colored
 
 LOG = logging.getLogger(__name__)
 
+
 class SuiteRunner:
     def __init__(self, boto_ecs_client, boto_s3_client):
         self.boto_ecs_client = boto_ecs_client

--- a/samcli/lib/test_runner/invoke_testsuite.py
+++ b/samcli/lib/test_runner/invoke_testsuite.py
@@ -2,8 +2,11 @@
 Kicks off a testsuite in a Fargate container
 """
 from typing import List
+import logging
 from samcli.commands.exceptions import ReservedEnvironmentVariableException
+from samcli.lib.utils.colors import Colored
 
+LOG = logging.getLogger(__name__)
 
 class SuiteRunner:
     def __init__(self, boto_ecs_client, boto_s3_client):
@@ -105,6 +108,8 @@ class SuiteRunner:
             },
             taskDefinition=task_definition_arn,
         )
+
+        LOG.info(Colored().yellow("=> Successfully kicked off testsuite, waiting for completion...\n"))
 
         results_upload_waiter = self.boto_s3_client.get_waiter("object_exists")
         results_upload_waiter.wait(Bucket=bucket, Key=path_in_bucket + "/results.tar.gz")

--- a/samcli/lib/test_runner/invoke_testsuite.py
+++ b/samcli/lib/test_runner/invoke_testsuite.py
@@ -1,0 +1,140 @@
+from typing import *
+import click
+from samcli.lib.utils.boto_utils import BotoProviderType
+from samcli.commands.exceptions import ReservedEnvironmentVariableException
+
+
+def get_subnets(boto_client_provider: BotoProviderType) -> List[str]:
+    """
+    Queries describe-subnets to get subnets associated with the customer account.
+
+    NOTE: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html
+
+    Parameters
+    ----------
+    boto_client_provider : BotoProviderType
+        Provides a boto3 client in order to query the describe-subnets API
+
+    Returns
+    -------
+    List[str]
+        A list of subnet ids associated with a customer account.
+
+    Raises
+    ------
+    botocore.ClientError
+        If the describe_subnets call fails
+    """
+    ec2_client = boto_client_provider("ec2")
+    subnets = ec2_client.describe_subnets().get("Subnets")
+    return [subnet["SubnetId"] for subnet in subnets]
+
+
+def invoke_testsuite(
+    boto_client_provider: BotoProviderType,
+    bucket: str,
+    path_in_bucket: str,
+    ecs_cluster: str,
+    container_name: str,
+    task_definition_arn: str,
+    other_env_vars: dict,
+    test_command_options: str,
+    do_await: bool = False,
+) -> None:
+
+    """
+    Kicks off a testsuite by making a runTask query.
+
+    NOTE: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
+
+    Parameters
+    ----------
+    boto_client_provider : BotoProviderType
+        Provides a boto3 client in order to make a runTask query.
+
+        Also used for waiting for results to appear in the s3 bucket.
+
+    bucket : str
+        The name of the bucket used to store results.
+
+    path_in_bucket : str
+        The path within the bucket where results are stored.
+
+    ecs_cluster : str
+        The name of the ECS Cluster to run the task on.
+
+    container_name : str
+        The name of the container in which the testsuite runs.
+
+        This is required to specify environment variables in a containerOverride.
+
+    task_definition_arn : str
+        The ARN of the task definition to run.
+
+    other_env_vars : dict
+        Other environment variables to be sent to the container.
+
+    test_command_options : str
+        Options to be passed to the test command.
+
+        For example, '--maxfail=2
+
+    do_await : Optional[bool]
+        If enabled, wait for the task to finish and for results to appear in the bucket.
+
+    Raises
+    ------
+    botocore.ClientError
+        If get_subnets, run_task, or waiters fail
+    """
+
+    # If the customer specifies their own subnet, use it, otherwise query describe-subnets.
+
+    subnets = other_env_vars.get("subnets") or get_subnets(boto_client_provider)
+
+    container_env_vars = [
+        {"name": "BUCKET", "value": bucket},
+        {"name": "TEST_RUN_ID", "value": path_in_bucket},
+        {"name": "OPTIONS", "value": test_command_options},
+    ]
+
+    for key, value in other_env_vars.items():
+        if key in ("BUCKET", "TEST_RUN_ID", "OPTIONS"):
+            raise ReservedEnvironmentVariableException(
+                f"{key} is a reserved environment variable, ensure that it is not present in your environment variables file."
+            )
+
+        container_env_vars.append({"name": key, "value": value})
+
+    ecs_client = boto_client_provider("ecs")
+
+    response = ecs_client.run_task(
+        cluster=ecs_cluster,
+        launchType="FARGATE",
+        networkConfiguration={"awsvpcConfiguration": {"subnets": subnets, "assignPublicIp": "ENABLED"}},
+        overrides={
+            "containerOverrides": [
+                {
+                    "name": container_name,
+                    "environment": container_env_vars,
+                }
+            ]
+        },
+        taskDefinition=task_definition_arn,
+    )
+
+    click.secho("Successfully kicked off testsuite!\n", fg="green")
+
+    # If await is specified, wait for the task to finish and the results.tar.gz to appear in the bucket
+    if do_await:
+        click.secho("Awaiting testsuite completion...\n", fg="yellow")
+
+        task_arn = response.get("tasks")[0].get("taskArn")
+        task_waiter = ecs_client.get_waiter("tasks_running")
+
+        s3_client = boto_client_provider("s3")
+
+        results_upload_waiter = s3_client.get_waiter("object_exists")
+        results_upload_waiter.wait(Bucket=bucket, Key=path_in_bucket + "/results.tar.gz")
+
+        task_waiter.wait(cluster=ecs_cluster, tasks=[task_arn])

--- a/tests/unit/lib/test_runner/test_invoke_testsuite.py
+++ b/tests/unit/lib/test_runner/test_invoke_testsuite.py
@@ -20,9 +20,7 @@ class Test_InvokeTestsuite(TestCase):
         }
 
     def test_invalid_var_names(self):
-
         self.params["other_env_vars"] = {r"0variable_name": "value", r"\othervariable_name": "othervalue"}
-
         with self.assertRaises(ValueError):
             self.runner.invoke_testsuite(**self.params)
 
@@ -43,22 +41,17 @@ class Test_InvokeTestsuite(TestCase):
 
     def test_bad_runtask(self):
         boto_ecs_client_mock = Mock()
-
         client_error_response = {"Error": {"Code": "Error Code", "Message": "Error Message"}}
-
         boto_ecs_client_mock.run_task.side_effect = ClientError(
             error_response=client_error_response, operation_name="run_task"
         )
-
         self.runner.boto_ecs_client = boto_ecs_client_mock
-
         with self.assertRaises(ClientError):
             self.runner.invoke_testsuite(**self.params)
 
     def test_results_waiter_fails(self):
         boto_ecs_client_mock = Mock()
         boto_ecs_client_mock.run_task.return_value = None
-
         boto_s3_client_mock = Mock()
         s3_waiter_mock = Mock()
         s3_waiter_mock.wait.side_effect = WaiterError(
@@ -67,9 +60,7 @@ class Test_InvokeTestsuite(TestCase):
             last_response=None,
         )
         boto_s3_client_mock.get_waiter.return_value = s3_waiter_mock
-
         self.runner.boto_ecs_client = boto_ecs_client_mock
         self.runner.boto_s3_client = boto_s3_client_mock
-
         with self.assertRaises(WaiterError):
             self.runner.invoke_testsuite(**self.params)

--- a/tests/unit/lib/test_runner/test_invoke_testsuite.py
+++ b/tests/unit/lib/test_runner/test_invoke_testsuite.py
@@ -1,0 +1,69 @@
+from botocore.exceptions import ClientError
+from unittest.mock import patch
+from unittest import TestCase
+from samcli.lib.test_runner.invoke_testsuite import invoke_testsuite, get_subnets
+from samcli.commands.exceptions import ReservedEnvironmentVariableException
+from samcli.lib.utils.boto_utils import get_boto_client_provider_with_config
+
+
+class Test_TemplateGenerator(TestCase):
+
+    @patch("samcli.lib.test_runner.invoke_testsuite.get_subnets")
+    def test_specify_reserved_variable(self, get_subnets_patch):
+        """
+        Ensure that customers cannot specify environment variables named BUCKET, TEST_RUN_ID, or OPTIONS
+        """
+        get_subnets_patch.return_value = ["subnet-xxxxxxxxxxxxxxxxx"]
+        params = {
+            "boto_client_provider": None,
+            "bucket": "test-bucket-name",
+            "path_in_bucket": "test_bucket_path",
+            "ecs_cluster": "test-cluster-name",
+            "container_name": "test-container-name",
+            "task_definition_arn": "test-task-def-arn",
+            "other_env_vars": {"BUCKET": "oh-no"},
+            "test_command_options": "--max-fail=1",
+            "do_await": False,
+        }
+
+        with self.assertRaises(ReservedEnvironmentVariableException):
+            invoke_testsuite(**params)
+
+        params["other_env_vars"] = {"TEST_RUN_ID": "oh-no"}
+
+        with self.assertRaises(ReservedEnvironmentVariableException):
+            invoke_testsuite(**params)
+
+        params["other_env_vars"] = {"OPTIONS": "oh-no"}
+
+        with self.assertRaises(ReservedEnvironmentVariableException):
+            invoke_testsuite(**params)
+
+    def test_get_subnets(self):
+        boto_client_provider = get_boto_client_provider_with_config()
+
+        subnets = get_subnets(boto_client_provider)
+
+        self.assertGreaterEqual(len(subnets), 1)
+
+        for subnet in subnets:
+            self.assertRegex(subnet, r"subnet-[a-z0-9]{17}")
+
+    def test_bad_params(self):
+        boto_client_provider = get_boto_client_provider_with_config()
+        params = {
+            "boto_client_provider": boto_client_provider, 
+            "bucket": "test-bucket-name",
+            "path_in_bucket": "test_bucket_path",
+            "ecs_cluster": "this-ecs-cluster-does-not-exist",
+            "container_name": "test-container-name",
+            "task_definition_arn": "this-task-definition-does-not-exist",
+            "other_env_vars": {},
+            "test_command_options": "--max-fail=1",
+            "do_await": False,
+        }
+
+        with self.assertRaises(ClientError):
+            invoke_testsuite(**params)
+
+

--- a/tests/unit/lib/test_runner/test_invoke_testsuite.py
+++ b/tests/unit/lib/test_runner/test_invoke_testsuite.py
@@ -6,7 +6,7 @@ from samcli.commands.exceptions import ReservedEnvironmentVariableException
 from samcli.lib.utils.boto_utils import get_boto_client_provider_with_config
 
 
-class Test_TemplateGenerator(TestCase):
+class Test_InvokeTestsuite(TestCase):
 
     @patch("samcli.lib.test_runner.invoke_testsuite.get_subnets")
     def test_specify_reserved_variable(self, get_subnets_patch):

--- a/tests/unit/lib/test_runner/test_invoke_testsuite.py
+++ b/tests/unit/lib/test_runner/test_invoke_testsuite.py
@@ -1,57 +1,75 @@
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, WaiterError
 from unittest import TestCase
+from unittest.mock import Mock
 from samcli.lib.test_runner.invoke_testsuite import invoke_testsuite
 from samcli.commands.exceptions import ReservedEnvironmentVariableException
-from samcli.lib.utils.boto_utils import get_boto_client_provider_with_config
 
 
 class Test_InvokeTestsuite(TestCase):
-    def test_specify_reserved_variable(self):
-        """
-        Ensure that customers cannot specify environment variables named TEST_RUNNER_BUCKET, TEST_RUN_ID, or TEST_COMMAND_OPTIONS
-        """
-
-        params = {
-            "boto_client_provider": None,
+    def setUp(self):
+        self.params = {
+            "boto_ecs_client": None,
+            "boto_s3_client": None,
             "bucket": "test-bucket-name",
             "path_in_bucket": "test_bucket_path",
             "ecs_cluster": "test-cluster-name",
             "container_name": "test-container-name",
             "task_definition_arn": "test-task-def-arn",
-            "other_env_vars": {"TEST_RUNNER_BUCKET": "oh-no"},
-            "test_command_options": "--max-fail=1",
-            "subnets": ["subnet-xxxxxxxxxxxxxxxxx"],
-            "do_await": False,
-        }
-
-        with self.assertRaises(ReservedEnvironmentVariableException):
-            invoke_testsuite(**params)
-
-        params["other_env_vars"] = {"TEST_RUN_ID": "oh-no"}
-
-        with self.assertRaises(ReservedEnvironmentVariableException):
-            invoke_testsuite(**params)
-
-        params["other_env_vars"] = {"TEST_COMMAND_OPTIONS": "oh-no"}
-
-        with self.assertRaises(ReservedEnvironmentVariableException):
-            invoke_testsuite(**params)
-
-
-    def test_bad_params(self):
-        boto_client_provider = get_boto_client_provider_with_config()
-        params = {
-            "boto_client_provider": boto_client_provider,
-            "bucket": "test-bucket-name",
-            "path_in_bucket": "test_bucket_path",
-            "ecs_cluster": "this-ecs-cluster-does-not-exist",
-            "container_name": "test-container-name",
-            "task_definition_arn": "this-task-definition-does-not-exist",
             "other_env_vars": {},
             "test_command_options": "--max-fail=1",
             "subnets": ["subnet-xxxxxxxxxxxxxxxxx"],
-            "do_await": False,
         }
 
+    def test_invalid_var_names(self):
+        self.params["other_env_vars"] = {r"0variable_name": "value", r"\othervariable_name": "othervalue"}
+
+        with self.assertRaises(ValueError):
+            invoke_testsuite(**self.params)
+
+    def test_specify_variable_bucket(self):
+        self.params["other_env_vars"] = {"TEST_RUNNER_BUCKET": "oh-no"}
+        with self.assertRaises(ReservedEnvironmentVariableException):
+            invoke_testsuite(**self.params)
+
+    def test_specify_variable_run_id(self):
+        self.params["other_env_vars"] = {"TEST_RUN_ID": "oh-no"}
+        with self.assertRaises(ReservedEnvironmentVariableException):
+            invoke_testsuite(**self.params)
+
+    def test_specify_variable_command_options(self):
+        self.params["other_env_vars"] = {"TEST_COMMAND_OPTIONS": "oh-no"}
+        with self.assertRaises(ReservedEnvironmentVariableException):
+            invoke_testsuite(**self.params)
+
+    def test_bad_runtask(self):
+        boto_ecs_client_mock = Mock()
+
+        client_error_response = {"Error": {"Code": "Error Code", "Message": "Error Message"}}
+
+        boto_ecs_client_mock.run_task.side_effect = ClientError(
+            error_response=client_error_response, operation_name="run_task"
+        )
+
+        self.params["boto_ecs_client"] = boto_ecs_client_mock
+
         with self.assertRaises(ClientError):
-            invoke_testsuite(**params)
+            invoke_testsuite(**self.params)
+
+    def test_results_waiter_fails(self):
+        boto_ecs_client_mock = Mock()
+        boto_ecs_client_mock.run_task.return_value = None
+
+        boto_s3_client_mock = Mock()
+        s3_waiter_mock = Mock()
+        s3_waiter_mock.wait.side_effect = WaiterError(
+            name="ObjectExists",
+            reason="Max attempts suceeded, results failed to appear in the bucket.",
+            last_response=None,
+        )
+        boto_s3_client_mock.get_waiter.return_value = s3_waiter_mock
+
+        self.params["boto_ecs_client"] = boto_ecs_client_mock
+        self.params["boto_s3_client"] = boto_s3_client_mock
+
+        with self.assertRaises(WaiterError):
+            invoke_testsuite(**self.params)

--- a/tests/unit/lib/test_runner/test_invoke_testsuite.py
+++ b/tests/unit/lib/test_runner/test_invoke_testsuite.py
@@ -1,18 +1,16 @@
 from botocore.exceptions import ClientError
-from unittest.mock import patch
 from unittest import TestCase
-from samcli.lib.test_runner.invoke_testsuite import invoke_testsuite, get_subnets
+from samcli.lib.test_runner.invoke_testsuite import invoke_testsuite
 from samcli.commands.exceptions import ReservedEnvironmentVariableException
 from samcli.lib.utils.boto_utils import get_boto_client_provider_with_config
 
 
 class Test_InvokeTestsuite(TestCase):
-    @patch("samcli.lib.test_runner.invoke_testsuite.get_subnets")
-    def test_specify_reserved_variable(self, get_subnets_patch):
+    def test_specify_reserved_variable(self):
         """
         Ensure that customers cannot specify environment variables named TEST_RUNNER_BUCKET, TEST_RUN_ID, or TEST_COMMAND_OPTIONS
         """
-        get_subnets_patch.return_value = ["subnet-xxxxxxxxxxxxxxxxx"]
+
         params = {
             "boto_client_provider": None,
             "bucket": "test-bucket-name",
@@ -22,6 +20,7 @@ class Test_InvokeTestsuite(TestCase):
             "task_definition_arn": "test-task-def-arn",
             "other_env_vars": {"TEST_RUNNER_BUCKET": "oh-no"},
             "test_command_options": "--max-fail=1",
+            "subnets": ["subnet-xxxxxxxxxxxxxxxxx"],
             "do_await": False,
         }
 
@@ -38,15 +37,6 @@ class Test_InvokeTestsuite(TestCase):
         with self.assertRaises(ReservedEnvironmentVariableException):
             invoke_testsuite(**params)
 
-    def test_get_subnets(self):
-        boto_client_provider = get_boto_client_provider_with_config()
-
-        subnets = get_subnets(boto_client_provider)
-
-        self.assertGreaterEqual(len(subnets), 1)
-
-        for subnet in subnets:
-            self.assertRegex(subnet, r"subnet-[a-z0-9]{17}")
 
     def test_bad_params(self):
         boto_client_provider = get_boto_client_provider_with_config()
@@ -59,6 +49,7 @@ class Test_InvokeTestsuite(TestCase):
             "task_definition_arn": "this-task-definition-does-not-exist",
             "other_env_vars": {},
             "test_command_options": "--max-fail=1",
+            "subnets": ["subnet-xxxxxxxxxxxxxxxxx"],
             "do_await": False,
         }
 

--- a/tests/unit/lib/test_runner/test_invoke_testsuite.py
+++ b/tests/unit/lib/test_runner/test_invoke_testsuite.py
@@ -7,11 +7,10 @@ from samcli.lib.utils.boto_utils import get_boto_client_provider_with_config
 
 
 class Test_InvokeTestsuite(TestCase):
-
     @patch("samcli.lib.test_runner.invoke_testsuite.get_subnets")
     def test_specify_reserved_variable(self, get_subnets_patch):
         """
-        Ensure that customers cannot specify environment variables named BUCKET, TEST_RUN_ID, or OPTIONS
+        Ensure that customers cannot specify environment variables named TEST_RUNNER_BUCKET, TEST_RUN_ID, or TEST_COMMAND_OPTIONS
         """
         get_subnets_patch.return_value = ["subnet-xxxxxxxxxxxxxxxxx"]
         params = {
@@ -21,7 +20,7 @@ class Test_InvokeTestsuite(TestCase):
             "ecs_cluster": "test-cluster-name",
             "container_name": "test-container-name",
             "task_definition_arn": "test-task-def-arn",
-            "other_env_vars": {"BUCKET": "oh-no"},
+            "other_env_vars": {"TEST_RUNNER_BUCKET": "oh-no"},
             "test_command_options": "--max-fail=1",
             "do_await": False,
         }
@@ -34,7 +33,7 @@ class Test_InvokeTestsuite(TestCase):
         with self.assertRaises(ReservedEnvironmentVariableException):
             invoke_testsuite(**params)
 
-        params["other_env_vars"] = {"OPTIONS": "oh-no"}
+        params["other_env_vars"] = {"TEST_COMMAND_OPTIONS": "oh-no"}
 
         with self.assertRaises(ReservedEnvironmentVariableException):
             invoke_testsuite(**params)
@@ -52,7 +51,7 @@ class Test_InvokeTestsuite(TestCase):
     def test_bad_params(self):
         boto_client_provider = get_boto_client_provider_with_config()
         params = {
-            "boto_client_provider": boto_client_provider, 
+            "boto_client_provider": boto_client_provider,
             "bucket": "test-bucket-name",
             "path_in_bucket": "test_bucket_path",
             "ecs_cluster": "this-ecs-cluster-does-not-exist",
@@ -65,5 +64,3 @@ class Test_InvokeTestsuite(TestCase):
 
         with self.assertRaises(ClientError):
             invoke_testsuite(**params)
-
-


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Adds functionality to kick off a testsuite by running a Fargate task with a set of environment variables, using a [runTask](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html) query.

#### Why is this change necessary?
In order for customers to run their testsuites on Fargate, there needs to be functionality to make a runTask query to start a test-running task.

#### How does it address the issue?
This change contains the code to make a test-running runTask query

#### What side effects does this change have?
N/A

### NOTE: 

The general image used in the Test Runner Task Definition is not yet public, so testing this is properly is not yet possible. Once remaining features are added, and the general image is public, thorough end to end testing can be done. Given that we are merging with a feature branch, I think waiting for further implementation and end to end tests is reasonable.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
