### PR TITLE
chore: revert version to 1.65.0

### DIFF
--- a/samcli/__init__.py
+++ b/samcli/__init__.py
@@ -2,4 +2,4 @@
 SAM CLI version
 """
 
-__version__ = "1.65.1"
+__version__ = "1.65.0"


### PR DESCRIPTION
Reverting back to version 1.65.0, as the 1.65.1 release got canceled

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
