### PR TITLE
fix: updated linux pyinstaller script

### DIFF
--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -69,7 +69,9 @@ if [ "$is_nightly" = "true" ]; then
 fi
 echo "samcli.spec content is:"
 cat installer/pyinstaller/samcli.spec
-../venv/bin/python -m PyInstaller -D --clean installer/pyinstaller/samcli.spec
+# --onedir/--onefile options not allowed when spec file provided for
+# updated pyinstaller version.
+../venv/bin/python -m PyInstaller --clean installer/pyinstaller/samcli.spec
 
 
 mkdir pyinstaller-output


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Pyinstaller version was bumped from 4.2 to 5.3 and build-linux.sh failed as the 
--onedir/--onefile options not allowed when spec file is provided.

#### How does it address the issue?
Removing -D flags builds the pyinstaller executable with the provided spec file

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
