### PR TITLE
Update aws-sam-cli-bot as user for internal pr labels

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,7 +21,12 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const maintainers = ['jfuss', 'hoffa', 'awood45', 'aahung', 'hawflau', 'mndeveci', 'ssenchenko', 'qingchm', 'moelasmar', 'xazhao', 'mildaniel', 'marekaiv', 'torresxb1', 'lucashuy', 'hnnasit', 'sriram-mv']
+            const maintainers = [
+              'aws-sam-cli-bot',
+              'jfuss', 'hoffa', 'awood45', 'aahung', 'hawflau', 'mndeveci', 'ssenchenko',
+              'qingchm', 'moelasmar', 'xazhao', 'mildaniel', 'marekaiv', 'torresxb1',
+              'lucashuy', 'hnnasit', 'sriram-mv'
+            ]
             if (maintainers.includes(context.payload.sender.login)) {
               github.rest.issues.addLabels({
                 issue_number: context.issue.number,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Currently PR created by "aws-sam-cli-bot" are labelled as external pr, which is not accurate.

#### How does it address the issue?
Add "aws-sam-cli-bot" as a maintainer in the PR label GH Action

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
