### PR TITLE
fix: check for `hook-package-id` only being allowed if a beta feature on `sam build`

### DIFF
--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -237,7 +237,7 @@ def do_cli(  # pylint: disable=too-many-locals, too-many-statements
     if (
         hook_package_id
         and ExperimentalFlag.IaCsSupport.get(hook_package_id) is not None
-        and not is_experimental_enabled(ExperimentalFlag.IaCsSupport.get(hook_package_id))
+        and not is_experimental_enabled(ExperimentalFlag.IaCsSupport[hook_package_id])
     ):
         LOG.info("Terraform Support beta feature is not enabled.")
         return

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Dict, Tuple
 import click
 
 from samcli.cli.context import Context
-from samcli.commands._utils.experimental import experimental
+from samcli.commands._utils.experimental import experimental, ExperimentalFlag, is_experimental_enabled
 from samcli.commands._utils.options import (
     template_option_without_build,
     docker_common_options,
@@ -234,6 +234,13 @@ def do_cli(  # pylint: disable=too-many-locals, too-many-statements
     """
     Implementation of the ``cli`` method
     """
+    if (
+        hook_package_id
+        and ExperimentalFlag.IaCsSupport.get(hook_package_id) is not None
+        and not is_experimental_enabled(ExperimentalFlag.IaCsSupport.get(hook_package_id))
+    ):
+        LOG.info("Terraform Support beta feature is not enabled.")
+        return
 
     from samcli.commands.build.build_context import BuildContext
 

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -78,6 +78,7 @@ class BuildIntegBase(TestCase):
         build_image=None,
         exclude=None,
         region=None,
+        hook_package_id=None,
         beta_features=False,
     ):
 
@@ -86,7 +87,7 @@ class BuildIntegBase(TestCase):
         if function_identifier:
             command_list += [function_identifier]
 
-        command_list += ["-t", self.template_path]
+        command_list += ["-t", self.template_path] if not hook_package_id else []
 
         if parameter_overrides:
             command_list += ["--parameter-overrides", self._make_parameter_override_arg(parameter_overrides)]
@@ -133,6 +134,9 @@ class BuildIntegBase(TestCase):
 
         if beta_features:
             command_list += ["--beta-features"]
+
+        if hook_package_id:
+            command_list += ["--hook-package-id", hook_package_id]
 
         return command_list
 

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -79,7 +79,7 @@ class BuildIntegBase(TestCase):
         exclude=None,
         region=None,
         hook_package_id=None,
-        beta_features=False,
+        beta_features=None,
     ):
 
         command_list = [self.cmd, "build"]
@@ -87,7 +87,7 @@ class BuildIntegBase(TestCase):
         if function_identifier:
             command_list += [function_identifier]
 
-        command_list += ["-t", self.template_path] if not hook_package_id else []
+        command_list += ["-t", self.template_path] if self.template_path else []
 
         if parameter_overrides:
             command_list += ["--parameter-overrides", self._make_parameter_override_arg(parameter_overrides)]
@@ -132,8 +132,8 @@ class BuildIntegBase(TestCase):
         if region:
             command_list += ["--region", region]
 
-        if beta_features:
-            command_list += ["--beta-features"]
+        if beta_features is not None:
+            command_list += ["--beta-features"] if beta_features else ["--no-beta-features"]
 
         if hook_package_id:
             command_list += ["--hook-package-id", hook_package_id]

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -24,6 +24,7 @@ from tests.testing_utils import (
     SKIP_DOCKER_TESTS,
     SKIP_DOCKER_BUILD,
     SKIP_DOCKER_MESSAGE,
+    run_command_with_input,
 )
 from .build_integ_base import (
     BuildIntegBase,
@@ -2564,3 +2565,18 @@ class TestBuildSAR(BuildIntegBase):
             # will fail the build as there is no mapping
             self.assertEqual(process_execute.process.returncode, 1)
             self.assertIn("Property \\'ApplicationId\\' cannot be resolved.", str(process_execute.stderr))
+
+
+class TestBuildWithHooksNoBeta(DedupBuildIntegBase):
+    def test_exit_success_non_beta_supply_hooks(self):
+        cmdlist = self.get_command_list(beta_features=False, hook_package_id="terraform")
+
+        LOG.info("Running Command: {}".format(cmdlist))
+        command_result = run_command_with_input(cmdlist, stdin_input=b"N\n\n", cwd=self.working_dir)
+        self._verify_process_code_and_output(command_result)
+
+    def _verify_process_code_and_output(self, command_result):
+        self.assertEqual(command_result.process.returncode, 0)
+        self.assertEqual(
+            command_result.stderr.strip().decode("utf-8"), "Terraform Support beta feature is not enabled."
+        )

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -2567,12 +2567,23 @@ class TestBuildSAR(BuildIntegBase):
             self.assertIn("Property \\'ApplicationId\\' cannot be resolved.", str(process_execute.stderr))
 
 
-class TestBuildWithHooksNoBeta(DedupBuildIntegBase):
-    def test_exit_success_non_beta_supply_hooks(self):
-        cmdlist = self.get_command_list(beta_features=False, hook_package_id="terraform")
+class TestBuildWithHooksNoBetaFeatures(DedupBuildIntegBase):
+    def setUp(self):
+        super(TestBuildWithHooksNoBetaFeatures, self).setUp()
+        self.template_path = None
+
+    def test_exit_success_no_beta_feature_flags_hooks(self):
+        cmdlist = self.get_command_list(beta_features=None, hook_package_id="terraform")
 
         LOG.info("Running Command: {}".format(cmdlist))
         command_result = run_command_with_input(cmdlist, stdin_input=b"N\n\n", cwd=self.working_dir)
+        self._verify_process_code_and_output(command_result)
+
+    def test_exit_success_no_beta_features_flags_supplied_hooks(self):
+        cmdlist = self.get_command_list(beta_features=False, hook_package_id="terraform")
+
+        LOG.info("Running Command: {}".format(cmdlist))
+        command_result = run_command(cmdlist, cwd=self.working_dir)
         self._verify_process_code_and_output(command_result)
 
     def _verify_process_code_and_output(self, command_result):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -66,10 +66,10 @@ def run_command(command_list, cwd=None, env=None, timeout=TIMEOUT) -> CommandRes
         raise
 
 
-def run_command_with_input(command_list, stdin_input, timeout=TIMEOUT) -> CommandResult:
+def run_command_with_input(command_list, stdin_input, cwd=None, timeout=TIMEOUT) -> CommandResult:
     LOG.info("Running command: %s", " ".join(command_list))
     LOG.info("With input: %s", stdin_input)
-    process_execute = Popen(command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+    process_execute = Popen(command_list, cwd=cwd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
     try:
         stdout_data, stderr_data = process_execute.communicate(stdin_input, timeout=timeout)
         LOG.info(f"Stdout: {stdout_data.decode('utf-8')}")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -66,7 +66,7 @@ def run_command(command_list, cwd=None, env=None, timeout=TIMEOUT) -> CommandRes
         raise
 
 
-def run_command_with_input(command_list, stdin_input, cwd=None, timeout=TIMEOUT) -> CommandResult:
+def run_command_with_input(command_list, stdin_input, timeout=TIMEOUT, cwd=None) -> CommandResult:
     LOG.info("Running command: %s", " ".join(command_list))
     LOG.info("With input: %s", stdin_input)
     process_execute = Popen(command_list, cwd=cwd, stdout=PIPE, stderr=PIPE, stdin=PIPE)

--- a/tests/unit/commands/buildcmd/test_command.py
+++ b/tests/unit/commands/buildcmd/test_command.py
@@ -63,6 +63,37 @@ class TestDoCli(TestCase):
         ctx_mock.run.assert_called_with()
         self.assertEqual(ctx_mock.run.call_count, 1)
 
+    @patch("samcli.commands.build.build_context.BuildContext")
+    def test_build_exits_supplied_hook_package_id(self, BuildContextMock):
+
+        ctx_mock = Mock()
+        BuildContextMock.return_value.__enter__.return_value = ctx_mock
+
+        do_cli(
+            ctx_mock,
+            "function_identifier",
+            None,
+            "base_dir",
+            "build_dir",
+            "cache_dir",
+            "clean",
+            "use_container",
+            "cached",
+            "parallel",
+            "manifest_path",
+            "docker_network",
+            "skip_pull_image",
+            "parameter_overrides",
+            "mode",
+            (""),
+            "container_env_var_file",
+            (),
+            (),
+            hook_package_id="terraform",
+        )
+        self.assertEqual(ctx_mock.call_count, 0)
+        self.assertEqual(ctx_mock.run.call_count, 0)
+
 
 class TestGetModeValueFromEnvvar(TestCase):
     def setUp(self):


### PR DESCRIPTION
There is no sam build logic for terraform applications yet. This PR only ensures that we check to see if beta features are enabled when executing a command with build command with `--hook-package-id`


#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?

 Only allow for `sam build` to continue if a hook package id is specified if executed within a beta context.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
