### PR TITLE
docs: ignore pycache when listing available hook package ids in help text

### DIFF
--- a/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
+++ b/samcli/hook_packages/terraform/copy_terraform_built_artifacts.py
@@ -51,8 +51,6 @@ import subprocess
 import zipfile
 import logging
 
-from six import string_types
-
 LOG = logging.getLogger(__name__)
 
 TF_BACKEND_OVERRIDE_FILENAME = "z_samcli_backend_override"
@@ -237,7 +235,7 @@ def find_and_copy_assets(directory_path, expression, data_object):
         LOG.error(ex.message, exc_info=True)
         cli_exit()
 
-    if not isinstance(extracted_attribute_path, string_types):
+    if not isinstance(extracted_attribute_path, str):
         LOG.error("Expected the extracted attribute to be a string")
         cli_exit()
     extracted_attribute_path = str(extracted_attribute_path)

--- a/samcli/lib/hook/hook_wrapper.py
+++ b/samcli/lib/hook/hook_wrapper.py
@@ -191,7 +191,7 @@ def get_available_hook_packages_ids() -> List[str]:
     LOG.debug("Return available internal hook packages")
     hook_packages_ids = []
     for child in INTERNAL_PACKAGES_ROOT.iterdir():
-        if child.is_dir() and child.name != "__pycache__":
+        if child.is_dir() and child.name[0].isalpha():
             hook_packages_ids.append(child.name)
 
     return hook_packages_ids

--- a/samcli/lib/hook/hook_wrapper.py
+++ b/samcli/lib/hook/hook_wrapper.py
@@ -191,7 +191,7 @@ def get_available_hook_packages_ids() -> List[str]:
     LOG.debug("Return available internal hook packages")
     hook_packages_ids = []
     for child in INTERNAL_PACKAGES_ROOT.iterdir():
-        if child.is_dir():
+        if child.is_dir() and child.name != "__pycache__":
             hook_packages_ids.append(child.name)
 
     return hook_packages_ids


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Help message looks like this:
```
  --hook-package-id TEXT          The id of the hook package to be used to
                                  extend the SAM CLI commands functionality.
                                  As an example, you can use `terraform` to
                                  extend SAM CLI commands functionality to
                                  support terraform applications. Available
                                  Hook Packages Ids ['terraform',
                                  '__pycache__']
```
At the end you can see pycache listed as one of the available hook package ids. We should ensure it doesn't appear there.

#### How does it address the issue?
Ignores `pycache`.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
