### PR TITLE
Terraform hooks - Adding integration tests for `sam build` (Terraform Hook) with Zip-based Lambda Functions

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -918,7 +918,7 @@ def _generate_makefile_rule_for_lambda_resource(
     """
     target = _get_makefile_build_target(logical_id)
     resource_address = sam_metadata_resource.resource.get("address", "")
-    apply_command_template = "terraform apply -target {resource_address} -auto-approve"
+    apply_command_template = "terraform apply -target {resource_address} -replace {resource_address} -auto-approve"
     apply_command_recipe = _format_makefile_recipe(apply_command_template.format(resource_address=resource_address))
     show_command_recipe = _format_makefile_recipe(
         _build_show_command(

--- a/tests/integration/buildcmd/test_build_terraform_applications.py
+++ b/tests/integration/buildcmd/test_build_terraform_applications.py
@@ -1,10 +1,15 @@
+import os
 import logging
 import shutil
+import uuid
+import time
 
 from pathlib import Path
 from subprocess import Popen, PIPE, TimeoutExpired
 from typing import Optional
 from unittest import skipIf
+
+import boto3
 
 from parameterized import parameterized
 
@@ -13,6 +18,7 @@ from tests.testing_utils import CI_OVERRIDE, IS_WINDOWS, RUNNING_ON_CI
 
 
 LOG = logging.getLogger(__name__)
+S3_SLEEP = 3
 
 
 class BuildTerraformApplicationIntegBase(BuildIntegBase):
@@ -23,6 +29,32 @@ class BuildTerraformApplicationIntegBase(BuildIntegBase):
     def setUpClass(cls):
         super(BuildTerraformApplicationIntegBase, cls).setUpClass()
         cls.terraform_application_path = str(Path(cls.test_data_path, cls.terraform_application))
+
+    def tearDown(self):
+        """Clean up the generated files during integ test run"""
+        try:
+            shutil.rmtree(str(Path(self.terraform_application_path) / ".aws-sam"))
+            shutil.rmtree(str(Path(self.terraform_application_path) / ".aws-sam-iacs"))
+            shutil.rmtree(str(Path(self.terraform_application_path) / ".terraform"))
+        except FileNotFoundError:
+            pass
+
+        try:
+            (Path(self.terraform_application_path) / "terraform.tfstate").unlink()
+        except FileNotFoundError:
+            pass
+
+        try:
+            (Path(self.terraform_application_path) / "terraform.tfstate.backup").unlink()
+        except FileNotFoundError:
+            pass
+
+        try:
+            (Path(self.terraform_application_path) / ".terraform.lock.hcl").unlink()
+        except FileNotFoundError:
+            pass
+
+        super().tearDown()
 
     def run_command(self, command_list, env=None, input=None):
         process = Popen(
@@ -108,32 +140,7 @@ class TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend(Bu
         "my_level1_lambda",
         "my_level2_lambda",
     ]
-    
-    def tearDown(self):
-        try:
-            shutil.rmtree(str(Path(self.terraform_application_path) / ".aws-sam"))
-            shutil.rmtree(str(Path(self.terraform_application_path) / ".aws-sam-iacs"))
-            shutil.rmtree(str(Path(self.terraform_application_path) / ".terraform"))
-        except FileNotFoundError:
-            pass
-        
-        try:
-            (Path(self.terraform_application_path) / "terraform.tfstate").unlink()
-        except FileNotFoundError:
-            pass
-        
-        try:
-            (Path(self.terraform_application_path) / "terraform.tfstate.backup").unlink()
-        except FileNotFoundError:
-            pass
-        
-        try:
-            (Path(self.terraform_application_path) / ".terraform.lock.hcl").unlink()
-        except FileNotFoundError:
-            pass
-        
-        super().tearDown()
-    
+
     @skipIf(
         not CI_OVERRIDE,
         "Skip Terraform test cases unless running in CI",
@@ -141,9 +148,7 @@ class TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend(Bu
     @parameterized.expand(functions)
     def test_build_and_invoke_lambda_functions(self, function_identifier):
         build_cmd_list = self.get_command_list(
-            beta_features=True,
-            hook_package_id="terraform",
-            function_identifier=function_identifier
+            beta_features=True, hook_package_id="terraform", function_identifier=function_identifier
         )
         LOG.info("command list: %s", build_cmd_list)
         _, _, return_code = self.run_command(build_cmd_list)
@@ -153,12 +158,98 @@ class TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend(Bu
             template_path=str(Path(self.terraform_application_path) / ".aws-sam/build/template.yaml"),
             function_logical_id=function_identifier,
             overrides=None,
-            expected_result={"statusCode": 200, "body": "[]"}
+            expected_result={"statusCode": 200, "body": "[]"},
         )
 
 
 class TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend(BuildTerraformApplicationIntegBase):
-    pass
+    terraform_application = Path("terraform/zip_based_lambda_functions_s3_backend")
+    functions = [
+        "aws_lambda_function.from_localfile",
+        "aws_lambda_function.from_s3",
+        "module.level1_lambda.aws_lambda_function.this",
+        "module.level1_lambda.module.level2_lambda.aws_lambda_function.this",
+        "my_function_from_localfile",
+        "my_function_from_s3",
+        "my_level1_lambda",
+        "my_level2_lambda",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """Setting up a S3 bucket (using pre-created or create a new bucket) to use as a Terraform backend"""
+        cls.region_name = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+
+        """Please read comments in package_integ_base.py for more details around this."""
+        bucket_env_var = os.environ.get("AWS_S3")
+        cls.pre_created_bucket = False
+        if bucket_env_var:
+            cls.pre_created_bucket = os.environ.get(bucket_env_var, False)
+        cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
+
+        s3 = boto3.resource("s3")
+        cls.s3_bucket = s3.Bucket(cls.bucket_name)
+        if not cls.pre_created_bucket:
+            cls.s3_bucket.create()
+            time.sleep(S3_SLEEP)
+
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up and delete the bucket if it is not pre-created"""
+        cls.s3_bucket.objects.all().delete()
+        time.sleep(S3_SLEEP)
+        if not cls.pre_created_bucket:
+            cls.s3_bucket.delete()
+
+    def setUp(self):
+        self.backend_key = str(Path("terraform-backend") / str(uuid.uuid4()))
+        self.backendconfig_path = str(Path(self.terraform_application_path) / "backend.conf")
+        with open(self.backendconfig_path, "w") as f:
+            f.write(f'bucket="{self.bucket_name}"\n')
+            f.write(f'key="{self.backend_key}"\n')
+            f.write(f'region="{self.region_name}"')
+
+        # We have to init the terraform project with specifying the S3 backend first
+        _, stderr, _ = self.run_command(
+            ["terraform", "init", f"-backend-config={self.backendconfig_path}", "-reconfigure"]
+        )
+        if stderr:
+            LOG.error(stderr)
+
+        super().setUp()
+
+    def tearDown(self):
+        """Clean up the terraform state file on S3 and remove the backendconfg locally"""
+        self.s3_bucket.delete_objects(Delete={"Objects": [{"Key": self.backend_key}]})
+        time.sleep(S3_SLEEP)
+        try:
+            Path(self.backendconfig_path).unlink()
+        except FileNotFoundError:
+            pass
+
+        super().tearDown()
+
+    @skipIf(
+        not CI_OVERRIDE,
+        "Skip Terraform test cases unless running in CI",
+    )
+    @parameterized.expand(functions)
+    def test_build_and_invoke_lambda_functions(self, function_identifier):
+        build_cmd_list = self.get_command_list(
+            beta_features=True, hook_package_id="terraform", function_identifier=function_identifier
+        )
+        LOG.info("command list: %s", build_cmd_list)
+        _, _, return_code = self.run_command(build_cmd_list)
+        self.assertEqual(return_code, 0)
+
+        self._verify_invoke_built_function(
+            template_path=str(Path(self.terraform_application_path) / ".aws-sam/build/template.yaml"),
+            function_logical_id=function_identifier,
+            overrides=None,
+            expected_result={"statusCode": 200, "body": "[]"},
+        )
 
 
 class TestBuildTerraformApplicationsWithImageBasedLambdaFunctionAndLocalBackend(BuildTerraformApplicationIntegBase):

--- a/tests/integration/buildcmd/test_build_terraform_applications.py
+++ b/tests/integration/buildcmd/test_build_terraform_applications.py
@@ -114,12 +114,24 @@ class TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend(Bu
             shutil.rmtree(str(Path(self.terraform_application_path) / ".aws-sam"))
             shutil.rmtree(str(Path(self.terraform_application_path) / ".aws-sam-iacs"))
             shutil.rmtree(str(Path(self.terraform_application_path) / ".terraform"))
-            (Path(self.terraform_application_path) / "terraform.tfstate").unlink()
-            (Path(self.terraform_application_path) / "terraform.tfstate.backup").unlink()
-            (Path(self.terraform_application_path) / ".terraform.lock.hcl").unlink()
-        except Exception:
-            LOG.exception("Something wrong when deleting files")
+        except FileNotFoundError:
             pass
+        
+        try:
+            (Path(self.terraform_application_path) / "terraform.tfstate").unlink()
+        except FileNotFoundError:
+            pass
+        
+        try:
+            (Path(self.terraform_application_path) / "terraform.tfstate.backup").unlink()
+        except FileNotFoundError:
+            pass
+        
+        try:
+            (Path(self.terraform_application_path) / ".terraform.lock.hcl").unlink()
+        except FileNotFoundError:
+            pass
+        
         super().tearDown()
     
     @skipIf(

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/lambda_tf_module/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/lambda_tf_module/main.tf
@@ -1,0 +1,59 @@
+variable "source_code_path" {
+    type = string
+}
+
+variable "handler" {
+    type = string
+}
+
+variable "function_name" {
+    type = string
+}
+
+variable "l2_source_code_path" {
+    type = string
+}
+
+variable "l2_handler" {
+    type = string
+}
+
+variable "l2_function_name" {
+    type = string
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_l1"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_lambda_function" "this" {
+	filename = var.source_code_path
+	handler = var.handler
+	runtime = "python3.8"
+	function_name = var.function_name
+	role = aws_iam_role.iam_for_lambda.arn
+}
+
+module "level2_lambda" {
+    source = "./nested_lambda_tf_module"
+    source_code_path = var.l2_source_code_path
+    handler = var.l2_handler
+    function_name = var.l2_function_name
+}

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/lambda_tf_module/nested_lambda_tf_module/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/lambda_tf_module/nested_lambda_tf_module/main.tf
@@ -1,0 +1,40 @@
+variable "source_code_path" {
+	type = string
+}
+
+variable "handler" {
+	type = string
+}
+
+variable "function_name" {
+	type = string
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_l2"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_lambda_function" "this" {
+	filename = var.source_code_path
+	handler = var.handler
+	runtime = "python3.8"
+	function_name = var.function_name
+	role = aws_iam_role.iam_for_lambda.arn
+}

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/main.tf
@@ -1,0 +1,182 @@
+provider "aws" {
+    region = "us-west-1"
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "dummy_iam_role"
+
+    assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "lambda.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+locals {
+    building_path = "./building"
+    lambda_src_path = "./src/list_books"
+    lambda_code_filename = "list_books.zip"
+    layer_src_path = "./my_layer_code"
+    layer_code_filename = "my_layer.zip"
+}
+
+resource "random_uuid" "s3_bucket" {
+    keepers = {
+        my_key = "my_key"
+    }
+}
+
+resource "aws_s3_bucket" "lambda_code_bucket" {
+    # bucket = "lambda_code_bucket-${random_uuid.s3_bucket.result}"
+    bucket = "lambda_code_bucket"
+}
+
+resource "aws_s3_object" "s3_lambda_code" {
+    bucket = aws_s3_bucket.lambda_code_bucket.bucket
+    key = "s3_lambda_code"
+    source = "${local.building_path}/${local.lambda_code_filename}"
+}
+
+resource "null_resource" "build_lambda_function" {
+    triggers = {
+        build_number = "${timestamp()}"
+    }
+
+    provisioner "local-exec" {
+        command = "./py_build.sh \"${local.lambda_src_path}\" \"${local.building_path}\" \"${local.lambda_code_filename}\""
+    }
+}
+
+resource "null_resource" "build_layer_version" {
+    triggers = {
+        build_number = "${timestamp()}"
+    }
+
+    provisioner "local-exec" {
+        command = "./py_build.sh \"${local.layer_src_path}\" \"${local.building_path}\" \"${local.layer_code_filename}\""
+    }
+}
+
+
+## /* Lambda Function with code from a local file ###
+resource "aws_lambda_function" "from_localfile" {
+    filename = "${local.building_path}/${local.lambda_code_filename}"
+    handler = "index.lambda_handler"
+    runtime = "python3.8"
+    function_name = "my_function_from_localfile"
+    role = aws_iam_role.iam_for_lambda.arn
+    depends_on = [
+        null_resource.build_lambda_function
+    ]
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_function_from_localfile" {
+    triggers = {
+        resource_name = "aws_lambda_function.from_localfile"
+        resource_type = "ZIP_LAMBDA_FUNCTION"
+        original_source_code = local.lambda_src_path
+        built_output_path = "${local.building_path}/${local.lambda_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_lambda_function
+    ]
+}
+## */
+
+## /* Lambda Function with code from S3
+resource "aws_lambda_function" "from_s3" {
+    s3_bucket = aws_s3_bucket.lambda_code_bucket.bucket
+    s3_key = aws_s3_object.s3_lambda_code.key
+    handler = "index.lambda_handler"
+    runtime = "python3.8"
+    function_name = "my_function_from_s3"
+    role = aws_iam_role.iam_for_lambda.arn
+    depends_on = [
+        null_resource.build_lambda_function
+    ]    
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_function_from_s3" {
+    triggers = {
+        resource_name = "aws_lambda_function.from_s3"
+        resource_type = "ZIP_LAMBDA_FUNCTION"
+        original_source_code = local.lambda_src_path
+        built_output_path = "${local.building_path}/${local.lambda_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_lambda_function
+    ]
+}
+## */
+
+## /* Level1 Lambda Module and Level2 Lambda Module
+module "level1_lambda" {
+    source = "./lambda_tf_module"
+    source_code_path = "${local.building_path}/${local.lambda_code_filename}"
+    handler = "index.lambda_handler"
+    function_name = "my_level1_lambda"
+    l2_source_code_path = "${local.building_path}/${local.lambda_code_filename}"
+    l2_handler = "index.lambda_handler"
+    l2_function_name = "my_level2_lambda"
+    depends_on = [
+        null_resource.build_lambda_function
+    ]
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_function_level1_lambda" {
+    triggers = {
+        resource_name = "module.level1_lambda.aws_lambda_function.this"
+        resource_type = "ZIP_LAMBDA_FUNCTION"
+        original_source_code = local.lambda_src_path
+        built_output_path = "${local.building_path}/${local.lambda_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_lambda_function
+    ] 
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_function_level2_lambda" {
+    triggers = {
+        resource_name = "module.level1_lambda.module.level2_lambda.aws_lambda_function.this"
+        resource_type = "ZIP_LAMBDA_FUNCTION"
+        original_source_code = local.lambda_src_path
+        built_output_path = "${local.building_path}/${local.lambda_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_lambda_function
+    ] 
+}
+## */
+
+## /* Lambda Layer with local source code
+resource "aws_lambda_layer_version" "from_local" {
+    filename = "${local.building_path}/${local.layer_code_filename}"
+    layer_name = "my_layer"
+
+    compatible_runtimes = ["python3.8", "python3.9"]
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_layer_version_from_local" {
+    triggers = {
+        resource_name = "aws_lambda_layer_version.from_local"
+        resource_type = "LAMBDA_LAYER"
+
+        original_source_code = local.layer_src_path
+        source_code_property = "path"
+        built_output_path = "${local.building_path}/${local.layer_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_layer_version
+    ]
+}
+## */

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/my_layer_code/layer.py
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/my_layer_code/layer.py
@@ -1,0 +1,4 @@
+import numpy
+
+def layer_method():
+    return {"pi": "{0:.2f}".format(numpy.pi)}

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/my_layer_code/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/my_layer_code/requirements.txt
@@ -1,0 +1,7 @@
+# These are some hard packages to build. Using them here helps us verify that building works on various platforms
+
+# NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
+numpy<1.20.3
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/py_build.sh
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/py_build.sh
@@ -1,0 +1,16 @@
+src_code=$1
+build_path=$2
+output_name=$3
+echo "building ${src_code} into ${build_path}"
+pwd
+mkdir -p ${build_path}
+rm -rf ${build_path}/*
+mkdir -p ${build_path}/tmp_building
+tree ./
+cp -r $src_code/* ${build_path}/tmp_building
+pip install -r ${build_path}/tmp_building/requirements.txt -t ${build_path}/tmp_building/.
+pushd ${build_path}/tmp_building/ && zip -r $output_name . && popd
+mv "${build_path}/tmp_building/${output_name}" "${build_path}/$output_name"
+rm -rf ${build_path}/tmp_building
+pwd
+tree ./

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/src/list_books/index.py
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/src/list_books/index.py
@@ -1,0 +1,33 @@
+import json
+import boto3
+import os 
+
+#import ptvsd
+
+#ptvsd.enable_attach(address=('0.0.0.0', 9999), redirect_output=True)
+#ptvsd.wait_for_attach()
+
+def lambda_handler(event, context):
+    print("list books function start")
+
+    # books_table = os.environ['books_table_id']
+    # dynamodb = boto3.client('dynamodb')
+    # paginator = dynamodb.get_paginator("scan")
+    
+    books = []
+    # for page in paginator.paginate(TableName=books_table):
+    #     for item in page["Items"]:
+    #         print(f"Debugging Message - dynamodb scan output {item}")
+    #         print(f"Debugging Message - dynamodb scan output {item}")
+            
+    #         books.append({
+    #             "book_id": item.get("id").get("S"),
+    #             "book_title": item.get("title").get("S"),
+    #             "book_language": item.get("language").get("S"),
+    #         })
+
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(books),
+    }

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/src/list_books/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/src/list_books/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+ptvsd

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/lambda_tf_module/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/lambda_tf_module/main.tf
@@ -1,0 +1,59 @@
+variable "source_code_path" {
+    type = string
+}
+
+variable "handler" {
+    type = string
+}
+
+variable "function_name" {
+    type = string
+}
+
+variable "l2_source_code_path" {
+    type = string
+}
+
+variable "l2_handler" {
+    type = string
+}
+
+variable "l2_function_name" {
+    type = string
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_l1"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_lambda_function" "this" {
+	filename = var.source_code_path
+	handler = var.handler
+	runtime = "python3.8"
+	function_name = var.function_name
+	role = aws_iam_role.iam_for_lambda.arn
+}
+
+module "level2_lambda" {
+    source = "./nested_lambda_tf_module"
+    source_code_path = var.l2_source_code_path
+    handler = var.l2_handler
+    function_name = var.l2_function_name
+}

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/lambda_tf_module/nested_lambda_tf_module/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/lambda_tf_module/nested_lambda_tf_module/main.tf
@@ -1,0 +1,40 @@
+variable "source_code_path" {
+	type = string
+}
+
+variable "handler" {
+	type = string
+}
+
+variable "function_name" {
+	type = string
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_l2"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_lambda_function" "this" {
+	filename = var.source_code_path
+	handler = var.handler
+	runtime = "python3.8"
+	function_name = var.function_name
+	role = aws_iam_role.iam_for_lambda.arn
+}

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/main.tf
@@ -1,0 +1,186 @@
+terraform {
+    backend "s3" {}
+}
+
+provider "aws" {
+    region = "us-west-1"
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "dummy_iam_role"
+
+    assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "lambda.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+locals {
+    building_path = "./building"
+    lambda_src_path = "./src/list_books"
+    lambda_code_filename = "list_books.zip"
+    layer_src_path = "./my_layer_code"
+    layer_code_filename = "my_layer.zip"
+}
+
+resource "random_uuid" "s3_bucket" {
+    keepers = {
+        my_key = "my_key"
+    }
+}
+
+resource "aws_s3_bucket" "lambda_code_bucket" {
+    # bucket = "lambda_code_bucket-${random_uuid.s3_bucket.result}"
+    bucket = "lambda_code_bucket"
+}
+
+resource "aws_s3_object" "s3_lambda_code" {
+    bucket = aws_s3_bucket.lambda_code_bucket.bucket
+    key = "s3_lambda_code"
+    source = "${local.building_path}/${local.lambda_code_filename}"
+}
+
+resource "null_resource" "build_lambda_function" {
+    triggers = {
+        build_number = "${timestamp()}"
+    }
+
+    provisioner "local-exec" {
+        command = "./py_build.sh \"${local.lambda_src_path}\" \"${local.building_path}\" \"${local.lambda_code_filename}\""
+    }
+}
+
+resource "null_resource" "build_layer_version" {
+    triggers = {
+        build_number = "${timestamp()}"
+    }
+
+    provisioner "local-exec" {
+        command = "./py_build.sh \"${local.layer_src_path}\" \"${local.building_path}\" \"${local.layer_code_filename}\""
+    }
+}
+
+
+## /* Lambda Function with code from a local file ###
+resource "aws_lambda_function" "from_localfile" {
+    filename = "${local.building_path}/${local.lambda_code_filename}"
+    handler = "index.lambda_handler"
+    runtime = "python3.8"
+    function_name = "my_function_from_localfile"
+    role = aws_iam_role.iam_for_lambda.arn
+    depends_on = [
+        null_resource.build_lambda_function
+    ]
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_function_from_localfile" {
+    triggers = {
+        resource_name = "aws_lambda_function.from_localfile"
+        resource_type = "ZIP_LAMBDA_FUNCTION"
+        original_source_code = local.lambda_src_path
+        built_output_path = "${local.building_path}/${local.lambda_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_lambda_function
+    ]
+}
+## */
+
+## /* Lambda Function with code from S3
+resource "aws_lambda_function" "from_s3" {
+    s3_bucket = aws_s3_bucket.lambda_code_bucket.bucket
+    s3_key = aws_s3_object.s3_lambda_code.key
+    handler = "index.lambda_handler"
+    runtime = "python3.8"
+    function_name = "my_function_from_s3"
+    role = aws_iam_role.iam_for_lambda.arn
+    depends_on = [
+        null_resource.build_lambda_function
+    ]    
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_function_from_s3" {
+    triggers = {
+        resource_name = "aws_lambda_function.from_s3"
+        resource_type = "ZIP_LAMBDA_FUNCTION"
+        original_source_code = local.lambda_src_path
+        built_output_path = "${local.building_path}/${local.lambda_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_lambda_function
+    ]
+}
+## */
+
+## /* Level1 Lambda Module and Level2 Lambda Module
+module "level1_lambda" {
+    source = "./lambda_tf_module"
+    source_code_path = "${local.building_path}/${local.lambda_code_filename}"
+    handler = "index.lambda_handler"
+    function_name = "my_level1_lambda"
+    l2_source_code_path = "${local.building_path}/${local.lambda_code_filename}"
+    l2_handler = "index.lambda_handler"
+    l2_function_name = "my_level2_lambda"
+    depends_on = [
+        null_resource.build_lambda_function
+    ]
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_function_level1_lambda" {
+    triggers = {
+        resource_name = "module.level1_lambda.aws_lambda_function.this"
+        resource_type = "ZIP_LAMBDA_FUNCTION"
+        original_source_code = local.lambda_src_path
+        built_output_path = "${local.building_path}/${local.lambda_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_lambda_function
+    ] 
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_function_level2_lambda" {
+    triggers = {
+        resource_name = "module.level1_lambda.module.level2_lambda.aws_lambda_function.this"
+        resource_type = "ZIP_LAMBDA_FUNCTION"
+        original_source_code = local.lambda_src_path
+        built_output_path = "${local.building_path}/${local.lambda_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_lambda_function
+    ] 
+}
+## */
+
+## /* Lambda Layer with local source code
+resource "aws_lambda_layer_version" "from_local" {
+    filename = "${local.building_path}/${local.layer_code_filename}"
+    layer_name = "my_layer"
+
+    compatible_runtimes = ["python3.8", "python3.9"]
+}
+
+resource "null_resource" "sam_metadata_aws_lambda_layer_version_from_local" {
+    triggers = {
+        resource_name = "aws_lambda_layer_version.from_local"
+        resource_type = "LAMBDA_LAYER"
+
+        original_source_code = local.layer_src_path
+        source_code_property = "path"
+        built_output_path = "${local.building_path}/${local.layer_code_filename}"
+    }
+    depends_on = [
+        null_resource.build_layer_version
+    ]
+}
+## */

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/my_layer_code/layer.py
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/my_layer_code/layer.py
@@ -1,0 +1,4 @@
+import numpy
+
+def layer_method():
+    return {"pi": "{0:.2f}".format(numpy.pi)}

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/my_layer_code/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/my_layer_code/requirements.txt
@@ -1,0 +1,7 @@
+# These are some hard packages to build. Using them here helps us verify that building works on various platforms
+
+# NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
+numpy<1.20.3
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/py_build.sh
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/py_build.sh
@@ -1,0 +1,16 @@
+src_code=$1
+build_path=$2
+output_name=$3
+echo "building ${src_code} into ${build_path}"
+pwd
+mkdir -p ${build_path}
+rm -rf ${build_path}/*
+mkdir -p ${build_path}/tmp_building
+tree ./
+cp -r $src_code/* ${build_path}/tmp_building
+pip install -r ${build_path}/tmp_building/requirements.txt -t ${build_path}/tmp_building/.
+pushd ${build_path}/tmp_building/ && zip -r $output_name . && popd
+mv "${build_path}/tmp_building/${output_name}" "${build_path}/$output_name"
+rm -rf ${build_path}/tmp_building
+pwd
+tree ./

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/src/list_books/index.py
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/src/list_books/index.py
@@ -1,0 +1,33 @@
+import json
+import boto3
+import os 
+
+#import ptvsd
+
+#ptvsd.enable_attach(address=('0.0.0.0', 9999), redirect_output=True)
+#ptvsd.wait_for_attach()
+
+def lambda_handler(event, context):
+    print("list books function start")
+
+    # books_table = os.environ['books_table_id']
+    # dynamodb = boto3.client('dynamodb')
+    # paginator = dynamodb.get_paginator("scan")
+    
+    books = []
+    # for page in paginator.paginate(TableName=books_table):
+    #     for item in page["Items"]:
+    #         print(f"Debugging Message - dynamodb scan output {item}")
+    #         print(f"Debugging Message - dynamodb scan output {item}")
+            
+    #         books.append({
+    #             "book_id": item.get("id").get("S"),
+    #             "book_title": item.get("title").get("S"),
+    #             "book_language": item.get("language").get("S"),
+    #         })
+
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(books),
+    }

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/src/list_books/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/src/list_books/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+ptvsd


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?

- Adding integration tests for `sam build` (Terraform Hook) with Zip-based Lambda Functions
- We also found an issue in which the sam metadata resource might not be refreshed if a previous terraform state exists.

#### How does it address the issue?
- Add integration tests
- Update `Makefile` rule to force refreshing the sam metadata resource

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
