### PR TITLE
fix: set `flaky` marker on sam publish tests

### DIFF
--- a/tests/integration/publish/test_command_integ.py
+++ b/tests/integration/publish/test_command_integ.py
@@ -5,6 +5,7 @@ from subprocess import Popen, PIPE, TimeoutExpired
 
 from unittest import skipIf
 
+import pytest
 from parameterized import parameterized
 
 from samcli.commands.publish.command import SEMANTIC_VERSION
@@ -44,6 +45,7 @@ class TestPublishExistingApp(PublishAppIntegBase):
             ("template_create_app_with_readme_body.yaml", "metadata_create_app_with_readme_body.json"),
         ]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_update_application(self, template_filename, expected_template_filename):
         template_path = self.temp_dir.joinpath(template_filename)
         command_list = self.get_command_list(template_path=template_path, region=self.region_name)
@@ -57,6 +59,7 @@ class TestPublishExistingApp(PublishAppIntegBase):
         app_metadata = json.loads(app_metadata_text)
         self.assert_metadata_details(app_metadata, result_msg)
 
+    @pytest.mark.flaky(reruns=3)
     def test_update_application_version_with_semantic_version_option(self):
         template_path = self.temp_dir.joinpath("template_create_app_version.yaml")
         command_list = self.get_command_list(
@@ -86,6 +89,7 @@ class TestPublishNewApp(PublishAppIntegBase):
         if self.application_id:
             self.sar_client.delete_application(ApplicationId=self.application_id)
 
+    @pytest.mark.flaky(reruns=3)
     def test_create_application(self):
         template_path = self.temp_dir.joinpath("template_create_app.yaml")
         command_list = self.get_command_list(template_path=template_path, region=self.region_name)
@@ -103,6 +107,7 @@ class TestPublishNewApp(PublishAppIntegBase):
         match = re.search(pattern, result.stdout.decode("utf-8"))
         self.application_id = match.group().replace("~", "/")
 
+    @pytest.mark.flaky(reruns=3)
     def test_publish_not_packaged_template(self):
         template_path = self.temp_dir.joinpath("template_not_packaged.yaml")
         command_list = self.get_command_list(template_path=template_path, region=self.region_name)
@@ -118,6 +123,7 @@ class TestPublishNewApp(PublishAppIntegBase):
         expected_msg = "Please make sure that you have uploaded application artifacts to S3"
         self.assertIn(expected_msg, process_stderr.decode("utf-8"))
 
+    @pytest.mark.flaky(reruns=3)
     def test_create_application_infer_region_from_env(self):
         template_path = self.temp_dir.joinpath("template_create_app.yaml")
         command_list = self.get_command_list(template_path=template_path)
@@ -133,6 +139,7 @@ class TestPublishNewApp(PublishAppIntegBase):
         self.application_id = match.group().replace("~", "/")
         self.assertIn(self.region_name, self.application_id)
 
+    @pytest.mark.flaky(reruns=3)
     def test_create_application_version_with_license_body(self):
         template_path = self.temp_dir.joinpath("template_create_app_with_license_body.yaml")
         command_list = self.get_command_list(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
 * flaky canary runs


#### Why is this change necessary?
* higher availability for nightly canary runs.

#### How does it address the issue?
* re-run the test 3 times.

#### What side effects does this change have?
* potentially longer failure times.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
