### PR TITLE
Add dotnet7 build method for the provided runtime

### DIFF
--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -140,7 +140,10 @@ def get_workflow_config(
         namedtuple that represents the Builder Workflow Config
     """
 
-    selectors_by_build_method = {"makefile": BasicWorkflowSelector(PROVIDED_MAKE_CONFIG)}
+    selectors_by_build_method = {
+        "makefile": BasicWorkflowSelector(PROVIDED_MAKE_CONFIG),
+        "dotnet7": BasicWorkflowSelector(DOTNET_CLIPACKAGE_CONFIG)
+    }
 
     selectors_by_runtime = {
         "python3.6": BasicWorkflowSelector(PYTHON_PIP_CONFIG),

--- a/tests/unit/lib/build_module/test_workflow_config.py
+++ b/tests/unit/lib/build_module/test_workflow_config.py
@@ -52,6 +52,19 @@ class Test_get_workflow_config(TestCase):
         self.assertIn(Event("BuildWorkflowUsed", "provided-None"), EventTracker.get_tracked_events())
 
     @parameterized.expand([("provided",)])
+    def test_must_work_for_provided_with_build_method_dotnet7(self, runtime):
+        result = get_workflow_config(runtime, self.code_dir, self.project_dir,
+                                     specified_workflow="dotnet7")
+        self.assertEqual(result.language, "dotnet")
+        self.assertEqual(result.dependency_manager, 'cli-package')
+        self.assertEqual(result.application_framework, None)
+        self.assertEqual(result.manifest_name, ".csproj")
+        self.assertIsNone(result.executable_search_paths)
+        self.assertEqual(len(EventTracker.get_tracked_events()), 1)
+        self.assertIn(Event("BuildWorkflowUsed", "dotnet-cli-package"),
+                      EventTracker.get_tracked_events())
+
+    @parameterized.expand([("provided",)])
     def test_must_work_for_provided_with_no_specified_workflow(self, runtime):
         # Implicitly look for makefile capability.
         result = get_workflow_config(runtime, self.code_dir, self.project_dir)


### PR DESCRIPTION
* Added 'BuildMethod: dotnet7' using 'Runtime:provided'
* 'Runtime:provided' is only for the provided runtime and not the dotnet runtime
* As a pre-requisite, the latest Lambda tools with NativeAOT support needs to be installed.

Testing with sample SAM template:
 ( See BuildMethod and Runtime below )
...
  HelloWorldFunction: Type: AWS::Serverless::Function Metadata: BuildMethod: dotnet7 Properties: CodeUri: ./src/HelloWorld/ Handler: HelloWorld::HelloWorld.Function::FunctionHandler Runtime: provided Architectures: - x86_64 ...

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
