### PR TITLE
feat: get the cfn resource that match the sam metadata resource name property

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -7,7 +7,7 @@ import json
 import os
 from pathlib import Path
 from subprocess import run, CalledProcessError
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 import hashlib
 import logging
 
@@ -343,6 +343,68 @@ def _enrich_mapped_resources(
                 f"is not a correct resource type. The resource type should be one of these values "
                 f"{resources_types_enrichment_functions.keys()}"
             )
+
+
+def _get_relevant_cfn_resource(
+    sam_metadata_resource: SamMetadataResource, cfn_resources: Dict[str, Dict]
+) -> Tuple[Dict, str]:
+    """
+    use the sam metadata resource name property to determine the resource address, and transform the address to logical
+    id to use it to get the cfn_resource.
+
+    Parameters
+    ----------
+    sam_metadata_resource: SamMetadataResource
+        sam metadata resource that contain extra information about some resource.
+    cfn_resources: Dict
+        CloudFormation resources
+
+    Returns
+    -------
+    tuple(Dict, str)
+        The cfn resource that mentioned in the sam metadata resource, and the resource logical id
+    """
+    sam_metadata_resource_address = sam_metadata_resource.resource.get("address")
+    resource_name = sam_metadata_resource.resource.get("values", {}).get("triggers", {}).get("resource_name")
+    if not resource_name:
+        raise InvalidSamMetadataPropertiesException(
+            f"sam cli expects the sam metadata resource {sam_metadata_resource_address} to contain a resource name "
+            f"that will be enriched using this metadata resource"
+        )
+
+    # the provided resource name can be the name without the module address, or can be a complete resource address name
+    # check first if the provided name is without the module address
+    LOG.info(
+        "Check if the input source name %s is a postfix to the current module address %s",
+        resource_name,
+        sam_metadata_resource.current_module_address,
+    )
+    full_resource_address = (
+        f"{sam_metadata_resource.current_module_address}.{resource_name}"
+        if sam_metadata_resource.current_module_address
+        else resource_name
+    )
+    LOG.debug("check if the resource address %s has a relevant cfn resource or not", full_resource_address)
+    logical_id = _build_cfn_logical_id(full_resource_address)
+    cfn_resource = cfn_resources.get(logical_id)
+    if cfn_resource:
+        LOG.info("The CFN resource that match the input resource name %s is %s", resource_name, logical_id)
+        return cfn_resource, logical_id
+
+    LOG.info("Check if the input source name %s is a complete address", resource_name)
+    # check if the provided name is a complete resource address
+    if sam_metadata_resource.current_module_address:
+        full_resource_address = resource_name
+        LOG.debug("check if the resource address %s has a relevant cfn resource or not", full_resource_address)
+        logical_id = _build_cfn_logical_id(full_resource_address)
+        cfn_resource = cfn_resources.get(logical_id)
+        if cfn_resource:
+            LOG.info("The CFN resource that match the input resource name %s is %s", resource_name, logical_id)
+            return cfn_resource, logical_id
+
+    raise InvalidSamMetadataPropertiesException(
+        f"There is no resource found that match the provided resource name " f"{resource_name}"
+    )
 
 
 def _translate_properties(tf_properties: dict, property_builder_mapping: PropertyBuilderMapping) -> dict:

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -372,8 +372,8 @@ def _get_relevant_cfn_resource(
             f"that will be enriched using this metadata resource"
         )
 
-    # the provided resource name can be the name without the module address, or can be a complete resource address name
-    # check first if the provided name is without the module address
+    # the provided resource name will be always a postfix to the module address. The customer could not set a full
+    # address within a module.
     LOG.info(
         "Check if the input resource name %s is a postfix to the current module address %s",
         resource_name,
@@ -390,17 +390,6 @@ def _get_relevant_cfn_resource(
     if cfn_resource:
         LOG.info("The CFN resource that match the input resource name %s is %s", resource_name, logical_id)
         return cfn_resource, logical_id
-
-    LOG.info("Check if the input resource name %s is a complete address", resource_name)
-    # check if the provided name is a complete resource address
-    if sam_metadata_resource.current_module_address:
-        full_resource_address = resource_name
-        LOG.debug("check if the resource address %s has a relevant cfn resource or not", full_resource_address)
-        logical_id = _build_cfn_logical_id(full_resource_address)
-        cfn_resource = cfn_resources.get(logical_id)
-        if cfn_resource:
-            LOG.info("The CFN resource that match the input resource name %s is %s", resource_name, logical_id)
-            return cfn_resource, logical_id
 
     raise InvalidSamMetadataPropertiesException(
         f"There is no resource found that match the provided resource name " f"{resource_name}"

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -375,7 +375,7 @@ def _get_relevant_cfn_resource(
     # the provided resource name can be the name without the module address, or can be a complete resource address name
     # check first if the provided name is without the module address
     LOG.info(
-        "Check if the input source name %s is a postfix to the current module address %s",
+        "Check if the input resource name %s is a postfix to the current module address %s",
         resource_name,
         sam_metadata_resource.current_module_address,
     )
@@ -391,7 +391,7 @@ def _get_relevant_cfn_resource(
         LOG.info("The CFN resource that match the input resource name %s is %s", resource_name, logical_id)
         return cfn_resource, logical_id
 
-    LOG.info("Check if the input source name %s is a complete address", resource_name)
+    LOG.info("Check if the input resource name %s is a complete address", resource_name)
     # check if the provided name is a complete resource address
     if sam_metadata_resource.current_module_address:
         full_resource_address = resource_name


### PR DESCRIPTION
Use the sam metadata resource_name property to retrieve the CFN resource to be enriched. We first try to use this value as the resource only postfix address, so we should concatenate it to the module address to get the full address. If we could not find a resource that match the previous address, so may be the resource name value is a full address, so we will try to use it without any concatenation. Finally if we did not find any resources, we will raise an error.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
