### PR TITLE
feat: Move esbuild binary to normal dependency

### DIFF
--- a/tests/integration/testdata/buildcmd/Esbuild/Node/package.json
+++ b/tests/integration/testdata/buildcmd/Esbuild/Node/package.json
@@ -6,9 +6,7 @@
   "author": "",
   "license": "APACHE2.0",
   "dependencies": {
-    "minimal-request-promise": "*"
-  },
-  "devDependencies": {
+    "minimal-request-promise": "*",
     "esbuild": "^0.14.14"
   }
 }

--- a/tests/integration/testdata/buildcmd/Esbuild/TypeScript/package.json
+++ b/tests/integration/testdata/buildcmd/Esbuild/TypeScript/package.json
@@ -7,9 +7,7 @@
   "license": "APACHE2.0",
   "dependencies": {
     "minimal-request-promise": "*",
-    "@types/aws-lambda": "^8.10.92"
-  },
-  "devDependencies": {
+    "@types/aws-lambda": "^8.10.92",
     "esbuild": "^0.14.14"
   }
 }

--- a/tests/integration/testdata/sync/code/before/esbuild_function/app.ts
+++ b/tests/integration/testdata/sync/code/before/esbuild_function/app.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import axios from "axios";
 
 export const lambdaHandler = async (): Promise<object> => {


### PR DESCRIPTION
#### Why is this change necessary?
To ensure integration tests keep working after switching over to using the production flag for esbuild npm install (https://github.com/aws/aws-lambda-builders/pull/379) we need to move the dependency to be a non-dev dependency for the binary to be found.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
