### PR TITLE
fix: fix sam init schema tests

### DIFF
--- a/tests/integration/init/schemas/test_init_with_schemas_command.py
+++ b/tests/integration/init/schemas/test_init_with_schemas_command.py
@@ -19,7 +19,7 @@ class TestBasicInitWithEventBridgeCommand(SchemaTestDataSetup):
         # WHEN the user follows interactive init prompts
         # 1: AWS Quick Start Templates
         # 7: Infrastructure event management - Use case
-        # 2: Java Runtime (java11)
+        # 3: Java Runtime (java11)
         # 2: Maven
         # 2: select event-bridge app from scratch
         # N: disable adding xray tracing
@@ -32,7 +32,7 @@ class TestBasicInitWithEventBridgeCommand(SchemaTestDataSetup):
         user_input = """
 1
 7
-2
+3
 2
 2
 N
@@ -59,7 +59,7 @@ Y
         # WHEN the user follows interactive init prompts
         # 1: AWS Quick Start Templates
         # 7: Infrastructure event management - Use case
-        # 2: Java Runtime
+        # 3: Java Runtime
         # 2: Maven
         # 2: select event-bridge app from scratch
         # N: disable adding xray tracing
@@ -71,7 +71,7 @@ Y
         user_input = """
 1
 7
-2
+3
 2
 2
 N
@@ -108,7 +108,7 @@ Y
         # WHEN the user follows interactive init prompts
         # 1: AWS Quick Start Templates
         # 7: Infrastructure event management - Use case
-        # 2: Java Runtime
+        # 3: Java Runtime
         # 2: Maven
         # 2: select event-bridge app from scratch
         # N: disable adding xray tracing
@@ -122,7 +122,7 @@ Y
         user_input = """
 1
 7
-2
+3
 2
 2
 N
@@ -150,7 +150,7 @@ P
         # WHEN the user follows interactive init prompts
         # 1: AWS Quick Start Templates
         # 7: Infrastructure event management - Use case
-        # 2: Java Runtime
+        # 3: Java Runtime
         # 2: Maven
         # 2: select event-bridge app from scratch
         # N: disable adding xray tracing
@@ -162,7 +162,7 @@ P
         user_input = """
 1
 7
-2
+3
 2
 2
 N


### PR DESCRIPTION
With new application templates added (go provided.al2), schema tests have been failing since the order of the expected runtimes have changes. This PR addresses that issue by updating the input for the tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
