### PR TITLE
fix: pin Werkzeug version under 2.1 as well

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@ chevron~=0.12
 click~=8.0
 #2.1.x and later versions of Werkzeug library has a bug for setting up <path:*> endpoints
 Flask<2.1
+Werkzeug<2.1
 #Need to add Schemas latest SDK.
 boto3>=1.19.5,==1.*
 jmespath~=0.10.0

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -447,7 +447,9 @@ websocket-client==0.58.0 \
 werkzeug==2.0.3 \
     --hash=sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8 \
     --hash=sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c
-    # via flask
+    # via
+    #   aws-sam-cli (setup.py)
+    #   flask
 wheel==0.36.2 \
     --hash=sha256:78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e \
     --hash=sha256:e11eefd162658ea59a60a0f6c7d493a7190ea4b9a85e335b33489d9f17e0245e


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
