### PR TITLE
Extract full file name from Dockerfile path

### DIFF
--- a/samcli/lib/samlib/resource_metadata_normalizer.py
+++ b/samcli/lib/samlib/resource_metadata_normalizer.py
@@ -186,7 +186,7 @@ class ResourceMetadataNormalizer:
         """
         asset_path = Path(metadata.get(ASSET_PATH_METADATA_KEY, ""))
         dockerfile_path = Path(metadata.get(ASSET_DOCKERFILE_PATH_KEY), "")
-        dockerfile, path_from_asset = dockerfile_path.stem, dockerfile_path.parent
+        dockerfile, path_from_asset = dockerfile_path.name, dockerfile_path.parent
         dockerfile_context = str(Path(asset_path.joinpath(path_from_asset)))
         return {
             SAM_METADATA_DOCKERFILE_KEY: dockerfile,

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -86,6 +86,34 @@ class TestBuildCommand_PythonFunctions_Images(BuildIntegBase):
             self.built_template, self.FUNCTION_LOGICAL_ID_IMAGE, self._make_parameter_override_arg(overrides), expected
         )
 
+    @parameterized.expand([("3.6", False), ("3.7", False), ("3.8", False), ("3.9", False)])
+    @pytest.mark.flaky(reruns=3)
+    def test_with_dockerfile_extension(self, runtime, use_container):
+        _tag = f"{random.randint(1,100)}"
+        overrides = {
+            "Runtime": runtime,
+            "Handler": "main.handler",
+            "DockerFile": "Dockerfile.production",
+            "Tag": _tag,
+        }
+        cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
+
+        LOG.info("Running Command: ")
+        LOG.info(cmdlist)
+        run_command(cmdlist, cwd=self.working_dir)
+
+        self._verify_image_build_artifact(
+            self.built_template,
+            self.FUNCTION_LOGICAL_ID_IMAGE,
+            "ImageUri",
+            f"{self.FUNCTION_LOGICAL_ID_IMAGE.lower()}:{_tag}",
+        )
+
+        expected = {"pi": "3.14"}
+        self._verify_invoke_built_function(
+            self.built_template, self.FUNCTION_LOGICAL_ID_IMAGE, self._make_parameter_override_arg(overrides), expected
+        )
+
     @pytest.mark.flaky(reruns=3)
     def test_intermediate_container_deleted(self):
         _tag = f"{random.randint(1, 100)}"

--- a/tests/integration/testdata/buildcmd/PythonImage/Dockerfile.production
+++ b/tests/integration/testdata/buildcmd/PythonImage/Dockerfile.production
@@ -1,0 +1,15 @@
+ARG BASE_RUNTIME
+
+FROM public.ecr.aws/lambda/python:$BASE_RUNTIME
+
+ARG FUNCTION_DIR="/var/task"
+
+RUN mkdir -p $FUNCTION_DIR
+
+COPY main.py $FUNCTION_DIR
+
+COPY __init__.py $FUNCTION_DIR
+COPY requirements.txt $FUNCTION_DIR
+
+RUN python -m pip install -r $FUNCTION_DIR/requirements.txt -t $FUNCTION_DIR
+

--- a/tests/unit/lib/samlib/test_resource_metadata_normalizer.py
+++ b/tests/unit/lib/samlib/test_resource_metadata_normalizer.py
@@ -112,6 +112,41 @@ class TestResourceMetadataNormalizer(TestCase):
         self.assertEqual(docker_build_args, template_data["Resources"]["Function1"]["Metadata"]["DockerBuildArgs"])
         self.assertEqual("Function1", template_data["Resources"]["Function1"]["Metadata"]["SamResourceId"])
 
+    def test_replace_all_resources_that_contain_image_metadata_dockerfile_extensions(self):
+        docker_build_args = {"arg1": "val1", "arg2": "val2"}
+        asset_path = pathlib.Path("/path", "to", "asset")
+        dockerfile_path = pathlib.Path("path", "to", "Dockerfile.production")
+        template_data = {
+            "Resources": {
+                "Function1": {
+                    "Properties": {
+                        "Code": {
+                            "ImageUri": {
+                                "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-${AWS::AccountId}-${AWS::Region}:b5d75370ccc2882b90f701c8f98952aae957e85e1928adac8860222960209056"
+                            }
+                        }
+                    },
+                    "Metadata": {
+                        "aws:asset:path": asset_path,
+                        "aws:asset:property": "Code.ImageUri",
+                        "aws:asset:dockerfile-path": dockerfile_path,
+                        "aws:asset:docker-build-args": docker_build_args,
+                    },
+                },
+            }
+        }
+
+        ResourceMetadataNormalizer.normalize(template_data)
+
+        expected_docker_context_path = str(pathlib.Path("/path", "to", "asset", "path", "to"))
+        self.assertEqual("function1", template_data["Resources"]["Function1"]["Properties"]["Code"]["ImageUri"])
+        self.assertEqual(
+            expected_docker_context_path, template_data["Resources"]["Function1"]["Metadata"]["DockerContext"]
+        )
+        self.assertEqual("Dockerfile.production", template_data["Resources"]["Function1"]["Metadata"]["Dockerfile"])
+        self.assertEqual(docker_build_args, template_data["Resources"]["Function1"]["Metadata"]["DockerBuildArgs"])
+        self.assertEqual("Function1", template_data["Resources"]["Function1"]["Metadata"]["SamResourceId"])
+
     def test_replace_all_resources_that_contain_image_metadata_windows_paths(self):
         docker_build_args = {"arg1": "val1", "arg2": "val2"}
         asset_path = "C:\\path\\to\\asset"


### PR DESCRIPTION
Fixes #4355. Use `Path`/`PurePath`'s `name` property to extract a full Dockerfile file name. The current implementation uses `.stem` which omits the final suffix, is present.

#### Which issue(s) does this change fix?

Fixes #4355.

#### Why is this change necessary?

The `sam build` command does not properly locate Dockerfiles with extension(s) in their file names without this change.

#### How does it address the issue?

By using the `.name` property on `Path`/`PurePath` as opposed to `.stem`, the entire file name is guaranteed to be included.

See https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.name and https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.stem.

#### What side effects does this change have?

None. File names with no extension (e.g., `Dockerfile`) will be parsed in the same way after this change. 

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
