### PR TITLE
Swap column order for changeset table to match stack events table

### DIFF
--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -60,7 +60,7 @@ DESCRIBE_CHANGESET_FORMAT_STRING = "{Operation:<{0}} {ResourceType:<{1}} {Logica
 DESCRIBE_CHANGESET_DEFAULT_ARGS = OrderedDict(
     {
         "Operation": "Operation",
-        "ResourceType": "ResourceType",        
+        "ResourceType": "ResourceType",
         "LogicalResourceId": "LogicalResourceId",
         "Replacement": "Replacement",
     }

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -56,12 +56,12 @@ DESCRIBE_STACK_EVENTS_DEFAULT_ARGS = OrderedDict(
 
 DESCRIBE_STACK_EVENTS_TABLE_HEADER_NAME = "CloudFormation events from stack operations (refresh every {} seconds)"
 
-DESCRIBE_CHANGESET_FORMAT_STRING = "{Operation:<{0}} {LogicalResourceId:<{1}} {ResourceType:<{2}} {Replacement:<{3}}"
+DESCRIBE_CHANGESET_FORMAT_STRING = "{Operation:<{0}} {ResourceType:<{1}} {LogicalResourceId:<{2}} {Replacement:<{3}}"
 DESCRIBE_CHANGESET_DEFAULT_ARGS = OrderedDict(
     {
         "Operation": "Operation",
+        "ResourceType": "ResourceType",        
         "LogicalResourceId": "LogicalResourceId",
-        "ResourceType": "ResourceType",
         "Replacement": "Replacement",
     }
 )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
n/a

#### Why is this change necessary?
It's not _necessary_ per se. I'll understand if this PR is closed without merging, because it's a very trivial annoyance: the logical resource ID and resource type columns are inconsistent between the two tables during a SAM deploy. See screenshot:

![d327d6cd-1f94-4a4c-9b88-c266ed3094b0](https://user-images.githubusercontent.com/369053/208012930-a2b9c0e2-e355-4e79-847c-33e9cb2ad05e.png)

#### What side effects does this change have?
Purely UI side effects. I'm not sure if there is any software out there that is _parsing_ the output of this CLI action. If it is, it could break. Maybe that risk of that outweighs the benefit of consistency in the UI.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
