### PR TITLE
Fix send_events lock logic

### DIFF
--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -179,18 +179,19 @@ class EventTracker:
         """Sends the current list of events via Telemetry."""
         from samcli.lib.telemetry.metric import Metric  # pylint: disable=cyclic-import
 
+        msa = {}
+
         with EventTracker._event_lock:
             if not EventTracker._events:  # Don't do anything if there are no events to send
                 return
 
-            telemetry = Telemetry()
-
-            metric = Metric("events")
-            msa = {}
             msa["events"] = [e.to_json() for e in EventTracker._events]
-            metric.add_data("metricSpecificAttributes", msa)
-            telemetry.emit(metric)
             EventTracker._events = []  # Manual clear_trackers() since we're within the lock
+
+        telemetry = Telemetry()
+        metric = Metric("events")
+        metric.add_data("metricSpecificAttributes", msa)
+        telemetry.emit(metric)
 
 
 def track_long_event(start_event_name: str, start_event_value: str, end_event_name: str, end_event_value: str):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
While reviewing my code, I noticed that the structure of the `send_events` method was poorly formatted for multi-threading, as the method holds the `event` lock for its entire duration, including when connecting to Telemetry to send the events. This can cause long waits, which we attempted to get rid of by sending events in a separate thread in the first place.

#### How does it address the issue?
I rearranged the method, accessing the lock only for what is solely necessary. This means keeping the `telemetry.emit` method out of the lock, allowing it to properly execute in parallel if other Events are added to the tracker while sending.

#### What side effects does this change have?
This should cause notable increase in the speed of Events being tracked, especially on days that the Telemetry itself may be slower than usual.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
