### PR TITLE
fix:  Fix validate command integration tests console output missmatch and update pyyaml version requirement

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ Werkzeug<2.1
 #Need to add Schemas latest SDK.
 boto3>=1.19.5,==1.*
 jmespath~=0.10.0
-PyYAML~=5.3
+PyYAML>=5.4.1,==5.*
 cookiecutter~=2.1.1
 aws-sam-translator==1.55.0
 #docker minor version updates can include breaking changes. Auto update micro version only.

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -29,12 +29,12 @@ class TestValidate(TestCase):
     def setUpClass(cls):
         cls.patterns = {
             TemplateFileTypes.JSON: re.compile(
-                r"template\.json can be transformed to a Cloudformation template."
-                ' Please run "sam validate --lint -t template.yaml" for additional validation(\r\n)?$'
+                r"template\.json is a valid SAM Template. This is according to basic SAM Validation, "
+                'for additional validation, please run "sam validate --lint"(\r\n)?$'
             ),
             TemplateFileTypes.YAML: re.compile(
-                r"template\.yaml can be transformed to a Cloudformation template."
-                ' Please run "sam validate --lint -t template.yaml" for additional validation(\r\n)?$'
+                r"template\.yaml is a valid SAM Template. This is according to basic SAM Validation, "
+                'for additional validation, please run "sam validate --lint"(\r\n)?$'
             ),
         }
         cls.lint_patterns = {


### PR DESCRIPTION
#### Which issue(s) does this change fix?
- The validate integration tests are failing due to the expected non-lint output pattern not matching with what `sam validate` without `--lint` option will log to stdout
- Validate command will fail for using the --lint option if the pyyaml version is not >=5.4.1

#### Why is this change necessary?
- To fix the failing integration tests and resolve the console output mismatch
- To update pyyaml version in base.txt for compatible version requirement since to use --lint option, pyyaml > 5.4 is needed
  - Note: since reproducible linux already has pyyaml as 5.4.1, no changes are introduced onto reproducible-linux.txt and THIRD-PARTY-LICENSES

#### How does it address the issue?
- Updated the related integration test and verified the tests are passing locally
- Updated base.txt under requirements folder

#### What side effects does this change have?
N.A.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
