### PR TITLE
fix: implicit api warnings

### DIFF
--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -525,6 +525,7 @@ class Stack:
         self.template_dict = template_dict
         self.metadata = metadata
         self._resources: Optional[Dict] = None
+        self._raw_resources: Optional[Dict] = None
 
     @property
     def stack_id(self) -> str:
@@ -560,6 +561,16 @@ class Stack:
         processed_template_dict: Dict[str, Dict] = SamBaseProvider.get_template(self.template_dict, self.parameters)
         self._resources = cast(Dict, processed_template_dict.get("Resources", {}))
         return self._resources
+
+    @property
+    def raw_resources(self) -> Dict:
+        """
+        Return the resources dictionary without running SAM Transform
+        """
+        if self._raw_resources is not None:
+            return self._raw_resources
+        self._raw_resources = cast(Dict, self.template_dict.get("Resources", {}))
+        return self._raw_resources
 
     def get_output_template_path(self, build_root: str) -> str:
         """

--- a/samcli/lib/providers/sam_api_provider.py
+++ b/samcli/lib/providers/sam_api_provider.py
@@ -332,7 +332,7 @@ class SamApiProvider(CfnBaseApiProvider):
     @staticmethod
     def check_implicit_api_resource_ids(stacks: List[Stack]) -> None:
         for stack in stacks:
-            for logical_id in stack.resources:
+            for logical_id in stack.raw_resources:
                 if logical_id in (
                     SamApiProvider.IMPLICIT_API_RESOURCE_ID,
                     SamApiProvider.IMPLICIT_HTTP_API_RESOURCE_ID,

--- a/tests/unit/commands/local/lib/test_api_provider.py
+++ b/tests/unit/commands/local/lib/test_api_provider.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, Mock
 
 from parameterized import parameterized
 
-from samcli.lib.providers.provider import Api
+from samcli.lib.providers.provider import Api, Stack
 from samcli.lib.providers.api_provider import ApiProvider
 from samcli.lib.providers.sam_api_provider import SamApiProvider
 from samcli.lib.providers.cfn_api_provider import CfnApiProvider
@@ -242,21 +242,45 @@ class TestApiProvider_merge_routes(TestCase):
 
 
 class TestApiProvider_check_implicit_api_resource_ids(TestCase):
+    @patch("samcli.lib.providers.sam_base_provider.SamBaseProvider.get_template")
     @patch("samcli.lib.providers.sam_api_provider.LOG.warning")
-    def test_check_implicit_api_resource_ids_false(self, warning_mock):
-        SamApiProvider.check_implicit_api_resource_ids([Mock(resources={"Api1": {"Properties": Mock()}})])
+    def test_check_implicit_api_resource_ids_false(self, warning_mock, get_template_mock):
+        SamApiProvider.check_implicit_api_resource_ids(
+            [Stack("", "stack", "location", None, {"Resources": {"Api1": {"Properties": Mock()}}})]
+        )
         warning_mock.assert_not_called()
+        get_template_mock.assert_not_called()
 
+    @patch("samcli.lib.providers.sam_base_provider.SamBaseProvider.get_template")
     @patch("samcli.lib.providers.sam_api_provider.LOG.warning")
-    def test_check_implicit_api_resource_ids_rest_api(self, warning_mock):
+    def test_check_implicit_api_resource_ids_rest_api(self, warning_mock, get_template_mock):
         SamApiProvider.check_implicit_api_resource_ids(
-            [Mock(resources={"Api1": {"Properties": Mock()}, "ServerlessRestApi": {"Properties": Mock()}})]
+            [
+                Stack(
+                    "",
+                    "stack",
+                    "location",
+                    None,
+                    {"Resources": {"Api1": {"Properties": Mock()}, "ServerlessRestApi": {"Properties": Mock()}}},
+                )
+            ]
         )
         warning_mock.assert_called_once()
+        get_template_mock.assert_not_called()
 
+    @patch("samcli.lib.providers.sam_base_provider.SamBaseProvider.get_template")
     @patch("samcli.lib.providers.sam_api_provider.LOG.warning")
-    def test_check_implicit_api_resource_ids_http_api(self, warning_mock):
+    def test_check_implicit_api_resource_ids_http_api(self, warning_mock, get_template_mock):
         SamApiProvider.check_implicit_api_resource_ids(
-            [Mock(resources={"Api1": {"Properties": Mock()}, "ServerlessHttpApi": {"Properties": Mock()}})]
+            [
+                Stack(
+                    "",
+                    "stack",
+                    "location",
+                    None,
+                    {"Resources": {"Api1": {"Properties": Mock()}, "ServerlessHttpApi": {"Properties": Mock()}}},
+                )
+            ]
         )
         warning_mock.assert_called_once()
+        get_template_mock.assert_not_called()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#4290 


#### Why is this change necessary?
When running `sam build`, SAM CLI provides a warning message about using `ServerlessRestApi` and/or `ServerlessHttpApi` as a resource in the template. But that logic first transforms the template and then run the validation, which prints the warning message even customers don't define these resources in their template.


#### How does it address the issue?
Instead of looping through `Resources` from transformed template, we now loop through the resources without running SAM transform.


#### What side effects does this change have?
None


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
