### PR TITLE
feat: create stub function for generating custom makefile

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -251,7 +251,9 @@ def _translate_to_cfn(tf_json: dict, output_directory_path: str, terraform_appli
         )
 
         LOG.debug("Generate custom makefile for building Lambda resources")
-        _generate_custom_makefile(sam_metadata_resources, cfn_dict.get("Resources", {}), output_directory_path)
+        _generate_custom_makefile(
+            sam_metadata_resources, cfn_dict.get("Resources", {}), output_directory_path, terraform_application_dir
+        )
     else:
         LOG.debug("There is no sam metadata resources, no enrichment or custom makefile is required")
 
@@ -262,6 +264,7 @@ def _generate_custom_makefile(
     sam_metadata_resources: List[SamMetadataResource],
     cfn_resources: Dict[str, Dict],
     output_directory_path: str,
+    terraform_application_dir: str,
 ) -> None:
     """
     Generates a makefile with a target/recipe for each lambda resource to be built
@@ -274,6 +277,8 @@ def _generate_custom_makefile(
         CloudFormation resources
     output_directory_path: str
         the output directory path to write the generated metadata and makefile
+    terraform_application_dir: str
+        the terraform project root directory
     """
     # TODO
 

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -249,10 +249,33 @@ def _translate_to_cfn(tf_json: dict, output_directory_path: str, terraform_appli
         _enrich_mapped_resources(
             sam_metadata_resources, cfn_dict["Resources"], output_directory_path, terraform_application_dir
         )
+
+        LOG.debug("Generate custom makefile for building Lambda resources")
+        _generate_custom_makefile(sam_metadata_resources, cfn_dict["Resources"], output_directory_path)
     else:
-        LOG.debug("There is no sam metadata resources, no enrichment is required")
+        LOG.debug("There is no sam metadata resources, no enrichment or custom makefile is required")
 
     return cfn_dict
+
+
+def _generate_custom_makefile(
+    sam_metadata_resources: List[SamMetadataResource],
+    cfn_resources: Dict[str, Dict],
+    output_directory_path: str,
+) -> None:
+    """
+    Generates a makefile with a target/recipe for each lambda resource to be built
+
+    Parameters
+    ----------
+    sam_metadata_resources: List[SamMetadataResource]
+        The list of sam metadata resources defined in the terraform project.
+    cfn_resources: dict
+        CloudFormation resources
+    output_directory_path: str
+        the output directory path to write the generated metadata and makefile
+    """
+    # TODO
 
 
 def _validate_referenced_resource_matches_sam_metadata_type(

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -242,16 +242,16 @@ def _translate_to_cfn(tf_json: dict, output_directory_path: str, terraform_appli
 
     # map s3 object sources to corresponding functions
     LOG.debug("Mapping S3 object sources to corresponding functions")
-    _map_s3_sources_to_functions(s3_hash_to_source, cfn_dict["Resources"])
+    _map_s3_sources_to_functions(s3_hash_to_source, cfn_dict.get("Resources", {}))
 
     if sam_metadata_resources:
         LOG.debug("Enrich the mapped resources with the sam metadata information")
         _enrich_mapped_resources(
-            sam_metadata_resources, cfn_dict["Resources"], output_directory_path, terraform_application_dir
+            sam_metadata_resources, cfn_dict.get("Resources", {}), output_directory_path, terraform_application_dir
         )
 
         LOG.debug("Generate custom makefile for building Lambda resources")
-        _generate_custom_makefile(sam_metadata_resources, cfn_dict["Resources"], output_directory_path)
+        _generate_custom_makefile(sam_metadata_resources, cfn_dict.get("Resources", {}), output_directory_path)
     else:
         LOG.debug("There is no sam metadata resources, no enrichment or custom makefile is required")
 

--- a/tests/unit/hook_packages/terraform/test_prepare_hook.py
+++ b/tests/unit/hook_packages/terraform/test_prepare_hook.py
@@ -890,32 +890,27 @@ class TestPrepareHook(TestCase):
             self.tf_json_with_root_module_with_sam_metadata_resources, self.output_dir, self.project_root
         )
 
-        expected_sam_metadata_resources_in_call = [
-            SamMetadataResource(
-                current_module_address=None, resource=self.tf_lambda_function_resource_zip_sam_metadata
-            ),
-            SamMetadataResource(
-                current_module_address=None,
-                resource=self.tf_lambda_function_resource_zip_2_sam_metadata,
-            ),
-            SamMetadataResource(
-                current_module_address=None,
-                resource=self.tf_image_package_type_lambda_function_resource_sam_metadata,
-            ),
-        ]
-
-        mock_enrich_mapped_resources.assert_called_once_with(
-            expected_sam_metadata_resources_in_call,
+        expected_arguments_in_call = (
+            [
+                SamMetadataResource(
+                    current_module_address=None, resource=self.tf_lambda_function_resource_zip_sam_metadata
+                ),
+                SamMetadataResource(
+                    current_module_address=None,
+                    resource=self.tf_lambda_function_resource_zip_2_sam_metadata,
+                ),
+                SamMetadataResource(
+                    current_module_address=None,
+                    resource=self.tf_image_package_type_lambda_function_resource_sam_metadata,
+                ),
+            ],
             translated_cfn_dict["Resources"],
             self.output_dir,
             self.project_root,
         )
 
-        mock_generate_custom_makefile.assert_called_once_with(
-            expected_sam_metadata_resources_in_call,
-            translated_cfn_dict["Resources"],
-            self.output_dir,
-        )
+        mock_enrich_mapped_resources.assert_called_once_with(*expected_arguments_in_call)
+        mock_generate_custom_makefile.assert_called_once_with(*expected_arguments_in_call)
 
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_custom_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare._enrich_mapped_resources")
@@ -928,45 +923,40 @@ class TestPrepareHook(TestCase):
             self.tf_json_with_child_modules_with_sam_metadata_resource, self.output_dir, self.project_root
         )
 
-        expected_sam_metadata_resources_in_call = [
-            SamMetadataResource(
-                current_module_address=None, resource=self.tf_lambda_function_resource_zip_sam_metadata
-            ),
-            SamMetadataResource(
-                current_module_address="module.mymodule1",
-                resource={
-                    **self.tf_lambda_function_resource_zip_2_sam_metadata,
-                    "address": f"module.mymodule1.null_resource.sam_metadata_{self.zip_function_name_2}",
-                },
-            ),
-            SamMetadataResource(
-                current_module_address="module.mymodule1.module.mymodule2",
-                resource={
-                    **self.tf_lambda_function_resource_zip_3_sam_metadata,
-                    "address": f"module.mymodule1.module.mymodule2.null_resource.sam_metadata_{self.zip_function_name_3}",
-                },
-            ),
-            SamMetadataResource(
-                current_module_address="module.mymodule1.module.mymodule3",
-                resource={
-                    **self.tf_lambda_function_resource_zip_4_sam_metadata,
-                    "address": f"module.mymodule1.module.mymodule3.null_resource.sam_metadata_{self.zip_function_name_4}",
-                },
-            ),
-        ]
-
-        mock_enrich_mapped_resources.assert_called_once_with(
-            expected_sam_metadata_resources_in_call,
+        expected_arguments_in_call = (
+            [
+                SamMetadataResource(
+                    current_module_address=None, resource=self.tf_lambda_function_resource_zip_sam_metadata
+                ),
+                SamMetadataResource(
+                    current_module_address="module.mymodule1",
+                    resource={
+                        **self.tf_lambda_function_resource_zip_2_sam_metadata,
+                        "address": f"module.mymodule1.null_resource.sam_metadata_{self.zip_function_name_2}",
+                    },
+                ),
+                SamMetadataResource(
+                    current_module_address="module.mymodule1.module.mymodule2",
+                    resource={
+                        **self.tf_lambda_function_resource_zip_3_sam_metadata,
+                        "address": f"module.mymodule1.module.mymodule2.null_resource.sam_metadata_{self.zip_function_name_3}",
+                    },
+                ),
+                SamMetadataResource(
+                    current_module_address="module.mymodule1.module.mymodule3",
+                    resource={
+                        **self.tf_lambda_function_resource_zip_4_sam_metadata,
+                        "address": f"module.mymodule1.module.mymodule3.null_resource.sam_metadata_{self.zip_function_name_4}",
+                    },
+                ),
+            ],
             translated_cfn_dict["Resources"],
             self.output_dir,
             self.project_root,
         )
 
-        mock_generate_custom_makefile.assert_called_once_with(
-            expected_sam_metadata_resources_in_call,
-            translated_cfn_dict["Resources"],
-            self.output_dir,
-        )
+        mock_enrich_mapped_resources.assert_called_once_with(*expected_arguments_in_call)
+        mock_generate_custom_makefile.assert_called_once_with(*expected_arguments_in_call)
 
     @patch("samcli.hook_packages.terraform.hooks.prepare._enrich_mapped_resources")
     @patch("samcli.hook_packages.terraform.hooks.prepare.str_checksum")
@@ -1722,12 +1712,6 @@ class TestPrepareHook(TestCase):
     def test_prepare_with_no_output_dir_path(self):
         with self.assertRaises(PrepareHookException, msg="OutputDirPath was not supplied"):
             prepare({})
-
-    def test_prepare_with_sam_metadata_resources(self):
-        pass
-
-    def test_prepare_without_sam_metadata_resources(self):
-        pass
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.os")
     @patch("samcli.hook_packages.terraform.hooks.prepare.Path")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
After the prepare hook finds the SAM Metadata and links it to a specific Lambda resource, we need to create a makefile with a target/recipe for each lambda resource to be built. 

#### How does it address the issue?
Defines a stubbed function, and calls it after finding the sam metadata resources. 

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
