### PR TITLE
Ignore ResourceWarning in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ addopts = --maxfail=1000 -rf
 filterwarnings =
     error
     ignore::DeprecationWarning:docker
+    ignore::ResourceWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@ addopts = --maxfail=1000 -rf
 filterwarnings =
     error
     ignore::DeprecationWarning:docker
-    ignore::ResourceWarning
+    default::ResourceWarning


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
To not raise `ResourceWarning` in pytest as errors, but still print them.

We should look into closing the resources properly. But we just don't raise it as error for now: 
```
ResourceWarning: unclosed <ssl.SSLSocket fd=1568, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('10.0.0.50', 50416), raddr=('54.239.29.24', 443)>
Exception ignored in: <ssl.SSLSocket fd=1668, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('10.0.0.50', 51558), raddr=('54.239.28.247', 443)>
ResourceWarning: unclosed <ssl.SSLSocket fd=1668, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('10.0.0.50', 51558), raddr=('54.239.28.247', 443)>
Exception ignored in: <ssl.SSLSocket fd=1408, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('10.0.0.50', 52215), raddr=('54.239.28.223', 443)>
ResourceWarning: unclosed <ssl.SSLSocket fd=1408, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('10.0.0.50', 52215), raddr=('54.239.28.223', 443)>
Command executed with exception: ResourceWarning: unclosed <ssl.SSLSocket fd=1408, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('10.0.0.50', 52215), raddr=('54.239.28.223', 443)>
```

#### How does it address the issue?
modify pytest.ini

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
