### PR TITLE
fix: make terraform project root arg required, and move script into the terraform hook package dir

### DIFF
--- a/installer/pyinstaller/hook-samcli.py
+++ b/installer/pyinstaller/hook-samcli.py
@@ -4,10 +4,9 @@ from installer.pyinstaller.hidden_imports import SAM_CLI_HIDDEN_IMPORTS
 hiddenimports = SAM_CLI_HIDDEN_IMPORTS
 
 datas = (
-    # collect just the scripts
-    hooks.collect_all("samcli",
-                      include_py_files=True,
-                      include_datas=["scripts/*.py"])[0]
+    hooks.collect_all(
+        "samcli", include_py_files=True, include_datas=["hook_packages/terraform/copy_terraform_built_artifacts.py"]
+    )[0]
     + hooks.collect_data_files("samcli")
     + hooks.collect_data_files("samtranslator")
     + hooks.collect_data_files("aws_lambda_builders")

--- a/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
+++ b/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
@@ -217,27 +217,24 @@ if __name__ == "__main__":
     argparser.add_argument(
         "--terraform-project-root",
         type=str,
-        required=False,
+        required=True,
         default=None,
-        help="Extracted expression (path) will be relative to the terraform project root if provided.",
+        help="Extracted expression (path), if relative, will be relative to the provided terraform project root.",
     )
 
     arguments = argparser.parse_args()
     directory_path = os.path.abspath(arguments.directory)
 
-    terraform_project_root = (
-        os.path.abspath(arguments.terraform_project_root) if arguments.terraform_project_root else None
-    )
+    terraform_project_root = os.path.abspath(arguments.terraform_project_root)
     extracted_attribute_path = None
     data_object = None
 
     if not os.path.exists(directory_path) or not os.path.isdir(directory_path):
         LOG.error("Expected --directory to be a valid directory!")
         cli_exit()
-    if terraform_project_root:
-        if not os.path.exists(terraform_project_root) or not os.path.isdir(terraform_project_root):
-            LOG.error("Expected --terraform-project-path to be a valid directory!")
-            cli_exit()
+    if not os.path.exists(terraform_project_root) or not os.path.isdir(terraform_project_root):
+        LOG.error("Expected --terraform-project-path to be a valid directory!")
+        cli_exit()
 
     # Load and Parse
     try:
@@ -251,11 +248,11 @@ if __name__ == "__main__":
     except ResolverException as ex:
         LOG.error(ex.message, exc_info=True)
         cli_exit()
-    # Construct an absolute path based on if extracted path is relative or absolute and if
-    # terraform project root is provided.
+
+    # Construct an absolute path based on if extracted path is relative or absolute.
     abs_attribute_path = (
         os.path.abspath(os.path.join(terraform_project_root, extracted_attribute_path))
-        if terraform_project_root and not os.path.isabs(extracted_attribute_path)
+        if not os.path.isabs(extracted_attribute_path)
         else os.path.abspath(extracted_attribute_path)
     )
     if not os.path.exists(abs_attribute_path):
@@ -264,6 +261,7 @@ if __name__ == "__main__":
     if abs_attribute_path == directory_path:
         LOG.error("Extracted expression path cannot be the same as the supplied directory path")
         cli_exit()
+
     try:
         if zipfile.is_zipfile(abs_attribute_path):
             with zipfile.ZipFile(abs_attribute_path, "r") as z:

--- a/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
+++ b/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
@@ -42,6 +42,8 @@ import sys
 import zipfile
 import logging
 
+from six import string_types
+
 LOG = logging.getLogger(__name__)
 
 
@@ -248,6 +250,11 @@ if __name__ == "__main__":
     except ResolverException as ex:
         LOG.error(ex.message, exc_info=True)
         cli_exit()
+
+    if not isinstance(extracted_attribute_path, string_types):
+        LOG.error("Expected the extracted attribute to be a string")
+        cli_exit()
+    extracted_attribute_path = str(extracted_attribute_path)
 
     # Construct an absolute path based on if extracted path is relative or absolute.
     abs_attribute_path = (

--- a/tests/integration/scripts/test_copy_terraform_built_artifacts.py
+++ b/tests/integration/scripts/test_copy_terraform_built_artifacts.py
@@ -11,7 +11,7 @@ TIMEOUT = 3
 
 class TestCopyTerraformBuiltArtifacts(TestCase):
     def setUp(self) -> None:
-        self.script_dir = pathlib.Path(__file__).parents[3].joinpath("samcli").joinpath("scripts")
+        self.script_dir = pathlib.Path(__file__).parents[3].joinpath("samcli/hook_packages/terraform")
         self.script_name = "copy_terraform_built_artifacts.py"
         self.script_location = self.script_dir.joinpath(self.script_name)
         self.testdata_directory = pathlib.Path(__file__).parent.joinpath("testdata")

--- a/tests/integration/scripts/test_copy_terraform_built_artifacts.py
+++ b/tests/integration/scripts/test_copy_terraform_built_artifacts.py
@@ -11,7 +11,7 @@ TIMEOUT = 3
 
 class TestCopyTerraformBuiltArtifacts(TestCase):
     def setUp(self) -> None:
-        self.script_dir = pathlib.Path(__file__).parents[3].joinpath("samcli/hook_packages/terraform")
+        self.script_dir = pathlib.Path(__file__).parents[3].joinpath("samcli", "hook_packages", "terraform")
         self.script_name = "copy_terraform_built_artifacts.py"
         self.script_location = self.script_dir.joinpath(self.script_name)
         self.testdata_directory = pathlib.Path(__file__).parent.joinpath("testdata")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
The current logic would make it so that if the terraform project root arg was not provided, extracted relative paths would be made relative to the current working directory (wherever the script was executed, so from the prepare hook's dir). 

Also, since hook packages should be independent/isolated, I moved the script into the terraform hook package. 
**NOTE:** not sure, however, where to move the integration test

#### How does it address the issue?
The arg was made required.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
