### PR TITLE
fix: remove the terraform project root parameter from built artifacts copy script.

### DIFF
--- a/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
+++ b/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
@@ -216,26 +216,16 @@ if __name__ == "__main__":
         required=True,
         help="Directory to which extracted expression " "contents are copied/unzipped to",
     )
-    argparser.add_argument(
-        "--terraform-project-root",
-        type=str,
-        required=True,
-        default=None,
-        help="Extracted expression (path), if relative, will be relative to the provided terraform project root.",
-    )
 
     arguments = argparser.parse_args()
     directory_path = os.path.abspath(arguments.directory)
 
-    terraform_project_root = os.path.abspath(arguments.terraform_project_root)
+    terraform_project_root = os.getcwd()
     extracted_attribute_path = None
     data_object = None
 
     if not os.path.exists(directory_path) or not os.path.isdir(directory_path):
         LOG.error("Expected --directory to be a valid directory!")
-        cli_exit()
-    if not os.path.exists(terraform_project_root) or not os.path.isdir(terraform_project_root):
-        LOG.error("Expected --terraform-project-path to be a valid directory!")
         cli_exit()
 
     # Load and Parse

--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -959,7 +959,7 @@ def _build_show_command(
     """
     show_command_template = (
         "terraform show -json | {python_command_name} {terraform_built_artifacts_script_path} "
-        '--expression "{jpath_string}" --directory "$(ARTIFACTS_DIR)" --terraform-project-root "{project_root_dir}"'
+        '--expression "{jpath_string}" --directory "$(ARTIFACTS_DIR)"'
     )
     jpath_string = _build_jpath_string(sam_metadata_resource, resource_address)
     terraform_built_artifacts_script_path = Path(output_dir, TERRAFORM_BUILD_SCRIPT).relative_to(
@@ -969,7 +969,6 @@ def _build_show_command(
         python_command_name=python_command_name,
         terraform_built_artifacts_script_path=terraform_built_artifacts_script_path,
         jpath_string=jpath_string,
-        project_root_dir=terraform_application_dir,
     )
 
 

--- a/tests/integration/scripts/test_copy_terraform_built_artifacts.py
+++ b/tests/integration/scripts/test_copy_terraform_built_artifacts.py
@@ -12,6 +12,7 @@ TIMEOUT = 3
 class TestCopyTerraformBuiltArtifacts(TestCase):
     def setUp(self) -> None:
         self.script_dir = pathlib.Path(__file__).parents[3].joinpath("samcli", "hook_packages", "terraform")
+        self.working_dir = pathlib.Path(__file__).parents[0]
         self.script_name = "copy_terraform_built_artifacts.py"
         self.script_location = self.script_dir.joinpath(self.script_name)
         self.testdata_directory = pathlib.Path(__file__).parent.joinpath("testdata")
@@ -33,7 +34,9 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             self.expression,
         ]
         with open(self.input_file, "rb") as f:
-            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=self.working_dir
+            )
             try:
                 process.communicate(timeout=TIMEOUT, input=f.read())
             except TimeoutError:
@@ -53,7 +56,9 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             self.expression,
         ]
         with open(input_zip_file, "rb") as f:
-            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=self.working_dir
+            )
             try:
                 process.communicate(timeout=TIMEOUT, input=f.read())
             except TimeoutError:
@@ -73,7 +78,9 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             self.expression,
         ]
         with open(self.input_file, "rb") as f:
-            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=self.working_dir
+            )
             try:
                 process.communicate(timeout=TIMEOUT, input=f.read())
             except TimeoutError:
@@ -95,7 +102,9 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             expression,
         ]
         with open(self.input_file, "rb") as f:
-            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=self.working_dir
+            )
             try:
                 process.communicate(timeout=TIMEOUT, input=f.read())
             except TimeoutError:
@@ -117,7 +126,9 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             expression,
         ]
         with open(self.input_file, "rb") as f:
-            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=self.working_dir
+            )
             try:
                 process.communicate(timeout=TIMEOUT, input=f.read())
             except TimeoutError:
@@ -136,7 +147,9 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             self.expression,
         ]
         with open(self.input_file, "rb") as f:
-            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=self.working_dir
+            )
             try:
                 process.communicate(timeout=TIMEOUT, input=f.read())
             except TimeoutError:
@@ -153,7 +166,9 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             "--expression",
             self.expression,
         ]
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=self.working_dir
+        )
         try:
             process.communicate(timeout=TIMEOUT)
         except TimeoutError:
@@ -170,7 +185,9 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             "--expression",
             self.expression,
         ]
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=self.working_dir
+        )
         try:
             process.communicate(timeout=TIMEOUT, input=b"invalid_json")
         except TimeoutError:

--- a/tests/integration/scripts/test_copy_terraform_built_artifacts.py
+++ b/tests/integration/scripts/test_copy_terraform_built_artifacts.py
@@ -31,8 +31,6 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             str(self.directory),
             "--expression",
             self.expression,
-            "--terraform-project-root",
-            f"{str(self.testdata_directory)}",
         ]
         with open(self.input_file, "rb") as f:
             process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
@@ -53,8 +51,6 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             str(self.directory),
             "--expression",
             self.expression,
-            "--terraform-project-root",
-            f"{str(self.testdata_directory)}",
         ]
         with open(input_zip_file, "rb") as f:
             process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
@@ -75,8 +71,6 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             directory,
             "--expression",
             self.expression,
-            "--terraform-project-root",
-            f"{str(self.testdata_directory)}",
         ]
         with open(self.input_file, "rb") as f:
             process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
@@ -99,8 +93,6 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             f"{str(self.directory)}",
             "--expression",
             expression,
-            "--terraform-project-root",
-            f"{str(self.testdata_directory)}",
         ]
         with open(self.input_file, "rb") as f:
             process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
@@ -123,8 +115,6 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             f"{str(self.directory)}",
             "--expression",
             expression,
-            "--terraform-project-root",
-            f"{str(self.testdata_directory)}",
         ]
         with open(self.input_file, "rb") as f:
             process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
@@ -144,8 +134,6 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             f"{str(directory)}",
             "--expression",
             self.expression,
-            "--terraform-project-root",
-            f"{str(self.testdata_directory)}",
         ]
         with open(self.input_file, "rb") as f:
             process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
@@ -164,8 +152,6 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             f"{str(self.directory)}",
             "--expression",
             self.expression,
-            "--terraform-project-root",
-            f"{str(self.testdata_directory)}",
         ]
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
         try:
@@ -183,8 +169,6 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             f"{str(self.directory)}",
             "--expression",
             self.expression,
-            "--terraform-project-root",
-            f"{str(self.testdata_directory)}",
         ]
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
         try:
@@ -193,24 +177,3 @@ class TestCopyTerraformBuiltArtifacts(TestCase):
             process.kill()
             raise
         self.assertEqual(1, process.returncode)
-
-    def test_script_output_path_invalid_terraform_project_root(self):
-        command = [
-            f"{str(sys.executable)}",
-            f"{str(self.script_location)}",
-            "--directory",
-            f"{str(self.directory)}",
-            "--expression",
-            self.expression,
-            "--terraform-project-root",
-            "not-a-dir",
-        ]
-
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
-        with open(self.input_file, "rb") as f:
-            try:
-                process.communicate(timeout=TIMEOUT, input=f.read())
-            except TimeoutError:
-                process.kill()
-                raise
-            self.assertEqual(1, process.returncode)

--- a/tests/integration/scripts/testdata/build-output-path-dir.json
+++ b/tests/integration/scripts/testdata/build-output-path-dir.json
@@ -7,7 +7,7 @@
 					"address": "sam_metadata_address",
 					"values": {
 						"triggers": {
-							"built_output_path": "output_path_dir"
+							"built_output_path": "testdata/output_path_dir"
 						}
 					}
 				}]

--- a/tests/integration/scripts/testdata/build-output-path-zip.json
+++ b/tests/integration/scripts/testdata/build-output-path-zip.json
@@ -7,7 +7,7 @@
 					"address": "sam_metadata_address",
 					"values": {
 						"triggers": {
-							"built_output_path": "artifact_dir/test_artifact.zip"
+							"built_output_path": "testdata/artifact_dir/test_artifact.zip"
 						}
 					}
 				}]

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
@@ -2652,8 +2652,7 @@ class TestPrepareHook(TestCase):
             f"terraform show -json | python {script_path} "
             '--expression "|values|root_module|resources|'
             '[?address=="null_resource.sam_metadata_aws_lambda_function"]'
-            '|values|triggers|built_output_path" --directory "$(ARTIFACTS_DIR)'
-            '" --terraform-project-root "/some/dir/path"'
+            '|values|triggers|built_output_path" --directory "$(ARTIFACTS_DIR)"'
         )
         self.assertEqual(show_command, expected_show_command)
 


### PR DESCRIPTION
Remove the `terraform-project-root` parameter from the copy terraform built artifacts script, as it is not required. If the built artifact path is a relative path, it will be relative to the current project root directory, which is the copied project to the scratch directory, which is the MakeFile working directory. 

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
