### PR TITLE
chore: Update third party license information on certifi version update

### DIFF
--- a/installer/assets/THIRD-PARTY-LICENSES
+++ b/installer/assets/THIRD-PARTY-LICENSES
@@ -1982,7 +1982,7 @@ DEALINGS IN THE SOFTWARE.
 
 ------
 
-** certifi; version 2020.12.05 -- https://github.com/certifi/python-certifi/
+** certifi; version 2022.12.7 -- https://github.com/certifi/python-certifi/
 (c) 1999 VeriSign, Inc.
 (c) 2007 GeoTrust Inc.
 (c) 2006 VeriSign, Inc.


### PR DESCRIPTION
#### Which issue(s) does this change fix?
We previously auto-updated certifi version, but the third party license file still needs an update.

#### Why is this change necessary?
So that the third party license that we distribute with the installation package is update to date

#### How does it address the issue?
Updated the third party license file with the newest certifi version

#### What side effects does this change have?
N.A.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
