### PR TITLE
fix: `pyinstaller` binaries

### DIFF
--- a/installer/pyinstaller/hidden_imports.py
+++ b/installer/pyinstaller/hidden_imports.py
@@ -12,5 +12,5 @@ SAM_CLI_HIDDEN_IMPORTS = _SAM_CLI_COMMAND_PACKAGES + [
     "pkg_resources.py2_warn",
     "aws_lambda_builders.workflows",
     "configparser",
-    "cfnlint.rules"
+    "cfnlint"
 ]

--- a/installer/pyinstaller/hook-samcli.py
+++ b/installer/pyinstaller/hook-samcli.py
@@ -8,8 +8,7 @@ datas = (
     hooks.collect_all(
         "samcli", include_py_files=True, include_datas=["hook_packages/terraform/copy_terraform_built_artifacts.py"]
     )[0]
-    + hooks.collect_all("cfnlint", include_py_files=True)[0]
-    + hooks.collect_all("jschema_to_python", include_py_files=True)[0]
+    + hooks.collect_all("jschema_to_python", include_py_files=False)[0]
     # Collect ONLY data files.
     + hooks.collect_data_files("samcli")
     + hooks.collect_data_files("samtranslator")

--- a/installer/pyinstaller/hook-samcli.py
+++ b/installer/pyinstaller/hook-samcli.py
@@ -4,9 +4,13 @@ from installer.pyinstaller.hidden_imports import SAM_CLI_HIDDEN_IMPORTS
 hiddenimports = SAM_CLI_HIDDEN_IMPORTS
 
 datas = (
+    # Collect data files, raw python files (if include_py_files=True) and package metadata directories.
     hooks.collect_all(
         "samcli", include_py_files=True, include_datas=["hook_packages/terraform/copy_terraform_built_artifacts.py"]
     )[0]
+    + hooks.collect_all("cfnlint", include_py_files=True)[0]
+    + hooks.collect_all("jschema_to_python", include_py_files=True)[0]
+    # Collect ONLY data files.
     + hooks.collect_data_files("samcli")
     + hooks.collect_data_files("samtranslator")
     + hooks.collect_data_files("aws_lambda_builders")


### PR DESCRIPTION
- With the inclusion of `cfn-lint` as a dependency. There are data files, python files that need to be included for `cfn-lint`.

- One of the dependencies brought in by `cfn-lint` is `pbr`, this in turn has a dependency on `jschema-to-python`. The way around it is to explictly set `PBR_VERSION` as per https://docs.openstack.org/pbr/latest/user/packagers.html. However this solution is brittle and will leak dependency code into AWS SAM CLI codebase, the cleaner solution is to package `jschema-to-python` metadata only for pyinstaller instead.

#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
* To get a working pyinstaller binary.

#### How does it address the issue?
* Built and checked a working installer binary at: https://github.com/sriram-mv/aws-sam-cli/actions/runs/3706626011

#### What side effects does this change have?
* None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
