### PR TITLE
perf: push `--help` text to 150ms, 2.6x improvement - supercharge the cli.

### DIFF
--- a/samcli/cli/context.py
+++ b/samcli/cli/context.py
@@ -6,10 +6,6 @@ import logging
 import uuid
 from typing import Optional, cast, List
 
-import boto3
-import botocore
-import botocore.session
-from botocore import credentials
 import click
 
 from samcli.commands.exceptions import CredentialsError
@@ -181,8 +177,11 @@ class Context:
         the Boto3's session object are read-only. Therefore when Click parses new AWS session related properties (like
         region & profile), it will call this method to create a new session with latest values for these properties.
         """
+        import boto3
+        from botocore import credentials, exceptions, session
+
         try:
-            botocore_session = botocore.session.get_session()
+            botocore_session = session.get_session()
             boto3.setup_default_session(
                 botocore_session=botocore_session, region_name=self._aws_region, profile_name=self._aws_profile
             )
@@ -191,7 +190,7 @@ class Context:
                 "assume-role"
             ).cache = credentials.JSONFileCache()
 
-        except botocore.exceptions.ProfileNotFound as ex:
+        except exceptions.ProfileNotFound as ex:
             raise CredentialsError(str(ex)) from ex
 
 

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -4,11 +4,10 @@ Entry point for the CLI
 
 import logging
 import json
-import atexit
+
 import click
 
 from samcli import __version__
-from samcli.lib.telemetry.metric import send_installed_metric, emit_all_metrics
 from samcli.lib.utils.sam_logging import (
     LAMBDA_BULDERS_LOGGER_NAME,
     SamCliLogger,
@@ -115,6 +114,9 @@ def cli(ctx):
     You can find more in-depth guide about the SAM specification here:
     https://github.com/awslabs/serverless-application-model.
     """
+    import atexit
+    from samcli.lib.telemetry.metric import send_installed_metric, emit_all_metrics
+
     gc = GlobalConfig()
     if gc.telemetry_enabled is None:
         enabled = True

--- a/samcli/commands/init/command.py
+++ b/samcli/commands/init/command.py
@@ -12,9 +12,9 @@ from samcli.cli.main import pass_context, common_options, print_cmdline_args
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.local.common.runtime_template import INIT_RUNTIMES, SUPPORTED_DEP_MANAGERS, LAMBDA_IMAGES_RUNTIMES
 from samcli.lib.telemetry.metric import track_command
-from samcli.commands.init.interactive_init_flow import _get_runtime_from_image, get_architectures, get_sorted_runtimes
+from samcli.commands.init.init_flow_helpers import _get_runtime_from_image, get_architectures, get_sorted_runtimes
 from samcli.commands._utils.click_mutex import ClickMutex
-from samcli.lib.build.app_builder import DEPRECATED_RUNTIMES
+from samcli.lib.build.deprecated_runtimes import DEPRECATED_RUNTIMES
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.architecture import X86_64, ARM64
 

--- a/samcli/commands/init/init_flow_helpers.py
+++ b/samcli/commands/init/init_flow_helpers.py
@@ -1,0 +1,165 @@
+import logging
+import functools
+import re
+
+from samcli.lib.utils.architecture import X86_64
+from samcli.local.common.runtime_template import INIT_RUNTIMES, is_custom_runtime, LAMBDA_IMAGES_RUNTIMES_MAP
+
+LOG = logging.getLogger(__name__)
+
+
+def get_sorted_runtimes(runtime_option_list):
+    """
+    Return a list of sorted runtimes in ascending order of runtime names and
+    descending order of runtime version.
+
+    Parameters
+    ----------
+    runtime_option_list : list
+        list of possible runtime to be selected
+
+    Returns
+    -------
+    list
+        sorted list of possible runtime to be selected
+    """
+    supported_runtime_list = get_supported_runtime(runtime_option_list)
+    return sorted(supported_runtime_list, key=functools.cmp_to_key(compare_runtimes))
+
+
+def get_supported_runtime(runtime_list):
+    """
+    Returns a list of only runtimes supported by the current version of SAMCLI.
+    This is the list that is presented to the customer to select from.
+
+    Parameters
+    ----------
+    runtime_list : list
+        List of runtime
+
+    Returns
+    -------
+    list
+        List of supported runtime
+    """
+    supported_runtime_list = []
+    error_message = ""
+    for runtime in runtime_list:
+        if runtime not in INIT_RUNTIMES and not is_custom_runtime(runtime):
+            if not error_message:
+                error_message = "Additional runtimes may be available in the latest SAM CLI version. \
+                    Upgrade your SAM CLI to see the full list."
+                LOG.debug(error_message)
+            continue
+        supported_runtime_list.append(runtime)
+
+    return supported_runtime_list
+
+
+def compare_runtimes(first_runtime, second_runtime):
+    """
+    Logic to compare supported runtime for sorting.
+
+    Parameters
+    ----------
+    first_runtime : str
+        runtime to be compared
+    second_runtime : str
+        runtime to be compared
+
+    Returns
+    -------
+    int
+        comparison result
+    """
+
+    first_runtime_name, first_version_number = _split_runtime(first_runtime)
+    second_runtime_name, second_version_number = _split_runtime(second_runtime)
+
+    if first_runtime_name == second_runtime_name:
+        if first_version_number == second_version_number:
+            # If it's the same runtime and version return al2 first
+            return -1 if first_runtime.endswith(".al2") else 1
+        return second_version_number - first_version_number
+
+    return 1 if first_runtime_name > second_runtime_name else -1
+
+
+def _split_runtime(runtime):
+    """
+    Split a runtime into its name and version number.
+
+    Parameters
+    ----------
+    runtime : str
+        Runtime in the format supported by Lambda
+
+    Returns
+    -------
+    (str, float)
+        Tuple of runtime name and runtime version
+    """
+    return (_get_runtime_name(runtime), _get_version_number(runtime))
+
+
+def _get_runtime_name(runtime):
+    """
+    Return the runtime name without the version
+
+    Parameters
+    ----------
+    runtime : str
+        Runtime in the format supported by Lambda.
+
+    Returns
+    -------
+    str
+        Runtime name, which is obtained as everything before the first number
+    """
+    return re.split(r"\d", runtime)[0]
+
+
+def _get_version_number(runtime):
+    """
+    Return the runtime version number
+
+    Parameters
+    ----------
+    runtime_version : str
+        version of a runtime
+
+    Returns
+    -------
+    float
+        Runtime version number
+    """
+
+    if is_custom_runtime(runtime):
+        return 1.0
+    return float(re.search(r"\d+(\.\d+)?", runtime).group())
+
+
+def _get_templates_with_dependency_manager(templates_options, dependency_manager):
+    return [t for t in templates_options if t.get("dependencyManager") == dependency_manager]
+
+
+def _get_runtime_from_image(image):
+    """
+    Get corresponding runtime from the base-image parameter
+    """
+    runtime = image[image.find("/") + 1 : image.find("-")]
+    return runtime
+
+
+def _get_image_from_runtime(runtime):
+    """
+    Get corresponding base-image from the runtime parameter
+    """
+    return LAMBDA_IMAGES_RUNTIMES_MAP[runtime]
+
+
+def get_architectures(architecture):
+    """
+    Returns list of architecture value based on the init input value
+    """
+    return [X86_64] if architecture is None else [architecture]

--- a/samcli/commands/init/init_flow_helpers.py
+++ b/samcli/commands/init/init_flow_helpers.py
@@ -1,3 +1,6 @@
+"""
+Init flow based helper functions
+"""
 import logging
 import functools
 import re

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -1,8 +1,6 @@
 """
 Isolates interactive init prompt flow. Expected to call generator logic at end of flow.
 """
-import functools
-import re
 import tempfile
 import logging
 from typing import Optional, Tuple
@@ -10,6 +8,13 @@ import click
 
 from botocore.exceptions import ClientError, WaiterError
 
+from samcli.commands.init.init_flow_helpers import (
+    get_architectures,
+    _get_runtime_from_image,
+    get_sorted_runtimes,
+    _get_templates_with_dependency_manager,
+    _get_image_from_runtime,
+)
 from samcli.commands.init.interactive_event_bridge_flow import (
     get_schema_template_details,
     get_schemas_api_caller,
@@ -18,7 +23,6 @@ from samcli.commands.init.interactive_event_bridge_flow import (
 from samcli.commands.exceptions import SchemasApiException, InvalidInitOptionException
 from samcli.lib.schemas.schemas_code_manager import do_download_source_code_binding, do_extract_and_merge_schemas_code
 from samcli.local.common.runtime_template import (
-    INIT_RUNTIMES,
     LAMBDA_IMAGES_RUNTIMES_MAP,
     get_provided_runtime_from_custom_runtime,
     is_custom_runtime,
@@ -27,7 +31,6 @@ from samcli.commands.init.init_generator import do_generate
 from samcli.commands.init.init_templates import InitTemplates, InvalidInitTemplateError
 from samcli.lib.utils.osutils import remove
 from samcli.lib.utils.packagetype import IMAGE, ZIP
-from samcli.lib.utils.architecture import X86_64
 
 LOG = logging.getLogger(__name__)
 
@@ -396,137 +399,6 @@ def _get_choice_from_options(chosen, options, question, msg):
     return options_list[int(choice) - 1]
 
 
-def get_sorted_runtimes(runtime_option_list):
-    """
-    Return a list of sorted runtimes in ascending order of runtime names and
-    descending order of runtime version.
-
-    Parameters
-    ----------
-    runtime_option_list : list
-        list of possible runtime to be selected
-
-    Returns
-    -------
-    list
-        sorted list of possible runtime to be selected
-    """
-    supported_runtime_list = get_supported_runtime(runtime_option_list)
-    return sorted(supported_runtime_list, key=functools.cmp_to_key(compare_runtimes))
-
-
-def get_supported_runtime(runtime_list):
-    """
-    Returns a list of only runtimes supported by the current version of SAMCLI.
-    This is the list that is presented to the customer to select from.
-
-    Parameters
-    ----------
-    runtime_list : list
-        List of runtime
-
-    Returns
-    -------
-    list
-        List of supported runtime
-    """
-    supported_runtime_list = []
-    error_message = ""
-    for runtime in runtime_list:
-        if runtime not in INIT_RUNTIMES and not is_custom_runtime(runtime):
-            if not error_message:
-                error_message = "Additional runtimes may be available in the latest SAM CLI version. \
-                    Upgrade your SAM CLI to see the full list."
-                LOG.debug(error_message)
-            continue
-        supported_runtime_list.append(runtime)
-
-    return supported_runtime_list
-
-
-def compare_runtimes(first_runtime, second_runtime):
-    """
-    Logic to compare supported runtime for sorting.
-
-    Parameters
-    ----------
-    first_runtime : str
-        runtime to be compared
-    second_runtime : str
-        runtime to be compared
-
-    Returns
-    -------
-    int
-        comparison result
-    """
-
-    first_runtime_name, first_version_number = _split_runtime(first_runtime)
-    second_runtime_name, second_version_number = _split_runtime(second_runtime)
-
-    if first_runtime_name == second_runtime_name:
-        if first_version_number == second_version_number:
-            # If it's the same runtime and version return al2 first
-            return -1 if first_runtime.endswith(".al2") else 1
-        return second_version_number - first_version_number
-
-    return 1 if first_runtime_name > second_runtime_name else -1
-
-
-def _split_runtime(runtime):
-    """
-    Split a runtime into its name and version number.
-
-    Parameters
-    ----------
-    runtime : str
-        Runtime in the format supported by Lambda
-
-    Returns
-    -------
-    (str, float)
-        Tuple of runtime name and runtime version
-    """
-    return (_get_runtime_name(runtime), _get_version_number(runtime))
-
-
-def _get_runtime_name(runtime):
-    """
-    Return the runtime name without the version
-
-    Parameters
-    ----------
-    runtime : str
-        Runtime in the format supported by Lambda.
-
-    Returns
-    -------
-    str
-        Runtime name, which is obtained as everything before the first number
-    """
-    return re.split(r"\d", runtime)[0]
-
-
-def _get_version_number(runtime):
-    """
-    Return the runtime version number
-
-    Parameters
-    ----------
-    runtime_version : str
-        version of a runtime
-
-    Returns
-    -------
-    float
-        Runtime version number
-    """
-
-    if is_custom_runtime(runtime):
-        return 1.0
-    return float(re.search(r"\d+(\.\d+)?", runtime).group())
-
-
 def _get_app_template_choice(templates_options, dependency_manager):
     templates = _get_templates_with_dependency_manager(templates_options, dependency_manager)
     chosen_template = templates[0]
@@ -539,25 +411,6 @@ def _get_app_template_choice(templates_options, dependency_manager):
         template_choice = click.prompt("Template", type=click.Choice(click_template_choices), show_choices=False)
         chosen_template = templates[int(template_choice) - 1]
     return chosen_template
-
-
-def _get_templates_with_dependency_manager(templates_options, dependency_manager):
-    return [t for t in templates_options if t.get("dependencyManager") == dependency_manager]
-
-
-def _get_runtime_from_image(image):
-    """
-    Get corresponding runtime from the base-image parameter
-    """
-    runtime = image[image.find("/") + 1 : image.find("-")]
-    return runtime
-
-
-def _get_image_from_runtime(runtime):
-    """
-    Get corresponding base-image from the runtime parameter
-    """
-    return LAMBDA_IMAGES_RUNTIMES_MAP[runtime]
 
 
 def _get_dependency_manager(options, dependency_manager, runtime):
@@ -604,13 +457,6 @@ def _package_schemas_code(runtime, schemas_api_caller, schema_template_details, 
         ) from e
     finally:
         remove(download_location.name)
-
-
-def get_architectures(architecture):
-    """
-    Returns list of architecture value based on the init input value
-    """
-    return [X86_64] if architecture is None else [architecture]
 
 
 def generate_summary_message(

--- a/samcli/lib/build/deprecated_runtimes.py
+++ b/samcli/lib/build/deprecated_runtimes.py
@@ -1,0 +1,12 @@
+from typing import Set
+
+DEPRECATED_RUNTIMES: Set[str] = {
+    "nodejs4.3",
+    "nodejs6.10",
+    "nodejs8.10",
+    "nodejs10.x",
+    "dotnetcore2.0",
+    "dotnetcore2.1",
+    "python2.7",
+    "ruby2.5",
+}

--- a/samcli/lib/build/deprecated_runtimes.py
+++ b/samcli/lib/build/deprecated_runtimes.py
@@ -1,3 +1,7 @@
+"""
+Set of Deprecated Runtimes for AWS Lambda
+"""
+
 from typing import Set
 
 DEPRECATED_RUNTIMES: Set[str] = {

--- a/tests/unit/cli/test_context.py
+++ b/tests/unit/cli/test_context.py
@@ -70,27 +70,25 @@ class TestContext(TestCase):
         self.assertEqual(ctx.region, region)
         self.assertEqual(region, boto3._get_default_session().region_name)
 
-    @patch("samcli.cli.context.boto3")
-    def test_must_set_aws_profile_in_boto_session(self, boto_mock):
+    @patch("boto3.setup_default_session")
+    def test_must_set_aws_profile_in_boto_session(self, mock_setup_default_session):
         profile = "foo"
 
         ctx = Context()
 
         ctx.profile = profile
         self.assertEqual(ctx.profile, profile)
-        boto_mock.setup_default_session.assert_called_with(region_name=None, profile_name=profile, botocore_session=ANY)
+        mock_setup_default_session.assert_called_with(region_name=None, profile_name=profile, botocore_session=ANY)
 
-    @patch("samcli.cli.context.boto3")
-    def test_must_set_all_aws_session_properties(self, boto_mock):
+    @patch("boto3.setup_default_session")
+    def test_must_set_all_aws_session_properties(self, mock_setup_default_session):
         profile = "foo"
         region = "myregion"
         ctx = Context()
 
         ctx.profile = profile
         ctx.region = region
-        boto_mock.setup_default_session.assert_called_with(
-            region_name=region, profile_name=profile, botocore_session=ANY
-        )
+        mock_setup_default_session.assert_called_with(region_name=region, profile_name=profile, botocore_session=ANY)
 
     @patch("samcli.cli.context.uuid")
     def test_must_set_session_id_to_uuid(self, uuid_mock):

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -33,7 +33,7 @@ class TestCliBase(TestCase):
             result = runner.invoke(cli, ["local", "generate-event", "s3", "put", "--debug"])
             self.assertEqual(result.exit_code, 0)
 
-    @patch("samcli.cli.main.send_installed_metric")
+    @patch("samcli.lib.telemetry.metric.send_installed_metric")
     def test_cli_enable_telemetry_with_prompt(self, send_installed_metric_mock):
         with patch("samcli.cli.global_config.GlobalConfig.telemetry_enabled", new_callable=PropertyMock) as mock_flag:
             mock_flag.return_value = None
@@ -44,7 +44,7 @@ class TestCliBase(TestCase):
             # If telemetry is enabled, this should be called
             send_installed_metric_mock.assert_called_once()
 
-    @patch("samcli.cli.main.send_installed_metric")
+    @patch("samcli.lib.telemetry.metric.send_installed_metric")
     def test_prompt_skipped_when_value_set(self, send_installed_metric_mock):
         with patch("samcli.cli.global_config.GlobalConfig.telemetry_enabled", new_callable=PropertyMock) as mock_flag:
             mock_flag.return_value = True

--- a/tests/unit/lib/telemetry/test_metric.py
+++ b/tests/unit/lib/telemetry/test_metric.py
@@ -1,7 +1,5 @@
-import pathlib
 import platform
 import time
-import uuid
 import traceback
 
 from parameterized import parameterized


### PR DESCRIPTION
- This is faster than the earlier commit of https://github.com/aws/aws-sam-cli/pull/4205
- One more 2.6x improvement going to 144ms from 377ms for `sam --help` text, total improvement of 5.26x from last release.
- sam init help text 1.76x faster.

## BEFORE - `sam --help`

![189021650-aeb091be-cc77-409a-8103-ea57c19d318c](https://user-images.githubusercontent.com/3770774/189506065-95f6fbd5-93ce-4ca6-95af-b0938ae817c6.png)

## AFTER - `sam --help`

![Screen Shot 2022-09-10 at 5 11 54 PM](https://user-images.githubusercontent.com/3770774/189506070-94257252-49d5-4bee-9b68-d4dc1248db95.png)

## BEFORE - `sam init --help`
![Screen Shot 2022-09-11 at 5 57 41 PM](https://user-images.githubusercontent.com/3770774/189557329-1ed9dc86-eb04-4942-b60c-4941c9ff7a42.png)


## AFTER - `sam init --help`
![Screen Shot 2022-09-11 at 5 57 24 PM](https://user-images.githubusercontent.com/3770774/189557336-e3e16737-5937-4fb6-9a7c-f140de1f72e1.png)



#### Which issue(s) does this change fix?
* slowness of the CLI

#### Why is this change necessary?
* better UX

#### How does it address the issue?
* move expensive imports to be inside code blocks

#### What side effects does this change have?
* N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
