### PR TITLE
feat: skip sync confirmation for subsequent runs

### DIFF
--- a/samcli/cli/global_config.py
+++ b/samcli/cli/global_config.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 import click
 
+from samcli.lib.utils.hash import str_checksum
 
 LOG = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ class DefaultEntry:
     INSTALLATION_ID = ConfigEntry("installationId", None)
     LAST_VERSION_CHECK = ConfigEntry("lastVersionCheck", None)
     TELEMETRY = ConfigEntry("telemetryEnabled", "SAM_CLI_TELEMETRY")
+    ACCELERATE_OPT_IN_STACKS = ConfigEntry("accelerateOptInStacks", None)
 
 
 class Singleton(type):
@@ -413,3 +415,24 @@ class GlobalConfig(metaclass=Singleton):
     @last_version_check.setter
     def last_version_check(self, value: float):
         self.set_value(DefaultEntry.LAST_VERSION_CHECK, value)
+
+    def is_accelerate_opt_in_stack(self, template_file: str, stack_name: str) -> bool:
+        """
+        Returns True, if current folder with stack name is been accepted to use sam sync before.
+        Returns False, if this is first time that user runs sam sync with current folder and given stack name.
+        """
+        accelerate_opt_in_stacks = (
+            self.get_value(DefaultEntry.ACCELERATE_OPT_IN_STACKS, value_type=list, default=[]) or []
+        )
+        return str_checksum(template_file + stack_name) in accelerate_opt_in_stacks
+
+    def set_accelerate_opt_in_stack(self, template_file: str, stack_name: str) -> None:
+        """
+        Stores current folder and stack name into config, so that next time that user runs sam sync, they don't need
+        to accept warning message again.
+        """
+        accelerate_opt_in_stacks = (
+                self.get_value(DefaultEntry.ACCELERATE_OPT_IN_STACKS, value_type=list, default=[]) or []
+        )
+        accelerate_opt_in_stacks.append(str_checksum(template_file + stack_name))
+        self.set_value(DefaultEntry.ACCELERATE_OPT_IN_STACKS, accelerate_opt_in_stacks)

--- a/samcli/cli/global_config.py
+++ b/samcli/cli/global_config.py
@@ -432,7 +432,7 @@ class GlobalConfig(metaclass=Singleton):
         to accept warning message again.
         """
         accelerate_opt_in_stacks = (
-                self.get_value(DefaultEntry.ACCELERATE_OPT_IN_STACKS, value_type=list, default=[]) or []
+            self.get_value(DefaultEntry.ACCELERATE_OPT_IN_STACKS, value_type=list, default=[]) or []
         )
         accelerate_opt_in_stacks.append(str_checksum(template_file + stack_name))
         self.set_value(DefaultEntry.ACCELERATE_OPT_IN_STACKS, accelerate_opt_in_stacks)

--- a/tests/unit/cli/test_global_config.py
+++ b/tests/unit/cli/test_global_config.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from unittest.mock import ANY, MagicMock, patch, mock_open
 from unittest import TestCase
 from samcli.cli.global_config import ConfigEntry, DefaultEntry, GlobalConfig
@@ -308,3 +309,14 @@ class TestGlobalConfig(TestCase):
     def test_set_last_version_check(self):
         GlobalConfig().last_version_check = 123.4
         self.assertEqual(GlobalConfig()._config_data[DefaultEntry.LAST_VERSION_CHECK.config_key], 123.4)
+
+    def test_is_accelerate_opt_in_stack_return_false_first_time(self):
+        self.assertFalse(GlobalConfig().is_accelerate_opt_in_stack(uuid.uuid4().hex, uuid.uuid4().hex))
+
+    def test_is_accelerate_opt_in_stack_return_true_second_time(self):
+        template_path = uuid.uuid4().hex
+        stack_name = uuid.uuid4().hex
+        self.assertFalse(GlobalConfig().is_accelerate_opt_in_stack(template_path, stack_name))
+
+        GlobalConfig().set_accelerate_opt_in_stack(template_path, stack_name)
+        self.assertTrue(GlobalConfig().is_accelerate_opt_in_stack(template_path, stack_name))


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
As per user feedback, accepting the warning message at the beginning of `sam sync` starts to feel redundant


#### How does it address the issue?
After user accepts the warning message, this change will be storing information of the current folder and stack and subsequent runs won't be asking this question to run `sam sync`.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
