### PR TITLE
fix: `hooks` data imports for pyinstaller

### DIFF
--- a/installer/pyinstaller/hook-samcli.py
+++ b/installer/pyinstaller/hook-samcli.py
@@ -9,6 +9,7 @@ datas = (
         "samcli", include_py_files=True, include_datas=["hook_packages/terraform/copy_terraform_built_artifacts.py"]
     )[0]
     + hooks.collect_all("jschema_to_python", include_py_files=False)[0]
+    + hooks.collect_all("cfnlint", include_py_files=True)[0]
     # Collect ONLY data files.
     + hooks.collect_data_files("samcli")
     + hooks.collect_data_files("samtranslator")


### PR DESCRIPTION
- import `cfnlint` with data files, python files and package metadata directories.

#### Which issue(s) does this change fix?
* Nightly builds for pyinstaller


#### Why is this change necessary?
* Previous change did not include the hidden imports

#### How does it address the issue?
* validate with `--lint` now works with the appropriate imports.

#### What side effects does this change have?
* N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
