### PR TITLE
Added Next Command Suggestions

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -5,6 +5,7 @@ Common CLI options shared by various commands
 import os
 import logging
 from functools import partial
+from typing import List
 
 import click
 from click.types import FuncParamType
@@ -790,7 +791,7 @@ def _space_separated_list_func_type(value):
 _space_separated_list_func_type.__name__ = "LIST"
 
 
-def generate_next_command_recommendation(command_tuples: list):
+def generate_next_command_recommendation(command_tuples: List[tuple]):
     """
     Generates a message containing some suggested commands to run next.
 
@@ -806,5 +807,5 @@ Commands you can use next:
     """
     command_list_txt = ""
     for command, description in command_tuples:
-        command_list_txt += "\n[*] " + f"{os.linesep}[*] ".join([f"{command} : {description}"])
+        command_list_txt += f"{os.linesep}[*] {command}: {description}"
     return template.format(command_list_txt)

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -801,11 +801,9 @@ def generate_next_command_recommendation(command_tuples: List[tuple]):
     template = """
 Commands you can use next:
 ================================
-{}
-
-================================
-    """
+{}"""
     command_list_txt = ""
     for description, command in command_tuples:
-        command_list_txt += f"{os.linesep}[*] {description}: {command}"
+        command_list_txt += f"[*] {description}: {command}\n"
+    command_list_txt.rstrip()
     return template.format(command_list_txt)

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -806,6 +806,6 @@ Commands you can use next:
 ================================
     """
     command_list_txt = ""
-    for command, description in command_tuples:
-        command_list_txt += f"{os.linesep}[*] {command}: {description}"
+    for description, command in command_tuples:
+        command_list_txt += f"{os.linesep}[*] {description}: {command}"
     return template.format(command_list_txt)

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -788,3 +788,23 @@ def _space_separated_list_func_type(value):
 
 
 _space_separated_list_func_type.__name__ = "LIST"
+
+
+def generate_next_command_recommendation(command_tuples: list):
+    """
+    Generates a message containing some suggested commands to run next.
+
+    :type command_tuples: list
+    :param command_tuples: list of tuples containing the command with their respective description
+    """
+    template = """
+Commands you can use next:
+================================
+{}
+
+================================
+    """
+    command_list_txt = ""
+    for command, description in command_tuples:
+        command_list_txt += "\n[*] " + f"{os.linesep}[*] ".join([f"{command} : {description}"])
+    return template.format(command_list_txt)

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -795,7 +795,7 @@ def generate_next_command_recommendation(command_tuples: List[tuple]):
     """
     Generates a message containing some suggested commands to run next.
 
-    :type command_tuples: list
+    :type command_tuples: list[tuple]
     :param command_tuples: list of tuples containing the command with their respective description
     """
     template = """

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -801,6 +801,7 @@ def generate_next_command_recommendation(command_tuples: List[Tuple[str, str]]) 
     template = """
 Commands you can use next
 =========================
-{}"""
+{}
+"""
     command_list_txt = "\n".join(f"[*] {description}: {command}" for description, command in command_tuples)
     return template.format(command_list_txt)

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -5,7 +5,7 @@ Common CLI options shared by various commands
 import os
 import logging
 from functools import partial
-from typing import List
+from typing import List, Tuple
 
 import click
 from click.types import FuncParamType
@@ -791,7 +791,7 @@ def _space_separated_list_func_type(value):
 _space_separated_list_func_type.__name__ = "LIST"
 
 
-def generate_next_command_recommendation(command_tuples: List[tuple]):
+def generate_next_command_recommendation(command_tuples: List[Tuple[str, str]]) -> str:
     """
     Generates a message containing some suggested commands to run next.
 

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -799,8 +799,8 @@ def generate_next_command_recommendation(command_tuples: List[tuple]):
     :param command_tuples: list of tuples containing the command with their respective description
     """
     template = """
-Commands you can use next:
-================================
+Commands you can use next
+=========================
 {}"""
     command_list_txt = ""
     for description, command in command_tuples:

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -802,8 +802,5 @@ def generate_next_command_recommendation(command_tuples: List[tuple]):
 Commands you can use next
 =========================
 {}"""
-    command_list_txt = ""
-    for description, command in command_tuples:
-        command_list_txt += f"[*] {description}: {command}\n"
-    command_list_txt.rstrip()
+    command_list_txt = "\n".join(f"[*] {description}: {command}" for description, command in command_tuples)
     return template.format(command_list_txt)

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -239,14 +239,14 @@ def _generate_from_use_case(
     )
 
     click.echo(summary_msg)
-    nextcommandsuggestions = generate_next_command_recommendation(
+    command_suggestions = generate_next_command_recommendation(
         [
             ("Create pipeline", f"cd {name} && sam pipeline init --bootstrap"),
             ("Validate SAM template", f"cd {name} && sam validate"),
             ("Test Function in the Cloud", f"cd {name} && sam sync --stack-name {{stack-name}} --watch"),
         ]
     )
-    click.secho(nextcommandsuggestions, fg="yellow")
+    click.secho(command_suggestions, fg="yellow")
 
     do_generate(
         location,

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -31,6 +31,7 @@ from samcli.commands.init.init_generator import do_generate
 from samcli.commands.init.init_templates import InitTemplates, InvalidInitTemplateError
 from samcli.lib.utils.osutils import remove
 from samcli.lib.utils.packagetype import IMAGE, ZIP
+from samcli.commands._utils.options import generate_next_command_recommendation
 
 LOG = logging.getLogger(__name__)
 
@@ -238,14 +239,15 @@ def _generate_from_use_case(
     )
 
     click.echo(summary_msg)
-    next_commands_msg = f"""
-    Commands you can use next
-    =========================
-    [*] Create pipeline: cd {name} && sam pipeline init --bootstrap
-    [*] Validate SAM template: cd {name} && sam validate
-    [*] Test Function in the Cloud: cd {name} && sam sync --stack-name {{stack-name}} --watch
-    """
-    click.secho(next_commands_msg, fg="yellow")
+    nextcommandsuggestions = generate_next_command_recommendation(
+        [
+            ("Create pipeline", f"cd {name} && sam pipeline init --bootstrap"),
+            ("Validate SAM template", f"cd {name} && sam validate"),
+            ("Test Function in the Cloud", f"cd {name} && sam sync --stack-name {{stack-name}} --watch"),
+        ]
+    )
+    click.secho(nextcommandsuggestions, fg="yellow")
+
     do_generate(
         location,
         package_type,

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -199,7 +199,6 @@ def do_cli(  # pylint: disable=R0914
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)
             service.start()
             click.secho(COMMAND_SUGGESTIONS, fg="yellow")
-            
     except NoApisDefined as ex:
         raise UserException(
             "Template does not have any APIs connected to Lambda functions", wrapped_from=ex.__class__.__name__

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -32,6 +32,7 @@ Allows you to run your Serverless application locally for quick development & te
  compiled languages or projects requiring complex packing support, we recommended you run your own building solution
 and point SAM to the directory or file containing build artifacts.
 """
+
 COMMAND_SUGGESTIONS = """
 Commands you can use next
 =========================

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -36,9 +36,9 @@ and point SAM to the directory or file containing build artifacts.
 COMMAND_SUGGESTIONS = """
 Commands you can use next
 =========================
-[*]Validate SAM template: sam validate
-[*]Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
-[*]Deploy: sam deploy --guided
+[*] Validate SAM template: sam validate
+[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
+[*] Deploy: sam deploy --guided
 """
 
 @click.command(
@@ -199,7 +199,7 @@ def do_cli(  # pylint: disable=R0914
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)
             service.start()
             click.secho(COMMAND_SUGGESTIONS, fg="yellow")
-
+            
     except NoApisDefined as ex:
         raise UserException(
             "Template does not have any APIs connected to Lambda functions", wrapped_from=ex.__class__.__name__

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -192,14 +192,14 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)
             service.start()
-            nextcommandsuggestions = generate_next_command_recommendation(
+            command_suggestions = generate_next_command_recommendation(
                 [
                     ("Validate SAM template", "sam validate"),
                     ("Test Function in the Cloud", "sam sync --stack-name {{stack-name}} --watch"),
                     ("Deploy", "sam deploy --guided"),
                 ]
             )
-            click.secho(nextcommandsuggestions, fg="yellow")
+            click.secho(command_suggestions, fg="yellow")
 
     except NoApisDefined as ex:
         raise UserException(

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -199,7 +199,6 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)
             service.start()
-
             click.secho(COMMAND_SUGGESTIONS, fg="yellow")
 
     except NoApisDefined as ex:

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -32,6 +32,13 @@ Allows you to run your Serverless application locally for quick development & te
  compiled languages or projects requiring complex packing support, we recommended you run your own building solution
 and point SAM to the directory or file containing build artifacts.
 """
+COMMAND_SUGGESTIONS = """
+Commands you can use next
+=========================
+[*]Validate SAM template: sam validate
+[*]Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
+[*]Deploy: sam deploy --guided
+"""
 
 
 @click.command(
@@ -191,6 +198,8 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)
             service.start()
+
+            click.secho(COMMAND_SUGGESTIONS, fg="yellow")
 
     except NoApisDefined as ex:
         raise UserException(

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -41,7 +41,6 @@ Commands you can use next
 [*]Deploy: sam deploy --guided
 """
 
-
 @click.command(
     "start-api",
     help=HELP_TEXT,

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -18,6 +18,7 @@ from samcli.cli.cli_config_file import configuration_option, TomlProvider
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.local.docker.exceptions import ContainerNotStartableException
 from samcli.commands._utils.option_value_processor import process_image_options
+from samcli.commands._utils.options import generate_next_command_recommendation
 
 LOG = logging.getLogger(__name__)
 
@@ -31,14 +32,6 @@ Allows you to run your Serverless application locally for quick development & te
  a interpreted language, local changes will be available immediately in Docker container on every invoke. For more
  compiled languages or projects requiring complex packing support, we recommended you run your own building solution
 and point SAM to the directory or file containing build artifacts.
-"""
-
-COMMAND_SUGGESTIONS = """
-Commands you can use next
-=========================
-[*] Validate SAM template: sam validate
-[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
-[*] Deploy: sam deploy --guided
 """
 
 
@@ -199,7 +192,15 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)
             service.start()
-            click.secho(COMMAND_SUGGESTIONS, fg="yellow")
+            nextcommandsuggestions = generate_next_command_recommendation(
+                [
+                    ("Validate SAM template", "sam validate"),
+                    ("Test Function in the Cloud", "sam sync --stack-name {{stack-name}} --watch"),
+                    ("Deploy", "sam deploy --guided"),
+                ]
+            )
+            click.secho(nextcommandsuggestions, fg="yellow")
+
     except NoApisDefined as ex:
         raise UserException(
             "Template does not have any APIs connected to Lambda functions", wrapped_from=ex.__class__.__name__

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -41,6 +41,7 @@ Commands you can use next
 [*] Deploy: sam deploy --guided
 """
 
+
 @click.command(
     "start-api",
     help=HELP_TEXT,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -225,7 +225,7 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)
             service.start()
-            click.secho(COMMAND_SUGGESTIONS, fg="yellow")  
+            click.secho(COMMAND_SUGGESTIONS, fg="yellow")
     except (
         InvalidSamDocumentException,
         OverridesNotWellDefinedError,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -225,8 +225,7 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)
             service.start()
-            click.secho(COMMAND_SUGGESTIONS, fg="yellow")
-            
+            click.secho(COMMAND_SUGGESTIONS, fg="yellow")  
     except (
         InvalidSamDocumentException,
         OverridesNotWellDefinedError,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -57,9 +57,9 @@ Here is a Python example:
 COMMAND_SUGGESTIONS = """
 Commands you can use next
 =========================
-[*]Validate SAM template: sam validate
-[*]Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
-[*]Deploy: sam deploy --guided
+[*] Validate SAM template: sam validate
+[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
+[*] Deploy: sam deploy --guided
 """
 
 @click.command(

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -20,6 +20,7 @@ from samcli.cli.cli_config_file import configuration_option, TomlProvider
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.local.docker.exceptions import ContainerNotStartableException
 from samcli.commands._utils.option_value_processor import process_image_options
+from samcli.commands._utils.options import generate_next_command_recommendation
 
 LOG = logging.getLogger(__name__)
 
@@ -52,14 +53,6 @@ Here is a Python example:
                                                 read_timeout=0,
                                                 retries={'max_attempts': 0}))
     self.lambda_client.invoke(FunctionName="HelloWorldFunction")
-"""
-
-COMMAND_SUGGESTIONS = """
-Commands you can use next
-=========================
-[*] Validate SAM template: sam validate
-[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
-[*] Deploy: sam deploy --guided
 """
 
 
@@ -226,7 +219,15 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)
             service.start()
-            click.secho(COMMAND_SUGGESTIONS, fg="yellow")
+            nextcommandsuggestions = generate_next_command_recommendation(
+                [
+                    ("Validate SAM template", "sam validate"),
+                    ("Test Function in the Cloud", "sam sync --stack-name {{stack-name}} --watch"),
+                    ("Deploy", "sam deploy --guided"),
+                ]
+            )
+            click.secho(nextcommandsuggestions, fg="yellow")
+
     except (
         InvalidSamDocumentException,
         OverridesNotWellDefinedError,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -227,6 +227,7 @@ def do_cli(  # pylint: disable=R0914
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)
             service.start()
             click.secho(COMMAND_SUGGESTIONS, fg="yellow")
+            
     except (
         InvalidSamDocumentException,
         OverridesNotWellDefinedError,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -219,14 +219,14 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)
             service.start()
-            nextcommandsuggestions = generate_next_command_recommendation(
+            command_suggestions = generate_next_command_recommendation(
                 [
                     ("Validate SAM template", "sam validate"),
                     ("Test Function in the Cloud", "sam sync --stack-name {{stack-name}} --watch"),
                     ("Deploy", "sam deploy --guided"),
                 ]
             )
-            click.secho(nextcommandsuggestions, fg="yellow")
+            click.secho(command_suggestions, fg="yellow")
 
     except (
         InvalidSamDocumentException,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -54,6 +54,14 @@ Here is a Python example:
     self.lambda_client.invoke(FunctionName="HelloWorldFunction")
 """
 
+COMMAND_SUGGESTIONS = """
+Commands you can use next
+=========================
+[*]Validate SAM template: sam validate
+[*]Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
+[*]Deploy: sam deploy --guided
+"""
+
 
 @click.command(
     "start-lambda",
@@ -218,7 +226,7 @@ def do_cli(  # pylint: disable=R0914
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)
             service.start()
-
+            click.secho(COMMAND_SUGGESTIONS, fg="yellow")
     except (
         InvalidSamDocumentException,
         OverridesNotWellDefinedError,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -62,6 +62,7 @@ Commands you can use next
 [*] Deploy: sam deploy --guided
 """
 
+
 @click.command(
     "start-lambda",
     help=HELP_TEXT,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -62,7 +62,6 @@ Commands you can use next
 [*]Deploy: sam deploy --guided
 """
 
-
 @click.command(
     "start-lambda",
     help=HELP_TEXT,

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -185,7 +185,7 @@ def do_cli(
         puller.load_time_period(sanitized_start_time, sanitized_end_time, filter_pattern)
 
     if tailing:
-        nextcommandsuggestions = generate_next_command_recommendation(
+        command_suggestions = generate_next_command_recommendation(
             [
                 (
                     "Tail Logs from All Support Resources and X-Ray",
@@ -194,4 +194,4 @@ def do_cli(
                 ("Tail X-Ray Information", "sam traces --tail"),
             ]
         )
-        click.secho(nextcommandsuggestions, fg="yellow")
+        click.secho(command_suggestions, fg="yellow")

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -189,9 +189,9 @@ def do_cli(
             [
                 (
                     "Tail Logs from All Support Resources and X-Ray",
-                    f"sam logs --stack-name {stack_name} --tail --include-traces"
+                    f"sam logs --stack-name {stack_name} --tail --include-traces",
                 ),
-                ("Tail X-Ray Information", "sam traces --tail")
+                ("Tail X-Ray Information", "sam traces --tail"),
             ]
         )
         click.secho(nextcommandsuggestions, fg="yellow")

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -16,6 +16,7 @@ from samcli.commands.logs.validation_and_exception_handlers import (
 from samcli.lib.telemetry.metric import track_command
 from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.lib.utils.version_checker import check_newer_version
+from samcli.commands._utils.options import generate_next_command_recommendation
 
 LOG = logging.getLogger(__name__)
 
@@ -184,10 +185,13 @@ def do_cli(
         puller.load_time_period(sanitized_start_time, sanitized_end_time, filter_pattern)
 
     if tailing:
-        next_commands_msg = f"""
-            Commands you can use next
-            =========================
-            [*] Tail Logs from All Support Resources and X-Ray: sam logs --stack-name {stack_name} --tail --include-traces
-            [*] Tail X-Ray Information: sam traces --tail
-            """
-        click.secho(next_commands_msg, fg="yellow")
+        nextcommandsuggestions = generate_next_command_recommendation(
+            [
+                (
+                    "Tail Logs from All Support Resources and X-Ray",
+                    f"sam logs --stack-name {stack_name} --tail --include-traces"
+                ),
+                ("Tail X-Ray Information", "sam traces --tail")
+            ]
+        )
+        click.secho(nextcommandsuggestions, fg="yellow")

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -543,6 +543,5 @@ Commands you can use next
 =========================
 [*] Validate SAM template: sam validate
 [*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
-[*] Deploy: sam deploy --guided
-"""
+[*] Deploy: sam deploy --guided"""
         self.assertEqual(output, expectedOutput)

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -22,6 +22,7 @@ from samcli.commands._utils.options import (
     image_repositories_callback,
     _space_separated_list_func_type,
     skip_prepare_infra_callback,
+    generate_next_command_recommendation,
 )
 from samcli.commands._utils.parameterized_option import parameterized_option
 from samcli.commands.package.exceptions import PackageResolveS3AndS3SetError, PackageResolveS3AndS3NotSetError
@@ -527,3 +528,20 @@ class TestSkipPrepareInfraOption(TestCase):
             skip_prepare_infra_callback(ctx_mock, param_mock, True)
 
         self.assertEqual(str(ex.exception), "Missing option --hook-name")
+
+
+class TestNextCommandSuggestions(TestCase):
+    def test_generate_next_command_recommendation(self):
+        listOfTuples = [("command1", "description1"), ("command2", "description2"), ("command3", "description3")]
+        output = generate_next_command_recommendation(listOfTuples)
+        expectedOutput = """
+Commands you can use next:
+================================
+
+[*] command1: description1
+[*] command2: description2
+[*] command3: description3
+
+================================
+    """
+        self.assertEqual(output, expectedOutput)

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -543,5 +543,6 @@ Commands you can use next
 =========================
 [*] Validate SAM template: sam validate
 [*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
-[*] Deploy: sam deploy --guided"""
+[*] Deploy: sam deploy --guided
+"""
         self.assertEqual(output, expectedOutput)

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -532,15 +532,15 @@ class TestSkipPrepareInfraOption(TestCase):
 
 class TestNextCommandSuggestions(TestCase):
     def test_generate_next_command_recommendation(self):
-        listOfTuples = [("command1", "description1"), ("command2", "description2"), ("command3", "description3")]
+        listOfTuples = [("description1", "command1"), ("description2", "command2"), ("description3", "command3")]
         output = generate_next_command_recommendation(listOfTuples)
         expectedOutput = """
 Commands you can use next:
 ================================
 
-[*] command1: description1
-[*] command2: description2
-[*] command3: description3
+[*] description1: command1
+[*] description2: command2
+[*] description3: command3
 
 ================================
     """

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -532,16 +532,17 @@ class TestSkipPrepareInfraOption(TestCase):
 
 class TestNextCommandSuggestions(TestCase):
     def test_generate_next_command_recommendation(self):
-        listOfTuples = [("description1", "command1"), ("description2", "command2"), ("description3", "command3")]
+        listOfTuples = [
+            ("Validate SAM template", "sam validate"),
+            ("Test Function in the Cloud", "sam sync --stack-name {{stack-name}} --watch"),
+            ("Deploy", "sam deploy --guided"),
+        ]
         output = generate_next_command_recommendation(listOfTuples)
         expectedOutput = """
 Commands you can use next:
 ================================
-
-[*] description1: command1
-[*] description2: command2
-[*] description3: command3
-
-================================
-    """
+[*] Validate SAM template: sam validate
+[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
+[*] Deploy: sam deploy --guided
+"""
         self.assertEqual(output, expectedOutput)

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -539,8 +539,8 @@ class TestNextCommandSuggestions(TestCase):
         ]
         output = generate_next_command_recommendation(listOfTuples)
         expectedOutput = """
-Commands you can use next:
-================================
+Commands you can use next
+=========================
 [*] Validate SAM template: sam validate
 [*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
 [*] Deploy: sam deploy --guided


### PR DESCRIPTION
#### Which issue(s) does this change fix?
we are targeting to add a section for sam local start-lambda and sam local start-api commands. When users run these commands, a message will be printed as shown below to suggest a few commands that they can use next.

```
Commands you can use next
=========================

[*] Validate SAM template: sam validate
[*] Test Function in the Cloud: sam sync --stack-name {{stack-name}} --watch
[*] Deploy: sam deploy --guided

=========================
```

#### Why is this change necessary?
Informative messages suggesting users some commands that can be used next improves user experience.

#### How does it address the issue?
Added 

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
