### PR TITLE
fix: allow relative paths for `--config-file`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,6 +292,9 @@ docs/_build/
 # pyenv
 .python-version
 
+# pyright
+pyrightconfig.json
+
 # celery beat schedule file
 celerybeat-schedule.*
 

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -130,20 +130,20 @@ def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx,
     config_env_name = ctx.params.get("config_env") or DEFAULT_ENV
 
     config_file = ctx.params.get("config_file") or DEFAULT_CONFIG_FILE_NAME
-    if config_file and config_file != DEFAULT_CONFIG_FILE_NAME and not Path(config_file).is_file():
-        error_msg = f"Config file {config_file} does not exist or could not be read"
+    config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
+    # If --config-file is an absolute path, use it, if not, start from config_dir
+    config_file_path = config_file if os.path.isabs(config_file) else os.path.join(config_dir, config_file)
+    if config_file and config_file != DEFAULT_CONFIG_FILE_NAME and not Path(config_file_path).absolute().is_file():
+        error_msg = f"Config file {config_file} does not exist or could not be read!"
         LOG.debug(error_msg)
         raise ConfigException(error_msg)
 
-    config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
-    # If --config-file is an absolute path, use it, if not, start from config_dir
-    config_file_name = config_file if os.path.isabs(config_file) else os.path.join(config_dir, config_file)
     config = get_ctx_defaults(
         cmd_name,
         provider,
         ctx,
         config_env_name=config_env_name,
-        config_file=config_file_name,
+        config_file=config_file_path,
     )
     ctx.default_map.update(config)
 

--- a/tests/integration/package/test_package_command_image.py
+++ b/tests/integration/package/test_package_command_image.py
@@ -265,4 +265,4 @@ class TestPackageImage(PackageIntegBase):
         for image, tag in images:
             # check string like this:
             # ...python-ce689abb4f0d-3.9-slim: digest:...
-            self.assertRegex(process_stderr, fr"{image}-.+-{tag}: digest:")
+            self.assertRegex(process_stderr, rf"{image}-.+-{tag}: digest:")

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 from samcli.commands.exceptions import ConfigException
 from samcli.cli.cli_config_file import TomlProvider, configuration_option, configuration_callback, get_ctx_defaults
-from samcli.lib.config.samconfig import SamConfig, DEFAULT_ENV, DEFAULT_CONFIG_FILE_NAME
+from samcli.lib.config.samconfig import DEFAULT_ENV
 
 
 class MockContext:
@@ -84,6 +84,7 @@ class TestCliConfiguration(TestCase):
         self.ctx = MagicMock()
         self.param = MagicMock()
         self.value = MagicMock()
+        self.config_file = "otherconfig.toml"
 
     class Dummy:
         pass
@@ -128,6 +129,35 @@ class TestCliConfiguration(TestCase):
                 param=self.param,
                 value=self.value,
             )
+
+    def test_callback_with_valid_config_file_path(self):
+        mock_context1 = MockContext(info_name="sam", parent=None)
+        mock_context2 = MockContext(info_name="local", parent=mock_context1)
+        mock_context3 = MockContext(info_name="start-api", parent=mock_context2)
+        self.ctx.parent = mock_context3
+        self.ctx.info_name = "test_info"
+        # Create a temporary directory.
+        temp_dir = tempfile.mkdtemp()
+        # Create a new config file path that is one layer above the temporary directory.
+        config_file_path = Path(temp_dir).parent.joinpath(self.config_file)
+        with open(config_file_path, "wb"):
+            # Set the `samconfig_dir` to be temporary directory that was created.
+            setattr(self.ctx, "samconfig_dir", temp_dir)
+            # set a relative path for the config file from `samconfig_dir`.
+            self.ctx.params = {"config_file": os.path.join("..", self.config_file)}
+            configuration_callback(
+                cmd_name=self.cmd_name,
+                option_name=self.option_name,
+                saved_callback=self.saved_callback,
+                provider=self.provider,
+                ctx=self.ctx,
+                param=self.param,
+                value=self.value,
+            )
+        self.assertEqual(self.saved_callback.call_count, 1)
+        for arg in [self.ctx, self.param, DEFAULT_ENV]:
+            self.assertIn(arg, self.saved_callback.call_args[0])
+        self.assertNotIn(self.value, self.saved_callback.call_args[0])
 
     def test_configuration_option(self):
         toml_provider = TomlProvider()


### PR DESCRIPTION
* PR https://github.com/aws/aws-sam-cli/pull/4044 has caused a
  regression.

#### Which issue(s) does this change fix?
* https://github.com/aws/aws-sam-cli/pull/4044 


#### Why is this change necessary?
* Re allow usage of relative paths for `--config-file`

#### How does it address the issue?
* Only check for the path being a file after resolving it to be absolute.

#### What side effects does this change have?
* N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
