### PR TITLE
fix: Ignore template option when using hook package

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -373,7 +373,7 @@ class BuildContext:
         deploy_suggestion = "Deploy: sam deploy --guided"
         start_lambda_suggestion = "Emulate local Lambda functions: sam local start-lambda"
 
-        if not is_default_build_dir:
+        if not is_default_build_dir and not self._hook_package_id:
             invoke_suggestion += " -t {}".format(output_template_path)
             deploy_suggestion += " --template-file {}".format(output_template_path)
 

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -1274,15 +1274,13 @@ class TestBuildContext_gen_success_msg(TestCase):
         self.build_context._hook_package_id = False
 
         msg = self.build_context._gen_success_msg(self.build_dir, self.template_file, False)
-        expected_msg = """\nBuilt Artifacts  : build_dir
+        expected_msg = f"""\nBuilt Artifacts  : build_dir
 Built Template   : template_file
-
 Commands you can use next
 =========================
-[*] Validate SAM template: sam validate
-[*] Invoke Function: sam local invoke -t template_file
-[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
-[*] Deploy: sam deploy --guided --template-file template_file"""
+[*] Validate SAM template: sam validate{os.linesep}[*] Invoke Function: sam local invoke -t template_file{os.linesep}"""
+f"""[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch{os.linesep}[*] Deploy: sam deploy """
+"""--guided --template-file template_file"""
 
         self.assertEqual(msg, expected_msg)
 
@@ -1290,12 +1288,12 @@ Commands you can use next
         self.build_context._hook_package_id = "iac"
 
         msg = self.build_context._gen_success_msg(self.build_dir, self.template_file, False)
-        expected_msg = """\nBuilt Artifacts  : build_dir
+        expected_msg = f"""\nBuilt Artifacts  : build_dir
 Built Template   : template_file
 
 Commands you can use next
 =========================
-[*] Invoke Function: sam local invoke --hook-package-id iac
-[*] Emulate local Lambda functions: sam local start-lambda --hook-package-id iac"""
+[*] Invoke Function: sam local invoke --hook-package-id iac{os.linesep}[*] Emulate local Lambda functions: sam local """
+"""start-lambda --hook-package-id iac"""
 
         self.assertEqual(msg, expected_msg)

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -1274,13 +1274,15 @@ class TestBuildContext_gen_success_msg(TestCase):
         self.build_context._hook_package_id = False
 
         msg = self.build_context._gen_success_msg(self.build_dir, self.template_file, False)
-        expected_msg = f"""\nBuilt Artifacts  : build_dir
-Built Template   : template_file
+        expected_msg = (
+            f"""\nBuilt Artifacts  : build_dir
+Built Template   : template_file\n
 Commands you can use next
 =========================
-[*] Validate SAM template: sam validate{os.linesep}[*] Invoke Function: sam local invoke -t template_file{os.linesep}"""
-f"""[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch{os.linesep}[*] Deploy: sam deploy """
-"""--guided --template-file template_file"""
+[*] Validate SAM template: sam validate{os.linesep}[*] Invoke Function: sam local invoke -t template_file"""
+            f"""{os.linesep}[*] Test Function in the Cloud: sam sync --stack-name {"{{stack-name}}"} --watch"""
+            f"""{os.linesep}[*] Deploy: sam deploy --guided --template-file template_file"""
+        )
 
         self.assertEqual(msg, expected_msg)
 
@@ -1288,12 +1290,14 @@ f"""[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
         self.build_context._hook_package_id = "iac"
 
         msg = self.build_context._gen_success_msg(self.build_dir, self.template_file, False)
-        expected_msg = f"""\nBuilt Artifacts  : build_dir
+        expected_msg = (
+            f"""\nBuilt Artifacts  : build_dir
 Built Template   : template_file
 
 Commands you can use next
 =========================
-[*] Invoke Function: sam local invoke --hook-package-id iac{os.linesep}[*] Emulate local Lambda functions: sam local """
-"""start-lambda --hook-package-id iac"""
+[*] Invoke Function: sam local invoke --hook-package-id iac{os.linesep}[*] Emulate local Lambda functions: sam """
+            """local start-lambda --hook-package-id iac"""
+        )
 
         self.assertEqual(msg, expected_msg)

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -1252,3 +1252,50 @@ class TestBuildContext_exclude_warning(TestCase):
             log_mock.warning.assert_called_once_with(BuildContext._EXCLUDE_WARNING_MESSAGE)
         else:
             log_mock.warning.assert_not_called()
+
+
+class TestBuildContext_gen_success_msg(TestCase):
+    def setUp(self):
+        self.build_dir = "build_dir"
+        self.template_file = "template_file"
+
+        self.build_context = BuildContext(
+            resource_identifier="function_identifier",
+            template_file=self.template_file,
+            base_dir="base_dir",
+            build_dir=self.build_dir,
+            cache_dir="cache_dir",
+            parallel=False,
+            mode="mode",
+            cached=False,
+        )
+
+    def test_gen_message_with_non_default_build_without_hook_package(self):
+        self.build_context._hook_package_id = False
+
+        msg = self.build_context._gen_success_msg(self.build_dir, self.template_file, False)
+        expected_msg = """\nBuilt Artifacts  : build_dir
+Built Template   : template_file
+
+Commands you can use next
+=========================
+[*] Validate SAM template: sam validate
+[*] Invoke Function: sam local invoke -t template_file
+[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
+[*] Deploy: sam deploy --guided --template-file template_file"""
+
+        self.assertEqual(msg, expected_msg)
+
+    def test_gen_message_with_non_default_build_with_hook_package(self):
+        self.build_context._hook_package_id = "iac"
+
+        msg = self.build_context._gen_success_msg(self.build_dir, self.template_file, False)
+        expected_msg = """\nBuilt Artifacts  : build_dir
+Built Template   : template_file
+
+Commands you can use next
+=========================
+[*] Invoke Function: sam local invoke --hook-package-id iac
+[*] Emulate local Lambda functions: sam local start-lambda --hook-package-id iac"""
+
+        self.assertEqual(msg, expected_msg)


### PR DESCRIPTION
#### Why is this change necessary?
Fixes one of the suggested commands to not include `-t/--template` when using `--hook-package-id`.

#### How does it address the issue?
Adds another check for hook package ID.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
