### PR TITLE
fix: add `MaxAttempts` to `sam delete`

### DIFF
--- a/samcli/commands/delete/exceptions.py
+++ b/samcli/commands/delete/exceptions.py
@@ -5,23 +5,29 @@ from samcli.commands.exceptions import UserException
 
 
 class DeleteFailedError(UserException):
-    def __init__(self, stack_name, msg):
+    def __init__(self, stack_name, msg, stack_status=None):
         self.stack_name = stack_name
         self.msg = msg
+        self.stack_status = stack_status
 
-        message_fmt = "Failed to delete the stack: {stack_name}, {msg}"
+        message = f"Failed to delete the stack: {stack_name}, msg: {msg}"
+        if self.stack_status:
+            message += f", status: {self.stack_status}"
 
-        super().__init__(message=message_fmt.format(stack_name=self.stack_name, msg=msg))
+        super().__init__(message=message.format(stack_name=self.stack_name, msg=msg))
 
 
 class CfDeleteFailedStatusError(UserException):
-    def __init__(self, stack_name, msg):
+    def __init__(self, stack_name, msg, stack_status=None):
         self.stack_name = stack_name
         self.msg = msg
+        self.stack_status = stack_status
 
-        message_fmt = "Stack could not be deleted as it encountered DELETE_FAILED status: {stack_name}, {msg}"
+        message = f"Stack {stack_name} could not be deleted as it encountered DELETE_FAILED, " f"msg: {msg}"
+        if self.stack_status:
+            message += f", status: {self.stack_status}"
 
-        super().__init__(message=message_fmt.format(stack_name=self.stack_name, msg=msg))
+        super().__init__(message=message)
 
 
 class FetchTemplateFailedError(UserException):
@@ -29,6 +35,6 @@ class FetchTemplateFailedError(UserException):
         self.stack_name = stack_name
         self.msg = msg
 
-        message_fmt = "Failed to fetch the template for the stack: {stack_name}, {msg}"
+        message = f"Failed to fetch the template for the stack: {stack_name}, {msg}"
 
-        super().__init__(message=message_fmt.format(stack_name=self.stack_name, msg=msg))
+        super().__init__(message=message)

--- a/samcli/commands/delete/exceptions.py
+++ b/samcli/commands/delete/exceptions.py
@@ -14,7 +14,7 @@ class DeleteFailedError(UserException):
         if self.stack_status:
             message += f", status: {self.stack_status}"
 
-        super().__init__(message=message.format(stack_name=self.stack_name, msg=msg))
+        super().__init__(message=message)
 
 
 class CfDeleteFailedStatusError(UserException):

--- a/samcli/lib/delete/cfn_utils.py
+++ b/samcli/lib/delete/cfn_utils.py
@@ -116,8 +116,8 @@ class CfnUtils:
 
         # Wait for Delete to Finish
         waiter = self._client.get_waiter("stack_delete_complete")
-        # Poll every 5 seconds and set max attempts to be 3.
-        waiter_config = {"Delay": 5, "MaxAttempts": 3}
+        # Poll every 30 seconds and set max attempts to be 3.
+        waiter_config = {"Delay": 30, "MaxAttempts": 3}
         try:
             waiter.wait(StackName=stack_name, WaiterConfig=waiter_config)
         except WaiterError as ex:


### PR DESCRIPTION
* Add better error messaging when a stack fails to delete.

#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/3754


#### Why is this change necessary?
* Try a finite number of times and exit if unsuccessful.

#### How does it address the issue?
* The waiter config now has a finite number of attempts baked in and when it fails it showcases the last stack status.

#### What side effects does this change have?
* N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
