### PR TITLE
fix: regresssion on `sam delete`

### DIFF
--- a/samcli/lib/delete/cfn_utils.py
+++ b/samcli/lib/delete/cfn_utils.py
@@ -116,8 +116,9 @@ class CfnUtils:
 
         # Wait for Delete to Finish
         waiter = self._client.get_waiter("stack_delete_complete")
-        # Poll every 30 seconds and set max attempts to be 3.
-        waiter_config = {"Delay": 30, "MaxAttempts": 3}
+        # Do not set `MaxAttempts` in waiter_config
+        # Regression: https://github.com/aws/aws-sam-cli/issues/4361
+        waiter_config = {"Delay": 30}
         try:
             waiter.wait(StackName=stack_name, WaiterConfig=waiter_config)
         except WaiterError as ex:

--- a/samcli/lib/delete/cfn_utils.py
+++ b/samcli/lib/delete/cfn_utils.py
@@ -116,7 +116,7 @@ class CfnUtils:
 
         # Wait for Delete to Finish
         waiter = self._client.get_waiter("stack_delete_complete")
-        # Do not set `MaxAttempts` in waiter_config
+        # Remove `MaxAttempts` from waiter_config.
         # Regression: https://github.com/aws/aws-sam-cli/issues/4361
         waiter_config = {"Delay": 30}
         try:

--- a/tests/unit/lib/delete/test_cfn_utils.py
+++ b/tests/unit/lib/delete/test_cfn_utils.py
@@ -24,6 +24,7 @@ class TestCfUtils(TestCase):
         self.cloudformation_client = self.session.client("cloudformation")
         self.s3_client = self.session.client("s3")
         self.cf_utils = CfnUtils(self.cloudformation_client)
+        self.waiter_config = {"Delay": 30}
 
     def test_cf_utils_init(self):
         self.assertEqual(self.cf_utils._client, self.cloudformation_client)
@@ -104,6 +105,22 @@ class TestCfUtils(TestCase):
         self.cf_utils._client.delete_stack = MagicMock(side_effect=Exception())
         with self.assertRaises(Exception):
             self.cf_utils.delete_stack("test", ["retain_logical_id"])
+
+    def test_cf_utils_wait_for_delete_check_waiter_config(self):
+        exception = WaiterError(
+            name="wait_for_delete",
+            reason="unit-test",
+            last_response={"Stacks": [{"Status": "Failed", "StackStatusReason": "It's a unit test stack failure"}]},
+        )
+        # Patch MockDeleteWaiter's wait to be Mock to get access to call_args for assertion
+        with patch.object(MockDeleteWaiter, "wait", side_effect=exception):
+            self.cf_utils._client.get_waiter = MagicMock(return_value=MockDeleteWaiter())
+            with self.assertRaises(DeleteFailedError):
+                self.cf_utils.wait_for_delete("test")
+            # Assert waiter config.
+            self.cf_utils._client.get_waiter.return_value.wait.assert_called_with(
+                StackName="test", WaiterConfig=self.waiter_config
+            )
 
     def test_cf_utils_wait_for_delete_exception_stack_status(self):
         self.cf_utils._client.get_waiter = MagicMock(


### PR DESCRIPTION
- Remove `MaxAttempts` and let it be set to default of 120 per https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#waiters

#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/4361


#### Why is this change necessary?
- Removes the total number of attempts before change of state to be the default. This stems from a wrong understanding of what `MaxAttempts` meant during the previous implementation of the fix.

#### How does it address the issue?
- Unsets `MaxAttempts` and restores default behavior.

#### What side effects does this change have?
- Fixes regression https://github.com/aws/aws-sam-cli/issues/4361 and should not have any other side effects.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
