### PR TITLE
fix: speed up help by 2x on `sam` binary

### DIFF
--- a/tests/integration/root/root_integ_base.py
+++ b/tests/integration/root/root_integ_base.py
@@ -1,0 +1,38 @@
+import os
+from unittest import TestCase
+
+
+class RootIntegBase(TestCase):
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    @staticmethod
+    def base_command():
+        command = "sam"
+        if os.getenv("SAM_CLI_DEV"):
+            command = "samdev"
+
+        return command
+
+    def root_command_list(
+        self,
+        info=False,
+        debug=False,
+        version=False,
+        _help=False,
+    ):
+        command_list = [RootIntegBase.base_command()]
+
+        if info:
+            command_list += ["--info"]
+        if debug:
+            command_list += ["--debug"]
+        if _help:
+            command_list += ["--help"]
+        if version:
+            command_list += ["--version"]
+
+        return command_list

--- a/tests/integration/root/test_root_command.py
+++ b/tests/integration/root/test_root_command.py
@@ -1,0 +1,17 @@
+from parameterized import parameterized
+
+from tests.integration.root.root_integ_base import RootIntegBase
+from tests.testing_utils import run_command
+
+
+class TestRoot(RootIntegBase):
+    def test_no_args(self):
+        command = self.root_command_list()
+        execute_process = run_command(command)
+        self.assertEqual(execute_process.process.returncode, 0)
+
+    @parameterized.expand([({"_help": True}, 0), ({"version": True}, 0), ({"info": True}, 0), ({"debug": True}, 2)])
+    def test_help(self, arguments, return_code):
+        command = self.root_command_list(**arguments)
+        execute_process = run_command(command)
+        self.assertEqual(execute_process.process.returncode, return_code)

--- a/tests/unit/cli/test_command.py
+++ b/tests/unit/cli/test_command.py
@@ -32,49 +32,70 @@ class TestBaseCommand(TestCase):
     def test_get_command_must_return_command_module(self, importlib_mock):
         module_mock = Mock()
         module_mock.cli = Mock()
+        ctx = Mock()
+        ctx.obj = Mock()
 
         importlib_mock.import_module = Mock()
         importlib_mock.import_module.return_value = module_mock
 
         cmd = BaseCommand(cmd_packages=self.packages)
 
-        result = cmd.get_command(None, "cmd1")
+        result = cmd.get_command(ctx, "cmd1")
         self.assertEqual(result, module_mock.cli)
 
-        result = cmd.get_command(None, "cmd2")
+        result = cmd.get_command(ctx, "cmd2")
         self.assertEqual(result, module_mock.cli)
 
-        result = cmd.get_command(None, "cmd3")
+        result = cmd.get_command(ctx, "cmd3")
         self.assertEqual(result, module_mock.cli)
 
         # Library to import the modules must be called three times
         importlib_mock.import_module.assert_has_calls([call("a.b.cmd1"), call("foo.cmd2"), call("cmd3")])
 
     def test_get_command_must_skip_unknown_commands(self):
+        ctx = Mock()
+        ctx.obj = Mock()
 
         cmd = BaseCommand(cmd_packages=self.packages)
-        result = cmd.get_command(None, "unknown_command")
+        result = cmd.get_command(ctx, "unknown_command")
 
         self.assertEqual(result, None, "must not return a command")
 
     @patch("samcli.cli.command.importlib")
     def test_get_command_must_skip_on_exception_loading_module(self, importlib_mock):
+        ctx = Mock()
+        ctx.obj = Mock()
 
         cmd = BaseCommand(cmd_packages=self.packages)
 
         importlib_mock.import_module = Mock()
         importlib_mock.import_module.side_effect = ImportError()
 
-        result = cmd.get_command(None, "cmd1")
+        result = cmd.get_command(ctx, "cmd1")
         self.assertEqual(result, None, "must not return a command")
 
     @patch("samcli.cli.command.importlib")
     def test_get_command_must_skip_on_absence_of_cli_method(self, importlib_mock):
+        ctx = Mock()
+        ctx.obj = Mock()
 
         cmd = BaseCommand(cmd_packages=self.packages)
 
         importlib_mock.import_module = Mock()
         importlib_mock.import_module.return_value = {}  # Returned Module does *not* have 'cli' property
 
-        result = cmd.get_command(None, "cmd1")
+        result = cmd.get_command(ctx, "cmd1")
         self.assertEqual(result, None, "must not return a command")
+
+    @patch("samcli.cli.command.importlib")
+    def test_get_command_root_command(self, importlib_mock):
+        ctx = Mock()
+        ctx.obj = None
+
+        cmd = BaseCommand(cmd_packages=self.packages)
+
+        importlib_mock.import_module = Mock()
+        importlib_mock.import_module.return_value = {}  # Returned Module does *not* have 'cli' property
+
+        cmd.get_command(ctx, "cmd1")
+        self.assertEqual(importlib_mock.import_module.call_count, 0)


### PR DESCRIPTION
- Only import cli commands for specific invocations of non-root
  commands, eg: `sam build` not for `sam`

### BEFORE

![Screen Shot 2022-09-07 at 7 39 33 PM](https://user-images.githubusercontent.com/3770774/189021707-293b08eb-70d5-4c47-8811-8e388e48e2f8.png)


### AFTER

![Screen Shot 2022-09-07 at 7 40 23 PM](https://user-images.githubusercontent.com/3770774/189021650-aeb091be-cc77-409a-8103-ea57c19d318c.png)


#### Which issue(s) does this change fix?
Speed up help for aws sam cli.

#### Why is this change necessary?
The `--help` page which is the first command that arguably a user would load for their first experience with aws sam cli. This command should be blazingly fast.

#### How does it address the issue?
Only import modules if the child commands such as `sam build --help` etc are loaded, otherwise load a generic command with a name and a short help. 

#### What side effects does this change have?
N/A, This will probably break a bunch of tests that I will need to fix.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
