### PR TITLE
FEAT: Test Runner - Add --allow-iam option to init command

### DIFF
--- a/samcli/commands/test_runner/init/cli.py
+++ b/samcli/commands/test_runner/init/cli.py
@@ -201,7 +201,8 @@ def _create_test_runner_template(
     if allow_iam:
         LOG.info(
             COLOR.red(
-                "! NOTE: You have set the --allow-iam flag. This means that generated IAM statements will contain (enabled, not commented out) basic actions for some of your resources. Make sure you are aware of what permissions you are granting to the Fargate container."
+                "! NOTE: You have set the --allow-iam flag. This means that generated IAM statements will contain enabled (not commented out) basic actions for some of your resources."
+                " Make sure you are aware of what permissions you are granting to the Fargate container.\n"
             )
         )
 

--- a/samcli/commands/test_runner/init/cli.py
+++ b/samcli/commands/test_runner/init/cli.py
@@ -73,7 +73,6 @@ Specify the name of the generated resource-ARN map YAML file. This file can be p
     "--allow-iam",
     required=False,
     is_flag=True,
-
     # TODO: Link to a table or something showing WHICH resources get which actions generated.
     help=f"""
 IAM statements with basic actions will be written for each of your resources associated with the supplied tag.

--- a/samcli/lib/test_runner/test_runner_template_generator.py
+++ b/samcli/lib/test_runner/test_runner_template_generator.py
@@ -196,6 +196,10 @@ Resources:
         resource_arn : str
             The arn of the resource for which the IAM statement is generated.
 
+        allow_iam : bool
+            If False, IAM actions are generated "commented out", with a '#' in front of the action.
+            Else, IAM actions will NOT be commented out when generated.
+
         Returns
         -------
         str:
@@ -250,7 +254,9 @@ Resources:
             The URI of the Image to be used by the Test Runner Fargate task definition.
 
         allow_iam : bool
-            If True, actions within generated IAM statements will NOT be commented out.
+            If False, IAM actions are generated "commented out", with a '#' in front of the action.
+            Else, IAM actions will NOT be commented out when generated.
+
 
         Returns
         -------

--- a/samcli/lib/test_runner/test_runner_template_generator.py
+++ b/samcli/lib/test_runner/test_runner_template_generator.py
@@ -181,7 +181,7 @@ Resources:
             if re.search(arn_regex, resource_arn) is not None:
                 return resource_type
 
-    def _create_iam_statement_string(self, resource_arn: str) -> Union[str, None]:
+    def _create_iam_statement_string(self, resource_arn: str, allow_iam: bool) -> Union[str, None]:
         """
         Returns an IAM Statement in the form of a YAML string corresponding to the supplied resource ARN.
 
@@ -218,7 +218,11 @@ Resources:
 
         new_statement = self._indent_string("  - Effect: Allow\n", 6) + self._indent_string("Action:\n", 7)
         for action in action_list:
-            new_statement += self._indent_string(f"   # - {action}\n", 7)
+            new_statement += (
+                self._indent_string(f"   - {action}\n", 7)
+                if allow_iam
+                else self._indent_string(f"   # - {action}\n", 7)
+            )
 
         # APIGW API IAM Statements:
         # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
@@ -235,7 +239,7 @@ Resources:
         """
         return "test-runner-bucket-" + str(uuid.uuid4())
 
-    def generate_test_runner_template_string(self, image_uri: str) -> Union[dict, None]:
+    def generate_test_runner_template_string(self, image_uri: str, allow_iam: bool = False) -> Union[dict, None]:
         """
         Creates a CloudFormation (YAML) Template string to create the Test Runner Stack.
 
@@ -244,6 +248,9 @@ Resources:
 
         image_uri : str
             The URI of the Image to be used by the Test Runner Fargate task definition.
+
+        allow_iam : bool
+            If True, actions within generated IAM statements will NOT be commented out.
 
         Returns
         -------
@@ -256,7 +263,7 @@ Resources:
         if self.resource_arn_list:
             statements_list = []
             for arn in self.resource_arn_list:
-                statement = self._create_iam_statement_string(arn)
+                statement = self._create_iam_statement_string(arn, allow_iam)
                 if statement:
                     statements_list.append(statement)
             # Compile all the statements into a single string

--- a/tests/unit/commands/test_runner/test_init_command.py
+++ b/tests/unit/commands/test_runner/test_init_command.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -40,6 +41,7 @@ class TestCli(TestCase):
                 template_name=self.TEST_TEMPLATE_NAME,
                 env_file=self.TEST_ENV_FILE_NAME,
                 image_uri="test_image_uri",
+                allow_iam=False,
                 runtime="python3.8",
             )
             self.assertTrue(os.path.exists(self.TEST_TEMPLATE_NAME))
@@ -56,6 +58,7 @@ class TestCli(TestCase):
                 template_name=self.TEST_TEMPLATE_NAME,
                 env_file=self.TEST_ENV_FILE_NAME,
                 image_uri="test_image_uri",
+                allow_iam=False,
                 runtime="python3.8",
             )
         self.assertFalse(os.path.exists(self.TEST_TEMPLATE_NAME))
@@ -76,6 +79,7 @@ class TestCli(TestCase):
                 template_name=self.TEST_TEMPLATE_NAME,
                 env_file=self.TEST_ENV_FILE_NAME,
                 image_uri="test_image_uri",
+                allow_iam=False,
                 runtime="python3.8",
             )
 
@@ -102,6 +106,7 @@ class TestCli(TestCase):
                 template_name=self.TEST_TEMPLATE_NAME,
                 env_file=self.TEST_ENV_FILE_NAME,
                 image_uri="test_image_uri",
+                allow_iam=False,
                 runtime="python3.8",
             )
 
@@ -123,10 +128,38 @@ class TestCli(TestCase):
                 template_name=self.TEST_TEMPLATE_NAME,
                 env_file=self.TEST_ENV_FILE_NAME,
                 image_uri="test_image_uri",
+                allow_iam=False,
                 runtime="python3.8",
             )
             self.assertTrue(os.path.exists(self.TEST_TEMPLATE_NAME))
             self.assertTrue(os.path.exists(self.TEST_ENV_FILE_NAME))
+        finally:
+            os.remove(self.TEST_TEMPLATE_NAME)
+            os.remove(self.TEST_ENV_FILE_NAME)
+
+    @patch("samcli.commands.test_runner.init.cli.query_tagging_api")
+    @patch("samcli.lib.utils.boto_utils.get_boto_client_provider_with_config")
+    def test_valid_tagging_api_response_with_allow_iam(self, boto_client_provider_patch, query_tagging_api_patch):
+        mock_ctx = Mock()
+        mock_ctx.region = "test-region"
+        mock_ctx.profile = "test-profile"
+        boto_client_provider_patch.return_value = None
+        query_tagging_api_patch.return_value = ["arn:aws:lambda:us-east-1:123456789123:function:valid-lambda-arn"]
+
+        try:
+            do_cli(
+                ctx=mock_ctx,
+                tags={"Key": "Value"},
+                template_name=self.TEST_TEMPLATE_NAME,
+                env_file=self.TEST_ENV_FILE_NAME,
+                image_uri="test_image_uri",
+                allow_iam=True,
+                runtime="python3.8",
+            )
+            self.assertTrue(os.path.exists(self.TEST_TEMPLATE_NAME))
+            self.assertTrue(os.path.exists(self.TEST_ENV_FILE_NAME))
+
+            self.assertFalse("#" in Path.read_text(Path(self.TEST_TEMPLATE_NAME)))
         finally:
             os.remove(self.TEST_TEMPLATE_NAME)
             os.remove(self.TEST_ENV_FILE_NAME)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
This option improves UX by providing a shortcut to customers who are confident in the generated IAM permissions, and do not want to go through and "enable" them manually by un-commenting them.

A TODO: Having readily available public documentation describing which resources will have which IAM actions generated for them. This is vital knowledge for the customer to be aware of which actions they are granting by enabling `--allow-iam`.

#### How does it address the issue?
Includes code to generate IAM actions that are not commented out in the Test Runner CloudFormation Template if the `--allow-iam` flag is present for the `init` command.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
