### PR TITLE
fix: pin flask version, suppress flask output, fix integration tests

### DIFF
--- a/installer/assets/THIRD-PARTY-LICENSES
+++ b/installer/assets/THIRD-PARTY-LICENSES
@@ -699,11 +699,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ** click; version 8.1.3 -- https://click.palletsprojects.com/en/8.1.x/
 Copyright 2014 Pallets
-** Flask; version 2.2.2 -- https://pypi.org/project/Flask/
+** Flask; version 2.0.3 -- https://pypi.org/project/Flask/
 Copyright 2010 Pallets
 ** jinja2; version 3.1.2 -- https://github.com/pallets/jinja
 Copyright 2007 Pallets
-** Werkzeug; version 2.2.2 -- https://pypi.org/project/Werkzeug/
+** Werkzeug; version 2.0.3 -- https://pypi.org/project/Werkzeug/
 Copyright 2007 Pallets
 
 Redistribution and use in source and binary forms, with or without

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 chevron~=0.12
 click~=8.0
-Flask~=2.0
+#2.1.x and later versions of Werkzeug library has a bug for setting up <path:*> endpoints
+Flask~=2.0.0
 #Need to add Schemas latest SDK.
 boto3>=1.19.5,==1.*
 jmespath~=0.10.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 chevron~=0.12
 click~=8.0
 #2.1.x and later versions of Werkzeug library has a bug for setting up <path:*> endpoints
-Flask~=2.0.0
+Flask<2.1
 #Need to add Schemas latest SDK.
 boto3>=1.19.5,==1.*
 jmespath~=0.10.0

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -264,9 +264,7 @@ markupsafe==2.1.1 \
     --hash=sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933 \
     --hash=sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a \
     --hash=sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7
-    # via
-    #   jinja2
-    #   werkzeug
+    # via jinja2
 pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
@@ -446,9 +444,9 @@ websocket-client==0.58.0 \
     --hash=sha256:44b5df8f08c74c3d82d28100fdc81f4536809ce98a17f0757557813275fbb663 \
     --hash=sha256:63509b41d158ae5b7f67eb4ad20fecbb4eee99434e73e140354dc3ff8e09716f
     # via docker
-werkzeug==2.2.2 \
-    --hash=sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f \
-    --hash=sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5
+werkzeug==2.0.3 \
+    --hash=sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8 \
+    --hash=sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c
     # via flask
 wheel==0.36.2 \
     --hash=sha256:78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e \

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -183,9 +183,9 @@ docker==4.2.2 \
     --hash=sha256:03a46400c4080cb6f7aa997f881ddd84fef855499ece219d75fbdb53289c17ab \
     --hash=sha256:26eebadce7e298f55b76a88c4f8802476c5eaddbdbe38dbc6cce8781c47c9b54
     # via aws-sam-cli (setup.py)
-flask==2.2.2 \
-    --hash=sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b \
-    --hash=sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526
+flask==2.0.3 \
+    --hash=sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f \
+    --hash=sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d
     # via aws-sam-cli (setup.py)
 idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
@@ -196,7 +196,6 @@ importlib-metadata==4.11.3 \
     --hash=sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
     # via
     #   click
-    #   flask
     #   jsonschema
 itsdangerous==2.1.2 \
     --hash=sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44 \

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -56,9 +56,10 @@ class BaseLocalService:
 
         LOG.debug("Localhost server is starting up. Multi-threading = %s", multi_threaded)
 
-        # This environ signifies we are running a main function for Flask. This is true, since we are using it within
-        # our cli and not on a production server.
-        os.environ["WERKZEUG_RUN_MAIN"] = "true"
+        # Suppress flask dev server output
+        # See: https://github.com/cs01/gdbgui/issues/425#issuecomment-1119836533
+        import flask.cli
+        flask.cli.show_server_banner = lambda *args: None
 
         self._app.run(threaded=multi_threaded, host=self.host, port=self.port)
 

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import os
 
 from flask import Response
 
@@ -59,6 +58,7 @@ class BaseLocalService:
         # Suppress flask dev server output
         # See: https://github.com/cs01/gdbgui/issues/425#issuecomment-1119836533
         import flask.cli
+
         flask.cli.show_server_banner = lambda *args: None
 
         self._app.run(threaded=multi_threaded, host=self.host, port=self.port)

--- a/tests/iac_integration/cdk/test_sam_cdk_integration.py
+++ b/tests/iac_integration/cdk/test_sam_cdk_integration.py
@@ -71,7 +71,7 @@ class TestSamCdkIntegration(TestCase):
 
         while True:
             line = cls.start_api_process.stderr.readline()
-            if "(Press CTRL+C to quit)" in str(line):
+            if "Press CTRL+C to quit" in str(line):
                 break
 
         cls.stop_api_reading_thread = False

--- a/tests/integration/local/common_utils.py
+++ b/tests/integration/local/common_utils.py
@@ -25,7 +25,7 @@ def wait_for_local_process(process, port):
         if "Address already in use" in line_as_str:
             LOG.info(f"Attempted to start port on {port} but it is already in use, restarting on a new port.")
             raise InvalidAddressException()
-        if "(Press CTRL+C to quit)" in line_as_str:
+        if "Press CTRL+C to quit" in line_as_str:
             break
 
 

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -291,7 +291,7 @@ class TestSyncCode(TestSyncCodeBase):
         sync_process_execute = run_command_with_input(sync_command_list, "y\n".encode())
         self.assertEqual(sync_process_execute.process.returncode, 2)
         self.assertIn(
-            "Invalid value for '--resource': invalid choice: AWS::Serverless::InvalidResource",
+            "Error: Invalid value for '--resource': 'AWS::Serverless::InvalidResource' is not one of",
             str(sync_process_execute.stderr),
         )
 


### PR DESCRIPTION
Related: https://github.com/aws/aws-sam-cli/pull/4326

With the latest version of flask and click libraries, some of the output of them has changed, which is affecting our integration tests. This PR is addressing them by correcting expected output from CLI.

This also downgrades Flask (and werkzeug) version lower than 2.1 since versions from 2.1 and later is creating issues when defining `<path:*>` endpoints.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
