### PR TITLE
Add workflow events

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -270,8 +270,6 @@ class BuildContext:
 
             for f in self.get_resources_to_build().functions:
                 EventTracker.track_event("BuildFunctionRuntime", f.runtime)
-                if f.metadata and f.metadata.get("BuildMethod", "") == "esbuild":
-                    EventTracker.track_event("UsedFeature", "ESBuild")
 
             click.secho("\nBuild Succeeded", fg="green")
 

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -209,8 +209,6 @@ def get_workflow_config(
         config = cast(WorkFlowSelector, selector).get_config(code_dir, project_dir)
 
         EventTracker.track_event("WorkflowUsed", f"{config.language}-{config.dependency_manager}")
-        if config.dependency_manager == "npm-esbuild":
-            EventTracker.track_event("UsedFeature", "ESBuild")
 
         return config
     except ValueError as ex:

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -4,97 +4,24 @@ Contains Builder Workflow Configs for different Runtimes
 
 import os
 import logging
-from collections import namedtuple
 from typing import Dict, List, Optional, Tuple, Union, cast
 
+from samcli.lib.build.workflows import (
+    CONFIG,
+    PYTHON_PIP_CONFIG,
+    NODEJS_NPM_CONFIG,
+    RUBY_BUNDLER_CONFIG,
+    JAVA_GRADLE_CONFIG,
+    JAVA_KOTLIN_GRADLE_CONFIG,
+    JAVA_MAVEN_CONFIG,
+    DOTNET_CLIPACKAGE_CONFIG,
+    GO_MOD_CONFIG,
+    PROVIDED_MAKE_CONFIG,
+    NODEJS_NPM_ESBUILD_CONFIG,
+)
 from samcli.lib.telemetry.event import EventTracker
 
 LOG = logging.getLogger(__name__)
-
-CONFIG = namedtuple(
-    "Capability",
-    ["language", "dependency_manager", "application_framework", "manifest_name", "executable_search_paths"],
-)
-
-PYTHON_PIP_CONFIG = CONFIG(
-    language="python",
-    dependency_manager="pip",
-    application_framework=None,
-    manifest_name="requirements.txt",
-    executable_search_paths=None,
-)
-
-NODEJS_NPM_CONFIG = CONFIG(
-    language="nodejs",
-    dependency_manager="npm",
-    application_framework=None,
-    manifest_name="package.json",
-    executable_search_paths=None,
-)
-
-RUBY_BUNDLER_CONFIG = CONFIG(
-    language="ruby",
-    dependency_manager="bundler",
-    application_framework=None,
-    manifest_name="Gemfile",
-    executable_search_paths=None,
-)
-
-JAVA_GRADLE_CONFIG = CONFIG(
-    language="java",
-    dependency_manager="gradle",
-    application_framework=None,
-    manifest_name="build.gradle",
-    executable_search_paths=None,
-)
-
-JAVA_KOTLIN_GRADLE_CONFIG = CONFIG(
-    language="java",
-    dependency_manager="gradle",
-    application_framework=None,
-    manifest_name="build.gradle.kts",
-    executable_search_paths=None,
-)
-
-JAVA_MAVEN_CONFIG = CONFIG(
-    language="java",
-    dependency_manager="maven",
-    application_framework=None,
-    manifest_name="pom.xml",
-    executable_search_paths=None,
-)
-
-DOTNET_CLIPACKAGE_CONFIG = CONFIG(
-    language="dotnet",
-    dependency_manager="cli-package",
-    application_framework=None,
-    manifest_name=".csproj",
-    executable_search_paths=None,
-)
-
-GO_MOD_CONFIG = CONFIG(
-    language="go",
-    dependency_manager="modules",
-    application_framework=None,
-    manifest_name="go.mod",
-    executable_search_paths=None,
-)
-
-PROVIDED_MAKE_CONFIG = CONFIG(
-    language="provided",
-    dependency_manager=None,
-    application_framework=None,
-    manifest_name="Makefile",
-    executable_search_paths=None,
-)
-
-NODEJS_NPM_ESBUILD_CONFIG = CONFIG(
-    language="nodejs",
-    dependency_manager="npm-esbuild",
-    application_framework=None,
-    manifest_name="package.json",
-    executable_search_paths=None,
-)
 
 
 class UnsupportedRuntimeException(Exception):
@@ -281,8 +208,7 @@ def get_workflow_config(
         # Identify workflow configuration from the workflow selector.
         config = cast(WorkFlowSelector, selector).get_config(code_dir, project_dir)
 
-        EventTracker.track_event("WorkflowLanguage", config.language)
-        EventTracker.track_event("WorkflowDependencyManager", config.dependency_manager)
+        EventTracker.track_event("WorkflowUsed", f"{config.language}-{config.dependency_manager}")
         if config.dependency_manager == "npm-esbuild":
             EventTracker.track_event("UsedFeature", "ESBuild")
 

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -208,7 +208,7 @@ def get_workflow_config(
         # Identify workflow configuration from the workflow selector.
         config = cast(WorkFlowSelector, selector).get_config(code_dir, project_dir)
 
-        EventTracker.track_event("WorkflowUsed", f"{config.language}-{config.dependency_manager}")
+        EventTracker.track_event("BuildWorkflowUsed", f"{config.language}-{config.dependency_manager}")
 
         return config
     except ValueError as ex:

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -7,6 +7,8 @@ import logging
 from collections import namedtuple
 from typing import Dict, List, Optional, Tuple, Union, cast
 
+from samcli.lib.telemetry.event import EventTracker
+
 LOG = logging.getLogger(__name__)
 
 CONFIG = namedtuple(
@@ -278,6 +280,12 @@ def get_workflow_config(
 
         # Identify workflow configuration from the workflow selector.
         config = cast(WorkFlowSelector, selector).get_config(code_dir, project_dir)
+
+        EventTracker.track_event("WorkflowLanguage", config.language)
+        EventTracker.track_event("WorkflowDependencyManager", config.dependency_manager)
+        if config.dependency_manager == "npm-esbuild":
+            EventTracker.track_event("UsedFeature", "ESBuild")
+
         return config
     except ValueError as ex:
         raise UnsupportedRuntimeException(

--- a/samcli/lib/build/workflows.py
+++ b/samcli/lib/build/workflows.py
@@ -1,0 +1,102 @@
+"""Module for storing information about existing workflows."""
+
+from collections import namedtuple
+from typing import List
+
+CONFIG = namedtuple(
+    "Capability",
+    ["language", "dependency_manager", "application_framework", "manifest_name", "executable_search_paths"],
+)
+
+PYTHON_PIP_CONFIG = CONFIG(
+    language="python",
+    dependency_manager="pip",
+    application_framework=None,
+    manifest_name="requirements.txt",
+    executable_search_paths=None,
+)
+
+NODEJS_NPM_CONFIG = CONFIG(
+    language="nodejs",
+    dependency_manager="npm",
+    application_framework=None,
+    manifest_name="package.json",
+    executable_search_paths=None,
+)
+
+RUBY_BUNDLER_CONFIG = CONFIG(
+    language="ruby",
+    dependency_manager="bundler",
+    application_framework=None,
+    manifest_name="Gemfile",
+    executable_search_paths=None,
+)
+
+JAVA_GRADLE_CONFIG = CONFIG(
+    language="java",
+    dependency_manager="gradle",
+    application_framework=None,
+    manifest_name="build.gradle",
+    executable_search_paths=None,
+)
+
+JAVA_KOTLIN_GRADLE_CONFIG = CONFIG(
+    language="java",
+    dependency_manager="gradle",
+    application_framework=None,
+    manifest_name="build.gradle.kts",
+    executable_search_paths=None,
+)
+
+JAVA_MAVEN_CONFIG = CONFIG(
+    language="java",
+    dependency_manager="maven",
+    application_framework=None,
+    manifest_name="pom.xml",
+    executable_search_paths=None,
+)
+
+DOTNET_CLIPACKAGE_CONFIG = CONFIG(
+    language="dotnet",
+    dependency_manager="cli-package",
+    application_framework=None,
+    manifest_name=".csproj",
+    executable_search_paths=None,
+)
+
+GO_MOD_CONFIG = CONFIG(
+    language="go",
+    dependency_manager="modules",
+    application_framework=None,
+    manifest_name="go.mod",
+    executable_search_paths=None,
+)
+
+PROVIDED_MAKE_CONFIG = CONFIG(
+    language="provided",
+    dependency_manager=None,
+    application_framework=None,
+    manifest_name="Makefile",
+    executable_search_paths=None,
+)
+
+NODEJS_NPM_ESBUILD_CONFIG = CONFIG(
+    language="nodejs",
+    dependency_manager="npm-esbuild",
+    application_framework=None,
+    manifest_name="package.json",
+    executable_search_paths=None,
+)
+
+ALL_CONFIGS: List[CONFIG] = [
+    PYTHON_PIP_CONFIG,
+    NODEJS_NPM_CONFIG,
+    RUBY_BUNDLER_CONFIG,
+    JAVA_GRADLE_CONFIG,
+    JAVA_KOTLIN_GRADLE_CONFIG,
+    JAVA_MAVEN_CONFIG,
+    DOTNET_CLIPACKAGE_CONFIG,
+    GO_MOD_CONFIG,
+    PROVIDED_MAKE_CONFIG,
+    NODEJS_NPM_ESBUILD_CONFIG,
+]

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -19,11 +19,12 @@ class EventName(Enum):
     """Enum for the names of available events to track."""
 
     USED_FEATURE = "UsedFeature"
-    DEPLOY = "Deploy"
     BUILD_FUNCTION_RUNTIME = "BuildFunctionRuntime"
     SYNC_USED = "SyncUsed"
     SYNC_FLOW_START = "SyncFlowStart"
     SYNC_FLOW_END = "SyncFlowEnd"
+    WORKFLOW_LANGUAGE = "WorkflowLanguage"
+    WORKFLOW_DEPENDENCY_MANAGER = "WorkflowDependencyManager"
 
 
 class EventType:
@@ -43,17 +44,30 @@ class EventType:
         "StepFunctionsSyncFlow",
         "ZipFunctionSyncFlow",
     ]
+    _WORKFLOW_LANGUAGES = [
+        "python",
+        "nodejs",
+        "ruby",
+        "java",
+        "dotnet",
+        "go",
+        "provided",
+    ]
+    _WORKFLOW_DEPENDENCY_MANAGERS = [
+        "pip",
+        "npm",
+        "bundler",
+        "gradle",
+        "maven",
+        "cli-package",
+        "modules",
+        "npm-esbuild",
+    ]
     _events = {
         EventName.USED_FEATURE: [
             "ESBuild",
             "Accelerate",
             "CDK",
-        ],
-        EventName.DEPLOY: [
-            "CreateChangeSetStart",
-            "CreateChangeSetInProgress",
-            "CreateChangeSetFailed",
-            "CreateChangeSetSuccess",
         ],
         EventName.BUILD_FUNCTION_RUNTIME: INIT_RUNTIMES,
         EventName.SYNC_USED: [
@@ -62,6 +76,8 @@ class EventType:
         ],
         EventName.SYNC_FLOW_START: _SYNC_FLOWS,
         EventName.SYNC_FLOW_END: _SYNC_FLOWS,
+        EventName.WORKFLOW_LANGUAGE: _WORKFLOW_LANGUAGES,
+        EventName.WORKFLOW_DEPENDENCY_MANAGER: _WORKFLOW_DEPENDENCY_MANAGERS,
     }
 
     @staticmethod

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -8,6 +8,7 @@ import logging
 import threading
 from typing import List
 
+from samcli.lib.build.workflows import ALL_CONFIGS
 from samcli.lib.telemetry.telemetry import Telemetry
 from samcli.local.common.runtime_template import INIT_RUNTIMES
 
@@ -23,8 +24,7 @@ class EventName(Enum):
     SYNC_USED = "SyncUsed"
     SYNC_FLOW_START = "SyncFlowStart"
     SYNC_FLOW_END = "SyncFlowEnd"
-    WORKFLOW_LANGUAGE = "WorkflowLanguage"
-    WORKFLOW_DEPENDENCY_MANAGER = "WorkflowDependencyManager"
+    WORKFLOW_USED = "WorkflowUsed"
 
 
 class EventType:
@@ -44,25 +44,7 @@ class EventType:
         "StepFunctionsSyncFlow",
         "ZipFunctionSyncFlow",
     ]
-    _WORKFLOW_LANGUAGES = [
-        "python",
-        "nodejs",
-        "ruby",
-        "java",
-        "dotnet",
-        "go",
-        "provided",
-    ]
-    _WORKFLOW_DEPENDENCY_MANAGERS = [
-        "pip",
-        "npm",
-        "bundler",
-        "gradle",
-        "maven",
-        "cli-package",
-        "modules",
-        "npm-esbuild",
-    ]
+    _WORKFLOWS = [f"{config.language}-{config.dependency_manager}" for config in ALL_CONFIGS]
     _events = {
         EventName.USED_FEATURE: [
             "ESBuild",
@@ -76,8 +58,7 @@ class EventType:
         ],
         EventName.SYNC_FLOW_START: _SYNC_FLOWS,
         EventName.SYNC_FLOW_END: _SYNC_FLOWS,
-        EventName.WORKFLOW_LANGUAGE: _WORKFLOW_LANGUAGES,
-        EventName.WORKFLOW_DEPENDENCY_MANAGER: _WORKFLOW_DEPENDENCY_MANAGERS,
+        EventName.WORKFLOW_USED: _WORKFLOWS,
     }
 
     @staticmethod

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -47,7 +47,6 @@ class EventType:
     _WORKFLOWS = [f"{config.language}-{config.dependency_manager}" for config in ALL_CONFIGS]
     _events = {
         EventName.USED_FEATURE: [
-            "ESBuild",
             "Accelerate",
             "CDK",
         ],

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -24,7 +24,7 @@ class EventName(Enum):
     SYNC_USED = "SyncUsed"
     SYNC_FLOW_START = "SyncFlowStart"
     SYNC_FLOW_END = "SyncFlowEnd"
-    WORKFLOW_USED = "WorkflowUsed"
+    BUILD_WORKFLOW_USED = "BuildWorkflowUsed"
 
 
 class EventType:
@@ -57,7 +57,7 @@ class EventType:
         ],
         EventName.SYNC_FLOW_START: _SYNC_FLOWS,
         EventName.SYNC_FLOW_END: _SYNC_FLOWS,
-        EventName.WORKFLOW_USED: _WORKFLOWS,
+        EventName.BUILD_WORKFLOW_USED: _WORKFLOWS,
     }
 
     @staticmethod

--- a/tests/unit/lib/build_module/test_workflow_config.py
+++ b/tests/unit/lib/build_module/test_workflow_config.py
@@ -109,9 +109,8 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.application_framework, None)
         self.assertEqual(result.manifest_name, "package.json")
         self.assertIsNone(result.executable_search_paths)
-        self.assertEqual(len(EventTracker.get_tracked_events()), 2)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 1)
         self.assertIn(Event("WorkflowUsed", "nodejs-npm-esbuild"), EventTracker.get_tracked_events())
-        self.assertIn(Event("UsedFeature", "ESBuild"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("java8", "unknown.manifest")])
     @patch("samcli.lib.build.workflow_config.os")

--- a/tests/unit/lib/build_module/test_workflow_config.py
+++ b/tests/unit/lib/build_module/test_workflow_config.py
@@ -7,12 +7,14 @@ from samcli.lib.build.workflow_config import (
     UnsupportedRuntimeException,
     UnsupportedBuilderException,
 )
+from samcli.lib.telemetry.event import Event, EventTracker
 
 
 class Test_get_workflow_config(TestCase):
     def setUp(self):
         self.code_dir = ""
         self.project_dir = ""
+        EventTracker.clear_trackers()
 
     @parameterized.expand([("python3.6",), ("python3.7",), ("python3.8",)])
     def test_must_work_for_python(self, runtime):
@@ -23,6 +25,8 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.application_framework, None)
         self.assertEqual(result.manifest_name, "requirements.txt")
         self.assertIsNone(result.executable_search_paths)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 1)
+        self.assertIn(Event("WorkflowUsed", "python-pip"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",)])
     def test_must_work_for_nodejs(self, runtime):
@@ -33,6 +37,8 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.application_framework, None)
         self.assertEqual(result.manifest_name, "package.json")
         self.assertIsNone(result.executable_search_paths)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 1)
+        self.assertIn(Event("WorkflowUsed", "nodejs-npm"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("provided",)])
     def test_must_work_for_provided(self, runtime):
@@ -42,6 +48,8 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.application_framework, None)
         self.assertEqual(result.manifest_name, "Makefile")
         self.assertIsNone(result.executable_search_paths)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 1)
+        self.assertIn(Event("WorkflowUsed", "provided-None"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("provided",)])
     def test_must_work_for_provided_with_no_specified_workflow(self, runtime):
@@ -52,6 +60,8 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.application_framework, None)
         self.assertEqual(result.manifest_name, "Makefile")
         self.assertIsNone(result.executable_search_paths)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 1)
+        self.assertIn(Event("WorkflowUsed", "provided-None"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("provided",)])
     def test_raise_exception_for_bad_specified_workflow(self, runtime):
@@ -66,6 +76,8 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.application_framework, None)
         self.assertEqual(result.manifest_name, "Gemfile")
         self.assertIsNone(result.executable_search_paths)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 1)
+        self.assertIn(Event("WorkflowUsed", "ruby-bundler"), EventTracker.get_tracked_events())
 
     @parameterized.expand(
         [("java8", "build.gradle", "gradle"), ("java8", "build.gradle.kts", "gradle"), ("java8", "pom.xml", "maven")]
@@ -80,11 +92,14 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.dependency_manager, dep_manager)
         self.assertEqual(result.application_framework, None)
         self.assertEqual(result.manifest_name, build_file)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 1)
 
         if dep_manager == "gradle":
             self.assertEqual(result.executable_search_paths, [self.code_dir, self.project_dir])
+            self.assertIn(Event("WorkflowUsed", "java-gradle"), EventTracker.get_tracked_events())
         else:
             self.assertIsNone(result.executable_search_paths)
+            self.assertIn(Event("WorkflowUsed", "java-maven"), EventTracker.get_tracked_events())
 
     def test_must_get_workflow_for_esbuild(self):
         runtime = "nodejs12.x"
@@ -94,6 +109,9 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.application_framework, None)
         self.assertEqual(result.manifest_name, "package.json")
         self.assertIsNone(result.executable_search_paths)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 2)
+        self.assertIn(Event("WorkflowUsed", "nodejs-npm-esbuild"), EventTracker.get_tracked_events())
+        self.assertIn(Event("UsedFeature", "ESBuild"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("java8", "unknown.manifest")])
     @patch("samcli.lib.build.workflow_config.os")

--- a/tests/unit/lib/build_module/test_workflow_config.py
+++ b/tests/unit/lib/build_module/test_workflow_config.py
@@ -26,7 +26,7 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.manifest_name, "requirements.txt")
         self.assertIsNone(result.executable_search_paths)
         self.assertEqual(len(EventTracker.get_tracked_events()), 1)
-        self.assertIn(Event("WorkflowUsed", "python-pip"), EventTracker.get_tracked_events())
+        self.assertIn(Event("BuildWorkflowUsed", "python-pip"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("nodejs12.x",), ("nodejs14.x",), ("nodejs16.x",)])
     def test_must_work_for_nodejs(self, runtime):
@@ -38,7 +38,7 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.manifest_name, "package.json")
         self.assertIsNone(result.executable_search_paths)
         self.assertEqual(len(EventTracker.get_tracked_events()), 1)
-        self.assertIn(Event("WorkflowUsed", "nodejs-npm"), EventTracker.get_tracked_events())
+        self.assertIn(Event("BuildWorkflowUsed", "nodejs-npm"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("provided",)])
     def test_must_work_for_provided(self, runtime):
@@ -49,7 +49,7 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.manifest_name, "Makefile")
         self.assertIsNone(result.executable_search_paths)
         self.assertEqual(len(EventTracker.get_tracked_events()), 1)
-        self.assertIn(Event("WorkflowUsed", "provided-None"), EventTracker.get_tracked_events())
+        self.assertIn(Event("BuildWorkflowUsed", "provided-None"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("provided",)])
     def test_must_work_for_provided_with_no_specified_workflow(self, runtime):
@@ -61,7 +61,7 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.manifest_name, "Makefile")
         self.assertIsNone(result.executable_search_paths)
         self.assertEqual(len(EventTracker.get_tracked_events()), 1)
-        self.assertIn(Event("WorkflowUsed", "provided-None"), EventTracker.get_tracked_events())
+        self.assertIn(Event("BuildWorkflowUsed", "provided-None"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("provided",)])
     def test_raise_exception_for_bad_specified_workflow(self, runtime):
@@ -77,7 +77,7 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.manifest_name, "Gemfile")
         self.assertIsNone(result.executable_search_paths)
         self.assertEqual(len(EventTracker.get_tracked_events()), 1)
-        self.assertIn(Event("WorkflowUsed", "ruby-bundler"), EventTracker.get_tracked_events())
+        self.assertIn(Event("BuildWorkflowUsed", "ruby-bundler"), EventTracker.get_tracked_events())
 
     @parameterized.expand(
         [("java8", "build.gradle", "gradle"), ("java8", "build.gradle.kts", "gradle"), ("java8", "pom.xml", "maven")]
@@ -96,10 +96,10 @@ class Test_get_workflow_config(TestCase):
 
         if dep_manager == "gradle":
             self.assertEqual(result.executable_search_paths, [self.code_dir, self.project_dir])
-            self.assertIn(Event("WorkflowUsed", "java-gradle"), EventTracker.get_tracked_events())
+            self.assertIn(Event("BuildWorkflowUsed", "java-gradle"), EventTracker.get_tracked_events())
         else:
             self.assertIsNone(result.executable_search_paths)
-            self.assertIn(Event("WorkflowUsed", "java-maven"), EventTracker.get_tracked_events())
+            self.assertIn(Event("BuildWorkflowUsed", "java-maven"), EventTracker.get_tracked_events())
 
     def test_must_get_workflow_for_esbuild(self):
         runtime = "nodejs12.x"
@@ -110,7 +110,7 @@ class Test_get_workflow_config(TestCase):
         self.assertEqual(result.manifest_name, "package.json")
         self.assertIsNone(result.executable_search_paths)
         self.assertEqual(len(EventTracker.get_tracked_events()), 1)
-        self.assertIn(Event("WorkflowUsed", "nodejs-npm-esbuild"), EventTracker.get_tracked_events())
+        self.assertIn(Event("BuildWorkflowUsed", "nodejs-npm-esbuild"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("java8", "unknown.manifest")])
     @patch("samcli.lib.build.workflow_config.os")

--- a/tests/unit/lib/telemetry/test_event.py
+++ b/tests/unit/lib/telemetry/test_event.py
@@ -69,6 +69,9 @@ class TestEventCreation(TestCase):
 
 
 class TestEventTracker(TestCase):
+    def setUp(self):
+        EventTracker.clear_trackers()
+
     @patch("samcli.lib.telemetry.event.EventTracker._event_lock")
     @patch("samcli.lib.telemetry.event.Event")
     def test_track_event(self, event_mock, lock_mock):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
Events previously exist to capture the runtime of functions as they are built. However, up until now, we do not have a way to capture the information of workflow configs.

#### How does it address the issue?
With a new `WorkflowUsed` Event, we will be able to capture and analyze data on which workflows customers are using most. This can reveal information such as the most common languages of workflows, most common dependency managers, and how many different workflow configs are used per build.

#### What side effects does this change have?
A new file, `workflows.py`, has been created to prevent a cyclic import, and allow for dynamic computing of Event values. Thus, for any new workflow to be added, it would need to be created there, and then be imported by `workflow_config.py`.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
