### PR TITLE
Remove conflict test case

### DIFF
--- a/tests/integration/pipeline/test_bootstrap_command.py
+++ b/tests/integration/pipeline/test_bootstrap_command.py
@@ -94,8 +94,7 @@ class TestBootstrap(BootstrapIntegBase):
             self.assertSetEqual(common_resources, set(self._extract_created_resource_logical_ids(stack_name)))
             self.validate_pipeline_config(stack_name, stage_configuration_name)
 
-    @parameterized.expand([("create_image_repository",), (False,)])
-    def test_interactive_with_no_resources_provided_using_oidc(self, create_image_repository):
+    def test_interactive_with_no_resources_provided_using_oidc(self):
         stage_configuration_name, stack_name = self._get_stage_and_stack_name()
         self.stack_names = [stack_name]
 
@@ -115,11 +114,8 @@ class TestBootstrap(BootstrapIntegBase):
             "",  # Pipeline execution role
             "",  # CloudFormation execution role
             "",  # Artifacts bucket
-            "y" if create_image_repository else "N",  # Should we create ECR repo
+            "N",  # Should we create ECR repo
         ]
-
-        if create_image_repository:
-            inputs.append("")  # Create image repository
 
         inputs.append("")  # Confirm summary
         inputs.append("y")  # Create resources
@@ -141,20 +137,10 @@ class TestBootstrap(BootstrapIntegBase):
         }
         CFN_OUTPUT_TO_CONFIG_KEY["OidcProvider"] = "oidc_provider_url"
         del CFN_OUTPUT_TO_CONFIG_KEY["PipelineUser"]
-        if create_image_repository:
-            self.assertSetEqual(
-                {
-                    *common_resources,
-                    "ImageRepository",
-                },
-                set(self._extract_created_resource_logical_ids(stack_name)),
-            )
-            CFN_OUTPUT_TO_CONFIG_KEY["ImageRepository"] = "image_repository"
-            self.validate_pipeline_config(stack_name, stage_configuration_name, list(CFN_OUTPUT_TO_CONFIG_KEY.keys()))
-            del CFN_OUTPUT_TO_CONFIG_KEY["ImageRepository"]
-        else:
-            self.assertSetEqual(common_resources, set(self._extract_created_resource_logical_ids(stack_name)))
-            self.validate_pipeline_config(stack_name, stage_configuration_name)
+
+        self.assertSetEqual(common_resources, set(self._extract_created_resource_logical_ids(stack_name)))
+        self.validate_pipeline_config(stack_name, stage_configuration_name)
+
         del CFN_OUTPUT_TO_CONFIG_KEY["OidcProvider"]
         CFN_OUTPUT_TO_CONFIG_KEY["PipelineUser"] = "pipeline_user"
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Canary integration tests failed.


#### Why is this change necessary?
Two integration tests shares the same OIDC identity provider however only the first test to run will create it. But we don't have control which one will run first. And the other test with create image has been tested in other test cases. Hence remove it.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
