### PR TITLE
feat: raise error for terraform expression that mix between constant values and references 

### DIFF
--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -1115,8 +1115,8 @@ class TestResourceLinking(TestCase):
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
     def test_process_resolved_layers_constant_only(
-            self,
-            process_reference_layer_value_mock,
+        self,
+        process_reference_layer_value_mock,
     ):
         tf_layers = Mock()
         resource = Mock()
@@ -1128,8 +1128,8 @@ class TestResourceLinking(TestCase):
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
     def test_process_resolved_layers_references_only(
-            self,
-            process_reference_layer_value_mock,
+        self,
+        process_reference_layer_value_mock,
     ):
         tf_layers = Mock()
         resource = Mock()
@@ -1164,8 +1164,8 @@ class TestResourceLinking(TestCase):
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
     def test_process_resolved_layers_mixed_data_sources_and_references(
-            self,
-            process_reference_layer_value_mock,
+        self,
+        process_reference_layer_value_mock,
     ):
         tf_layers = Mock()
         resource = Mock()

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -1114,19 +1114,80 @@ class TestResourceLinking(TestCase):
         self.assertEqual(exc.exception.args[0], expected_exception)
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
-    def test_process_resolved_layers(
+    def test_process_resolved_layers_constant_only(
+            self,
+            process_reference_layer_value_mock,
+    ):
+        tf_layers = Mock()
+        resource = Mock()
+        constant_value_resolved_layer = ConstantValue("layer1.arn")
+        resolved_layers = [constant_value_resolved_layer]
+        layers = _process_resolved_layers(resource, resolved_layers, tf_layers)
+        self.assertEqual(layers, [])
+        process_reference_layer_value_mock.assert_not_called()
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
+    def test_process_resolved_layers_references_only(
+            self,
+            process_reference_layer_value_mock,
+    ):
+        tf_layers = Mock()
+        resource = Mock()
+        reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")
+        resolved_layers = [reference_resolved_layer]
+        process_reference_layer_value_mock.return_value = [{"Ref": "Layer1LogicalId"}]
+        layers = _process_resolved_layers(resource, resolved_layers, tf_layers)
+        self.assertEqual(layers, [{"Ref": "Layer1LogicalId"}])
+        process_reference_layer_value_mock.assert_called_with(resource, reference_resolved_layer, tf_layers)
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
+    def test_process_resolved_layers_mixed_constant_and_references(
         self,
         process_reference_layer_value_mock,
     ):
         tf_layers = Mock()
         resource = Mock()
+        resource.full_address = "func_full_address"
         constant_value_resolved_layer = ConstantValue("layer1.arn")
         reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")
         resolved_layers = [reference_resolved_layer, constant_value_resolved_layer]
         process_reference_layer_value_mock.return_value = [{"Ref": "Layer1LogicalId"}]
-        layers = _process_resolved_layers(resource, resolved_layers, tf_layers)
-        self.assertEqual(layers, [{"Ref": "Layer1LogicalId"}])
+        expected_exception = (
+            "AWS SAM CLI could not process a Terraform project that contains Lambda functions that are linked to more "
+            f"than one lambda layer. Layer(s) defined by {resolved_layers} could not be linked to lambda function "
+            f"func_full_address.{os.linesep}Related issue: {ONE_LAMBDA_LAYER_LINKING_ISSUE_LINK}."
+        )
+        with self.assertRaises(OneLambdaLayerLinkingLimitationException) as exc:
+            _process_resolved_layers(resource, resolved_layers, tf_layers)
+        self.assertEqual(exc.exception.args[0], expected_exception)
         process_reference_layer_value_mock.assert_called_with(resource, reference_resolved_layer, tf_layers)
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
+    def test_process_resolved_layers_mixed_data_sources_and_references(
+            self,
+            process_reference_layer_value_mock,
+    ):
+        tf_layers = Mock()
+        resource = Mock()
+        resource.full_address = "func_full_address"
+        data_resources_resolved_layer = ResolvedReference("data.aws_region.current.name", "module.layer1")
+        reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")
+        resolved_layers = [reference_resolved_layer, data_resources_resolved_layer]
+        process_reference_layer_value_mock.side_effect = [[{"Ref": "Layer1LogicalId"}], []]
+        expected_exception = (
+            "AWS SAM CLI could not process a Terraform project that contains Lambda functions that are linked to more "
+            f"than one lambda layer. Layer(s) defined by {resolved_layers} could not be linked to lambda function "
+            f"func_full_address.{os.linesep}Related issue: {ONE_LAMBDA_LAYER_LINKING_ISSUE_LINK}."
+        )
+        with self.assertRaises(OneLambdaLayerLinkingLimitationException) as exc:
+            _process_resolved_layers(resource, resolved_layers, tf_layers)
+        self.assertEqual(exc.exception.args[0], expected_exception)
+        process_reference_layer_value_mock.assert_has_calls(
+            [
+                call(resource, reference_resolved_layer, tf_layers),
+                call(resource, data_resources_resolved_layer, tf_layers),
+            ]
+        )
 
     def test_process_reference_layer_value_data_resource_reference(self):
         reference_resolved_layer = ResolvedReference("data.aws_lambda_layer_version.layer1", "module.layer1")


### PR DESCRIPTION
This change will let SAM CLI raise error for the following Terraform expressions:

```
layers = var.stage == "gamma" ? [aws_lambda_layer_version.layer1[0].arn] : "layer.arn"
```

```
layers = var.stage == "gamma" ? [aws_lambda_layer_version.layer1[0].arn] : "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:layer:${var.layer_name}:1"
```

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
