### PR TITLE
chore: bump golang version in CI jobs

### DIFF
--- a/appveyor-iac-integration-ubuntu.yml
+++ b/appveyor-iac-integration-ubuntu.yml
@@ -38,7 +38,7 @@ install:
   # AppVeyor's apt-get cache might be outdated, and the package could potentially be 404.
   - sh: "sudo apt-get update"
 
-  - sh: "gvm use go1.15"
+  - sh: "gvm use go1.19"
   - sh: "echo $PATH"
   - sh: "ls /usr/"
   - sh: "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -57,7 +57,7 @@ install:
   # AppVeyor's apt-get cache might be outdated, and the package could potentially be 404.
   - sh: "sudo apt-get update"
 
-  - sh: "gvm use go1.15"
+  - sh: "gvm use go1.19"
   - sh: "echo $PATH"
   - sh: "ls /usr/"
   - sh: "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -123,7 +123,7 @@ for:
       # AppVeyor's apt-get cache might be outdated, and the package could potentially be 404.
       - sh: "sudo apt-get update"
 
-      - sh: "gvm use go1.15"
+      - sh: "gvm use go1.19"
       - sh: "echo $PATH"
       - sh: "ls /usr/"
       - sh: "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"


### PR DESCRIPTION
[golang 1.15 is the oldest version that is supported in Appveyor images](https://www.appveyor.com/docs/linux-images-software/), which will probably be dropped in the near future. This PR is addressing that concern by upgrading its version to latest one (1.19).

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
