### PR TITLE
fix: Update expected message read for ADL sync code watch integration test

### DIFF
--- a/tests/integration/sync/test_sync_adl.py
+++ b/tests/integration/sync/test_sync_adl.py
@@ -133,7 +133,7 @@ class TestSyncAdlWithWatchStartWithNoDependencies(TestSyncWatchBase):
         )
         read_until_string(
             self.watch_process,
-            "\x1b[32mFinished syncing Function Layer Reference Sync HelloWorldFunction.\x1b[0m\n",
+            "\x1b[32mFinished syncing Layer HelloWorldFunction",
             timeout=60,
         )
         lambda_response = json.loads(self._get_lambda_response(lambda_functions[0]))

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -151,10 +151,10 @@ class TestValidate(TestCase):
         output = command_result.stdout.decode("utf-8")
 
         warning_message = (
-            f'E0000 Duplicate found "HelloWorldFunction" (line 5)\n'
-            "{}/templateError.yaml:5:3\n\n"
+            'E0000 Duplicate found "HelloWorldFunction" (line 5)\n'
+            f'{os.path.join(test_data_path, "templateError.yaml")}:5:3\n\n'
             'E0000 Duplicate found "HelloWorldFunction" (line 12)\n'
-            "{}/templateError.yaml:12:3\n\n".format(test_data_path, test_data_path)
+            f'{os.path.join(test_data_path, "templateError.yaml")}:12:3\n\n'
         )
 
         self.assertIn(warning_message, output)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Integration test failure on test_sync_adl.TestSyncAdlWithWatchStartWithNoDependencies testMethod=test_sync_watch_code
This is a follow up to https://github.com/aws/aws-sam-cli/pull/4485

#### Why is this change necessary?
Since after we change the hash comparison to use the correct permissions, such code syncs should not deploy the ADLs again thus shouldn't trigger Function Layer Reference sync anymore. We need to update the expected output from sync watch.

#### How does it address the issue?
Updated the expected string

#### What side effects does this change have?
N.A.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
