### PR TITLE
fix: Create layer root folder before adding layer readme for ADL

### DIFF
--- a/samcli/lib/bootstrap/nested_stack/nested_stack_manager.py
+++ b/samcli/lib/bootstrap/nested_stack/nested_stack_manager.py
@@ -159,9 +159,9 @@ class NestedStackManager:
         if layer_root_folder.exists():
             shutil.rmtree(layer_root_folder)
         layer_contents_folder = layer_root_folder.joinpath(get_layer_subfolder(function_runtime))
+        layer_root_folder.mkdir(BUILD_DIR_PERMISSIONS, parents=True)
         if os.path.isdir(dependencies_dir):
             if is_experimental_enabled(ExperimentalFlag.BuildPerformance):
-                layer_root_folder.mkdir(BUILD_DIR_PERMISSIONS, parents=True)
                 osutils.create_symlink_or_copy(dependencies_dir, str(layer_contents_folder))
             else:
                 layer_contents_folder.mkdir(BUILD_DIR_PERMISSIONS, parents=True)

--- a/tests/unit/lib/bootstrap/nested_stack/test_nested_stack_manager.py
+++ b/tests/unit/lib/bootstrap/nested_stack/test_nested_stack_manager.py
@@ -185,6 +185,7 @@ class TestNestedStackManager(TestCase):
         )
 
         patched_shutil.rmtree.assert_called_with(layer_root_folder)
+        layer_root_folder.mkdir.assert_called_with(BUILD_DIR_PERMISSIONS, parents=True)
         layer_contents_folder.mkdir.assert_called_with(BUILD_DIR_PERMISSIONS, parents=True)
         patched_osutils.copytree.assert_called_with(dependencies_dir, str(layer_contents_folder))
         patched_add_layer_readme.assert_called_with(str(layer_root_folder), function_logical_id)
@@ -215,7 +216,10 @@ class TestNestedStackManager(TestCase):
         NestedStackManager.update_layer_folder(
             build_dir, dependencies_dir, layer_logical_id, function_logical_id, function_runtime
         )
+        layer_root_folder.mkdir.assert_called_with(BUILD_DIR_PERMISSIONS, parents=True)
+        layer_contents_folder.mkdir.assert_not_called()
         patched_osutils.copytree.assert_not_called()
+        patched_add_layer_readme.assert_called_with(str(layer_root_folder), function_logical_id)
 
     @parameterized.expand([("python3.8", True), ("ruby2.7", False)])
     def test_is_runtime_supported(self, runtime, supported):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N.A.

#### Why is this change necessary?
For ADL skipping copy when function has no dependencies, a layer root folder is needed to add layer readme

#### How does it address the issue?
Calls the mkdir operation even if dependencies_dir is not a valid dir

#### What side effects does this change have?
Not known

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
