### PR TITLE
chore: Clarify note about code building on `sam local start-api`

### DIFF
--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -72,8 +72,8 @@ class LocalApiService:
         LOG.info(
             "You can now browse to the above endpoints to invoke your functions. "
             "You do not need to restart/reload SAM CLI while working on your functions, "
-            "changes will be reflected instantly/automatically. You only need to restart "
-            "SAM CLI if you update your AWS SAM template"
+            "changes will be reflected instantly/automatically (note: code still needs to be built). "
+            "You only need to restart SAM CLI if you update your AWS SAM template"
         )
 
         service.run()

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -72,8 +72,8 @@ class LocalApiService:
         LOG.info(
             "You can now browse to the above endpoints to invoke your functions. "
             "You do not need to restart/reload SAM CLI while working on your functions, "
-            "changes will be reflected instantly/automatically (note: you will need to build "
-            "code every time source or dependencies change). You only need to restart "
+            "changes will be reflected instantly/automatically (note: you will still need to "
+            "build code every time source or dependencies change). You only need to restart "
             "SAM CLI if you update your AWS SAM template"
         )
 

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -72,8 +72,9 @@ class LocalApiService:
         LOG.info(
             "You can now browse to the above endpoints to invoke your functions. "
             "You do not need to restart/reload SAM CLI while working on your functions, "
-            "changes will be reflected instantly/automatically (note: code still needs to be built). "
-            "You only need to restart SAM CLI if you update your AWS SAM template"
+            "changes will be reflected instantly/automatically (note: you will need to build "
+            "code every time source or dependencies change). You only need to restart "
+            "SAM CLI if you update your AWS SAM template"
         )
 
         service.run()

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -72,9 +72,9 @@ class LocalApiService:
         LOG.info(
             "You can now browse to the above endpoints to invoke your functions. "
             "You do not need to restart/reload SAM CLI while working on your functions, "
-            changes will be reflected instantly/automatically. If you used sam build before running local commands, you will need to re-run sam build for the changes to be picked up. You only need to restart
-            "build code every time source or dependencies change). You only need to restart "
-            "SAM CLI if you update your AWS SAM template"
+            "changes will be reflected instantly/automatically. If you used sam build before "
+            "running local commands, you will need to re-run sam build for the changes "
+            "to be picked up. You only need to restart SAM CLI if you update your AWS SAM template"
         )
 
         service.run()

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -72,7 +72,7 @@ class LocalApiService:
         LOG.info(
             "You can now browse to the above endpoints to invoke your functions. "
             "You do not need to restart/reload SAM CLI while working on your functions, "
-            "changes will be reflected instantly/automatically (note: you will still need to "
+            changes will be reflected instantly/automatically. If you used sam build before running local commands, you will need to re-run sam build for the changes to be picked up. You only need to restart
             "build code every time source or dependencies change). You only need to restart "
             "SAM CLI if you update your AWS SAM template"
         )


### PR DESCRIPTION
Hi team,

Running code locally with `sam local start-api` and see this message 

> You can now browse to the above endpoints to invoke your functions. You do not need to restart/reload SAM CLI while working on your functions, changes will be reflected instantly/automatically. You only need to restart SAM CLI if you update your AWS SAM template

I assumed (similar to what was described here https://github.com/aws/aws-sam-cli/issues/901 and https://github.com/aws/aws-sam-cli/issues/1921) that my typescript code will be built as well but it is not the case.

Thought of clarifying this in the text of that note.

Please let me know if this makes sense.

Thank you


> By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
