### PR TITLE
FEAT: Test Runner - Command Exit Code Based On Test Results

### DIFF
--- a/samcli/commands/test_runner/run/cli.py
+++ b/samcli/commands/test_runner/run/cli.py
@@ -2,18 +2,17 @@
 CLI command for the "test_runner run" command
 """
 import logging
-from datetime import datetime
-from typing import Optional, List
+import sys
 from collections import OrderedDict
+from datetime import datetime
+from typing import List, Optional
 
 import click
 
 from samcli.cli.main import pass_context
 from samcli.commands._utils.custom_options.option_nargs import OptionNargs
-from ...exceptions import InvalidEnvironmentVariableException
 
-import sys
-
+from samcli.commands.exceptions import InvalidEnvironmentVariableException
 
 LOG = logging.getLogger(__name__)
 
@@ -21,6 +20,7 @@ SHORT_HELP = "Run your testsuite on Fargate! Test results will automatically be 
 HELP_TEXT = """
 This command takes a Test Runner CloudFormation template, deploys it (updates if it already exists), and executes your testsuite on Fargate"
 """
+
 
 def _get_unique_bucket_directory_name() -> str:
     """
@@ -37,6 +37,7 @@ def _get_unique_bucket_directory_name() -> str:
     current_date = current_date.replace("-", "_").replace(":", "_")
 
     return f"test_run_{current_date}"
+
 
 @click.command("run", help=HELP_TEXT, short_help=SHORT_HELP)
 @click.option(
@@ -217,8 +218,7 @@ def do_cli(
 
 
 def _validate_other_env_vars(other_env_vars: dict, reserved_var_names: List[str]) -> None:
-    from samcli.commands.exceptions import InvalidEnvironmentVariableException
-    from samcli.commands.exceptions import ReservedEnvironmentVariableException
+    from samcli.commands.exceptions import InvalidEnvironmentVariableException, ReservedEnvironmentVariableException
 
     reserved_vars = []
     for key in other_env_vars.keys():

--- a/samcli/lib/test_runner/fargate_testsuite_runner.py
+++ b/samcli/lib/test_runner/fargate_testsuite_runner.py
@@ -9,12 +9,10 @@ from pathlib import Path
 from typing import List, Optional
 
 from samcli.commands.deploy.exceptions import DeployFailedError
-from samcli.commands.exceptions import MissingTestRunnerTemplateException, InvalidTestRunnerTemplateException
+from samcli.commands.exceptions import InvalidTestRunnerTemplateException, MissingTestRunnerTemplateException
 from samcli.lib.deploy.deployer import Deployer
 from samcli.lib.utils.boto_utils import BotoProviderType
 from samcli.lib.utils.colors import Colored
-from samcli.lib.utils.tar import create_tarball
-
 from samcli.lib.utils.tar import create_tarball
 
 LOG = logging.getLogger(__name__)
@@ -284,7 +282,7 @@ class FargateTestsuiteRunner:
         # Compress tests into a temporary tarfile to send to S3 bucket
         # We set arcname to the stem of the tests_path to avoid including all the parent directories in the tarfile
         # E.g. If the customer specifies tests_path as a/b/c/tests, we want the tar to expand as tests, not a
-        with create_tarball({self.tests_path: self.tests_path.stem}, mode='w:gz') as tests_tar:
+        with create_tarball({self.tests_path: self.tests_path.stem}, mode="w:gz") as tests_tar:
             self.boto_s3_client.put_object(
                 Body=tests_tar,
                 Bucket=bucket,

--- a/samcli/lib/test_runner/fargate_testsuite_runner.py
+++ b/samcli/lib/test_runner/fargate_testsuite_runner.py
@@ -13,6 +13,7 @@ from samcli.commands.exceptions import MissingTestRunnerTemplateException, Inval
 from samcli.lib.deploy.deployer import Deployer
 from samcli.lib.utils.boto_utils import BotoProviderType
 from samcli.lib.utils.colors import Colored
+from samcli.lib.utils.tar import create_tarball
 
 LOG = logging.getLogger(__name__)
 
@@ -259,7 +260,7 @@ class FargateTestsuiteRunner:
         subnets = self.boto_ec2_client.describe_subnets().get("Subnets")
         return [subnet["SubnetId"] for subnet in subnets]
 
-    def _upload_tests_and_reqs(self, bucket: str, temp_tarfile_name: str = str(uuid.uuid4())) -> None:
+    def _upload_tests_and_reqs(self, bucket: str) -> None:
         """
         Compress and upload tests and requirements to an S3 Bucket for the Fargate container to pick up.
 
@@ -271,11 +272,6 @@ class FargateTestsuiteRunner:
             This is passed in because it is not known at the time of FargateTestsuiteRunner creation where the bucket name will come from.
             If a bucket override is not provided, the bucket contained in the Test Runner Stack must be used. The stack must be created/updated before this
             bucket can be fetched.
-
-        temp_tarfile_name : str
-            The name of the temporary tarball that the tests are compressed into. Once uploaded to the bucket, the tarball is removed.
-
-            Exists as a parameter for testing.
         """
         LOG.info(
             self.color.yellow(
@@ -286,21 +282,12 @@ class FargateTestsuiteRunner:
         # Compress tests into a temporary tarfile to send to S3 bucket
         # We set arcname to the stem of the tests_path to avoid including all the parent directories in the tarfile
         # E.g. If the customer specifies tests_path as a/b/c/tests, we want the tar to expand as tests, not a
-        with tarfile.open(temp_tarfile_name, "w:gz") as tar:
-            tar.add(self.tests_path, arcname=self.tests_path.stem)
-
-        # Upload compressed file to S3 bucket
-        try:
-            with open(temp_tarfile_name, "rb") as tests_tar:
-                self.boto_s3_client.put_object(
-                    Body=tests_tar,
-                    Bucket=bucket,
-                    Key=self.path_in_bucket.joinpath(Path(self.COMPRESSED_TESTS_FILE_NAME)).as_posix(),
-                )
-        finally:
-            # Remove the tarfile after the upload is complete
-            os.remove(temp_tarfile_name)
-
+        with create_tarball({self.tests_path: self.tests_path.stem}) as tests_tar:
+            self.boto_s3_client.put_object(
+                Body=tests_tar,
+                Bucket=bucket,
+                Key=self.path_in_bucket.joinpath(Path(self.COMPRESSED_TESTS_FILE_NAME)).as_posix(),
+            )
         LOG.info(
             self.color.yellow(
                 f"=> Uploading {self.requirements_file_path} to {Path(bucket).joinpath(self.path_in_bucket).as_posix()}\n"

--- a/samcli/lib/test_runner/fargate_testsuite_runner.py
+++ b/samcli/lib/test_runner/fargate_testsuite_runner.py
@@ -284,7 +284,7 @@ class FargateTestsuiteRunner:
         # Compress tests into a temporary tarfile to send to S3 bucket
         # We set arcname to the stem of the tests_path to avoid including all the parent directories in the tarfile
         # E.g. If the customer specifies tests_path as a/b/c/tests, we want the tar to expand as tests, not a
-        with create_tarball({self.tests_path: self.tests_path.stem}) as tests_tar:
+        with create_tarball({self.tests_path: self.tests_path.stem}, mode='w:gz') as tests_tar:
             self.boto_s3_client.put_object(
                 Body=tests_tar,
                 Bucket=bucket,
@@ -393,6 +393,11 @@ class FargateTestsuiteRunner:
 
         task_definition_arn : str
             The ARN of the task definition to run.
+
+        Returns
+        -------
+        taskArn : str
+            The ARN of the task created
 
         Raises
         ------

--- a/tests/unit/commands/test_runner/test_run_command.py
+++ b/tests/unit/commands/test_runner/test_run_command.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -100,9 +101,13 @@ class TestCli(TestCase):
             get_boto_client_provider_patch.return_value = boto_client_provider_mock
             runnerMock = Mock()
             runnerMock.do_testsuite = Mock()
+            # Exit code
+            runnerMock.do_testsuite.return_value = 0
             FargateTestsuiteRunnerPatch.return_value = runnerMock
 
-            do_cli(**self.do_cli_params)
+            with pytest.raises(SystemExit) as pytest_wrapped_exit:
+                do_cli(**self.do_cli_params)
+                self.assertEqual(pytest_wrapped_exit.value.code,0)
 
             get_boto_client_provider_patch.assert_called_with(region="test-region", profile="test-profile")
             FargateTestsuiteRunnerPatch.assert_called_with(

--- a/tests/unit/commands/test_runner/test_run_command.py
+++ b/tests/unit/commands/test_runner/test_run_command.py
@@ -1,12 +1,12 @@
 import os
-import pytest
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
+import pytest
 from parameterized import parameterized
 
 from samcli.commands.exceptions import InvalidEnvironmentVariableException, ReservedEnvironmentVariableException
-from samcli.commands.test_runner.run.cli import _validate_other_env_vars, do_cli, _get_unique_bucket_directory_name
+from samcli.commands.test_runner.run.cli import _get_unique_bucket_directory_name, _validate_other_env_vars, do_cli
 from samcli.lib.test_runner.fargate_testsuite_runner import FargateTestsuiteRunner
 
 
@@ -107,7 +107,7 @@ class TestCli(TestCase):
 
             with pytest.raises(SystemExit) as pytest_wrapped_exit:
                 do_cli(**self.do_cli_params)
-                self.assertEqual(pytest_wrapped_exit.value.code,0)
+                self.assertEqual(pytest_wrapped_exit.value.code, 0)
 
             get_boto_client_provider_patch.assert_called_with(region="test-region", profile="test-profile")
             FargateTestsuiteRunnerPatch.assert_called_with(

--- a/tests/unit/lib/test_runner/test_fargate_testsuite_runner.py
+++ b/tests/unit/lib/test_runner/test_fargate_testsuite_runner.py
@@ -245,7 +245,7 @@ class Test_InvokeTestsuite(TestCase):
         self.runner.RESULTS_STDOUT_FILE_NAME = fake_test_stdout_file_name
 
         try:
-            self.runner._download_results("test-bucket",failed=False)
+            self.runner._download_results("test-bucket", failed=False)
 
             boto_s3_client_mock.download_file.assert_called_once()
             self.assertTrue(os.path.exists(fake_results_stdout_file_path))
@@ -265,17 +265,7 @@ class Test_InvokeTestsuite(TestCase):
     def test_no_other_vars(self):
         boto_ecs_client_mock = Mock()
         boto_ecs_client_mock.run_task = Mock()
-        boto_ecs_client_mock.run_task.return_value = {
-            'tasks' : [
-                {
-                    'containers' : [
-                        {
-                            'taskArn' : 'example-task-arn'
-                        }
-                    ]
-                }
-            ]
-        }
+        boto_ecs_client_mock.run_task.return_value = {"tasks": [{"containers": [{"taskArn": "example-task-arn"}]}]}
 
         boto_s3_client_mock = Mock()
         boto_s3_waiter_mock = Mock()
@@ -313,22 +303,12 @@ class Test_InvokeTestsuite(TestCase):
             taskDefinition="test-task-def-arn",
         )
         boto_s3_waiter_mock.wait.assert_called_once()
-        self.assertEqual(task_arn,'example-task-arn')
+        self.assertEqual(task_arn, "example-task-arn")
 
     def test_good_invoke(self):
         boto_ecs_client_mock = Mock()
         boto_ecs_client_mock.run_task = Mock()
-        boto_ecs_client_mock.run_task.return_value = {
-            'tasks' : [
-                {
-                    'containers' : [
-                        {
-                            'taskArn' : 'example-task-arn'
-                        }
-                    ]
-                }
-            ]
-        }
+        boto_ecs_client_mock.run_task.return_value = {"tasks": [{"containers": [{"taskArn": "example-task-arn"}]}]}
 
         boto_s3_client_mock = Mock()
         boto_s3_waiter_mock = Mock()
@@ -367,7 +347,7 @@ class Test_InvokeTestsuite(TestCase):
             taskDefinition="test-task-def-arn",
         )
         boto_s3_waiter_mock.wait.assert_called_once()
-        self.assertEqual(task_arn,'example-task-arn')
+        self.assertEqual(task_arn, "example-task-arn")
 
     def test_stack_not_exists_and_no_template(self):
         self.runner.deployer = MockDeployer(has_stack_return_value=False)
@@ -426,9 +406,9 @@ class Test_InvokeTestsuite(TestCase):
         self.runner.boto_ecs_client.get_waiter.return_value = Mock()
         self.runner.boto_ecs_client.describe_tasks.return_value = {"tasks": [{"containers": [{"exitCode": 47}]}]}
 
-        exit_code = self.runner._get_task_exit_code('test-task-arn','test-ecs-cluster')
+        exit_code = self.runner._get_task_exit_code("test-task-arn", "test-ecs-cluster")
 
-        self.assertEqual(exit_code,47)
+        self.assertEqual(exit_code, 47)
 
     def test_do_testsuite(self):
 
@@ -441,7 +421,7 @@ class Test_InvokeTestsuite(TestCase):
         self.runner._get_container_name = Mock()
         self.runner._upload_tests_and_reqs = Mock()
         self.runner._invoke_testsuite = Mock()
-        self.runner._invoke_testsuite.return_value = 'sample-task-arn'
+        self.runner._invoke_testsuite.return_value = "sample-task-arn"
         self.runner._get_task_exit_code = Mock()
         self.runner._get_task_exit_code.return_value = 1
         self.runner._download_results = Mock()
@@ -472,5 +452,5 @@ class Test_InvokeTestsuite(TestCase):
             container_name="test-container",
             task_definition_arn="test-task-definition-arn",
         )
-        self.runner._get_task_exit_code.assert_called_once_with('sample-task-arn','test-cluster')
-        self.runner._download_results.assert_called_once_with('test-bucket',failed=True)
+        self.runner._get_task_exit_code.assert_called_once_with("sample-task-arn", "test-cluster")
+        self.runner._download_results.assert_called_once_with("test-bucket", failed=True)

--- a/tests/unit/lib/test_runner/test_fargate_testsuite_runner.py
+++ b/tests/unit/lib/test_runner/test_fargate_testsuite_runner.py
@@ -193,8 +193,6 @@ class Test_InvokeTestsuite(TestCase):
         with open(fake_reqs_path, "w") as fake_reqs_file:
             fake_reqs_file.write("Some fake requirements")
 
-        temp_tarfile_name = str(uuid.uuid4())
-
         boto_s3_client_mock = Mock()
         boto_s3_client_mock.put_object = Mock()
 
@@ -209,9 +207,7 @@ class Test_InvokeTestsuite(TestCase):
         self.runner.requirements_file_path = fake_reqs_path
 
         try:
-            self.runner._upload_tests_and_reqs("test-bucket", temp_tarfile_name)
-            # Ensure tarfile gets cleaned up
-            self.assertFalse(os.path.exists(temp_tarfile_name))
+            self.runner._upload_tests_and_reqs("test-bucket")
             # Ensure both the tests tar and the requirements were uploaded
             self.assertEqual(boto_s3_client_mock.put_object.call_count, 2)
             # Ensure both the tests and requirements were waited for
@@ -219,12 +215,6 @@ class Test_InvokeTestsuite(TestCase):
         except Exception as ex:
             self.fail(f"Failure due to unexpected exception {ex}")
         finally:
-            # Although the _upload_tests_and_reqs function SHOULD delete the tarfile,
-            # we don't want to leave artifacts in any case
-            try:
-                os.remove(temp_tarfile_name)
-            except OSError:
-                pass
             os.remove(fake_tests_path)
             os.rmdir(test_dir_name)
             os.remove(fake_reqs_path)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
If tests fail, the command should return a non-zero exit code so that the customer can implement logic around test success or failure. Especially useful for automated workflows, CI/CD.

Additionally, test output can be coloured red in the event of failure :)

#### How does it address the issue?
The `sam test-runner run` command will exit with the same code as the test run container.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
