### PR TITLE
Make minor tweaks before launch

### DIFF
--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -132,8 +132,8 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
 @tags_option
 @capabilities_option(default=DEFAULT_CAPABILITIES)  # pylint: disable=E1120
 @pass_context
-@track_long_event("SyncUsed", "Start", "SyncUsed", "End")
 @track_command
+@track_long_event("SyncUsed", "Start", "SyncUsed", "End")
 @image_repository_validation
 @track_template_warnings([CodeDeployWarning.__name__, CodeDeployConditionWarning.__name__])
 @check_newer_version

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -164,9 +164,8 @@ class EventTracker:
                         ctx = Context.get_current_context()
                         if ctx:
                             EventTracker._session_id = ctx.session_id
-                            LOG.debug("EventTracker: Obtained session ID '%s'", EventTracker._session_id)
                     except RuntimeError:
-                        pass
+                        LOG.debug("EventTracker: Unable to obtain session ID")
                 if len(EventTracker._events) >= EventTracker.MAX_EVENTS:
                     should_send = True
             if should_send:

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -164,6 +164,7 @@ class EventTracker:
                         ctx = Context.get_current_context()
                         if ctx:
                             EventTracker._session_id = ctx.session_id
+                            LOG.debug("EventTracker: Obtained session ID '%s'", EventTracker._session_id)
                     except RuntimeError:
                         pass
                 if len(EventTracker._events) >= EventTracker.MAX_EVENTS:

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -162,7 +162,7 @@ class TestExperimentalMetric(IntegBase):
             self.assertGreaterEqual(len(all_requests), 1, "Command run metric must be sent")
             request = all_requests[0]
             for req in all_requests:
-                if "commandRun" in req["data"]["metrics"]:
+                if "commandRun" in req["data"]["metrics"][0]:
                     request = req  # We're only testing the commandRun metric
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -159,9 +159,9 @@ class TestExperimentalMetric(IntegBase):
                 optout_envvar_value="1",
             )
             process.communicate()
-            EventTracker.send_events = temp  # Re-enable EventTracker
 
             all_requests = server.get_all_requests()
+            EventTracker.send_events = temp  # Re-enable EventTracker
             self.assertEqual(len(all_requests), 1, "Command run metric must be sent")
             request = all_requests[0]
             self.assertIn("Content-Type", request["headers"])

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -133,7 +133,7 @@ class TestExperimentalMetric(IntegBase):
             self.assertEqual(request["data"], expected_data)
         os.environ["SAM_CLI_BETA_FEATURES"] = "0"
 
-    def test_must_send_cdk_project_type_metrics(self, event_mock):
+    def test_must_send_cdk_project_type_metrics(self):
         """
         Metrics should be sent if "Disabled via config file but Enabled via Envvar"
         """

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -3,7 +3,7 @@ import platform
 import time
 from pathlib import Path
 from unittest import skip
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, Mock, patch
 
 from .integ_base import IntegBase, TelemetryServer
 from samcli import __version__ as SAM_CLI_VERSION
@@ -131,11 +131,13 @@ class TestExperimentalMetric(IntegBase):
             self.assertEqual(request["data"], expected_data)
         os.environ["SAM_CLI_BETA_FEATURES"] = "0"
 
-    @patch("samcli.lib.telemetry.event.EventTracker.send_events", return_value=None)  # Don't send Event metrics
+    @patch("samcli.lib.telemetry.event.EventTracker.send_events")  # Don't send Event metrics
     def test_must_send_cdk_project_type_metrics(self, event_mock):
         """
         Metrics should be sent if "Disabled via config file but Enabled via Envvar"
         """
+        event_mock = Mock()
+        event_mock.return_value = None
         # Disable it via configuration file
         self.unset_config()
         self.set_config(telemetry_enabled=True)

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -136,8 +136,6 @@ class TestExperimentalMetric(IntegBase):
         """
         Metrics should be sent if "Disabled via config file but Enabled via Envvar"
         """
-        event_mock = Mock()
-        event_mock.return_value = None
         # Disable it via configuration file
         self.unset_config()
         self.set_config(telemetry_enabled=True)
@@ -152,6 +150,7 @@ class TestExperimentalMetric(IntegBase):
             .joinpath("cdk_template.yaml")
         )
         with TelemetryServer() as server:
+            event_mock = Mock(return_value=None, side_effect=None)
             # Run without any envvar.Should not publish metrics
             process = self.run_cmd(
                 cmd_list=[self.cmd, "build", "--build-dir", self.config_dir, "--template", str(template_path)],
@@ -160,7 +159,7 @@ class TestExperimentalMetric(IntegBase):
             process.communicate()
 
             all_requests = server.get_all_requests()
-            self.assertGreaterEqual(len(all_requests), 1, "Command run metric must be sent")
+            self.assertEqual(len(all_requests), 1, "Command run metric must be sent")
             request = all_requests[0]
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -3,9 +3,7 @@ import platform
 import time
 from pathlib import Path
 from unittest import skip
-from unittest.mock import ANY, Mock, patch
-
-from samcli.lib.telemetry.event import EventTracker
+from unittest.mock import ANY
 
 from .integ_base import IntegBase, TelemetryServer
 from samcli import __version__ as SAM_CLI_VERSION

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -131,7 +131,7 @@ class TestExperimentalMetric(IntegBase):
             self.assertEqual(request["data"], expected_data)
         os.environ["SAM_CLI_BETA_FEATURES"] = "0"
 
-    @patch("samcli.lib.telemetry.event.EventTracker", return_value=None)  # Don't send Event metrics
+    @patch("samcli.lib.telemetry.event.EventTracker.send_events", return_value=None)  # Don't send Event metrics
     def test_must_send_cdk_project_type_metrics(self, event_mock):
         """
         Metrics should be sent if "Disabled via config file but Enabled via Envvar"

--- a/tests/unit/lib/telemetry/test_event.py
+++ b/tests/unit/lib/telemetry/test_event.py
@@ -109,7 +109,9 @@ class TestEventTracker(TestCase):
         telemetry_mock.return_value = dummy_telemetry
 
         # Verify that no events are sent if tracker is empty
-        EventTracker.send_events()
+        # Note we are using the in-line version of the method, as the regular send_events will
+        # simply call this method in a new thread
+        EventTracker._send_events_in_thread()
 
         self.assertEqual(emitted_events, [])  # No events should have been collected
         dummy_telemetry.emit.assert_not_called()  # Nothing should have been sent (empty list)
@@ -121,7 +123,7 @@ class TestEventTracker(TestCase):
         dummy_event.to_json.return_value = Event.to_json(dummy_event)
         EventTracker._events.append(dummy_event)
 
-        EventTracker.send_events()
+        EventTracker._send_events_in_thread()
 
         dummy_telemetry.emit.assert_called()
         self.assertEqual(len(emitted_events), 1)  # The list of metrics (1) is copied into emitted_events


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
There were a few things I wasn't happy with reflecting on some of my previous code, and they were too small to fit into PRs on their own. Thus, they've been delegated to *this* PR, which has many tiny adjustments and tweaks, outlined below in order of significance.

#### How does it address the issue?
- `EventTracker.send_events` now executes on a thread! Previously, this logic was only implemented when the function was called at capacity. Now, it's the default!
- `EventTracker` now stores `session_id` locally. This fixes a bug I was only recently made aware of, where Events sent in a thread did not contain the session ID, thus preventing us from linking the data. With the new implementation, the session ID is appended to the Metric before it is sent out.
- The decorators on `sam sync` are rearranged (namely, `track_command` and `track_long_event` have swapped places). This will prevent one `send_events` from being called, then the "end event" being added, and then one more `send_events` being called.
  - This reasoning has also been added to the docstring for the `track_long_event` decorator.
- The attribute `EventType._events` has been renamed to `EventType._event_values`. This not only prevents ambiguity, but also prevents confusion with `EventTracker._events`.
- Added a docstring to `EventTracker.get_tracked_events` method.
- Added a comment beside `EventType._event_values` to provide explanation as to what the value represents.
- Added comments in the `track_long_event` decorator to provide clarity on the process of the method.

#### What side effects does this change have?
Aside from some readability improvements within my code, the only notable side effect is the `EventTracker.send_events` executing on a separate thread always.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
