### PR TITLE
chore: Move Close Stale issues to manual workflow for testing

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -2,9 +2,10 @@ name: Close stale issues
 
 # Controls when the action will run.
 on:
-  schedule:
-  # Uses UTC so it runs at 10PM PDT
-  - cron: "0 6 * * *"
+  workflow_dispatch:
+  # schedule:
+  # # Uses UTC so it runs at 10PM PDT
+  # - cron: "0 6 * * *"
 
 jobs:
   cleanup:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
None

#### Why is this change necessary?
I want to test the workflow by manually invoking to ensure things are working as expected.

#### How does it address the issue?
Moves the "close stale issues" Github Action to a `workflow_dispatch` which allows manually invoking. I will move this back to a schedule one I am happy with the results. 

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
