### PR TITLE
fix: Fix esbuild Properties Integration Tests

### DIFF
--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -348,7 +348,7 @@ class BuildIntegEsbuildBase(BuildIntegBase):
             self.verify_pulled_image(runtime, architecture)
 
     def _test_with_various_properties(self, overrides):
-        overrides = self.get_override_metadata(**overrides)
+        overrides = self.get_override(**overrides)
         cmdlist = self.get_command_list(parameter_overrides=overrides)
 
         cmdlist.append("--beta-features")
@@ -396,40 +396,6 @@ class BuildIntegEsbuildBase(BuildIntegBase):
         all_artifacts = set(os.listdir(str(resource_artifact_dir)))
         actual_files = all_artifacts.intersection(expected_files)
         self.assertEqual(actual_files, expected_files)
-
-    @staticmethod
-    def get_override_metadata(
-        runtime,
-        code_uri,
-        architecture,
-        handler,
-        node_options=None,
-        global_node_options=None,
-        minify=None,
-        sourcemap=None,
-    ):
-        overrides = {
-            "Runtime": runtime,
-            "CodeUri": code_uri,
-            "Handler": handler,
-        }
-
-        if node_options:
-            overrides["NodeOptions"] = node_options
-
-        if global_node_options:
-            overrides["GlobalNodeOptions"] = global_node_options
-
-        if minify:
-            overrides["Minify"] = minify
-
-        if sourcemap:
-            overrides["Sourcemap"] = sourcemap
-
-        if architecture:
-            overrides["Architectures"] = architecture
-
-        return overrides
 
 
 class BuildIntegNodeBase(BuildIntegBase):

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -443,30 +443,23 @@ class TestBuildCommand_EsbuildFunctions(BuildIntegEsbuildBase):
     ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
     "Skip build tests on windows when running in CI unless overridden",
 )
+@parameterized_class(
+    ("template",),
+    [
+        ("esbuild_templates/template_with_metadata_node_options.yaml",),
+        ("esbuild_templates/template_with_metadata_global_node_options.yaml",),
+    ],
+)
 class TestBuildCommand_EsbuildFunctionProperties(BuildIntegEsbuildBase):
-    template = "template_with_metadata_no_sourcemap.yaml"
+    template = "esbuild_templates/template_with_metadata_node_options.yaml"
 
     @pytest.mark.flaky(reruns=3)
     def test_environment_generates_sourcemap(self):
         overrides = {
             "runtime": "nodejs16.x",
-            "code_uri": "Esbuild/TypeScript",
+            "code_uri": "../Esbuild/TypeScript",
             "handler": "app.lambdaHandler",
             "architecture": "x86_64",
-            "minify": True,
-            "node_options": "--enable-source-maps",
-        }
-        self._test_with_various_properties(overrides)
-
-    @pytest.mark.flaky(reruns=3)
-    def test_global_environment_generates_sourcemap(self):
-        overrides = {
-            "runtime": "nodejs16.x",
-            "code_uri": "Esbuild/TypeScript",
-            "handler": "app.lambdaHandler",
-            "architecture": "x86_64",
-            "minify": True,
-            "global_node_options": "--enable-source-maps",
         }
         self._test_with_various_properties(overrides)
 

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -451,8 +451,6 @@ class TestBuildCommand_EsbuildFunctions(BuildIntegEsbuildBase):
     ],
 )
 class TestBuildCommand_EsbuildFunctionProperties(BuildIntegEsbuildBase):
-    template = "esbuild_templates/template_with_metadata_node_options.yaml"
-
     @pytest.mark.flaky(reruns=3)
     def test_environment_generates_sourcemap(self):
         overrides = {

--- a/tests/integration/testdata/buildcmd/esbuild_templates/template_with_metadata_global_node_options.yaml
+++ b/tests/integration/testdata/buildcmd/esbuild_templates/template_with_metadata_global_node_options.yaml
@@ -10,24 +10,12 @@ Parameteres:
     Type: String
   Architectures:
     Type: String
-  NodeOptions:
-    Type: String
-    Default: "No-op"
-  GlobalNodeOptions:
-    Type: String
-    Default: "No-op"
-  Minify:
-    Type: String
-    Default: true
-  Sourcemap:
-    Type: String
-    Default: true
 
 Globals:
   Function:
-     Environment:
-       Variables:
-         NODE_OPTIONS: !Ref GlobalNodeOptions
+    Environment:
+      Variables:
+        NODE_OPTIONS: --enable-source-maps
 
 Resources:
   Function:
@@ -37,13 +25,11 @@ Resources:
       Runtime: !Ref Runtime
       CodeUri: !Ref CodeUri
       Timeout: 600
-      Environment:
-        Variables:
-          NODE_OPTIONS: !Ref NodeOptions
       Architectures:
         - !Ref Architectures
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
-        Minify: !Ref Minify
+        Minify: true
         Target: "es2020"
+        Sourcemap: true

--- a/tests/integration/testdata/buildcmd/esbuild_templates/template_with_metadata_node_options.yaml
+++ b/tests/integration/testdata/buildcmd/esbuild_templates/template_with_metadata_node_options.yaml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameteres:
+  Runtime:
+    Type: String
+  CodeUri:
+    Type: String
+  Handler:
+    Type: String
+  Architectures:
+    Type: String
+
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: !Ref Handler
+      Runtime: !Ref Runtime
+      CodeUri: !Ref CodeUri
+      Timeout: 600
+      Environment:
+        Variables:
+          NODE_OPTIONS: --enable-source-maps
+      Architectures:
+        - !Ref Architectures
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true


### PR DESCRIPTION
#### Why is this change necessary?
esbuild integration tests started failing after releasing the newest lambda builders which changes some of the default values. The tests were then unable to substitute the default parameters leading them to fail.

#### How does it address the issue?
Parameters the templates used instead of the individual properties.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
