### PR TITLE
feat: Add logic for linking functions to layers

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -21,7 +21,8 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     _link_lambda_function_to_layer,
     _get_configuration_address,
     ConstantValue,
-    _build_module, References,
+    _build_module,
+    References,
 )
 from samcli.lib.hook.exceptions import PrepareHookException, InvalidSamMetadataPropertiesException
 from samcli.lib.utils import osutils

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
@@ -965,8 +965,15 @@ class TestPrepareHook(TestCase):
         )
         self.assertEqual(cfn_resources, expected_cfn_resources_after_mapping_s3_sources)
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook._enrich_resources_and_generate_makefile")
-    def test_translate_to_cfn_empty(self, mock_enrich_resources_and_generate_makefile):
+    def test_translate_to_cfn_empty(
+        self,
+        mock_enrich_resources_and_generate_makefile,
+        mock_link_lambda_functions_to_layers,
+        mock_get_configuration_address,
+    ):
         expected_empty_cfn_dict = {"AWSTemplateFormatVersion": "2010-09-09", "Resources": {}}
 
         tf_json_empty = {}
@@ -986,26 +993,48 @@ class TestPrepareHook(TestCase):
             self.assertEqual(translated_cfn_dict, expected_empty_cfn_dict)
             mock_enrich_resources_and_generate_makefile.assert_not_called()
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook._enrich_resources_and_generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook.str_checksum")
-    def test_translate_to_cfn_with_root_module_only(self, checksum_mock, mock_enrich_resources_and_generate_makefile):
+    def test_translate_to_cfn_with_root_module_only(
+        self,
+        checksum_mock,
+        mock_enrich_resources_and_generate_makefile,
+        mock_link_lambda_functions_to_layers,
+        mock_get_configuration_address,
+    ):
         checksum_mock.return_value = self.mock_logical_id_hash
         translated_cfn_dict = _translate_to_cfn(self.tf_json_with_root_module_only, self.output_dir, self.project_root)
         self.assertEqual(translated_cfn_dict, self.expected_cfn_with_root_module_only)
         mock_enrich_resources_and_generate_makefile.assert_not_called()
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook._enrich_resources_and_generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook.str_checksum")
-    def test_translate_to_cfn_with_child_modules(self, checksum_mock, mock_enrich_resources_and_generate_makefile):
+    def test_translate_to_cfn_with_child_modules(
+        self,
+        checksum_mock,
+        mock_enrich_resources_and_generate_makefile,
+        mock_link_lambda_functions_to_layers,
+        mock_get_configuration_address,
+    ):
         checksum_mock.return_value = self.mock_logical_id_hash
         translated_cfn_dict = _translate_to_cfn(self.tf_json_with_child_modules, self.output_dir, self.project_root)
         self.assertEqual(translated_cfn_dict, self.expected_cfn_with_child_modules)
         mock_enrich_resources_and_generate_makefile.assert_not_called()
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook._enrich_resources_and_generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook.str_checksum")
     def test_translate_to_cfn_with_root_module_with_sam_metadata_resource(
-        self, checksum_mock, mock_enrich_resources_and_generate_makefile
+        self,
+        checksum_mock,
+        mock_enrich_resources_and_generate_makefile,
+        mock_link_lambda_functions_to_layers,
+        mock_get_configuration_address,
     ):
         checksum_mock.return_value = self.mock_logical_id_hash
         translated_cfn_dict = _translate_to_cfn(
@@ -1033,10 +1062,16 @@ class TestPrepareHook(TestCase):
 
         mock_enrich_resources_and_generate_makefile.assert_called_once_with(*expected_arguments_in_call)
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook._enrich_resources_and_generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook.str_checksum")
     def test_translate_to_cfn_with_child_modules_with_sam_metadata_resource(
-        self, checksum_mock, mock_enrich_resources_and_generate_makefile
+        self,
+        checksum_mock,
+        mock_enrich_resources_and_generate_makefile,
+        mock_link_lambda_functions_to_layers,
+        mock_get_configuration_address,
     ):
         checksum_mock.return_value = self.mock_logical_id_hash
         translated_cfn_dict = _translate_to_cfn(
@@ -1077,10 +1112,16 @@ class TestPrepareHook(TestCase):
 
         mock_enrich_resources_and_generate_makefile.assert_called_once_with(*expected_arguments_in_call)
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook._enrich_resources_and_generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook.str_checksum")
     def test_translate_to_cfn_with_unsupported_provider(
-        self, checksum_mock, mock_enrich_resources_and_generate_makefile
+        self,
+        checksum_mock,
+        mock_enrich_resources_and_generate_makefile,
+        mock_link_lambda_functions_to_layers,
+        mock_get_configuration_address,
     ):
         checksum_mock.return_value = self.mock_logical_id_hash
         translated_cfn_dict = _translate_to_cfn(
@@ -1089,10 +1130,16 @@ class TestPrepareHook(TestCase):
         self.assertEqual(translated_cfn_dict, self.expected_cfn_with_unsupported_provider)
         mock_enrich_resources_and_generate_makefile.assert_not_called()
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook._enrich_resources_and_generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook.str_checksum")
     def test_translate_to_cfn_with_unsupported_resource_type(
-        self, checksum_mock, mock_enrich_resources_and_generate_makefile
+        self,
+        checksum_mock,
+        mock_enrich_resources_and_generate_makefile,
+        mock_link_lambda_functions_to_layers,
+        mock_get_configuration_address,
     ):
         checksum_mock.return_value = self.mock_logical_id_hash
         translated_cfn_dict = _translate_to_cfn(
@@ -1101,10 +1148,16 @@ class TestPrepareHook(TestCase):
         self.assertEqual(translated_cfn_dict, self.expected_cfn_with_unsupported_resource_type)
         mock_enrich_resources_and_generate_makefile.assert_not_called()
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook._enrich_resources_and_generate_makefile")
     @patch("samcli.hook_packages.terraform.hooks.prepare.hook.str_checksum")
     def test_translate_to_cfn_with_mapping_s3_source_to_function(
-        self, checksum_mock, mock_enrich_resources_and_generate_makefile
+        self,
+        checksum_mock,
+        mock_enrich_resources_and_generate_makefile,
+        mock_link_lambda_functions_to_layers,
+        mock_get_configuration_address,
     ):
         checksum_mock.return_value = self.mock_logical_id_hash
         translated_cfn_dict = _translate_to_cfn(


### PR DESCRIPTION
#### Why is this change necessary?
We need the TF prepare hook to call our layer linking logic.

#### How does it address the issue?
Add the connection logic from the hook to iterate through the resources in the TF modules and call the layer linking logic for each resource.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
