### PR TITLE
chore: fix sam sync integ tests after latest changes

### DIFF
--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -503,9 +503,6 @@ class TestSyncWatchCodeOnly(TestSyncWatchBase):
             tags="integ=true clarity=yes foo_bar=baz",
         )
         self.watch_process = start_persistent_process(sync_command_list, cwd=self.test_dir)
-        read_until_string(self.watch_process, "Enter Y to proceed with the command, or enter N to cancel:\n")
-
-        self.watch_process.stdin.write("y\n")
         read_until_string(self.watch_process, "\x1b[32mSync watch started.\x1b[0m\n", timeout=30)
 
         self.stack_resources = self._get_stacks(self.stack_name)


### PR DESCRIPTION
With latest changes, `sam sync` now skips confirmation message for subsequent runs of the same project. This addresses that change in our integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
