### PR TITLE
chore: remove redundant debug parameter for sync integration tests

### DIFF
--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -119,7 +119,6 @@ class TestSyncWatchBase(SyncIntegBase):
             s3_prefix=self.s3_prefix,
             kms_key_id=self.kms_key,
             tags="integ=true clarity=yes foo_bar=baz",
-            debug=True,
         )
         self.watch_process = start_persistent_process(sync_command_list, cwd=self.test_dir)
         read_until_string(self.watch_process, "Enter Y to proceed with the command, or enter N to cancel:\n")


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
