### PR TITLE
fix: use resource type instead of resource id for deciding zip method

### DIFF
--- a/samcli/lib/package/packageable_resources.py
+++ b/samcli/lib/package/packageable_resources.py
@@ -147,6 +147,7 @@ class ResourceZip(Resource):
         should_sign_package = self.code_signer.should_sign_package(resource_id)
         artifact_extension = "zip" if should_sign_package else None
         uploaded_url = upload_local_artifacts(
+            self.RESOURCE_TYPE,
             resource_id,
             resource_dict,
             self.PROPERTY_NAME,
@@ -325,7 +326,7 @@ class ResourceWithS3UrlDict(ResourceZip):
         """
 
         artifact_s3_url = upload_local_artifacts(
-            resource_id, resource_dict, self.PROPERTY_NAME, parent_dir, self.uploader
+            self.RESOURCE_TYPE, resource_id, resource_dict, self.PROPERTY_NAME, parent_dir, self.uploader
         )
 
         parsed_url = S3Uploader.parse_s3_url(

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -121,6 +121,7 @@ def upload_local_image_artifacts(resource_id, resource_dict, property_name, pare
 
 
 def upload_local_artifacts(
+    resource_type: str,
     resource_id: str,
     resource_dict: Dict,
     property_name: str,
@@ -140,6 +141,7 @@ def upload_local_artifacts(
 
     If path is already a path to S3 object, this method does nothing.
 
+    :param resource_type:   Type of the CloudFormation resource
     :param resource_id:     Id of the CloudFormation resource
     :param resource_dict:   Dictionary containing resource definition
     :param property_name:   Property name of CloudFormation resource where this
@@ -174,7 +176,7 @@ def upload_local_artifacts(
             local_path,
             uploader,
             extension,
-            zip_method=make_zip_with_lambda_permissions if resource_id in LAMBDA_LOCAL_RESOURCES else make_zip,
+            zip_method=make_zip_with_lambda_permissions if resource_type in LAMBDA_LOCAL_RESOURCES else make_zip,
         )
 
     # Path could be pointing to a file. Upload the file

--- a/tests/integration/sync/test_sync_adl.py
+++ b/tests/integration/sync/test_sync_adl.py
@@ -147,7 +147,7 @@ class TestSyncAdlWithWatchStartWithNoDependencies(TestSyncWatchBase):
         )
         read_until_string(
             self.watch_process,
-            "\x1b[32mFinished syncing Function Layer Reference Sync HelloWorldFunction.\x1b[0m\n",
+            "\x1b[32mFinished syncing Layer HelloWorldFunction",
             timeout=60,
         )
         self._confirm_lambda_error(lambda_functions[0])

--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -119,6 +119,7 @@ class TestSyncWatchBase(SyncIntegBase):
             s3_prefix=self.s3_prefix,
             kms_key_id=self.kms_key,
             tags="integ=true clarity=yes foo_bar=baz",
+            debug=True,
         )
         self.watch_process = start_persistent_process(sync_command_list, cwd=self.test_dir)
         read_until_string(self.watch_process, "Enter Y to proceed with the command, or enter N to cancel:\n")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -126,7 +126,7 @@ def read_until_string(process: Popen, expected_output: str, timeout: int = 5) ->
     """
 
     def _compare_output(output, _: List[str]) -> bool:
-        return bool(output == expected_output)
+        return bool(expected_output in output)
 
     try:
         read_until(process, _compare_output, timeout)

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -164,11 +164,22 @@ class TestArtifactExporter(unittest.TestCase):
             LambdaLayerVersionResource,
         ):
             upload_local_artifacts_mock.assert_called_once_with(
-                resource_id, resource_dict, test_class.PROPERTY_NAME, parent_dir, s3_uploader_mock
+                test_class.RESOURCE_TYPE,
+                resource_id,
+                resource_dict,
+                test_class.PROPERTY_NAME,
+                parent_dir,
+                s3_uploader_mock,
             )
         else:
             upload_local_artifacts_mock.assert_called_once_with(
-                resource_id, resource_dict, test_class.PROPERTY_NAME, parent_dir, s3_uploader_mock, None
+                test_class.RESOURCE_TYPE,
+                resource_id,
+                resource_dict,
+                test_class.PROPERTY_NAME,
+                parent_dir,
+                s3_uploader_mock,
+                None,
             )
         code_signer_mock.sign_package.assert_not_called()
         if "." in test_class.PROPERTY_NAME:
@@ -272,6 +283,7 @@ class TestArtifactExporter(unittest.TestCase):
         # Verifies that we package local artifacts appropriately
         property_name = "property"
         resource_id = "resource_id"
+        resource_type = "resource_type"
         expected_s3_url = "s3://foo/bar?versionId=baz"
 
         self.s3_uploader_mock.upload_with_dedup.return_value = expected_s3_url
@@ -283,7 +295,7 @@ class TestArtifactExporter(unittest.TestCase):
 
             resource_dict = {property_name: artifact_path}
             result = upload_local_artifacts(
-                resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock
+                resource_type, resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock
             )
             self.assertEqual(result, expected_s3_url)
 
@@ -300,6 +312,7 @@ class TestArtifactExporter(unittest.TestCase):
         # Verifies that we package local artifacts appropriately
         property_name = "property"
         resource_id = "resource_id"
+        resource_type = "resource_type"
         expected_s3_url = "s3://foo/bar?versionId=baz"
 
         self.s3_uploader_mock.upload_with_dedup.return_value = expected_s3_url
@@ -310,7 +323,7 @@ class TestArtifactExporter(unittest.TestCase):
 
             resource_dict = {property_name: artifact_path}
             result = upload_local_artifacts(
-                resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock
+                resource_type, resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock
             )
             self.assertEqual(result, expected_s3_url)
 
@@ -321,6 +334,7 @@ class TestArtifactExporter(unittest.TestCase):
     def test_upload_local_artifacts_local_folder(self, zip_and_upload_mock):
         property_name = "property"
         resource_id = "resource_id"
+        resource_type = "resource_type"
         expected_s3_url = "s3://foo/bar?versionId=baz"
 
         zip_and_upload_mock.return_value = expected_s3_url
@@ -331,7 +345,9 @@ class TestArtifactExporter(unittest.TestCase):
             parent_dir = tempfile.gettempdir()
             resource_dict = {property_name: artifact_path}
 
-            result = upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir, Mock())
+            result = upload_local_artifacts(
+                resource_type, resource_id, resource_dict, property_name, parent_dir, Mock()
+            )
             self.assertEqual(result, expected_s3_url)
 
             absolute_artifact_path = make_abs_path(parent_dir, artifact_path)
@@ -340,8 +356,9 @@ class TestArtifactExporter(unittest.TestCase):
 
     @patch("samcli.lib.package.utils.zip_and_upload")
     def test_upload_local_artifacts_local_folder_lambda_resources(self, zip_and_upload_mock):
-        for resource_id in LAMBDA_LOCAL_RESOURCES:
+        for resource_type in LAMBDA_LOCAL_RESOURCES:
             property_name = "property"
+            resource_id = "resource_id"
             expected_s3_url = "s3://foo/bar?versionId=baz"
 
             zip_and_upload_mock.return_value = expected_s3_url
@@ -351,7 +368,9 @@ class TestArtifactExporter(unittest.TestCase):
                 parent_dir = tempfile.gettempdir()
                 resource_dict = {property_name: artifact_path}
 
-                result = upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir, Mock())
+                result = upload_local_artifacts(
+                    resource_type, resource_id, resource_dict, property_name, parent_dir, Mock()
+                )
                 self.assertEqual(result, expected_s3_url)
 
                 absolute_artifact_path = make_abs_path(parent_dir, artifact_path)
@@ -371,8 +390,9 @@ class TestArtifactExporter(unittest.TestCase):
     @patch("samcli.lib.package.utils.zip_and_upload")
     def test_upload_local_artifacts_local_folder_non_lambda_resources(self, zip_and_upload_mock):
         non_lambda_resources = RESOURCES_WITH_LOCAL_PATHS.keys() - LAMBDA_LOCAL_RESOURCES
-        for resource_id in non_lambda_resources:
+        for resource_type in non_lambda_resources:
             property_name = "property"
+            resource_id = "resource_id"
             expected_s3_url = "s3://foo/bar?versionId=baz"
 
             zip_and_upload_mock.return_value = expected_s3_url
@@ -382,7 +402,9 @@ class TestArtifactExporter(unittest.TestCase):
                 parent_dir = tempfile.gettempdir()
                 resource_dict = {property_name: artifact_path}
 
-                result = upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir, Mock())
+                result = upload_local_artifacts(
+                    resource_type, resource_id, resource_dict, property_name, parent_dir, Mock()
+                )
                 self.assertEqual(result, expected_s3_url)
 
                 absolute_artifact_path = make_abs_path(parent_dir, artifact_path)
@@ -401,6 +423,7 @@ class TestArtifactExporter(unittest.TestCase):
     def test_upload_local_artifacts_no_path(self, zip_and_upload_mock):
         property_name = "property"
         resource_id = "resource_id"
+        resource_type = "resource_type"
         expected_s3_url = "s3://foo/bar?versionId=baz"
 
         zip_and_upload_mock.return_value = expected_s3_url
@@ -409,7 +432,9 @@ class TestArtifactExporter(unittest.TestCase):
         resource_dict = {}
         parent_dir = tempfile.gettempdir()
 
-        result = upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock)
+        result = upload_local_artifacts(
+            resource_type, resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock
+        )
         self.assertEqual(result, expected_s3_url)
 
         zip_and_upload_mock.assert_called_once_with(parent_dir, mock.ANY, None, zip_method=make_zip)
@@ -419,13 +444,16 @@ class TestArtifactExporter(unittest.TestCase):
     def test_upload_local_artifacts_s3_url(self, zip_and_upload_mock):
         property_name = "property"
         resource_id = "resource_id"
+        resource_type = "resource_type"
         object_s3_url = "s3://foo/bar?versionId=baz"
 
         # If URL is already S3 URL, this will be returned without zip/upload
         resource_dict = {property_name: object_s3_url}
         parent_dir = tempfile.gettempdir()
 
-        result = upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock)
+        result = upload_local_artifacts(
+            resource_type, resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock
+        )
         self.assertEqual(result, object_s3_url)
 
         zip_and_upload_mock.assert_not_called()
@@ -435,17 +463,22 @@ class TestArtifactExporter(unittest.TestCase):
     def test_upload_local_artifacts_invalid_value(self, zip_and_upload_mock):
         property_name = "property"
         resource_id = "resource_id"
+        resource_type = "resource_type"
         parent_dir = tempfile.gettempdir()
 
         with self.assertRaises(exceptions.InvalidLocalPathError):
             non_existent_file = "some_random_filename"
             resource_dict = {property_name: non_existent_file}
-            upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock)
+            upload_local_artifacts(
+                resource_type, resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock
+            )
 
         with self.assertRaises(exceptions.InvalidLocalPathError):
             non_existent_file = ["invalid datatype"]
             resource_dict = {property_name: non_existent_file}
-            upload_local_artifacts(resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock)
+            upload_local_artifacts(
+                resource_type, resource_id, resource_dict, property_name, parent_dir, self.s3_uploader_mock
+            )
 
         zip_and_upload_mock.assert_not_called()
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
@@ -481,7 +514,13 @@ class TestArtifactExporter(unittest.TestCase):
         resource.export(resource_id, resource_dict, parent_dir)
 
         upload_local_artifacts_mock.assert_called_once_with(
-            resource_id, resource_dict, resource.PROPERTY_NAME, parent_dir, self.s3_uploader_mock, None
+            resource.RESOURCE_TYPE,
+            resource_id,
+            resource_dict,
+            resource.PROPERTY_NAME,
+            parent_dir,
+            self.s3_uploader_mock,
+            None,
         )
 
         self.assertEqual(resource_dict[resource.PROPERTY_NAME], s3_url)
@@ -756,7 +795,13 @@ class TestArtifactExporter(unittest.TestCase):
         resource_dict = {}
         resource.export(resource_id, resource_dict, parent_dir)
         upload_local_artifacts_mock.assert_called_once_with(
-            resource_id, resource_dict, resource.PROPERTY_NAME, parent_dir, self.s3_uploader_mock, None
+            resource.RESOURCE_TYPE,
+            resource_id,
+            resource_dict,
+            resource.PROPERTY_NAME,
+            parent_dir,
+            self.s3_uploader_mock,
+            None,
         )
         self.code_signer_mock.should_sign_package.assert_called_once_with(resource_id)
         self.code_signer_mock.sign_package.assert_not_called()
@@ -851,7 +896,12 @@ class TestArtifactExporter(unittest.TestCase):
         resource.export(resource_id, resource_dict, parent_dir)
 
         upload_local_artifacts_mock.assert_called_once_with(
-            resource_id, resource_dict, resource.PROPERTY_NAME, parent_dir, self.s3_uploader_mock
+            resource.RESOURCE_TYPE,
+            resource_id,
+            resource_dict,
+            resource.PROPERTY_NAME,
+            parent_dir,
+            self.s3_uploader_mock,
         )
 
         self.assertEqual(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
With this PR https://github.com/aws/aws-sam-cli/pull/4462, we've changed some permissions of the files in ZIP package if the file is used for serverless function resources. But that is checking if logical id of the resource is type.


#### How does it address the issue?
With this change, we are checking the resource type instead of resource logical id.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
