### PR TITLE
feat: Implement _get_python_command_name

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -718,8 +718,15 @@ def _get_python_command_name() -> str:
     str
         The name of the python command installed
     """
-    # TODO
-    return ""
+    command_names_to_try = ["python", "python3"]
+    for command_name in command_names_to_try:
+        try:
+            run([command_name, "--version"], check=True, capture_output=True)
+        except CalledProcessError:
+            pass
+        else:
+            return command_name
+    raise PrepareHookException("Python not found. Please ensure that python is installed.")
 
 
 def _generate_makefile_rule_for_lambda_resource(

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -25,6 +25,10 @@ from samcli.lib.utils.resources import (
 
 LOG = logging.getLogger(__name__)
 
+# check for python 3, 3.7 or above
+# regex: search for 'Python', whitespace, '3.', digits 7-9 or 2+ digits, any digit or '.' 0+ times
+PYTHON_VERSION_REGEX = re.compile(r"Python\s*3.([7-9]|\d{2,})[\d.]*")
+
 TF_AWS_LAMBDA_FUNCTION = "aws_lambda_function"
 AWS_PROVIDER_NAME = "registry.terraform.io/hashicorp/aws"
 NULL_RESOURCE_PROVIDER_NAME = "registry.terraform.io/hashicorp/null"
@@ -726,10 +730,8 @@ def _get_python_command_name() -> str:
         except CalledProcessError:
             pass
         else:
-            # check for python 3, 3.7 or above
-            # regex: search for 'Python', whitespace, '3.', digits 7-9 or 2+ digits, any digit or '.' 0+ times
-            match = re.search(r"Python\s*3.([7-9]|\d{2,})[\d.]*", run_result.stdout)
-            if not match:
+            # check python version
+            if not PYTHON_VERSION_REGEX.match(run_result.stdout):
                 continue
             return command_name
     raise PrepareHookException("Python not found. Please ensure that python 3.7 or above is installed.")

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -596,6 +596,8 @@ def _enrich_resources_and_generate_makefile(
         the terraform project root directory
     """
 
+    python_command_name = _get_python_command_name()
+
     resources_types_enrichment_functions = {
         "ZIP_LAMBDA_FUNCTION": _enrich_zip_lambda_function,
         "IMAGE_LAMBDA_FUNCTION": _enrich_image_lambda_function,
@@ -624,7 +626,7 @@ def _enrich_resources_and_generate_makefile(
 
         # get makefile rule for resource
         makefile_rule = _generate_makefile_rule_for_lambda_resource(
-            sam_metadata_resource, logical_id, terraform_application_dir
+            sam_metadata_resource, logical_id, terraform_application_dir, python_command_name
         )
         makefile_rules.append(makefile_rule)
 
@@ -741,6 +743,7 @@ def _generate_makefile_rule_for_lambda_resource(
     sam_metadata_resource: SamMetadataResource,
     logical_id: str,
     terraform_application_dir: str,
+    python_command_name: str,
 ) -> str:
     """
     Generates and returns a makefile rule for the lambda resource associated with the given sam metadata resource.
@@ -754,6 +757,8 @@ def _generate_makefile_rule_for_lambda_resource(
         Logical ID of the lambda resource
     terraform_application_dir: str
         the terraform project root directory
+    python_command_name: str
+        the python command name to use for running a script in the makefile rule
 
     Returns
     -------

--- a/tests/unit/hook_packages/terraform/test_prepare_hook.py
+++ b/tests/unit/hook_packages/terraform/test_prepare_hook.py
@@ -1279,6 +1279,7 @@ class TestPrepareHook(TestCase):
         with self.assertRaises(InvalidSamMetadataPropertiesException, msg=exception_message):
             _get_relevant_cfn_resource(sam_metadata_resource, cfn_resources)
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare._get_python_command_name")
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_makefile_rule_for_lambda_resource")
     @patch("samcli.hook_packages.terraform.hooks.prepare._get_relevant_cfn_resource")
@@ -1291,7 +1292,10 @@ class TestPrepareHook(TestCase):
         mock_get_relevant_cfn_resource,
         mock_generate_makefile_rule_for_lambda_resource,
         mock_generate_makefile,
+        mock_get_python_command_name,
     ):
+        mock_get_python_command_name.return_value = "python"
+
         mock_get_lambda_function_source_code_path.side_effect = ["src/code/path1", "src/code/path2"]
         zip_function_1 = {
             "Type": CFN_AWS_LAMBDA_FUNCTION,
@@ -1376,6 +1380,7 @@ class TestPrepareHook(TestCase):
                     sam_metadata_resources[i],
                     list(expected_cfn_resources.keys())[i],
                     "/terraform/project/root",
+                    "python",
                 )
                 for i in range(len(sam_metadata_resources))
             ]
@@ -1383,6 +1388,7 @@ class TestPrepareHook(TestCase):
 
         mock_generate_makefile.assert_called_once_with(makefile_rules, "/output/dir")
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare._get_python_command_name")
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_makefile_rule_for_lambda_resource")
     @patch("samcli.hook_packages.terraform.hooks.prepare._get_relevant_cfn_resource")
@@ -1399,7 +1405,10 @@ class TestPrepareHook(TestCase):
         mock_get_relevant_cfn_resource,
         mock_generate_makefile_rule_for_lambda_resource,
         mock_generate_makefile,
+        mock_get_python_command_name,
     ):
+        mock_get_python_command_name.return_value = "python"
+
         mock_get_lambda_function_source_code_path.side_effect = ["src/code/path1", "src/code/path2"]
         zip_function_1 = {
             "Type": CFN_AWS_LAMBDA_FUNCTION,
@@ -1462,11 +1471,7 @@ class TestPrepareHook(TestCase):
 
         mock_generate_makefile_rule_for_lambda_resource.assert_has_calls(
             [
-                call(
-                    sam_metadata_resources[i],
-                    list(cfn_resources.keys())[i],
-                    "/terraform/project/root",
-                )
+                call(sam_metadata_resources[i], list(cfn_resources.keys())[i], "/terraform/project/root", "python")
                 for i in range(len(sam_metadata_resources))
             ]
         )
@@ -1520,6 +1525,7 @@ class TestPrepareHook(TestCase):
         )
         self.assertEqual(zip_function_1, expected_zip_function_1)
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare._get_python_command_name")
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_makefile_rule_for_lambda_resource")
     @patch("samcli.hook_packages.terraform.hooks.prepare._get_relevant_cfn_resource")
@@ -1532,7 +1538,10 @@ class TestPrepareHook(TestCase):
         mock_get_relevant_cfn_resource,
         mock_generate_makefile_rule_for_lambda_resource,
         mock_generate_makefile,
+        mock_get_python_command_name,
     ):
+        mock_get_python_command_name.return_value = "python"
+
         mock_get_lambda_function_source_code_path.side_effect = ["src/code/path1", "src/code/path2"]
         image_function_1 = {
             "Type": CFN_AWS_LAMBDA_FUNCTION,
@@ -1597,11 +1606,7 @@ class TestPrepareHook(TestCase):
 
         mock_generate_makefile_rule_for_lambda_resource.assert_has_calls(
             [
-                call(
-                    sam_metadata_resources[i],
-                    list(cfn_resources.keys())[i],
-                    "/terraform/project/root",
-                )
+                call(sam_metadata_resources[i], list(cfn_resources.keys())[i], "/terraform/project/root", "python")
                 for i in range(len(sam_metadata_resources))
             ]
         )
@@ -1667,6 +1672,7 @@ class TestPrepareHook(TestCase):
         )
         self.assertEqual(image_function_1, expected_image_function_1)
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare._get_python_command_name")
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare._generate_makefile_rule_for_lambda_resource")
     @patch("samcli.hook_packages.terraform.hooks.prepare._get_relevant_cfn_resource")
@@ -1683,7 +1689,10 @@ class TestPrepareHook(TestCase):
         mock_get_relevant_cfn_resource,
         mock_generate_makefile_rule_for_lambda_resource,
         mock_generate_makefile,
+        mock_get_python_command_name,
     ):
+        mock_get_python_command_name.return_value = "python"
+
         mock_get_lambda_function_source_code_path.side_effect = ["src/code/path1", "src/code/path2"]
         image_function_1 = {
             "Type": CFN_AWS_LAMBDA_FUNCTION,
@@ -1731,11 +1740,7 @@ class TestPrepareHook(TestCase):
 
         mock_generate_makefile_rule_for_lambda_resource.assert_has_calls(
             [
-                call(
-                    sam_metadata_resources[i],
-                    list(cfn_resources.keys())[i],
-                    "/terraform/project/root",
-                )
+                call(sam_metadata_resources[i], list(cfn_resources.keys())[i], "/terraform/project/root", "python")
                 for i in range(len(sam_metadata_resources))
             ]
         )

--- a/tests/unit/hook_packages/terraform/test_prepare_hook.py
+++ b/tests/unit/hook_packages/terraform/test_prepare_hook.py
@@ -1808,8 +1808,10 @@ class TestPrepareHook(TestCase):
                 sam_metadata_resource, image_function_1, "logical_id1", "/terraform/project/root", "/output/dir"
             )
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare._get_python_command_name")
     def test_enrich_resources_and_generate_makefile_invalid_source_type(
         self,
+        mock_get_python_command_name,
     ):
         image_function_1 = {
             "Type": CFN_AWS_LAMBDA_FUNCTION,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Verifies that python is installed and returns the name of the python command, to use for running python scripts.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
