### PR TITLE
FEAT: Test Runner - Allow init --tags option to accept multiple values per key

### DIFF
--- a/samcli/commands/test_runner/init/cli.py
+++ b/samcli/commands/test_runner/init/cli.py
@@ -39,7 +39,7 @@ COLOR = Colored()
 @click.option(
     "--tags",
     cls=OptionNargs,
-    type=CfnTags(),
+    type=CfnTags(multiple_values_per_key=True),
     required=False,
     help="A list of tags used to discover resources. "
     "Discovered resources will have IAM statement templates generated within the Test Runner CloudFormation Template, "
@@ -225,7 +225,7 @@ def query_tagging_api(tags: dict, boto_client_provider: BotoProviderType) -> Uni
     """
     # Convert tag format into one that the API accepts
     # NOTE: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/resourcegroupstaggingapi.html#ResourceGroupsTaggingAPI.Client.get_resources
-    tag_filters = [{"Key": k, "Values": [v]} for k, v in tags.items()]
+    tag_filters = [{"Key": k, "Values": v_list} for k, v_list in tags.items()]
     resource_tag_mapping_list = (
         boto_client_provider("resourcegroupstaggingapi")
         .get_resources(TagFilters=tag_filters)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
The init command makes a [get-resources](https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html) call with a tag filter, to get the ARNs of customer application resources with the specified tag.

It is possible that customers have resources tagged with the same key, but different values and would like to both to be discovered by the Test Runner (for IAM policy & Environment Variable generation).

Related: https://github.com/aws/aws-sam-cli/pull/4103

#### How does it address the issue?
Makes use of the `multiple_values_per_key` option for the `CfnTags` type.


#### What side effects does this change have?

N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
