### PR TITLE
fix: Fixed URI path being resolved incorrectly and remove experimental call

### DIFF
--- a/samcli/lib/build/bundler.py
+++ b/samcli/lib/build/bundler.py
@@ -23,7 +23,9 @@ class EsbuildBundlerManager:
         Checks if esbuild is configured on any resource in a given stack
         :return: True if there is a function instance using esbuild as the build method
         """
-        function_provider = SamFunctionProvider([self._stack], ignore_code_extraction_warnings=True)
+        function_provider = SamFunctionProvider(
+            [self._stack], use_raw_codeuri=True, ignore_code_extraction_warnings=True
+        )
         functions = list(function_provider.get_all())
         for function in functions:
             if function.metadata and function.metadata.get("BuildMethod", "") == ESBUILD_PROPERTY:

--- a/tests/integration/sync/test_sync_adl.py
+++ b/tests/integration/sync/test_sync_adl.py
@@ -176,8 +176,6 @@ class TestDisableAdlForEsbuildFunctions(SyncIntegBase):
     dependency_layer = True
 
     def test_sync_esbuild(self):
-        set_experimental(ExperimentalFlag.Esbuild)
-
         template_path = str(self.test_data_path.joinpath(self.template_file))
         stack_name = self._method_to_stack_name(self.id())
         self.stacks.append({"name": stack_name})

--- a/tests/unit/lib/build_module/test_bundler.py
+++ b/tests/unit/lib/build_module/test_bundler.py
@@ -165,3 +165,9 @@ class EsbuildBundler_esbuild_configured(TestCase):
         stack.location = "/location"
         esbuild_manager = EsbuildBundlerManager(stack)
         self.assertEqual(esbuild_manager.esbuild_configured(), expected)
+
+    @patch("samcli.lib.providers.sam_function_provider.SamFunctionProvider.__init__", return_value=None)
+    @patch("samcli.lib.providers.sam_function_provider.SamFunctionProvider.get_all", return_value={})
+    def test_use_raw_codeuri_passed(self, get_all_mock, provider_mock):
+        EsbuildBundlerManager([]).esbuild_configured()
+        provider_mock.assert_called_with([[]], use_raw_codeuri=True, ignore_code_extraction_warnings=True)


### PR DESCRIPTION
#### Why is this change necessary?
This change fixes URIs being resolved in the esbuild check, causing some URIs being resolved incorrectly
#### How does it address the issue?
Adds `use_raw_codeuri=True` to parameters.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
