### PR TITLE
exclude installer dir in build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ include requirements/pre-dev.txt
 include requirements/dev.txt
 recursive-include samcli *
 prune tests
+prune installer
 global-exclude *.py[cod]
 global-exclude *.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     author_email="aws-sam-developers@amazon.com",
     url="https://github.com/awslabs/aws-sam-cli",
     license="Apache License 2.0",
-    packages=find_packages(exclude=["tests.*", "tests"]),
+    packages=find_packages(exclude=["tests.*", "tests", "installer.*", "installer"]),
     keywords="AWS SAM CLI",
     # Support Python 3.7 or greater
     python_requires=">=3.7, <=4.0, !=4.0",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#4375 


#### Why is this change necessary?
SAM CLI installation copies the unnecessary "installer" directory, which might conflict with the Python "installer" library

#### How does it address the issue?
Exclude "installer"


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
