### PR TITLE
Add option to CfnTag parameter to accept multiple values per key

### DIFF
--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -239,7 +239,7 @@ class CfnTags(click.ParamType):
 
         return result
 
-    def _add_value(self, result, key, new_value):
+    def _add_value(self, result : dict, key : str, new_value : str):
         """
         Add a given value to a given key in the result map.
         """

--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -239,7 +239,7 @@ class CfnTags(click.ParamType):
 
         return result
 
-    def _add_value(self, result : dict, key : str, new_value : str):
+    def _add_value(self, result: dict, key: str, new_value: str):
         """
         Add a given value to a given key in the result map.
         """

--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -178,7 +178,15 @@ class CfnTags(click.ParamType):
     """
     Custom Click options type to accept values for tag parameters.
     tag parameters can be of the type KeyName1=string KeyName2=string
+
+    If multiple_values_per_key is set to True, the returned dictionary will map
+    each key to a list of corresponding values.
+
+    E.g. Input: KeyName1=Value1 KeyName1=Value2 Output: {KeyName1 : [Value1, Value2]}
     """
+
+    def __init__(self, multiple_values_per_key=False):
+        self.multiple_values_per_key = multiple_values_per_key
 
     _EXAMPLE = "KeyName1=string KeyName2=string"
     # Tags have additional constraints and they allow "+ - = . _ : / @" apart from alpha-numerics.
@@ -212,7 +220,7 @@ class CfnTags(click.ParamType):
                 parsed, tags = self._space_separated_key_value_parser(val)
             if parsed:
                 for k in tags:
-                    result[_unquote_wrapped_quotes(k)] = _unquote_wrapped_quotes(tags[k])
+                    self._add_value(result, _unquote_wrapped_quotes(k), _unquote_wrapped_quotes(tags[k]))
             else:
                 groups = re.findall(self._pattern, val)
 
@@ -220,8 +228,7 @@ class CfnTags(click.ParamType):
                     fail = True
                 for group in groups:
                     key, v = group
-                    # assign to result['KeyName1'] = string and so on.
-                    result[_unquote_wrapped_quotes(key)] = _unquote_wrapped_quotes(v)
+                    self._add_value(result, _unquote_wrapped_quotes(key), _unquote_wrapped_quotes(v))
 
             if fail:
                 return self.fail(
@@ -231,6 +238,17 @@ class CfnTags(click.ParamType):
                 )
 
         return result
+
+    def _add_value(self, result, key, new_value):
+        """
+        Add a given value to a given key in the result map.
+        """
+        if self.multiple_values_per_key:
+            if not result.get(key):
+                result[key] = []
+            result[key].append(new_value)
+            return
+        result[key] = new_value
 
     @staticmethod
     def _standard_key_value_parser(tag_value):


### PR DESCRIPTION
With `multiple_values_per_key=True`:
`Key1=Value1 Key1=Value2` -> `{Key1: [Value1, Value2]}`

Without `multiple_values_per_key` specified (before this change):
`Key1=Value1 Key1=Value2` -> `{Key1: Value2}`

#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
Currently, there is no way for a customer to specify "tag filters" consisting of keys with multiple values. This is useful for SAM CLI commands that make API calls such as [get-resources](https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#get-resources). If a customer would like to specify two resources with the same tag key but different values, this change makes that possible.

#### How does it address the issue?
An optional flag is added to the `CfnTags` parameter class. If enabled, the resulting dictionary will map each key to a list of values instead of the latest entered one. If not specified, `CfnTags` will function exactly as it did previously, only accepting one value per key.


#### What side effects does this change have?
None, all uses of CfnTags will function the same as before this change.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
