### PR TITLE
fix: remove the dependency on six module

### DIFF
--- a/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
+++ b/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
@@ -51,8 +51,6 @@ import subprocess
 import zipfile
 import logging
 
-from six import string_types
-
 LOG = logging.getLogger(__name__)
 
 TF_BACKEND_OVERRIDE_FILENAME = "z_samcli_backend_override"
@@ -237,7 +235,7 @@ def find_and_copy_assets(directory_path, expression, data_object):
         LOG.error(ex.message, exc_info=True)
         cli_exit()
 
-    if not isinstance(extracted_attribute_path, string_types):
+    if not isinstance(extracted_attribute_path, str):
         LOG.error("Expected the extracted attribute to be a string")
         cli_exit()
     extracted_attribute_path = str(extracted_attribute_path)


### PR DESCRIPTION
remove the dependency on six module, as it is not in the python core modules

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
