### PR TITLE
fix: Updated build success message for hook packages

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -371,7 +371,6 @@ class BuildContext:
         invoke_suggestion = "Invoke Function: sam local invoke"
         sync_suggestion = "Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch"
         deploy_suggestion = "Deploy: sam deploy --guided"
-        start_api_suggestion = "Start a local API: sam local start-api"
         start_lambda_suggestion = "Emulate local Lambda functions: sam local start-lambda"
 
         if not is_default_build_dir:
@@ -383,10 +382,9 @@ class BuildContext:
         # check if we have used a hook package before building
         if self._hook_package_id:
             hook_package_flag = f" --hook-package-id {self._hook_package_id}"
-            start_api_suggestion += hook_package_flag
             start_lambda_suggestion += hook_package_flag
 
-            commands = [invoke_suggestion, start_api_suggestion, start_lambda_suggestion]
+            commands = [invoke_suggestion, start_lambda_suggestion]
 
         msg = f"""\nBuilt Artifacts  : {artifacts_dir}
 Built Template   : {output_template_path}

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -382,7 +382,9 @@ class BuildContext:
         # check if we have used a hook package before building
         if self._hook_package_id:
             hook_package_flag = f" --hook-package-id {self._hook_package_id}"
+
             start_lambda_suggestion += hook_package_flag
+            invoke_suggestion += hook_package_flag
 
             commands = [invoke_suggestion, start_lambda_suggestion]
 

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -75,6 +75,7 @@ class BuildContext:
         stack_name: Optional[str] = None,
         print_success_message: bool = True,
         locate_layer_nested: bool = False,
+        hook_package_id: Optional[str] = None,
     ) -> None:
         """
         Initialize the class
@@ -126,6 +127,8 @@ class BuildContext:
             Print successful message
         locate_layer_nested: bool
             Locate layer to its actual, worked with nested stack
+        hook_package_id: Optional[str]
+            Name of the hook package
         """
 
         self._resource_identifier = resource_identifier
@@ -163,6 +166,7 @@ class BuildContext:
         self._container_manager: Optional[ContainerManager] = None
         self._stacks: List[Stack] = []
         self._locate_layer_nested = locate_layer_nested
+        self._hook_package_id = hook_package_id
 
     def __enter__(self) -> "BuildContext":
         self.set_up()
@@ -272,7 +276,7 @@ class BuildContext:
                 output_template_path_in_success_message = out_template_path
 
             if self._print_success_message:
-                msg = self.gen_success_msg(
+                msg = self._gen_success_msg(
                     build_dir_in_success_message,
                     output_template_path_in_success_message,
                     os.path.abspath(self.build_dir) == os.path.abspath(DEFAULT_BUILD_DIR),
@@ -344,29 +348,55 @@ class BuildContext:
 
             move_template(stack.location, output_template_path, modified_template)
 
-    @staticmethod
-    def gen_success_msg(artifacts_dir: str, output_template_path: str, is_default_build_dir: bool) -> str:
+    def _gen_success_msg(self, artifacts_dir: str, output_template_path: str, is_default_build_dir: bool) -> str:
+        """
+        Generates a success message containing some suggested commands to run
 
-        invoke_cmd = "sam local invoke"
+        Parameters
+        ----------
+        artifacts_dir: str
+            A string path representing the folder of built artifacts
+        output_template_path: str
+            A string path representing the final template file
+        is_default_build_dir: bool
+            True if the build folder is the folder defined by SAM CLI
+
+        Returns
+        -------
+        str
+            A formatted success message string
+        """
+
+        validate_suggestion = "Validate SAM template: sam validate"
+        invoke_suggestion = "Invoke Function: sam local invoke"
+        sync_suggestion = "Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch"
+        deploy_suggestion = "Deploy: sam deploy --guided"
+        start_api_suggestion = "Start a local API: sam local start-api"
+        start_lambda_suggestion = "Emulate local Lambda functions: sam local start-lambda"
+
         if not is_default_build_dir:
-            invoke_cmd += " -t {}".format(output_template_path)
+            invoke_suggestion += " -t {}".format(output_template_path)
+            deploy_suggestion += " --template-file {}".format(output_template_path)
 
-        deploy_cmd = "sam deploy --guided"
-        if not is_default_build_dir:
-            deploy_cmd += " --template-file {}".format(output_template_path)
+        commands = [validate_suggestion, invoke_suggestion, sync_suggestion, deploy_suggestion]
 
-        msg = """\nBuilt Artifacts  : {artifacts_dir}
-Built Template   : {template}
+        # check if we have used a hook package before building
+        if self._hook_package_id:
+            hook_package_flag = f" --hook-package-id {self._hook_package_id}"
+            start_api_suggestion += hook_package_flag
+            start_lambda_suggestion += hook_package_flag
+
+            commands = [invoke_suggestion, start_api_suggestion, start_lambda_suggestion]
+
+        msg = f"""\nBuilt Artifacts  : {artifacts_dir}
+Built Template   : {output_template_path}
 
 Commands you can use next
 =========================
-[*] Validate SAM template: sam validate
-[*] Invoke Function: {invokecmd}
-[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
-[*] Deploy: {deploycmd}
-        """.format(
-            invokecmd=invoke_cmd, deploycmd=deploy_cmd, artifacts_dir=artifacts_dir, template=output_template_path
-        )
+"""
+
+        # add bullet point then join all the commands with new line
+        msg += "[*] " + f"{os.linesep}[*] ".join(commands)
 
         return msg
 

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -268,6 +268,7 @@ def do_cli(  # pylint: disable=too-many-locals, too-many-statements
         build_images=processed_build_images,
         excluded_resources=exclude,
         aws_region=click_ctx.region,
+        hook_package_id=hook_package_id,
     ) as ctx:
         ctx.run()
 

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -712,7 +712,7 @@ class TestBuildContext__enter__(TestCase):
             create_auto_dependency_layer=auto_dependency_layer,
             print_success_message=False,
         ) as build_context:
-            with patch("samcli.commands.build.build_context.BuildContext.gen_success_msg") as mock_message:
+            with patch("samcli.commands.build.build_context.BuildContext._gen_success_msg") as mock_message:
                 build_context.run()
                 mock_message.assert_not_called()
 

--- a/tests/unit/commands/buildcmd/test_command.py
+++ b/tests/unit/commands/buildcmd/test_command.py
@@ -59,7 +59,7 @@ class TestDoCli(TestCase):
             build_images={},
             excluded_resources=(),
             aws_region=ctx_mock.region,
-            hook_package_id=None
+            hook_package_id=None,
         )
         ctx_mock.run.assert_called_with()
         self.assertEqual(ctx_mock.run.call_count, 1)

--- a/tests/unit/commands/buildcmd/test_command.py
+++ b/tests/unit/commands/buildcmd/test_command.py
@@ -59,6 +59,7 @@ class TestDoCli(TestCase):
             build_images={},
             excluded_resources=(),
             aws_region=ctx_mock.region,
+            hook_package_id=None
         )
         ctx_mock.run.assert_called_with()
         self.assertEqual(ctx_mock.run.call_count, 1)


### PR DESCRIPTION
#### Why is this change necessary?
Changes the build success messages to not mention commands that won't work with current hook packages.

#### How does it address the issue?
Checks for the hook package and changes which commands are mentioned in the message.

eg when using a hook package:
```
Build Succeeded

Built Artifacts  : .aws-sam/build
Built Template   : .aws-sam/build/template.yaml

Commands you can use next
=========================
[*] Invoke Function: sam local invoke
[*] Start a local API: sam local start-api --hook-package-id terraform
[*] Emulate local Lambda functions: sam local start-lambda --hook-package-id terraform
```

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
