### PR TITLE
feat: error out if input is required on terraform init

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -112,7 +112,7 @@ def prepare(params: dict) -> dict:
     try:
         # initialize terraform application
         LOG.info("Initializing Terraform application")
-        run(["terraform", "init"], check=True, capture_output=True, cwd=terraform_application_dir)
+        run(["terraform", "init", "-input=false"], check=True, capture_output=True, cwd=terraform_application_dir)
 
         # get json output of terraform plan
         LOG.info("Creating terraform plan and getting JSON output")

--- a/tests/integration/buildcmd/test_build_terraform_applications.py
+++ b/tests/integration/buildcmd/test_build_terraform_applications.py
@@ -481,6 +481,32 @@ class TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend(Build
     not CI_OVERRIDE,
     "Skip Terraform test cases unless running in CI",
 )
+class TestInvalidBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3BackendNoS3Config(
+    BuildTerraformApplicationIntegBase
+):
+    terraform_application = (
+        Path("terraform/zip_based_lambda_functions_s3_backend")
+        if not IS_WINDOWS
+        else Path("terraform/zip_based_lambda_functions_s3_backend_windows")
+    )
+
+    def test_build_no_s3_config(self):
+        command_list_parameters = {
+            "beta_features": True,
+            "hook_package_id": "terraform",
+        }
+        build_cmd_list = self.get_command_list(**command_list_parameters)
+        LOG.info("command list: %s", build_cmd_list)
+        environment_variables = os.environ.copy()
+        _, stderr, return_code = self.run_command(build_cmd_list, env=environment_variables)
+        LOG.info(stderr)
+        self.assertNotEqual(return_code, 0)
+
+
+@skipIf(
+    not CI_OVERRIDE,
+    "Skip Terraform test cases unless running in CI",
+)
 class TestBuildTerraformApplicationsWithImageBasedLambdaFunctionAndLocalBackend(BuildTerraformApplicationIntegBase):
     terraform_application = Path("terraform/image_based_lambda_functions_local_backend")
     functions = [

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
@@ -2547,7 +2547,7 @@ class TestPrepareHook(TestCase):
 
         mock_subprocess_run.assert_has_calls(
             [
-                call(["terraform", "init"], check=True, capture_output=True, cwd="iac/project/path"),
+                call(["terraform", "init", "-input=false"], check=True, capture_output=True, cwd="iac/project/path"),
                 call(
                     ["terraform", "plan", "-out", tf_plan_filename, "-input=false"],
                     check=True,
@@ -2627,7 +2627,12 @@ class TestPrepareHook(TestCase):
 
         mock_subprocess_run.assert_has_calls(
             [
-                call(["terraform", "init"], check=True, capture_output=True, cwd="/current/dir/iac/project/path"),
+                call(
+                    ["terraform", "init", "-input=false"],
+                    check=True,
+                    capture_output=True,
+                    cwd="/current/dir/iac/project/path",
+                ),
                 call(
                     ["terraform", "plan", "-out", tf_plan_filename, "-input=false"],
                     check=True,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Preparing a terraform project used to get stuck on the initializing part because it would wait for input (although this interactive part is not printed out on the cli).
<img width="666" alt="Screen Shot 2022-11-01 at 2 41 09 PM" src="https://user-images.githubusercontent.com/86501267/199347280-d7adff8b-a136-4b80-9a53-fe30f1287c0b.png">

This is what you would see if you ran `terraform init`:
<img width="684" alt="Screen Shot 2022-11-01 at 2 54 11 PM" src="https://user-images.githubusercontent.com/86501267/199349214-80c06632-d713-4188-bb04-f99990d9e24f.png">


#### How does it address the issue?
The prepare step now errors out if input is required (and wasn't provided in the config). 
<img width="661" alt="Screen Shot 2022-11-01 at 2 30 15 PM" src="https://user-images.githubusercontent.com/86501267/199347440-10a05b29-7d5d-4520-9338-3fdeebc3b77b.png">


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
