### PR TITLE
chore: Update Closed Stale Issues Github Action

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -54,4 +54,4 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         loglevel: DEBUG
         # Set dry-run to true to not perform label or close actions.
-        # dry-run: true
+        dry-run: true

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -30,10 +30,10 @@ jobs:
           If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
 
         # These labels are required
-        stale-issue-label: blocked/close-if-inactive
-        exempt-issue-labels: no-autoclose, stage/needs-attention, type/feature, stage/needs-triage, type/bug, stage/needs-investigation 
+        stale-issue-label: type/stale
+        exempt-issue-labels: no-autoclose, stage/needs-attention, type/feature, stage/needs-triage, type/bug, stage/needs-investigation, maintainer/need-followup, maintainer/need-response
         stale-pr-label: blocked/close-if-inactive
-        exempt-pr-labels: no-autoclose, stage/needs-triage, blocked/pending-security-review 
+        exempt-pr-labels: no-autoclose, stage/needs-triage, blocked/pending-security-review
         response-requested-label: blocked/more-info-needed
 
         # Don't set this to not apply a label when closing issues

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -10,6 +10,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write
     steps:
     - uses: aws-actions/stale-issue-cleanup@v3
       with:
@@ -29,9 +31,9 @@ jobs:
 
         # These labels are required
         stale-issue-label: blocked/close-if-inactive
-        exempt-issue-labels: no-autoclose, stage/needs-attention
+        exempt-issue-labels: no-autoclose, stage/needs-attention, type/feature, stage/needs-triage, type/bug, stage/needs-investigation 
         stale-pr-label: blocked/close-if-inactive
-        exempt-pr-labels: no-autoclose, type/feature
+        exempt-pr-labels: no-autoclose, stage/needs-triage, blocked/pending-security-review 
         response-requested-label: blocked/more-info-needed
 
         # Don't set this to not apply a label when closing issues
@@ -46,8 +48,10 @@ jobs:
         # threshold of "upvotes", you can set this here. An "upvote" is
         # the total number of +1, heart, hooray, and rocket reactions
         # on an issue.
-        minimum-upvotes-to-exempt: 10
+        minimum-upvotes-to-exempt: 1
 
         # need a repo scope token here to make this action can trigger other github actions
-        repo-token: ${{ secrets.STALE_BOT_PERSONAL_TOKEN }}
-
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        # dry-run: true


### PR DESCRIPTION
#### Which issue(s) does this change fix?
None

#### Why is this change necessary?
To reduce the load on maintainers, we will close stale issues. This keeps lingering issues to a minimum and gives maintainers better view of the repo state.

#### How does it address the issue?
GHA will run daily, and look for stale issues. If a stale issue is found and does not have an exempt label, it will be marked "stale". Once the issue is in a stale state, it will be closed after a determined about of time (see config).

This will not closed except labels, issues with 1 or more reactions, and issues that have been recently commented on. 

#### What side effects does this change have?
This will close issues and mark them stale but should be done only after a maintainer responses first (and removes one of the exempt labels set by default). If there are issues, the issues can always be reopen, making this not something we are locked into and can get around.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
