### PR TITLE
Send events via thread when at capacity

### DIFF
--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -139,7 +139,8 @@ class EventTracker:
                 if len(EventTracker._events) >= EventTracker.MAX_EVENTS:
                     should_send = True
             if should_send:
-                EventTracker.send_events()
+                send_thread = threading.Thread(target=EventTracker.send_events)
+                send_thread.start()
         except EventCreationError as e:
             LOG.debug("Error occurred while trying to track an event: %s", e)
 

--- a/tests/unit/lib/telemetry/test_event.py
+++ b/tests/unit/lib/telemetry/test_event.py
@@ -170,6 +170,12 @@ class TestEventTracker(TestCase):
         # Add one more event to trigger sending all events
         EventTracker.track_event("TheStrawThat", "BreaksTheCamel'sBack")
 
+        # Wait for all threads to complete
+        for thread in threading.enumerate():
+            if thread is threading.main_thread():
+                continue
+            thread.join()
+
         send_mock.assert_called()
 
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
Previously, when at capacity, Events would be sent inline. This could create slowdowns during execution if the Telemetry happens to be slow on a given day.

#### How does it address the issue?
By sending these Events in a separate thread, we ensure that they are sent without disrupting the flow of execution of other commands and functions.

#### What side effects does this change have?
There are no notable side effects to this change, besides the use of an additional thread during execution.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
