### PR TITLE
Fix copy script loc

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -145,7 +145,8 @@ def prepare(params: dict) -> dict:
         )
         raise PrepareHookException("There was an error while preparing the Terraform application.") from e
     except OSError as e:
-        raise PrepareHookException(f"Unable to create directory {output_dir_path}") from e
+        # raise PrepareHookException(f"Unable to create directory {output_dir_path}") from e
+        raise PrepareHookException(f"OSError: {e}") from e
 
 
 def _update_resources_paths(cfn_resources: Dict[str, Any], terraform_application_dir: str) -> None:
@@ -803,7 +804,7 @@ def _generate_makefile(
 
     # copy copy_terraform_built_artifacts.py script into output directory
     copy_terraform_built_artifacts_script_path = os.path.join(
-        Path(os.path.dirname(__file__)).parent, TERRAFORM_BUILD_SCRIPT
+        Path(os.path.dirname(__file__)).parent.parent, TERRAFORM_BUILD_SCRIPT
     )
     shutil.copy(copy_terraform_built_artifacts_script_path, output_directory_path)
 

--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -145,7 +145,6 @@ def prepare(params: dict) -> dict:
         )
         raise PrepareHookException("There was an error while preparing the Terraform application.") from e
     except OSError as e:
-        # raise PrepareHookException(f"Unable to create directory {output_dir_path}") from e
         raise PrepareHookException(f"OSError: {e}") from e
 
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Path of `copy_terraform_built_artifact.py` needs to be adjusted after splitting `prepare.py` into multiple files.
The error message for handling `OSError` is not accurate for what the real error is.

#### How does it address the issue?
- Update path variable
- Update error message when re-raising `PrepareHookException`

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
