### PR TITLE
fix: wrap _write_container_output with try/except to gracefully handle any unexpected errors from docker api

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -396,13 +396,17 @@ class Container:
             Stream writer to write stderr data from the Container into
         """
 
-        # Iterator returns a tuple of (stdout, stderr)
-        for stdout_data, stderr_data in output_itr:
-            if stdout_data and stdout:
-                stdout.write(stdout_data)
+        # following iterator might throw an exception (see: https://github.com/aws/aws-sam-cli/issues/4222)
+        try:
+            # Iterator returns a tuple of (stdout, stderr)
+            for stdout_data, stderr_data in output_itr:
+                if stdout_data and stdout:
+                    stdout.write(stdout_data)
 
-            if stderr_data and stderr:
-                stderr.write(stderr_data)
+                if stderr_data and stderr:
+                    stderr.write(stderr_data)
+        except Exception as ex:
+            LOG.debug("Failed to get the logs from the container", exc_info=ex)
 
     @property
     def network_id(self):

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -682,6 +682,19 @@ class TestContainer_wait_for_result(TestCase):
 
         self.assertEqual(mock_requests.post.call_count, 0)
 
+    def test_write_container_output_successful(self):
+        stdout_mock = Mock()
+        stderr_mock = Mock()
+
+        def _output_iterator():
+            yield "Hello", None
+            yield None, "World"
+            raise ValueError("The pipe has been ended.")
+
+        Container._write_container_output(_output_iterator(), stdout_mock, stderr_mock)
+        stdout_mock.assert_has_calls([call.write("Hello")])
+        stderr_mock.assert_has_calls([call.write("World")])
+
 
 class TestContainer_wait_for_logs(TestCase):
     def setUp(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/4222


#### Why is this change necessary?
With v4.12.0 version of docker desktop on Windows, getting output streams of the container started to raise exception once the container is done with its work.


#### How does it address the issue?
With this change, we are wrapping `_write_container_output` function to catch any unexpected errors from docker API so that these errors won't fail execution.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
