### PR TITLE
fix: add bzip2 devel for pyinstaller build - linux

### DIFF
--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -23,7 +23,7 @@ fi
 
 set -eu
 
-yum install -y zlib-devel openssl-devel libffi-devel
+yum install -y zlib-devel openssl-devel libffi-devel bzip2-devel
 
 echo "Making Folders"
 mkdir -p .build/src


### PR DESCRIPTION
#### Which issue(s) does this change fix?
 
N/A


#### Why is this change necessary?

`cfn-lint` depends on bz2 transitively.

#### How does it address the issue?
Builds a usable pyinstaller linux binary.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
