### PR TITLE
feat: implement function to construct Modules out of the terraform configuration

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -100,6 +100,9 @@ def _build_module(
     module.full_address = _build_module_full_address(module_name, parent_module_address)
     LOG.debug("Parsing module:` %s", module.full_address or "root")
 
+    if not module_configuration:
+        raise InvalidResourceLinkingException(f"No module configuration for module: {module.full_address or 'root'}")
+
     LOG.debug("Parsing module variables")
     module.variables = _build_module_variables_from_configuration(module_configuration, input_variables)
 

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -97,9 +97,18 @@ def _build_module(
     module = TFModule(None, None, {}, [], {}, {})
 
     module.full_address = _build_module_full_address(module_name, parent_module_address)
+    LOG.debug("Parsing module:` %s", module.full_address or "root")
+
+    LOG.debug("Parsing module variables")
     module.variables = _build_module_variables_from_configuration(module_configuration, input_variables)
+
+    LOG.debug("Parsing module resources")
     module.resources = _build_module_resources_from_configuration(module_configuration, module)
+
+    LOG.debug("Parsing module outputs")
     module.outputs = _build_module_outputs_from_configuration(module_configuration)
+
+    LOG.debug("Parsing module calls")
     module.child_modules = _build_child_modules_from_configuration(module_configuration, module)
 
     return module
@@ -184,7 +193,6 @@ def _build_module_resources_from_configuration(module_configuration: Dict, modul
         resource_attributes: Dict[str, Expression] = {}
 
         expressions = config_resource.get("expressions", {})
-        print(expressions)
         for expression_name, expression_value in expressions.items():
             parsed_expression = _build_expression_from_configuration(expression_value)
             resource_attributes[expression_name] = parsed_expression
@@ -278,9 +286,9 @@ def _build_expression_from_configuration(expression_configuration: Dict) -> Expr
 
     parsed_expression: Expression
 
-    if constant_value:
+    if constant_value is not None:
         parsed_expression = ConstantValue(constant_value)
-    elif references:
+    elif references is not None:
         parsed_expression = References(references)
 
     return parsed_expression

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -75,6 +75,25 @@ def _build_module(
     input_variables: Dict[str, Expression],
     parent_module_address: Optional[str],
 ) -> TFModule:
+    """
+    Builds and returns a TFModule
+
+    Parameters
+    ==========
+    module_name: Optional[str]
+        The module's name, if any
+    module_configuration: Dict
+        The module object from the terraform configuration
+    input_variables: Dict[str, Expression]
+        The input variables sent into the module
+    parent_module_address: Optional[str]
+        The module's parent address, if any
+
+    Returns
+    =======
+    TFModule
+        The constructed TFModule
+    """
     module = TFModule(None, None, {}, [], {}, {})
 
     module.full_address = _build_module_full_address(module_name, parent_module_address)
@@ -87,6 +106,24 @@ def _build_module(
 
 
 def _build_module_full_address(module_name: Optional[str], parent_module_address: Optional[str]) -> Optional[str]:
+    """
+    Returns the full address of a module, depending on whether it has a module name and a parent module address.
+
+    Parameters
+    ==========
+    module_name: Optional[str]
+        The module's name, if any
+    parent_module_address: Optional[str]
+        The module's parent address, if any
+
+    Returns
+    =======
+    Optional[str]
+        Returns None if no module_name is provided (e.g. root module).
+        Returns module.<module_name> if a module_name is provided
+        Returns <parent_module_address>.module.<module_name> if both module_name and
+            parent_module_address are provided
+    """
     full_address = None
     if module_name:
         full_address = f"module.{module_name}"
@@ -99,6 +136,21 @@ def _build_module_full_address(module_name: Optional[str], parent_module_address
 def _build_module_variables_from_configuration(
     module_configuration: Dict, input_variables: Dict[str, Expression]
 ) -> Dict[str, Expression]:
+    """
+    Builds and returns module variables as Expressions using a module terraform configuration
+
+    Parameters
+    ==========
+    module_configuration: dict
+        The module object from the terraform configuration
+    input_variables: Dict[str, Expression]
+        The input variables sent into the module to override default variables
+
+    Returns
+    =======
+    Dict[str, Expression]
+        Dictionary with the variable names as keys and parsed Expression as values.
+    """
     module_variables: Dict[str, Expression] = {}
 
     default_variables = module_configuration.get("variables", {})
@@ -110,6 +162,21 @@ def _build_module_variables_from_configuration(
 
 
 def _build_module_resources_from_configuration(module_configuration: Dict, module: TFModule) -> List[TFResource]:
+    """
+    Builds and returns module TFResources using a module terraform configuration
+
+    Parameters
+    ==========
+    module_configuration: dict
+        The module object from the terraform configuration
+
+    Returns
+    =======
+    List[TFResource]
+        List of TFResource for the parsed resources from the config
+    module: TFModule
+        The TFModule whose resources we're parsing
+    """
     module_resources = []
 
     config_resources = module_configuration.get("resources", [])
@@ -130,6 +197,19 @@ def _build_module_resources_from_configuration(module_configuration: Dict, modul
 
 
 def _build_module_outputs_from_configuration(module_configuration: Dict) -> Dict[str, Expression]:
+    """
+    Builds and returns module outputs as Expressions using a module terraform configuration
+
+    Parameters
+    ==========
+    module_configuration: dict
+        The module object from the terraform configuration
+
+    Returns
+    =======
+    Dict[str, Expression]
+        Dictionary with the output names as keys and parsed Expression as values.
+    """
     module_outputs = {}
 
     config_outputs = module_configuration.get("outputs", {})
@@ -142,6 +222,21 @@ def _build_module_outputs_from_configuration(module_configuration: Dict) -> Dict
 
 
 def _build_child_modules_from_configuration(module_configuration: Dict, module: TFModule) -> Dict[str, TFModule]:
+    """
+    Builds and returns child TFModules using a module terraform configuration
+
+    Parameters
+    ==========
+    module_configuration: dict
+        The module object from the terraform configuration
+    module: TFModule
+        The TFModule whose child modules we're building
+
+    Returns
+    =======
+    Dict[str, TFModule]
+        Dictionary with the module names as keys and parsed TFModule as values.
+    """
     child_modules = {}
 
     module_calls = module_configuration.get("module_calls", {})
@@ -165,6 +260,19 @@ def _build_child_modules_from_configuration(module_configuration: Dict, module: 
 
 
 def _build_expression_from_configuration(expression_configuration: Dict) -> Expression:
+    """
+    Parses an Expression from an expression terraform configuration.
+
+    Parameters
+    ==========
+    expression_configuration: dict
+        The expression object from the terraform configuration
+
+    Returns
+    =======
+    Expression
+        The parsed expression
+    """
     constant_value = expression_configuration.get("constant_value")
     references = expression_configuration.get("references")
 

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, call, create_autospec
 
 from parameterized import parameterized
 
@@ -13,6 +13,13 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     ConstantValue,
     References,
     _resolve_module_variable,
+    _build_module,
+    _build_expression_from_configuration,
+    _build_module_full_address,
+    _build_child_modules_from_configuration,
+    _build_module_outputs_from_configuration,
+    _build_module_resources_from_configuration,
+    _build_module_variables_from_configuration,
 )
 
 
@@ -350,3 +357,227 @@ class TestResourceLinking(TestCase):
             ex.exception.args[0],
             "An error occurred when attempting to link two resources: Couldn't find child module layer_module.",
         )
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_module_full_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_module_variables_from_configuration")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_module_resources_from_configuration")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_module_outputs_from_configuration")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_child_modules_from_configuration")
+    def test_build_module(
+        self,
+        patched_build_child_modules_from_configuration,
+        patched_build_module_outputs_from_configuration,
+        patched_build_module_resources_from_configuration,
+        patched_build_module_variables_from_configuration,
+        patched_build_module_full_address,
+    ):
+        mock_full_address = Mock()
+        patched_build_module_full_address.return_value = mock_full_address
+
+        mock_variables = Mock()
+        patched_build_module_variables_from_configuration.return_value = mock_variables
+
+        mock_resources = Mock()
+        patched_build_module_resources_from_configuration.return_value = mock_resources
+
+        mock_outputs = Mock()
+        patched_build_module_outputs_from_configuration.return_value = mock_outputs
+
+        mock_child_modules = Mock()
+        patched_build_child_modules_from_configuration.return_value = mock_child_modules
+
+        result = _build_module(Mock(), Mock(), Mock(), Mock())
+        expected_module = TFModule(
+            mock_full_address, None, mock_variables, mock_resources, mock_child_modules, mock_outputs
+        )
+
+        self.assertEqual(result, expected_module)
+
+    @parameterized.expand(
+        [
+            (None, None, None),
+            ("some_module", None, "module.some_module"),
+            ("some_module", "parent_module_address", "parent_module_address.module.some_module"),
+        ]
+    )
+    def test_build_module_full_address(self, module_name, parent_module_address, expected_full_address):
+        result = _build_module_full_address(module_name, parent_module_address)
+        self.assertEqual(result, expected_full_address)
+
+    def test_build_module_variables_from_configuration(self):
+        module_configuration = {
+            "variables": {
+                "var1": {"default": "var1_default_value"},
+                "var2": {"default": "var2_default_value"},
+                "var3": {},
+                "var4": {},
+            },
+        }
+
+        input_variables = {
+            "var2": ConstantValue("var2_input_value"),
+            "var4": ConstantValue("var4_input_value"),
+        }
+
+        result = _build_module_variables_from_configuration(module_configuration, input_variables)
+
+        self.assertEqual(result["var1"], ConstantValue("var1_default_value"))
+        self.assertEqual(result["var2"], input_variables["var2"])
+        self.assertEqual(result["var3"], ConstantValue(None))
+        self.assertEqual(result["var4"], ConstantValue("var4_input_value"))
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_expression_from_configuration")
+    def test_build_module_resources_from_configuration(
+        self,
+        patched_build_expression_from_configuration,
+    ):
+        mock_parsed_expression = Mock()
+        patched_build_expression_from_configuration.return_value = mock_parsed_expression
+
+        module_configuration = {
+            "resources": [
+                {
+                    "address": "resource1_address",
+                    "type": "resource1_type",
+                    "expressions": {
+                        "expression1": Mock(),
+                        "expression2": Mock(),
+                    },
+                },
+                {
+                    "address": "resource2_address",
+                    "type": "resource2_type",
+                    "expressions": {
+                        "expression3": Mock(),
+                        "expression4": Mock(),
+                    },
+                },
+            ]
+        }
+
+        mock_module = Mock()
+
+        result = _build_module_resources_from_configuration(module_configuration, mock_module)
+
+        expected_resources = [
+            TFResource(
+                "resource1_address",
+                "resource1_type",
+                mock_module,
+                {"expression1": mock_parsed_expression, "expression2": mock_parsed_expression},
+            ),
+            TFResource(
+                "resource2_address",
+                "resource2_type",
+                mock_module,
+                {"expression3": mock_parsed_expression, "expression4": mock_parsed_expression},
+            ),
+        ]
+
+        self.assertEqual(result, expected_resources)
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_expression_from_configuration")
+    def test_build_module_outputs_from_configuration(
+        self,
+        patched_build_expression_from_configuration,
+    ):
+        parsed_expression = Mock()
+        patched_build_expression_from_configuration.return_value = parsed_expression
+
+        module_configuration = {
+            "outputs": {
+                "output1": {
+                    "expression": Mock(),
+                },
+                "output2": {
+                    "expression": Mock(),
+                },
+            }
+        }
+
+        result = _build_module_outputs_from_configuration(module_configuration)
+
+        expected_outputs = {
+            "output1": parsed_expression,
+            "output2": parsed_expression,
+        }
+
+        self.assertEqual(result, expected_outputs)
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_expression_from_configuration")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._build_module")
+    def test_build_child_modules_from_configuration(
+        self,
+        patched_build_module,
+        patched_build_expression_from_configuration,
+    ):
+        mock_parsed_expression = Mock()
+        patched_build_expression_from_configuration.return_value = mock_parsed_expression
+
+        child_built_modules = [Mock(), Mock()]
+        patched_build_module.side_effect = child_built_modules
+
+        mock_child_config1 = Mock()
+        mock_child_config2 = Mock()
+        module_configuration = {
+            "module_calls": {
+                "module1": {
+                    "expressions": {
+                        "expression1": Mock(),
+                        "expression2": Mock(),
+                    },
+                    "module": mock_child_config1,
+                },
+                "module2": {
+                    "expressions": {
+                        "expression3": Mock(),
+                        "expression4": Mock(),
+                    },
+                    "module": mock_child_config2,
+                },
+            },
+        }
+
+        mock_module = Mock(full_address="module.some_address")
+
+        result = _build_child_modules_from_configuration(module_configuration, mock_module)
+
+        # check it builds child modules
+        patched_build_module.assert_has_calls(
+            [
+                call(
+                    "module1",
+                    mock_child_config1,
+                    {"expression1": mock_parsed_expression, "expression2": mock_parsed_expression},
+                    "module.some_address",
+                ),
+                call(
+                    "module2",
+                    mock_child_config2,
+                    {"expression3": mock_parsed_expression, "expression4": mock_parsed_expression},
+                    "module.some_address",
+                ),
+            ]
+        )
+
+        # check it sets parent module of each child
+        for child in child_built_modules:
+            self.assertEqual(child.parent_module, mock_module)
+
+        # check return result
+        self.assertCountEqual(list(result.keys()), ["module1", "module2"])
+        self.assertCountEqual(list(result.values()), child_built_modules)
+
+    @parameterized.expand(
+        [
+            ({"constant_value": "hello"}, ConstantValue("hello")),
+            ({"references": ["hello", "world"]}, References(["hello", "world"])),
+        ]
+    )
+    def test_build_expression_from_configuration(
+        self,
+        expression_configuration,
+        expected_parsed_expression,
+    ):
+        result = _build_expression_from_configuration(expression_configuration)
+        self.assertEqual(result, expected_parsed_expression)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Constructs a terraform module representation out of the terraform configuration.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
