### PR TITLE
fix: Patch sam-cli to support language extensions

### DIFF
--- a/samcli/lib/samlib/wrapper.py
+++ b/samcli/lib/samlib/wrapper.py
@@ -20,7 +20,9 @@ from samtranslator.model.exceptions import (
     InvalidResourceException,
     InvalidEventException,
 )
+from samtranslator.model.types import is_str
 from samtranslator.plugins import LifeCycleEvents
+from samtranslator.sdk.resource import SamResource, SamResourceType
 from samtranslator.translator.translator import prepare_plugins
 from samtranslator.validator.validator import SamTemplateValidator
 
@@ -64,6 +66,8 @@ class SamTranslatorWrapper:
             additional_plugins, parameters=self.parameter_values if self.parameter_values else {}
         )
 
+        self._patch_language_extensions()
+
         try:
             parser.parse(template_copy, all_plugins)  # parse() will run all configured plugins
         except InvalidDocumentException as e:
@@ -76,6 +80,30 @@ class SamTranslatorWrapper:
     @property
     def template(self):
         return copy.deepcopy(self._sam_template)
+
+    def _patch_language_extensions(self):
+        template_copy = self.template
+        if self._check_using_langauge_extension(template_copy):
+
+            def patched_func(self):
+                if self.condition:
+                    if not is_str()(self.condition, should_raise=False):
+                        raise InvalidDocumentException(
+                            [InvalidTemplateException("Every Condition member must be a string.")]
+                        )
+                return SamResourceType.has_value(self.type)
+
+            SamResource.valid = patched_func
+
+    @staticmethod
+    def _check_using_langauge_extension(template):
+        transform = template.get("Transform")
+        if transform:
+            if isinstance(transform, str) and transform == "AWS::LanguageExtensions":
+                return True
+            if isinstance(transform, list) and "AWS::LanguageExtensions" in transform:
+                return True
+        return False
 
 
 class _SamParserReimplemented:

--- a/samcli/runtime_config.json
+++ b/samcli/runtime_config.json
@@ -1,3 +1,3 @@
 {
-    "app_template_repo_commit": "b5e3b555bef25e95668717507d6d6473f09f20ce"
+    "app_template_repo_commit": "f7af69d483450d09f1bd5ea300d57e00032370c7"
 }

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -2536,3 +2536,18 @@ class TestBuildSAR(BuildIntegBase):
             # will fail the build as there is no mapping
             self.assertEqual(process_execute.process.returncode, 1)
             self.assertIn("Property \\'ApplicationId\\' cannot be resolved.", str(process_execute.stderr))
+
+
+@skipIf(
+    ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
+class TestBuildWithLanguageExtensions(BuildIntegBase):
+    template = "language-extensions.yaml"
+    def test_validation_does_not_error_out(self):
+        cmdlist = self.get_command_list()
+        LOG.info("Running Command: %s", cmdlist)
+        LOG.info(self.working_dir)
+        process_execute = run_command(cmdlist, cwd=self.working_dir)
+        self.assertEqual(process_execute.process.returncode, 0)
+        self.assertIn("template.yaml", os.listdir(self.default_build_dir))

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -2544,6 +2544,7 @@ class TestBuildSAR(BuildIntegBase):
 )
 class TestBuildWithLanguageExtensions(BuildIntegBase):
     template = "language-extensions.yaml"
+
     def test_validation_does_not_error_out(self):
         cmdlist = self.get_command_list()
         LOG.info("Running Command: %s", cmdlist)

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -1582,3 +1582,14 @@ to create a managed default bucket, or run sam deploy --guided",
         process_stdout = deploy_process_execute.stdout.decode()
         self.assertNotRegex(process_stdout, r"CREATE_COMPLETE.+HelloWorldFunction")
         self.assertRegex(process_stdout, r"UPDATE_COMPLETE.+HelloWorldFunction")
+
+    def test_deploy_with_language_extensions(self):
+        template = Path(__file__).resolve().parents[1].joinpath("testdata", "buildcmd", "language-extensions.yaml")
+        stack_name = self._method_to_stack_name(self.id())
+        self.stacks.append({"name": stack_name})
+
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template, stack_name=stack_name, capabilities="CAPABILITY_IAM"
+        )
+        deploy_process_execute = run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)

--- a/tests/integration/testdata/buildcmd/language-extensions.yaml
+++ b/tests/integration/testdata/buildcmd/language-extensions.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform:
+  - AWS::LanguageExtensions
+  - AWS::Serverless-2016-10-31
+
+Parameters:
+  Environment:
+    Type: String
+    Default: dev
+    AllowedValues:
+      - dev
+      - prod
+
+Conditions:
+  IsProd: !Equals [!Ref Environment, prod]
+
+Globals:
+  Function:
+    Timeout: 20
+    MemorySize: 512
+
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: !If [ IsProd, Retain, Delete ]
+    UpdateReplacePolicy: !If [ IsProd, Retain, Delete ]

--- a/tests/unit/lib/samlib/test_wrapper.py
+++ b/tests/unit/lib/samlib/test_wrapper.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from parameterized import parameterized
+
+from samcli.lib.samlib.wrapper import SamTranslatorWrapper
+
+
+class TestLanguageExtensionsPatching(TestCase):
+    @parameterized.expand(
+        [
+            ({"Transform": ["AWS::LanguageExtensions", "AWS::Serverless-2016-10-31"]}, True),
+            ({"Transform": ["AWS::LanguageExtensions"]}, True),
+            ({"Transform": "AWS::LanguageExtensions"}, True),
+            ({"Transform": "AWS::Serverless-2016-10-31"}, False),
+            ({}, False),
+        ]
+    )
+    def test_check_using_langauge_extension(self, template, expected):
+        self.assertEqual(SamTranslatorWrapper._check_using_langauge_extension(template), expected)
+
+    @patch("samcli.lib.samlib.wrapper.SamResource")
+    def test_patch_language_extensions(self, patched_sam_resource):
+        wrapper = SamTranslatorWrapper({"Transform": "AWS::LanguageExtensions"})
+        wrapper._patch_language_extensions()
+        self.assertEqual(patched_sam_resource.valid.__name__, "patched_func")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#4172

#### Why is this change necessary?
SAM-CLI shouldn't error out when validating certain intrinsic properties if `Transform: AWS::LanguageExtensions` is in the template.

#### How does it address the issue?
Temporarily patch the validation function to bypass certain validations.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
