### PR TITLE
chore: Enforce Pytest Warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ log_cli_level = INFO
 addopts = --maxfail=1000 -rf
 filterwarnings =
     error
+    ignore::DeprecationWarning:docker

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 log_cli = 1
 log_cli_level = INFO
 addopts = --maxfail=1000 -rf
-#filterwarnings =
-#    error
+filterwarnings =
+    error

--- a/tests/unit/lib/samlib/test_resource_metadata_normalizer.py
+++ b/tests/unit/lib/samlib/test_resource_metadata_normalizer.py
@@ -434,7 +434,7 @@ class TestResourceMetadataNormalizerGetResourceId(TestCase):
             "logical_id",
         )
 
-        self.assertEquals(expected_resource_id, resource_id)
+        self.assertEqual(expected_resource_id, resource_id)
 
     def test_use_logical_id_as_resource_id_incase_of_invalid_cdk_path(self):
         resource_id = ResourceMetadataNormalizer.get_resource_id(
@@ -442,7 +442,7 @@ class TestResourceMetadataNormalizerGetResourceId(TestCase):
             "logical_id",
         )
 
-        self.assertEquals("logical_id", resource_id)
+        self.assertEqual("logical_id", resource_id)
 
     def test_use_cdk_id_as_resource_id_for_nested_stack(self):
         resource_id = ResourceMetadataNormalizer.get_resource_id(
@@ -456,7 +456,7 @@ class TestResourceMetadataNormalizerGetResourceId(TestCase):
             "logical_id",
         )
 
-        self.assertEquals("nested_stack_id", resource_id)
+        self.assertEqual("nested_stack_id", resource_id)
 
     def test_use_provided_customer_defined_id(self):
         resource_id = ResourceMetadataNormalizer.get_resource_id(
@@ -468,7 +468,7 @@ class TestResourceMetadataNormalizerGetResourceId(TestCase):
             "logical_id",
         )
 
-        self.assertEquals("custom_id", resource_id)
+        self.assertEqual("custom_id", resource_id)
 
     def test_use_provided_customer_defined_id_for_nested_stack(self):
         resource_id = ResourceMetadataNormalizer.get_resource_id(
@@ -483,21 +483,21 @@ class TestResourceMetadataNormalizerGetResourceId(TestCase):
             "logical_id",
         )
 
-        self.assertEquals("custom_nested_stack_id", resource_id)
+        self.assertEqual("custom_nested_stack_id", resource_id)
 
     def test_use_logical_id_if_metadata_is_not_therer(self):
         resource_id = ResourceMetadataNormalizer.get_resource_id(
             {"Type": "any:value", "Properties": {"key": "value"}}, "logical_id"
         )
 
-        self.assertEquals("logical_id", resource_id)
+        self.assertEqual("logical_id", resource_id)
 
     def test_use_logical_id_if_cdk_path_not_exist(self):
         resource_id = ResourceMetadataNormalizer.get_resource_id(
             {"Type": "any:value", "Properties": {"key": "value"}, "Metadata": {}}, "logical_id"
         )
 
-        self.assertEquals("logical_id", resource_id)
+        self.assertEqual("logical_id", resource_id)
 
 
 class TestResourceMetadataNormalizerBuildPropertiesNormalizer(TestCase):

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -1759,7 +1759,7 @@ class TestPathConverter(TestCase):
         path_converter = CatchAllPathConverter(map)
         path = "/path/test/sub_path"
         output = path_converter.to_url(path)
-        self.assertEquals(path, output)
+        self.assertEqual(path, output)
 
     def test_path_converter_to_python_accepts_any_path(self):
         map = Mock()
@@ -1767,11 +1767,11 @@ class TestPathConverter(TestCase):
         path_converter = CatchAllPathConverter(map)
         path = "/path/test/sub_path"
         output = path_converter.to_python(path)
-        self.assertEquals(path, output)
+        self.assertEqual(path, output)
 
     def test_path_converter_matches_any_path(self):
         map = Mock()
         map.charset = "utf-8"
         path_converter = CatchAllPathConverter(map)
         path = "/path/test/sub_path"
-        self.assertRegexpMatches(path, path_converter.regex)
+        self.assertRegex(path, path_converter.regex)

--- a/tests/unit/local/lambda_service/test_local_lambda_invoke_service.py
+++ b/tests/unit/local/lambda_service/test_local_lambda_invoke_service.py
@@ -45,7 +45,7 @@ class TestLocalLambdaService(TestCase):
             methods=["POST"],
             provide_automatic_options=False,
         )
-        self.assertEquals({"function_path": FunctionNamePathConverter}, app_mock.url_map.converters)
+        self.assertEqual({"function_path": FunctionNamePathConverter}, app_mock.url_map.converters)
 
     @patch("samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService.service_response")
     @patch("samcli.local.lambda_service.local_lambda_invoke_service.LambdaOutputParser")
@@ -274,7 +274,7 @@ class TestPathConverter(TestCase):
         path_converter = FunctionNamePathConverter(map)
         full_path = "parent_stack/function_id"
         output = path_converter.to_url(full_path)
-        self.assertEquals(full_path, output)
+        self.assertEqual(full_path, output)
 
     def test_path_converter_to_python_accepts_function_full_path(self):
         map = Mock()
@@ -282,11 +282,11 @@ class TestPathConverter(TestCase):
         path_converter = FunctionNamePathConverter(map)
         full_path = "parent_stack/function_id"
         output = path_converter.to_python(full_path)
-        self.assertEquals(full_path, output)
+        self.assertEqual(full_path, output)
 
     def test_path_converter_matches_function_full_path(self):
         map = Mock()
         map.charset = "utf-8"
         path_converter = FunctionNamePathConverter(map)
         full_path = "parent_stack/function_id"
-        self.assertRegexpMatches(full_path, path_converter.regex)
+        self.assertRegex(full_path, path_converter.regex)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A


#### Why is this change necessary?
We should not be ignoring warnings that are outputted. Looking at the history, it seems like we turned off enforcing warnings in our Py2 removal (don't remember why). This PR re-enables pytest to fail if warnings are outputted and fixes the current failures.

#### How does it address the issue?
Enabled warnings to fail the pytest build and fixes the current failures.


#### What side effects does this change have?
None, they are all for test.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
