### PR TITLE
feat: Enable sam local start-api to respond with HTTP/1.1 version

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from flask import Flask, request
 from werkzeug.datastructures import Headers
 from werkzeug.routing import BaseConverter
+from werkzeug.serving import WSGIRequestHandler
 
 from samcli.lib.providers.provider import Cors
 from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser
@@ -155,6 +156,8 @@ class LocalApigwService(BaseLocalService):
         """
         Creates a Flask Application that can be started.
         """
+        # Setting sam local start-api to respond using HTTP/1.1 instead of the default HTTP/1.0
+        WSGIRequestHandler.protocol_version = "HTTP/1.1"
 
         self._app = Flask(
             __name__,

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -57,6 +57,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
             for result in results:
                 self.assertEqual(result.status_code, 200)
                 self.assertEqual(result.json(), {"message": "HelloWorld! I just slept and waking up."})
+                self.assertEqual(result.raw.version, 11) # Checks if the response is HTTP/1.1 version
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -86,6 +87,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
             for result in results:
                 self.assertEqual(result.status_code, 200)
                 self.assertEqual(result.json(), {"message": "HelloWorld! I just slept and waking up."})
+                self.assertEqual(result.raw.version, 11)
 
 
 @parameterized_class(
@@ -110,6 +112,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json(), {"message": "Missing Authentication Token"})
+        self.assertEqual(response.raw.version, 11) # Checks if the response is HTTP/1.1 version
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -118,6 +121,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -126,6 +130,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -159,6 +164,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11) # Checks if the response is HTTP/1.1 version
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -170,6 +176,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -181,6 +188,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -192,6 +200,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -202,6 +211,7 @@ class TestService(StartApiIntegBaseClass):
         response = requests.head(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -213,6 +223,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -223,6 +234,7 @@ class TestService(StartApiIntegBaseClass):
         response = requests.options(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -234,6 +246,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -246,6 +259,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
         self.assertEqual(response_data.get("body"), data)
+        self.assertEqual(response.raw.version, 11)
 
 
 @parameterized_class(
@@ -273,6 +287,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -284,6 +299,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -295,6 +311,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -306,6 +323,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -316,6 +334,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
         response = requests.head(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -327,6 +346,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -337,6 +357,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
         response = requests.options(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -348,6 +369,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -359,6 +381,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"foo": "bar"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -370,6 +393,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -381,6 +405,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "This is invalid")
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -392,6 +417,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "2")
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -403,6 +429,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+        self.assertEqual(response.raw.version, 11)
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -414,6 +441,7 @@ class TestServiceWithHttpApi(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
+        self.assertEqual(response.raw.version, 11)
 
 
 class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -57,7 +57,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
             for result in results:
                 self.assertEqual(result.status_code, 200)
                 self.assertEqual(result.json(), {"message": "HelloWorld! I just slept and waking up."})
-                self.assertEqual(result.raw.version, 11) # Checks if the response is HTTP/1.1 version
+                self.assertEqual(result.raw.version, 11)  # Checks if the response is HTTP/1.1 version
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -112,7 +112,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json(), {"message": "Missing Authentication Token"})
-        self.assertEqual(response.raw.version, 11) # Checks if the response is HTTP/1.1 version
+        self.assertEqual(response.raw.version, 11)  # Checks if the response is HTTP/1.1 version
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -164,7 +164,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
-        self.assertEqual(response.raw.version, 11) # Checks if the response is HTTP/1.1 version
+        self.assertEqual(response.raw.version, 11)  # Checks if the response is HTTP/1.1 version
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#3515 

#### Why is this change necessary?
Customers are facing issues on postman due to HTTP/1.0 responses from sam local start-api.

#### How does it address the issue?
New change allows the sam local start-api to respond using upgraded version HTTP/1.1

#### What side effects does this change have?
None found

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
