### PR TITLE
Fix integration test

### DIFF
--- a/tests/integration/pipeline/test_bootstrap_command.py
+++ b/tests/integration/pipeline/test_bootstrap_command.py
@@ -134,6 +134,7 @@ class TestBootstrap(BootstrapIntegBase):
             "ArtifactsLoggingBucketPolicy",
             "ArtifactsBucketPolicy",
             "PipelineExecutionRolePermissionPolicy",
+            "OidcProvider",
         }
         CFN_OUTPUT_TO_CONFIG_KEY["OidcProvider"] = "oidc_provider_url"
         del CFN_OUTPUT_TO_CONFIG_KEY["PipelineUser"]


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Fix the failed nightly canary. The test works fine on my account because the OIDC identity provider already exists hence no OIDC identity provider will be created. However, for the test account, it will create an OIDC identity provider.


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
