### PR TITLE
feat: Resolve Module Variables

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
@@ -1,0 +1,11 @@
+"""
+Module containing prepare hook-related exceptions
+"""
+
+
+class InvalidResourceLinkingException(Exception):
+    fmt = "An error occurred when attempting to link two resources: {message}"
+
+    def __init__(self, message):
+        msg = self.fmt.format(message=message)
+        Exception.__init__(self, msg)

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -150,7 +150,7 @@ def _resolve_module_variable(module: TFModule, variable_name: str) -> List[Union
             LOG.debug("Resolving reference: %s", reference)
             # refer to a variable passed to this module from its parent module
             if reference.startswith("var."):
-                config_var_name = _get_configuration_address(reference[4:])
+                config_var_name = _get_configuration_address(reference[len("var.") :])
                 if module.parent_module:
                     results += _resolve_module_variable(module.parent_module, config_var_name)
             # refer to another module output. This module will be defined in the same level as this module

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 from parameterized import parameterized
 
+from samcli.hook_packages.terraform.hooks.prepare.exceptions import InvalidResourceLinkingException
 from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     _clean_references_list,
     _get_configuration_address,
@@ -144,9 +145,8 @@ class TestResourceLinking(TestCase):
             parent_module=None,
         )
         results = _resolve_module_variable(module, "layer")
-        expected_result = "layer.arn"
-        for result in results:
-            self.assertEqual(result.value, expected_result)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].value, "layer.arn")
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._clean_references_list")
@@ -173,9 +173,8 @@ class TestResourceLinking(TestCase):
             parent_module=parent_module,
         )
         results = _resolve_module_variable(child_module, "layer")
-        expected_result = "layer.arn"
-        for result in results:
-            self.assertEqual(result.value, expected_result)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].value, "layer.arn")
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._clean_references_list")
@@ -184,19 +183,26 @@ class TestResourceLinking(TestCase):
         mock_clean_references.return_value = references
         mock_get_configuration_address.return_value = "layer_arn"
         local_reference = References(value=references)
-        module = TFModule(
-            variables={"layer": local_reference},
+        parent_module = TFModule(
+            variables={},
             resources=[],
             child_modules={},
             outputs={},
             full_address="full/address",
             parent_module=None,
         )
+        module = TFModule(
+            variables={"layer": local_reference},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="full/address",
+            parent_module=parent_module,
+        )
         results = _resolve_module_variable(module, "layer")
-        expected_result = "local.layer_arn"
-        for result in results:
-            self.assertEqual(result.value, expected_result)
-            self.assertEqual(result.module_address, "full/address")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].value, "local.layer_arn")
+        self.assertEqual(results[0].module_address, "full/address")
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._resolve_module_output")
@@ -228,9 +234,8 @@ class TestResourceLinking(TestCase):
         )
         parent_module.child_modules.update({"layer_module": child_module})
         results = _resolve_module_variable(child_module, "layer")
-        expected_result = "layer_arn"
-        for result in results:
-            self.assertEqual(result.value, expected_result)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].value, "layer_arn")
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._resolve_module_output")
@@ -265,11 +270,83 @@ class TestResourceLinking(TestCase):
         parent_module.child_modules.update({"layer_module": child_module})
         results_a = _resolve_module_variable(child_module, "layer")
         results_b = _resolve_module_variable(child_module, "layer_name_c")
-        expected_result = [
+        self.assertEqual(len(results_a), 2)
+        self.assertEqual(len(results_b), 1)
+        self.assertEqual(
+            results_a[0].value,
             "layer_arn_a",
+        )
+        self.assertEqual(
+            results_a[1].value,
             "layer_arn_b",
-        ]
-        for result in results_a:
-            self.assertIn(result.value, expected_result)
-        for result in results_b:
-            self.assertEqual(result.value, "layer_arn_c")
+        )
+        self.assertEqual(results_b[0].value, "layer_arn_c")
+
+    def test_resolve_module_variable_invalid_variable(self):
+        constant_value = None
+        module = TFModule(
+            variables={"layer": constant_value},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=None,
+        )
+
+        with self.assertRaises(InvalidResourceLinkingException) as ex:
+            _resolve_module_variable(module, "layer")
+
+        self.assertEqual(
+            ex.exception.args[0],
+            "An error occurred when attempting to link two resources: The variable "
+            "layer could not be found in module root module.",
+        )
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._clean_references_list")
+    def test_resolve_module_variable_enters_invalid_state(self, mock_clean_references, mock_get_configuration_address):
+        references = ["local.layer_arn"]
+        mock_clean_references.return_value = references
+        mock_get_configuration_address.return_value = "layer_arn"
+        local_reference = References(value=references)
+        module = TFModule(
+            variables={"layer": local_reference},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="full/address",
+            parent_module=None,
+        )
+
+        with self.assertRaises(InvalidResourceLinkingException) as ex:
+            _resolve_module_variable(module, "layer")
+
+        self.assertEqual(
+            ex.exception.args[0],
+            "An error occurred when attempting to link two resources: Resource linking entered an invalid state.",
+        )
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._clean_references_list")
+    def test_resolve_module_variable_invalid_module_reference(
+        self, mock_clean_references, mock_get_configuration_address
+    ):
+        references = ["module.layer_module"]
+        mock_clean_references.return_value = references
+        mock_get_configuration_address.return_value = "layer_module"
+        references = References(value=references)
+        child_module = TFModule(
+            variables={"layer": references},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=None,
+        )
+        with self.assertRaises(InvalidResourceLinkingException) as ex:
+            _resolve_module_variable(child_module, "layer")
+
+        self.assertEqual(
+            ex.exception.args[0],
+            "An error occurred when attempting to link two resources: Couldn't find child module layer_module.",
+        )

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from parameterized import parameterized
 
@@ -11,6 +11,7 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     TFResource,
     ConstantValue,
     References,
+    _resolve_module_variable,
 )
 
 
@@ -131,3 +132,144 @@ class TestResourceLinking(TestCase):
         module = TFModule(None, None, {}, {}, {}, {})
         resource = TFResource("resource_address", "type", module, {})
         self.assertEqual(resource.full_address, "resource_address")
+
+    def test_resolve_module_variable_constant_value(self):
+        constant_value = ConstantValue(value="layer.arn")
+        module = TFModule(
+            variables={"layer": constant_value},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=None,
+        )
+        results = _resolve_module_variable(module, "layer")
+        expected_result = "layer.arn"
+        for result in results:
+            self.assertEqual(result.value, expected_result)
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._clean_references_list")
+    def test_resolve_module_variable_nested_variables(self, mock_clean_references, mock_get_configuration_address):
+        references = ["var.layer_name"]
+        mock_clean_references.return_value = references
+        mock_get_configuration_address.return_value = "layer_name"
+        references = References(value=references)
+        constant_value = ConstantValue(value="layer.arn")
+        parent_module = TFModule(
+            variables={"layer_name": constant_value},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=None,
+        )
+        child_module = TFModule(
+            variables={"layer": references},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=parent_module,
+        )
+        results = _resolve_module_variable(child_module, "layer")
+        expected_result = "layer.arn"
+        for result in results:
+            self.assertEqual(result.value, expected_result)
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._clean_references_list")
+    def test_resolve_module_variable_local_variable(self, mock_clean_references, mock_get_configuration_address):
+        references = ["local.layer_arn"]
+        mock_clean_references.return_value = references
+        mock_get_configuration_address.return_value = "layer_arn"
+        local_reference = References(value=references)
+        module = TFModule(
+            variables={"layer": local_reference},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="full/address",
+            parent_module=None,
+        )
+        results = _resolve_module_variable(module, "layer")
+        expected_result = "local.layer_arn"
+        for result in results:
+            self.assertEqual(result.value, expected_result)
+            self.assertEqual(result.module_address, "full/address")
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._resolve_module_output")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._clean_references_list")
+    def test_resolve_module_variable_nested_modules(
+        self, mock_clean_references, mock_resolve_module_output, mock_get_configuration_address
+    ):
+        references = ["module.layer_module.layer_arn"]
+        mock_resolve_module_output.return_value = [ConstantValue(value="layer_arn")]
+        mock_clean_references.return_value = references
+        mock_get_configuration_address.return_value = "layer_module"
+        references = References(value=references)
+        constant_value = ConstantValue(value="layer_arn")
+        parent_module = TFModule(
+            variables={"layer_name": constant_value},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=None,
+        )
+        child_module = TFModule(
+            variables={"layer": references},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=parent_module,
+        )
+        parent_module.child_modules.update({"layer_module": child_module})
+        results = _resolve_module_variable(child_module, "layer")
+        expected_result = "layer_arn"
+        for result in results:
+            self.assertEqual(result.value, expected_result)
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._resolve_module_output")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._clean_references_list")
+    def test_resolve_module_variable_combined_nested_modules(
+        self, mock_clean_references, mock_resolve_module_output, mock_get_configuration_address
+    ):
+        references = ["module.layer_module.layer_arn", "var.layer_name_b"]
+        mock_resolve_module_output.return_value = [ConstantValue(value="layer_arn_a")]
+        mock_clean_references.return_value = references
+        mock_get_configuration_address.side_effect = ["layer_module", "layer_name_b"]
+        references = References(value=references)
+        parent_module = TFModule(
+            variables={
+                "layer_name": ConstantValue(value="layer_arn_a"),
+                "layer_name_b": ConstantValue(value="layer_arn_b"),
+            },
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=None,
+        )
+        child_module = TFModule(
+            variables={"layer": references, "layer_name_c": ConstantValue(value="layer_arn_c")},
+            resources=[],
+            child_modules={},
+            outputs={},
+            full_address="",
+            parent_module=parent_module,
+        )
+        parent_module.child_modules.update({"layer_module": child_module})
+        results_a = _resolve_module_variable(child_module, "layer")
+        results_b = _resolve_module_variable(child_module, "layer_name_c")
+        expected_result = [
+            "layer_arn_a",
+            "layer_arn_b",
+        ]
+        for result in results_a:
+            self.assertIn(result.value, expected_result)
+        for result in results_b:
+            self.assertEqual(result.value, "layer_arn_c")


### PR DESCRIPTION
#### Why is this change necessary?
Iterate over a module's variables and resolve them to either their final constant value or a reference that we don't yet fully resolve (e.g. locals).

#### How does it address the issue?
Adds recursive function for module variable resolution.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
