### PR TITLE
feat: Generate Makefile Rule

### DIFF
--- a/samcli/commands/_utils/custom_options/hook_package_id_option.py
+++ b/samcli/commands/_utils/custom_options/hook_package_id_option.py
@@ -82,7 +82,7 @@ class HookPackageIdOption(click.Option):
                 LOG.info("Running Prepare Hook to prepare the current application")
 
                 iac_project_path = os.getcwd()
-                output_dir_path = os.path.join(iac_project_path, ".aws-sam", "iacs_metadata")
+                output_dir_path = os.path.join(iac_project_path, ".aws-sam-iacs", "iacs_metadata")
                 if not os.path.exists(output_dir_path):
                     os.makedirs(output_dir_path, exist_ok=True)
                 debug = opts.get("debug", False)

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -959,7 +959,7 @@ def _build_show_command_rule(
     """
     show_command_template = (
         "terraform show -json | {python_command_name} {terraform_built_artifacts_script_path} "
-        "--expression {jpath_string} --directory $(ARTIFACTS_DIR) --terraform-project-root {project_root_dir}"
+        '--expression "{jpath_string}" --directory $(ARTIFACTS_DIR) --terraform-project-root {project_root_dir}'
     )
     jpath_string = _build_jpath_string(sam_metadata_resource, resource_address)
     terraform_built_artifacts_script_path = Path(output_dir, TERRAFORM_BUILD_SCRIPT).relative_to(

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -959,7 +959,7 @@ def _build_show_command_rule(
     """
     show_command_template = (
         "terraform show -json | {python_command_name} {terraform_built_artifacts_script_path} "
-        "{jpath_string} $(ARTIFACTS_DIR) {project_root_dir}"
+        "--expression {jpath_string} --directory $(ARTIFACTS_DIR) --terraform-project-root {project_root_dir}"
     )
     jpath_string = _build_jpath_string(sam_metadata_resource, resource_address)
     terraform_built_artifacts_script_path = Path(output_dir, TERRAFORM_BUILD_SCRIPT).relative_to(
@@ -992,7 +992,7 @@ def _build_jpath_string(sam_metadata_resource: SamMetadataResource, resource_add
        Full JPath string for a resource from planned_values to build_output_path
     """
     jpath_string_template = (
-        "|planned_values|root_module{child_modules}|resources"
+        "|planned_values|root_module{child_modules}|resources|"
         '[?address=="{resource_address}"]|values|triggers|built_output_path'
     )
     child_modules_template = "|child_modules[?address=={module_address}]"

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -1059,7 +1059,7 @@ def _get_makefile_build_target(logical_id: str) -> str:
     str
         The formatted Makefile rule build target
     """
-    return f"build-{logical_id}:\n"
+    return f"build-{logical_id}:{os.linesep}"
 
 
 def _format_makefile_recipe(rule_string: str) -> str:
@@ -1076,7 +1076,7 @@ def _format_makefile_recipe(rule_string: str) -> str:
     str
         The formatted target rule
     """
-    return f"\t{rule_string}\n"
+    return f"\t{rule_string}{os.linesep}"
 
 
 def _translate_properties(tf_properties: dict, property_builder_mapping: PropertyBuilderMapping) -> dict:

--- a/samcli/hook_packages/terraform/hooks/prepare.py
+++ b/samcli/hook_packages/terraform/hooks/prepare.py
@@ -996,7 +996,7 @@ def _build_jpath_string(sam_metadata_resource: SamMetadataResource, resource_add
         "|values|root_module{child_modules}|resources|"
         '[?address=="{resource_address}"]|values|triggers|built_output_path'
     )
-    child_modules_template = "|child_modules[?address=={module_address}]"
+    child_modules_template = "|child_modules|[?address=={module_address}]"
     module_address = sam_metadata_resource.current_module_address
     full_module_path = ""
     parent_modules = _get_parent_modules(module_address)
@@ -1029,6 +1029,11 @@ def _get_parent_modules(module_address: Optional[str]) -> List[str]:
     # Split the address on "." then combine it back with the "module" prefix for each module name
     modules = module_address.split(".")
     modules = [".".join(modules[i : i + 2]) for i in range(0, len(modules), 2)]
+
+    if not modules:
+        # The format of the address was somehow different than we expected from the
+        # module.<name>.module.<child_module_name>
+        return []
 
     # Prefix each nested module name with the previous
     previous_module = modules[0]

--- a/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic/lambda/lambda2/main.tf
+++ b/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic/lambda/lambda2/main.tf
@@ -38,3 +38,22 @@ resource "aws_lambda_function" "this" {
 	function_name = var.function_name
 	role = aws_iam_role.iam_for_lambda.arn
 }
+
+resource "null_resource" "sam_metadata_aws_lambda_function_s3_lambda" {
+  triggers = {
+    # This is a way to let SAM CLI correlates between the Lambda layer resource, and this metadata
+    # resource
+    resource_name = "aws_lambda_function.this"
+    resource_type = "ZIP_LAMBDA_FUNCTION"
+
+    # The Lambda layer source code.
+    original_source_code = "./src/test.py"
+
+    # a property to let SAM CLI knows where to find the Lambda layer source code if the provided
+    # value for original_source_code attribute is map.
+    source_code_property = "path"
+
+    # A property to let SAM CLI knows where to find the Lambda layer built output
+    built_output_path = "build/layer.zip"
+  }
+}

--- a/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic/lambda/main.tf
+++ b/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic/lambda/main.tf
@@ -45,3 +45,23 @@ module "level2_lambda" {
    handler = "app.lambda_handler"
    function_name = "level2_lambda_function"
 }
+
+resource "null_resource" "sam_metadata_aws_lambda_function_s3_lambda" {
+  triggers = {
+    # This is a way to let SAM CLI correlates between the Lambda layer resource, and this metadata
+    # resource
+    resource_name = "aws_lambda_function.this"
+    resource_type = "ZIP_LAMBDA_FUNCTION"
+
+    # The Lambda layer source code.
+    original_source_code = "./src/test.py"
+
+    # a property to let SAM CLI knows where to find the Lambda layer source code if the provided
+    # value for original_source_code attribute is map.
+    source_code_property = "path"
+
+    # A property to let SAM CLI knows where to find the Lambda layer built output
+    built_output_path = "build/layer.zip"
+  }
+}
+

--- a/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic/main.tf
+++ b/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic/main.tf
@@ -59,6 +59,25 @@ resource "aws_lambda_function" "root_lambda" {
         role = aws_iam_role.iam_for_lambda.arn
 }
 
+resource "null_resource" "sam_metadata_aws_lambda_function_s3_lambda" {
+  triggers = {
+    # This is a way to let SAM CLI correlates between the Lambda layer resource, and this metadata
+    # resource
+    resource_name = "aws_lambda_function.s3_lambda"
+    resource_type = "ZIP_LAMBDA_FUNCTION"
+
+    # The Lambda layer source code.
+    original_source_code = "./src/test.py"
+
+    # a property to let SAM CLI knows where to find the Lambda layer source code if the provided
+    # value for original_source_code attribute is map.
+    source_code_property = "path"
+
+    # A property to let SAM CLI knows where to find the Lambda layer built output
+    built_output_path = "build/layer.zip"
+  }
+}
+
 module "level1_lambda" {
    source = "./lambda"
    source_code_path = "HelloWorldFunction.zip"

--- a/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic/src/test.py
+++ b/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic/src/test.py
@@ -1,0 +1,2 @@
+def layer_function():
+    return 5

--- a/tests/unit/commands/_utils/custom_options/test_hook_package_id_option.py
+++ b/tests/unit/commands/_utils/custom_options/test_hook_package_id_option.py
@@ -94,7 +94,7 @@ class TestHookPackageIdOption(TestCase):
         args = []
         hook_package_id_option.handle_parse_result(ctx, opts, args)
         iac_hook_wrapper_instance_mock.prepare.assert_called_once_with(
-            os.path.join(cwd_path, ".aws-sam", "iacs_metadata"), cwd_path, False, None, None
+            os.path.join(cwd_path, ".aws-sam-iacs", "iacs_metadata"), cwd_path, False, None, None
         )
         self.assertEqual(opts.get("template_file"), metadata_path)
 
@@ -129,7 +129,7 @@ class TestHookPackageIdOption(TestCase):
         args = []
         hook_package_id_option.handle_parse_result(ctx, opts, args)
         iac_hook_wrapper_instance_mock.prepare.assert_called_once_with(
-            os.path.join(cwd_path, ".aws-sam", "iacs_metadata"),
+            os.path.join(cwd_path, ".aws-sam-iacs", "iacs_metadata"),
             cwd_path,
             True,
             "test",
@@ -273,7 +273,7 @@ class TestHookPackageIdOption(TestCase):
         hook_package_id_option.handle_parse_result(ctx, opts, args)
         prompt_experimental_mock.assert_not_called()
         iac_hook_wrapper_instance_mock.prepare.assert_called_once_with(
-            os.path.join(cwd_path, ".aws-sam", "iacs_metadata"),
+            os.path.join(cwd_path, ".aws-sam-iacs", "iacs_metadata"),
             cwd_path,
             False,
             None,
@@ -314,7 +314,7 @@ class TestHookPackageIdOption(TestCase):
         args = []
         hook_package_id_option.handle_parse_result(ctx, opts, args)
         iac_hook_wrapper_instance_mock.prepare.assert_called_once_with(
-            os.path.join(cwd_path, ".aws-sam", "iacs_metadata"), cwd_path, False, None, None
+            os.path.join(cwd_path, ".aws-sam-iacs", "iacs_metadata"), cwd_path, False, None, None
         )
         self.assertEqual(opts.get("template_file"), metadata_path)
 
@@ -354,7 +354,7 @@ class TestHookPackageIdOption(TestCase):
         args = []
         hook_package_id_option.handle_parse_result(ctx, opts, args)
         iac_hook_wrapper_instance_mock.prepare.assert_called_once_with(
-            os.path.join(cwd_path, ".aws-sam", "iacs_metadata"), cwd_path, False, None, None
+            os.path.join(cwd_path, ".aws-sam-iacs", "iacs_metadata"), cwd_path, False, None, None
         )
         self.assertEqual(opts.get("template_file"), metadata_path)
 
@@ -432,6 +432,6 @@ class TestHookPackageIdOption(TestCase):
         args = []
         hook_package_id_option.handle_parse_result(ctx, opts, args)
         iac_hook_wrapper_instance_mock.prepare.assert_called_once_with(
-            os.path.join(cwd_path, ".aws-sam", "iacs_metadata"), cwd_path, False, None, None
+            os.path.join(cwd_path, ".aws-sam-iacs", "iacs_metadata"), cwd_path, False, None, None
         )
         self.assertEqual(opts.get("template_file"), metadata_path)

--- a/tests/unit/hook_packages/terraform/test_prepare_hook.py
+++ b/tests/unit/hook_packages/terraform/test_prepare_hook.py
@@ -1621,6 +1621,7 @@ class TestPrepareHook(TestCase):
                     list(expected_cfn_resources.keys())[i],
                     "/terraform/project/root",
                     "python",
+                    "/output/dir",
                 )
                 for i in range(len(sam_metadata_resources))
             ]

--- a/tests/unit/hook_packages/terraform/test_prepare_hook.py
+++ b/tests/unit/hook_packages/terraform/test_prepare_hook.py
@@ -1,4 +1,5 @@
 """Test Terraform prepare hook"""
+from pathlib import Path
 from subprocess import CalledProcessError
 from unittest import TestCase
 from unittest import mock
@@ -2499,6 +2500,7 @@ class TestPrepareHook(TestCase):
 
         mock_copy_terraform_built_artifacts_script_path = Mock()
         mock_makefile_path = Mock()
+        mock_os.path.dirname.return_value = ""
         mock_os.path.join.side_effect = [mock_copy_terraform_built_artifacts_script_path, mock_makefile_path]
 
         mock_makefile = Mock()
@@ -2612,7 +2614,7 @@ class TestPrepareHook(TestCase):
         expected_makefile_rule_regex = (
             r"^build-function_logical_id:(\n|\r\n)"
             r"\tterraform apply -target null_resource\.sam_metadata_aws_lambda_function -auto-approve(\n|\r\n)"
-            r"\tterraform show -json \| python \.aws-sam\/output\/copy_terraform_built_artifacts\.py "
+            r"\tterraform show -json \| python .+ "
             r'\|planned_values\|root_module\|resources\[\?address=="null_resource\.sam_metadata_aws_lambda_function"\]'
             r"\|values\|triggers\|built_output_path \$\(ARTIFACTS_DIR\) \/some\/dir\/path(\n|\r\n)"
         )
@@ -2627,8 +2629,9 @@ class TestPrepareHook(TestCase):
             sam_metadata_resource=sam_metadata_resource,
             terraform_application_dir="/some/dir/path",
         )
+        script_path = Path(".aws-sam", "output", "copy_terraform_built_artifacts.py")
         expected_show_command = (
-            "terraform show -json | python .aws-sam/output/copy_terraform_built_artifacts.py "
+            f"terraform show -json | python {script_path} "
             '|planned_values|root_module|resources[?address=="null_resource.sam_metadata_aws_lambda_function"]'
             "|values|triggers|built_output_path $(ARTIFACTS_DIR) /some/dir/path"
         )

--- a/tests/unit/hook_packages/terraform/test_prepare_hook.py
+++ b/tests/unit/hook_packages/terraform/test_prepare_hook.py
@@ -2664,12 +2664,12 @@ class TestPrepareHook(TestCase):
             ),
             (
                 "module.level1_lambda",
-                "|values|root_module|child_modules[?address==module.level1_lambda]|resources|"
+                "|values|root_module|child_modules|[?address==module.level1_lambda]|resources|"
                 '[?address=="null_resource.sam_metadata_aws_lambda_function"]|values|triggers|built_output_path',
             ),
             (
                 "module.level1_lambda.module.level2_lambda",
-                "|values|root_module|child_modules[?address==module.level1_lambda]|child_modules"
+                "|values|root_module|child_modules|[?address==module.level1_lambda]|child_modules|"
                 "[?address==module.level1_lambda.module.level2_lambda]|resources|[?address=="
                 '"null_resource.sam_metadata_aws_lambda_function"]|values|triggers|built_output_path',
             ),


### PR DESCRIPTION
#### Why is this change necessary?
Generate the Makefile rule for building resources based on the SAM Metadata Terraform resource. 
The updated integration test example generates a Makefile that looks like this:

```
build-AwsLambdaFunctionS3Lambda54E19A65:
	terraform apply -target null_resource.sam_metadata_aws_lambda_function_s3_lambda -auto-approve
	terraform show -json | python3 .aws-sam-iacs/iacs_metadata/copy_terraform_built_artifacts.py --expression "|values|root_module|resources|[?address=="null_resource.sam_metadata_aws_lambda_function_s3_lambda"]|values|triggers|built_output_path" --directory "$(ARTIFACTS_DIR)" --terraform-project-root "/Users/mladan/ws/aws-sam-cli/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic"
build-AwsLambdaLayerVersionLambdaLayer556B22D0:
	terraform apply -target null_resource.sam_metadata_aws_lambda_layer_version_lambda_layer -auto-approve
	terraform show -json | python3 .aws-sam-iacs/iacs_metadata/copy_terraform_built_artifacts.py --expression "|values|root_module|resources|[?address=="null_resource.sam_metadata_aws_lambda_layer_version_lambda_layer"]|values|triggers|built_output_path" --directory "$(ARTIFACTS_DIR)" --terraform-project-root "/Users/mladan/ws/aws-sam-cli/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic"
build-ModuleLevel1LambdaAwsLambdaFunctionThis3C50012D:
	terraform apply -target module.level1_lambda.null_resource.sam_metadata_aws_lambda_function_s3_lambda -auto-approve
	terraform show -json | python3 .aws-sam-iacs/iacs_metadata/copy_terraform_built_artifacts.py --expression "|values|root_module|child_modules|[?address==module.level1_lambda]|resources|[?address=="module.level1_lambda.null_resource.sam_metadata_aws_lambda_function_s3_lambda"]|values|triggers|built_output_path" --directory "$(ARTIFACTS_DIR)" --terraform-project-root "/Users/mladan/ws/aws-sam-cli/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic"
build-ModuleLevel1LambdaModuleLevel2LambdaAwsLambdaFunctionThisE3D4D0C8:
	terraform apply -target module.level1_lambda.module.level2_lambda.null_resource.sam_metadata_aws_lambda_function_s3_lambda -auto-approve
	terraform show -json | python3 .aws-sam-iacs/iacs_metadata/copy_terraform_built_artifacts.py --expression "|values|root_module|child_modules|[?address==module.level1_lambda]|child_modules|[?address==module.level1_lambda.module.level2_lambda]|resources|[?address=="module.level1_lambda.module.level2_lambda.null_resource.sam_metadata_aws_lambda_function_s3_lambda"]|values|triggers|built_output_path" --directory "$(ARTIFACTS_DIR)" --terraform-project-root "/Users/mladan/ws/aws-sam-cli/tests/integration/testdata/invoke/terraform/simple_application_no_building_logic"
```

#### How does it address the issue?
This PR implements the `_generate_makefile_rule_for_lambda_resource()` function to return a string comprised of the Makefile rule based on the resource logical ID, the `terraform apply` command then the `terraform show` command piped into our custom build artifact script.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
