### PR TITLE
version: bring in latest lambda builders version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ docker~=4.2.0
 dateparser~=1.0
 requests==2.25.1
 serverlessrepo==0.1.10
-aws_lambda_builders==1.20.0
+aws_lambda_builders==1.21.0
 tomlkit==0.7.2
 watchdog==2.1.2
 pyopenssl==22.0.0

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -12,9 +12,9 @@ attrs==20.3.0 \
     --hash=sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6 \
     --hash=sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700
     # via jsonschema
-aws-lambda-builders==1.20.0 \
-    --hash=sha256:71b8b2870e735a2e2ac0e59e84295aa967bc8bdb36515feec539b10df2314549 \
-    --hash=sha256:7c78b9f81a75fae4af3cb958dc0b3b268c12ebe16c3aa5cfd93dcd0c05cefd23
+aws-lambda-builders==1.21.0 \
+    --hash=sha256:77a21d3fa969119b9d05c2a18abd8dd10cff9ee8ba9793932fa00953cefbe4e1 \
+    --hash=sha256:d79ae58b5d3961f9f55e6645c4759ad9f5455165fb6a7932bf10da39f6d275c0
     # via aws-sam-cli (setup.py)
 aws-sam-translator==1.53.0 \
     --hash=sha256:392ed4f5fb08f72cb68a8800f0bc278d2a3b6609bd1ac66bfcdeaaa94cdc18e5 \


### PR DESCRIPTION
- run integ tests on this branch once brought in.

#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
To bring in the streaming makefile builder changes and ensure integration tests continue to work as normal.

#### How does it address the issue?
N/A

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
