### PR TITLE
fix: Fix `--docker-volume-basedir` being ignored for sam local

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -221,6 +221,11 @@ class InvokeContext:
             ContainersMode.COLD: [self._stacks],
         }
 
+        # don't resolve the code URI immediately if we passed in docker vol by passing True for use_raw_codeuri
+        # this way at the end the code URI will get resolved against the basedir option
+        if self._docker_volume_basedir:
+            _function_providers_args[self._containers_mode].append(True)
+
         self._function_provider = _function_providers_class[self._containers_mode](
             *_function_providers_args[self._containers_mode]
         )

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -86,7 +86,7 @@ class TestInvokeContext__enter__(TestCase):
         self.assertEqual(invoke_context._invoke_images, {None: "image"})
 
         invoke_context._get_stacks.assert_called_once()
-        SamFunctionProviderMock.assert_called_with(stacks)
+        SamFunctionProviderMock.assert_called_with(stacks, True)
         self.assertEqual(invoke_context._global_parameter_overrides, {"AWS::Region": "region"})
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
@@ -172,7 +172,9 @@ class TestInvokeContext__enter__(TestCase):
         self.assertEqual(invoke_context._invoke_images, {None: "image"})
 
         invoke_context._get_stacks.assert_called_once()
-        RefreshableSamFunctionProviderMock.assert_called_with(stacks, parameter_overrides, global_parameter_overrides)
+        RefreshableSamFunctionProviderMock.assert_called_with(
+            stacks, parameter_overrides, global_parameter_overrides, True
+        )
         self.assertEqual(invoke_context._global_parameter_overrides, global_parameter_overrides)
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])
@@ -259,7 +261,9 @@ class TestInvokeContext__enter__(TestCase):
         self.assertEqual(invoke_context._invoke_images, {None: "image"})
 
         invoke_context._get_stacks.assert_called_once()
-        RefreshableSamFunctionProviderMock.assert_called_with(stacks, parameter_overrides, global_parameter_overrides)
+        RefreshableSamFunctionProviderMock.assert_called_with(
+            stacks, parameter_overrides, global_parameter_overrides, True
+        )
         self.assertEqual(invoke_context._global_parameter_overrides, global_parameter_overrides)
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(
@@ -344,7 +348,9 @@ class TestInvokeContext__enter__(TestCase):
         self.assertEqual(invoke_context._invoke_images, {None: "image"})
 
         invoke_context._get_stacks.assert_called_once()
-        RefreshableSamFunctionProviderMock.assert_called_with(stacks, parameter_overrides, global_parameter_overrides)
+        RefreshableSamFunctionProviderMock.assert_called_with(
+            stacks, parameter_overrides, global_parameter_overrides, True
+        )
         self.assertEqual(invoke_context._global_parameter_overrides, global_parameter_overrides)
         self.assertEqual(invoke_context._get_env_vars_value.call_count, 2)
         self.assertEqual(invoke_context._get_env_vars_value.call_args_list, [call(env_vars_file), call(None)])

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -437,13 +437,22 @@ class TestInvokeContext__enter__(TestCase):
         ]
     )
     @patch("samcli.lib.providers.sam_function_provider.SamFunctionProvider._extract_functions")
+    @patch("samcli.lib.utils.file_observer.SingletonFileObserver.start")
     def test_docker_volume_basedir_set_use_raw_codeuri(
-        self, container_mode, docker_volume_basedir, expected, extract_func_mock
+        self, container_mode, docker_volume_basedir, expected, observer_mock, extract_func_mock
     ):
         invoke_context = InvokeContext(
-            "template", warm_container_initialization_mode=container_mode, docker_volume_basedir=docker_volume_basedir
+            "template",
+            warm_container_initialization_mode=container_mode,
+            docker_volume_basedir=docker_volume_basedir,
+            shutdown=True,
         )
+
+        invoke_context._initialize_all_functions_containers = Mock()
+        invoke_context._get_container_manager = Mock(return_value=Mock())
+        invoke_context._get_debug_context = Mock(return_value=Mock())
         invoke_context._get_stacks = Mock(return_value=[])
+
         invoke_context.__enter__()
 
         extract_func_mock.assert_called_with([], expected, False, False)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#2837

#### Why is this change necessary?
This changes fixes `--docker-volume-basedir` not being used to resolve a relative code URI in the template file. Previously, the code URI was automatically resolved to an absolute path, causing checks later on to ignore the directory passed by `--docker-volume-basedir` since the code URI had already been resolved.

#### How does it address the issue?
If the command flag is passed, the invoke context will set `use_raw_codeuri=True` to the function providers, making sure that the code URI stays relative until the end.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
