### PR TITLE
chore: separate CI jobs for deploy, package, delete and sync

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -5,6 +5,9 @@ image:
 configuration:
   - BuildIntegTesting
   - DeployIntegTesting
+  - PackageIntegTesting
+  - DeleteIntegTesting
+  - SyncIntegTesting
   - LocalIntegTesting
   # other Integration testing, Dev, regression and smoke testing
   - OtherTesting
@@ -179,7 +182,7 @@ for:
       - sh: "JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"
       - sh: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java11_in_process"
 
-  # Integ testing deploy, package, delete, and sync
+  # Integ testing deploy
   -
     matrix:
       only:
@@ -188,7 +191,40 @@ for:
 
     test_script:
       - "pip install -e \".[dev]\""
-      - sh: "pytest -vv tests/integration/delete tests/integration/deploy tests/integration/package tests/integration/sync"
+      - sh: "pytest -vv tests/integration/deploy"
+
+  # Integ testing package
+  -
+    matrix:
+      only:
+        - image: Ubuntu
+          configuration: PackageIntegTesting
+
+    test_script:
+      - "pip install -e \".[dev]\""
+      - sh: "pytest -vv tests/integration/package"
+
+  # Integ testing delete
+  -
+    matrix:
+      only:
+        - image: Ubuntu
+          configuration: DeleteIntegTesting
+
+    test_script:
+      - "pip install -e \".[dev]\""
+      - sh: "pytest -vv tests/integration/delete"
+
+  # Integ testing sync
+  -
+    matrix:
+      only:
+        - image: Ubuntu
+          configuration: SyncIntegTesting
+
+    test_script:
+      - "pip install -e \".[dev]\""
+      - sh: "pytest -vv tests/integration/sync"
 
   # Integ testing local
   -

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -7,6 +7,9 @@ clone_folder: C:\source
 configuration:
   - BuildIntegTesting
   - DeployIntegTesting
+  - PackageIntegTesting
+  - DeleteIntegTesting
+  - SyncIntegTesting
   - LocalIntegTesting
   # other Integration testing, Dev, regression and smoke testing
   - OtherTesting
@@ -146,7 +149,43 @@ for:
       - "git --version"
       - "venv\\Scripts\\activate"
       - "docker system prune -a -f"
-      - ps: "pytest -vv tests/integration/delete tests/integration/deploy tests/integration/package tests/integration/sync"
+      - ps: "pytest -vv tests/integration/deploy"
+
+  # Integ testing package
+  - matrix:
+      only:
+        - configuration: PackageIntegTesting
+
+    test_script:
+      # Reactivate virtualenv before running tests
+      - "git --version"
+      - "venv\\Scripts\\activate"
+      - "docker system prune -a -f"
+      - ps: "pytest -vv tests/integration/package"
+
+  # Integ testing delete
+  - matrix:
+      only:
+        - configuration: DeleteIntegTesting
+
+    test_script:
+      # Reactivate virtualenv before running tests
+      - "git --version"
+      - "venv\\Scripts\\activate"
+      - "docker system prune -a -f"
+      - ps: "pytest -vv tests/integration/delete"
+
+  # Integ testing sync
+  - matrix:
+      only:
+        - configuration: SyncIntegTesting
+
+    test_script:
+      # Reactivate virtualenv before running tests
+      - "git --version"
+      - "venv\\Scripts\\activate"
+      - "docker system prune -a -f"
+      - ps: "pytest -vv tests/integration/sync"
 
   #Integ testing local
   - matrix:


### PR DESCRIPTION
Separating build, deploy, package and sync integration tests into their own groups to speed up canary tests.

Testing here;
[Linux Run](https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux-dev/builds/44954928)
[Windows Run](https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-windows-dev/builds/44954934)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
