### PR TITLE
Add mode option to create_tarball, in order to support compression

### DIFF
--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 
 
 @contextmanager
-def create_tarball(tar_paths, tar_filter=None):
+def create_tarball(tar_paths, tar_filter=None, mode="w"):
     """
     Context Manger that creates the tarball of the Docker Context to use for building the image
 
@@ -17,6 +17,9 @@ def create_tarball(tar_paths, tar_filter=None):
     tar_paths dict(str, str)
         Key representing a full path to the file or directory and the Value representing the path within the tarball
 
+    mode str
+        The mode in which the tarfile is opened. Defaults to "w".
+
     Yields
     ------
     IO
@@ -24,7 +27,7 @@ def create_tarball(tar_paths, tar_filter=None):
     """
     tarballfile = TemporaryFile()
 
-    with tarfile.open(fileobj=tarballfile, mode="w") as archive:
+    with tarfile.open(fileobj=tarballfile, mode=mode) as archive:
         for path_on_system, path_in_tarball in tar_paths.items():
             archive.add(path_on_system, arcname=path_in_tarball, filter=tar_filter)
 

--- a/tests/unit/lib/utils/test_tar.py
+++ b/tests/unit/lib/utils/test_tar.py
@@ -33,6 +33,32 @@ class TestTar(TestCase):
 
     @patch("samcli.lib.utils.tar.tarfile.open")
     @patch("samcli.lib.utils.tar.TemporaryFile")
+    def test_generating_tarball_with_gzip(self, temporary_file_patch, tarfile_open_patch):
+        temp_file_mock = Mock()
+        temporary_file_patch.return_value = temp_file_mock
+
+        tarfile_file_mock = Mock()
+        tarfile_open_patch.return_value.__enter__.return_value = tarfile_file_mock
+
+        with create_tarball({"/some/path": "/layer1", "/some/dockerfile/path": "/Dockerfile"}, mode="w:gz") as acutal:
+            self.assertEqual(acutal, temp_file_mock)
+
+        tarfile_file_mock.add.assert_called()
+        tarfile_file_mock.add.assert_has_calls(
+            [
+                call("/some/path", arcname="/layer1", filter=None),
+                call("/some/dockerfile/path", arcname="/Dockerfile", filter=None),
+            ],
+            any_order=True,
+        )
+
+        temp_file_mock.flush.assert_called_once()
+        temp_file_mock.seek.assert_called_once_with(0)
+        temp_file_mock.close.assert_called_once()
+        tarfile_open_patch.assert_called_once_with(fileobj=temp_file_mock, mode="w:gz")
+
+    @patch("samcli.lib.utils.tar.tarfile.open")
+    @patch("samcli.lib.utils.tar.TemporaryFile")
     def test_generating_tarball_with_filter(self, temporary_file_patch, tarfile_open_patch):
         temp_file_mock = Mock()
         temporary_file_patch.return_value = temp_file_mock


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
In order to keep the code for generating tarballs in one place, we should support different creation modes, such as gzip compression.

#### How does it address the issue?
Adds a `mode` option to the `create_tarball` function, with a default of `mode="w"`. This ensures any previous calls will function the same as before, but mode can be specified for alternative tarball creations.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
