### PR TITLE
feat: Allow mix of global and function specific env vars for sam local

### DIFF
--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -238,14 +238,15 @@ class LocalLambdaRunner:
         """
 
         function_id = function.function_id
-        name = function.name
+        logical_id = function.name
+        function_name = function.functionname
         full_path = function.full_path
 
         variables = None
         if isinstance(function.environment, dict) and "Variables" in function.environment:
             variables = function.environment["Variables"]
         else:
-            LOG.debug("No environment variables found for function '%s'", name)
+            LOG.debug("No environment variables found for function '%s'", logical_id)
 
         # This could either be in standard format, or a CloudFormation parameter file format, or mix of both.
         #
@@ -268,10 +269,11 @@ class LocalLambdaRunner:
             parameter_result = self.env_vars_values.get("Parameters", {})
             overrides.update(parameter_result)
 
-        # Precedence: logical_id -> function_id -> full_path, customer can use any of them
+        # Precedence: logical_id -> function_id -> function name -> full_path, customer can use any of them
         fn_file_env_vars = (
-            self.env_vars_values.get(name, None)
+            self.env_vars_values.get(logical_id, None)
             or self.env_vars_values.get(function_id, None)
+            or self.env_vars_values.get(function_name, None)
             or self.env_vars_values.get(full_path, None)
         )
         if fn_file_env_vars:

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -251,6 +251,7 @@ class LocalLambdaRunner:
         #
         # Standard format is {FunctionName: {key:value}, FunctionName: {key:value}}
         # CloudFormation parameter file is {"Parameters": {key:value}}
+        # Mixed format is {FunctionName: {key:value}, "Parameters": {key:value}}
 
         for env_var_value in self.env_vars_values.values():
             if not isinstance(env_var_value, dict):

--- a/tests/integration/local/invoke/test_integration_cli_images.py
+++ b/tests/integration/local/invoke/test_integration_cli_images.py
@@ -188,6 +188,22 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
         process_stdout = stdout.strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"MyVar"')
 
+    @parameterized.expand([("EchoGlobalCustomEnvVarFunction")])
+    @pytest.mark.flaky(reruns=3)
+    def test_invoke_with_global_env_vars_function(self, function_name):
+        command_list = self.get_command_list(
+            function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path
+        )
+
+        process = Popen(command_list, stdout=PIPE)
+        try:
+            stdout, _ = process.communicate(timeout=TIMEOUT)
+        except TimeoutExpired:
+            process.kill()
+            raise
+        process_stdout = stdout.strip()
+        self.assertEqual(process_stdout.decode("utf-8"), '"GlobalVar"')
+
     @pytest.mark.flaky(reruns=3)
     def test_invoke_when_function_writes_stdout(self):
         command_list = self.get_command_list(

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -201,6 +201,22 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = stdout.strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"MyVar"')
 
+    @parameterized.expand([("EchoGlobalCustomEnvVarFunction")])
+    @pytest.mark.flaky(reruns=3)
+    def test_invoke_with_global_env_vars_function(self, function_name):
+        command_list = self.get_command_list(
+            function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path
+        )
+
+        process = Popen(command_list, stdout=PIPE)
+        try:
+            stdout, _ = process.communicate(timeout=TIMEOUT)
+        except TimeoutExpired:
+            process.kill()
+            raise
+        process_stdout = stdout.strip()
+        self.assertEqual(process_stdout.decode("utf-8"), '"GlobalVar"')
+
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_invoke_image_provided(self):
         command_list = self.get_command_list(

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -77,6 +77,17 @@ Resources:
         Variables:
           CustomEnvVar: "MyOtherVar"
       Timeout: 600
+  
+  EchoGlobalCustomEnvVarFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.custom_env_var_echo_hanler
+      Runtime: python3.6
+      CodeUri: .
+      Environment:
+        Variables:
+          CustomEnvVar: "MyOtherVar"
+      Timeout: 600
 
   EchoCustomEnvVarWithFunctionNameDefinedFunction:
     Type: AWS::Serverless::Function

--- a/tests/integration/testdata/invoke/template_image.yaml
+++ b/tests/integration/testdata/invoke/template_image.yaml
@@ -86,6 +86,17 @@ Resources:
         Variables:
           CustomEnvVar: "MyOtherVar"
       Timeout: 600
+  
+  EchoGlobalCustomEnvVarFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.custom_env_var_echo_hanler
+      Runtime: python3.6
+      CodeUri: .
+      Environment:
+        Variables:
+          CustomEnvVar: "MyOtherVar"
+      Timeout: 600
 
   EchoCustomEnvVarWithFunctionNameDefinedFunction:
     Type: AWS::Serverless::Function

--- a/tests/integration/testdata/invoke/vars.json
+++ b/tests/integration/testdata/invoke/vars.json
@@ -2,6 +2,9 @@
   "EchoCustomEnvVarFunction": {
     "CustomEnvVar": "MyVar"
   },
+  "Parameters": {
+    "CustomEnvVar": "GlobalVar"
+  },
   "EchoCustomEnvVarWithFunctionNameDefinedFunction": {
     "CustomEnvVar": "MyVar"
   }

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -211,9 +211,12 @@ class TestLocalLambda_make_env_vars(TestCase):
             # Override for the full_path exists
             ({posixpath.join("somepath", "function_id"): {"a": "d"}}, {"a": "d"}),
             # Override for the function does *not* exist
-            ({"otherfunction": {"c": "d"}}, None),
+            ({"otherfunction": {"c": "d"}}, {}),
             # Using a CloudFormation parameter file format
             ({"Parameters": {"p1": "v1"}}, {"p1": "v1"}),
+            # Mix of Cloudformation and standard parameter format
+            ({"Parameters": {"p1": "v1"}, "logical_id": {"a": "b"}}, {"p1": "v1", "a": "b"}),
+            ({"Parameters": {"p1": "v1"}, "logical_id": {"p1": "v2"}}, {"p1": "v2"}),
         ]
     )
     @patch("samcli.commands.local.lib.local_lambda.EnvironmentVariables")
@@ -353,7 +356,7 @@ class TestLocalLambda_make_env_vars(TestCase):
             function.handler,
             variables=None,
             shell_env_values=os_environ,
-            override_values=None,
+            override_values={},
             aws_creds=self.aws_creds,
         )
 

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -208,6 +208,8 @@ class TestLocalLambda_make_env_vars(TestCase):
             ({"function_id": {"a": "b"}}, {"a": "b"}),
             # Override for the logical_id exists
             ({"logical_id": {"a": "c"}}, {"a": "c"}),
+            # Override for the functionname exists
+            ({"function_name": {"a": "d"}}, {"a": "d"}),
             # Override for the full_path exists
             ({posixpath.join("somepath", "function_id"): {"a": "d"}}, {"a": "d"}),
             # Override for the function does *not* exist


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#1045 

#### Why is this change necessary?
Users cannot provide both global and function specific environment variables
in the env-vars json file for sam local.

#### How does it address the issue?
This change allows users to use a mix of cloudformation and standard format for
environment variables

#### What side effects does this change have?
None found

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
