### PR TITLE
ci: validate hidden imports during unit & integration tests

### DIFF
--- a/installer/pyinstaller/hook-samcli.py
+++ b/installer/pyinstaller/hook-samcli.py
@@ -1,5 +1,5 @@
 from PyInstaller.utils import hooks
-from installer.pyinstaller.hidden_imports import SAM_CLI_HIDDEN_IMPORTS
+from samcli.cli.hidden_imports import SAM_CLI_HIDDEN_IMPORTS
 
 hiddenimports = SAM_CLI_HIDDEN_IMPORTS
 

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -1,7 +1,6 @@
 """
 Keeps list of hidden/dynamic imports that is being used in SAM CLI, so that pyinstaller can include these packages
 """
-import importlib
 import pkgutil
 from typing import cast
 from typing_extensions import Protocol

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -1,3 +1,6 @@
+"""
+Keeps list of hidden/dynamic imports that is being used in SAM CLI, so that pyinstaller can include these packages
+"""
 from samcli.cli.command import _SAM_CLI_COMMAND_PACKAGES
 
 SAM_CLI_HIDDEN_IMPORTS = _SAM_CLI_COMMAND_PACKAGES + [

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -22,6 +22,7 @@ def walk_modules(module: HasPathAndName, visited: set) -> None:
             submodule = cast(HasPathAndName, submodule)
             walk_modules(submodule, visited)
 
+
 samcli_modules = set(["samcli"])
 samcli = __import__("samcli")
 samcli = cast(HasPathAndName, samcli)

--- a/samcli/cli/import_module_proxy.py
+++ b/samcli/cli/import_module_proxy.py
@@ -1,0 +1,32 @@
+"""
+Proxy for import module, which can be used to catch dynamic imports which wasn't added to HIDDEN_IMPORTS
+to pyinstaller configuration
+"""
+
+import importlib
+import logging
+
+from samcli.cli import hidden_imports
+
+LOG = logging.getLogger(__name__)
+
+
+_original_import = importlib.import_module
+
+
+def _dynamic_import(name, package=None):
+    if name in hidden_imports.SAM_CLI_HIDDEN_IMPORTS:
+        LOG.debug(
+            "Importing a package which was already defined in hidden imports name: %s, package: %s", name, package
+        )
+        return _original_import(name, package)
+    if not name.startswith('samcli.'):
+        LOG.debug("Importing a package from 'samcli.' module name: %s, package: %s", name, package)
+        return _original_import(name, package)
+
+    LOG.info("Dynamic import name: %s package: %s, which is not defined in hidden imports", name, package)
+    raise ValueError(f'Dynamic import not allowed for {name} {package}')
+
+
+def attach_module_import_proxy():
+    importlib.import_module = _dynamic_import

--- a/samcli/cli/import_module_proxy.py
+++ b/samcli/cli/import_module_proxy.py
@@ -14,10 +14,6 @@ LOG = logging.getLogger(__name__)
 _original_import = importlib.import_module
 
 
-# This constant keeps all hidden imports + the 'tests' packages which is dynamically imported during unit tests
-SAFE_IMPORTS = ["tests", *hidden_imports.SAM_CLI_HIDDEN_IMPORTS]
-
-
 class MissingDynamicImportError(ImportError):
     """
     Thrown when a dynamic import is used without adding it into hidden imports constant
@@ -29,7 +25,7 @@ def _dynamic_import(name, package=None):
     Replaces original import_module function and then analyzes all the imports going through this call.
     If the package is not defined in hidden imports, then it will raise an error
     """
-    for hidden_import in SAFE_IMPORTS:
+    for hidden_import in hidden_imports.SAM_CLI_HIDDEN_IMPORTS:
         # An import should either match the exact hidden import string or should start with it following a "." (dot)
         # For instance if there is a hidden import definition like 'samtranslator', importing 'samtranslator' or
         # 'samtranslator.sub_module' should succeed. But if there is an import like 'samtranslator_side_module' it
@@ -55,3 +51,10 @@ def attach_import_module_proxy():
     hidden imports configuration
     """
     importlib.import_module = _dynamic_import
+
+
+def detach_import_module_proxy():
+    """
+    Detaches import_module proxy with original one so that behaviour can continue that it used to be before
+    """
+    importlib.import_module = _original_import

--- a/samcli/cli/import_module_proxy.py
+++ b/samcli/cli/import_module_proxy.py
@@ -37,7 +37,7 @@ def _dynamic_import(name, package=None):
             return _original_import(name, package)
 
     LOG.error(
-        "Dynamic import name: %s package: %s, which is not defined in hidden imports: %s",
+        "Dynamic import (name: %s package: %s) which is not defined in hidden imports: %s",
         name,
         package,
         hidden_imports.SAM_CLI_HIDDEN_IMPORTS,

--- a/samcli/cli/import_module_proxy.py
+++ b/samcli/cli/import_module_proxy.py
@@ -20,12 +20,12 @@ def _dynamic_import(name, package=None):
             "Importing a package which was already defined in hidden imports name: %s, package: %s", name, package
         )
         return _original_import(name, package)
-    if not name.startswith('samcli.'):
+    if not name.startswith("samcli."):
         LOG.debug("Importing a package from 'samcli.' module name: %s, package: %s", name, package)
         return _original_import(name, package)
 
     LOG.info("Dynamic import name: %s package: %s, which is not defined in hidden imports", name, package)
-    raise ValueError(f'Dynamic import not allowed for {name} {package}')
+    raise ValueError(f"Dynamic import not allowed for {name} {package}")
 
 
 def attach_module_import_proxy():

--- a/samcli/cli/import_module_proxy.py
+++ b/samcli/cli/import_module_proxy.py
@@ -51,10 +51,3 @@ def attach_import_module_proxy():
     hidden imports configuration
     """
     importlib.import_module = _dynamic_import
-
-
-def detach_import_module_proxy():
-    """
-    Detaches import_module proxy with original one so that behaviour can continue that it used to be before
-    """
-    importlib.import_module = _original_import

--- a/samcli/cli/import_module_proxy.py
+++ b/samcli/cli/import_module_proxy.py
@@ -14,19 +14,44 @@ LOG = logging.getLogger(__name__)
 _original_import = importlib.import_module
 
 
+# This constant keeps all hidden imports + the 'tests' packages which is dynamically imported during unit tests
+SAFE_IMPORTS = ["tests", *hidden_imports.SAM_CLI_HIDDEN_IMPORTS]
+
+
+class MissingDynamicImportError(ImportError):
+    """
+    Thrown when a dynamic import is used without adding it into hidden imports constant
+    """
+
+
 def _dynamic_import(name, package=None):
-    if name in hidden_imports.SAM_CLI_HIDDEN_IMPORTS:
-        LOG.debug(
-            "Importing a package which was already defined in hidden imports name: %s, package: %s", name, package
-        )
-        return _original_import(name, package)
-    if not name.startswith("samcli."):
-        LOG.debug("Importing a package from 'samcli.' module name: %s, package: %s", name, package)
-        return _original_import(name, package)
+    """
+    Replaces original import_module function and then analyzes all the imports going through this call.
+    If the package is not defined in hidden imports, then it will raise an error
+    """
+    for hidden_import in SAFE_IMPORTS:
+        # An import should either match the exact hidden import string or should start with it following a "." (dot)
+        # For instance if there is a hidden import definition like 'samtranslator', importing 'samtranslator' or
+        # 'samtranslator.sub_module' should succeed. But if there is an import like 'samtranslator_side_module' it
+        # should fail.
+        if name == hidden_import or name.startswith(f"{hidden_import}."):
+            LOG.debug(
+                "Importing a package which was already defined in hidden imports name: %s, package: %s", name, package
+            )
+            return _original_import(name, package)
 
-    LOG.info("Dynamic import name: %s package: %s, which is not defined in hidden imports", name, package)
-    raise ValueError(f"Dynamic import not allowed for {name} {package}")
+    LOG.error(
+        "Dynamic import name: %s package: %s, which is not defined in hidden imports: %s",
+        name,
+        package,
+        hidden_imports.SAM_CLI_HIDDEN_IMPORTS,
+    )
+    raise MissingDynamicImportError(f"Dynamic import not allowed for name: {name} package: {package}")
 
 
-def attach_module_import_proxy():
+def attach_import_module_proxy():
+    """
+    Attaches import_module proxy which will analyze every dynamic import and raise an error if it is not defined in
+    hidden imports configuration
+    """
     importlib.import_module = _dynamic_import

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -121,6 +121,7 @@ def cli(ctx):
     # to catch missing configuration for dynamic/hidden imports
     if ctx and ctx.command_path == "samdev":
         from samcli.cli.import_module_proxy import attach_module_import_proxy
+
         LOG.info("Attaching module import proxy for analyzing dynamic imports")
         attach_module_import_proxy()
 

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -14,10 +14,10 @@ from samcli.lib.utils.sam_logging import (
     SAM_CLI_FORMATTER,
     SAM_CLI_LOGGER_NAME,
 )
-from .options import debug_option, region_option, profile_option
-from .context import Context
-from .command import BaseCommand
-from .global_config import GlobalConfig
+from samcli.cli.options import debug_option, region_option, profile_option
+from samcli.cli.context import Context
+from samcli.cli.command import BaseCommand
+from samcli.cli.global_config import GlobalConfig
 
 LOG = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
@@ -116,6 +116,13 @@ def cli(ctx):
     """
     import atexit
     from samcli.lib.telemetry.metric import send_installed_metric, emit_all_metrics
+
+    # if development version of SAM CLI is used, attach module proxy
+    # to catch missing configuration for dynamic/hidden imports
+    if ctx and ctx.command_path == "samdev":
+        from samcli.cli.import_module_proxy import attach_module_import_proxy
+        LOG.info("Attaching module import proxy for analyzing dynamic imports")
+        attach_module_import_proxy()
 
     gc = GlobalConfig()
     if gc.telemetry_enabled is None:

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -119,7 +119,7 @@ def cli(ctx):
 
     # if development version of SAM CLI is used, attach module proxy
     # to catch missing configuration for dynamic/hidden imports
-    if ctx and ctx.command_path == "samdev":
+    if ctx and getattr(ctx, "command_path", None) == "samdev":
         from samcli.cli.import_module_proxy import attach_import_module_proxy
 
         LOG.info("Attaching import module proxy for analyzing dynamic imports")

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -120,10 +120,10 @@ def cli(ctx):
     # if development version of SAM CLI is used, attach module proxy
     # to catch missing configuration for dynamic/hidden imports
     if ctx and ctx.command_path == "samdev":
-        from samcli.cli.import_module_proxy import attach_module_import_proxy
+        from samcli.cli.import_module_proxy import attach_import_module_proxy
 
-        LOG.info("Attaching module import proxy for analyzing dynamic imports")
-        attach_module_import_proxy()
+        LOG.info("Attaching import module proxy for analyzing dynamic imports")
+        attach_import_module_proxy()
 
     gc = GlobalConfig()
     if gc.telemetry_enabled is None:

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -119,6 +119,8 @@ def cli(ctx):
 
     # if development version of SAM CLI is used, attach module proxy
     # to catch missing configuration for dynamic/hidden imports
+    # TODO: in general, we need better mechanisms to set which execution environment is SAM CLI operating
+    # rather than checking the executable name
     if ctx and getattr(ctx, "command_path", None) == "samdev":
         from samcli.cli.import_module_proxy import attach_import_module_proxy
 

--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -476,7 +476,7 @@ class TestInitForParametersCompatibility(TestCase):
 
             self.assertEqual(process.returncode, 2)
 
-            self.assertEqual(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertIn(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_apptemplate_location(self):
         stderr = None
@@ -505,7 +505,7 @@ class TestInitForParametersCompatibility(TestCase):
 
             self.assertEqual(process.returncode, 2)
 
-            self.assertEqual(
+            self.assertIn(
                 INCOMPATIBLE_PARAM_MESSAGE.strip().format("app-template", "location"),
                 "\n".join(stderr.strip().splitlines()),
             )
@@ -537,7 +537,7 @@ class TestInitForParametersCompatibility(TestCase):
 
             self.assertEqual(process.returncode, 2)
 
-            self.assertEqual(
+            self.assertIn(
                 INCOMPATIBLE_PARAM_MESSAGE.strip().format("runtime", "location"), "\n".join(stderr.strip().splitlines())
             )
 
@@ -568,7 +568,7 @@ class TestInitForParametersCompatibility(TestCase):
 
             self.assertEqual(process.returncode, 2)
 
-            self.assertEqual(
+            self.assertIn(
                 INCOMPATIBLE_PARAM_MESSAGE.strip().format("base-image", "location"),
                 "\n".join(stderr.strip().splitlines()),
             )
@@ -600,7 +600,7 @@ class TestInitForParametersCompatibility(TestCase):
 
             self.assertEqual(process.returncode, 2)
 
-            self.assertEqual(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertIn(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_no_interactive_packagetype_location(self):
         stderr = None
@@ -629,7 +629,7 @@ class TestInitForParametersCompatibility(TestCase):
 
             self.assertEqual(process.returncode, 2)
 
-            self.assertEqual(
+            self.assertIn(
                 INCOMPATIBLE_PARAM_MESSAGE.strip().format("package-type", "location"),
                 "\n".join(stderr.strip().splitlines()),
             )
@@ -659,7 +659,7 @@ class TestInitForParametersCompatibility(TestCase):
 
             self.assertEqual(process.returncode, 2)
 
-            self.assertEqual(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertIn(MISSING_REQUIRED_PARAM_MESSAGE.strip(), "\n".join(stderr.strip().splitlines()))
 
     def test_init_command_wrong_packagetype(self):
         stderr = None
@@ -693,7 +693,7 @@ Error: Invalid value for '-p' / '--package-type': 'WrongPT' is not one of 'Zip',
                 get_sam_command()
             )
 
-            self.assertEqual(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
+            self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
 
 class TestInitWithArbitraryProject(TestCase):

--- a/tests/unit/cli/test_import_module_proxy.py
+++ b/tests/unit/cli/test_import_module_proxy.py
@@ -40,4 +40,4 @@ class TestImportModuleProxy(TestCase):
 
     def test_import_should_fail_for_undefined_hidden_package(self):
         with self.assertRaises(MissingDynamicImportError):
-            importlib.import_module("samcli.yamlhelper")
+            importlib.import_module("some.other.module")

--- a/tests/unit/cli/test_import_module_proxy.py
+++ b/tests/unit/cli/test_import_module_proxy.py
@@ -5,7 +5,6 @@ from parameterized import parameterized
 
 from samcli.cli import hidden_imports
 from samcli.cli.import_module_proxy import (
-    detach_import_module_proxy,
     attach_import_module_proxy,
     MissingDynamicImportError,
 )
@@ -19,11 +18,12 @@ class TestImportModuleProxy(TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        cls.original_import_module = importlib.import_module
         attach_import_module_proxy()
 
     @classmethod
     def tearDownClass(cls) -> None:
-        detach_import_module_proxy()
+        importlib.import_module = cls.original_import_module
 
     @parameterized.expand(hidden_imports.SAM_CLI_HIDDEN_IMPORTS)
     def test_import_should_succeed_for_a_defined_hidden_package(self, package):

--- a/tests/unit/cli/test_import_module_proxy.py
+++ b/tests/unit/cli/test_import_module_proxy.py
@@ -15,6 +15,7 @@ class TestImportModuleProxy(TestCase):
     There is a chance that setUpClass method of this test class might cause flakiness with other tests if we run them
     in parallel.
     """
+    original_import_module = None
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -23,7 +24,8 @@ class TestImportModuleProxy(TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        importlib.import_module = cls.original_import_module
+        if cls.original_import_module:
+            importlib.import_module = cls.original_import_module
 
     @parameterized.expand(hidden_imports.SAM_CLI_HIDDEN_IMPORTS)
     def test_import_should_succeed_for_a_defined_hidden_package(self, package):

--- a/tests/unit/cli/test_import_module_proxy.py
+++ b/tests/unit/cli/test_import_module_proxy.py
@@ -15,6 +15,7 @@ class TestImportModuleProxy(TestCase):
     There is a chance that setUpClass method of this test class might cause flakiness with other tests if we run them
     in parallel.
     """
+
     original_import_module = None
 
     @classmethod

--- a/tests/unit/cli/test_import_module_proxy.py
+++ b/tests/unit/cli/test_import_module_proxy.py
@@ -12,6 +12,11 @@ from samcli.cli.import_module_proxy import (
 
 
 class TestImportModuleProxy(TestCase):
+    """
+    There is a chance that setUpClass method of this test class might cause flakiness with other tests if we run them
+    in parallel.
+    """
+
     @classmethod
     def setUpClass(cls) -> None:
         attach_import_module_proxy()

--- a/tests/unit/cli/test_import_module_proxy.py
+++ b/tests/unit/cli/test_import_module_proxy.py
@@ -1,0 +1,30 @@
+import importlib
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from samcli.cli import hidden_imports
+from samcli.cli.import_module_proxy import attach_import_module_proxy, MissingDynamicImportError
+
+
+class TestImportModuleProxy(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        attach_import_module_proxy()
+
+    def test_import_should_succeed_for_a_package_not_under_samcli(self):
+        importlib.import_module("aws_lambda_builders.workflows.custom_make.workflow")
+
+    @parameterized.expand(hidden_imports.SAM_CLI_HIDDEN_IMPORTS)
+    def test_import_should_succeed_for_a_defined_hidden_package(self, package):
+        try:
+            importlib.import_module(package)
+        except ModuleNotFoundError as ex:
+            # pkg_resources.py2_warn is required for pyinstaller, and it is not available in SAM CLI
+            # for this reason, skip any failures related to that package
+            if "No module named 'pkg_resources.py2_warn'" not in ex.msg:
+                raise ex
+
+    def test_import_should_fail_for_undefined_hidden_package(self):
+        with self.assertRaises(MissingDynamicImportError):
+            importlib.import_module("samcli.yamlhelper")

--- a/tests/unit/cli/test_import_module_proxy.py
+++ b/tests/unit/cli/test_import_module_proxy.py
@@ -4,7 +4,9 @@ from unittest import TestCase
 from parameterized import parameterized
 
 from samcli.cli import hidden_imports
-from samcli.cli.import_module_proxy import attach_import_module_proxy, MissingDynamicImportError
+from samcli.cli.import_module_proxy import (
+    detach_import_module_proxy, attach_import_module_proxy, MissingDynamicImportError
+)
 
 
 class TestImportModuleProxy(TestCase):
@@ -12,8 +14,9 @@ class TestImportModuleProxy(TestCase):
     def setUpClass(cls) -> None:
         attach_import_module_proxy()
 
-    def test_import_should_succeed_for_a_package_not_under_samcli(self):
-        importlib.import_module("aws_lambda_builders.workflows.custom_make.workflow")
+    @classmethod
+    def tearDownClass(cls) -> None:
+        detach_import_module_proxy()
 
     @parameterized.expand(hidden_imports.SAM_CLI_HIDDEN_IMPORTS)
     def test_import_should_succeed_for_a_defined_hidden_package(self, package):

--- a/tests/unit/cli/test_import_module_proxy.py
+++ b/tests/unit/cli/test_import_module_proxy.py
@@ -5,7 +5,9 @@ from parameterized import parameterized
 
 from samcli.cli import hidden_imports
 from samcli.cli.import_module_proxy import (
-    detach_import_module_proxy, attach_import_module_proxy, MissingDynamicImportError
+    detach_import_module_proxy,
+    attach_import_module_proxy,
+    MissingDynamicImportError,
 )
 
 

--- a/tests/unit/cli/test_pyinstaller_imports.py
+++ b/tests/unit/cli/test_pyinstaller_imports.py
@@ -1,7 +1,5 @@
-import click
-
 from unittest import TestCase
-from installer.pyinstaller import hidden_imports
+from samcli.cli import hidden_imports
 from samcli.cli.command import BaseCommand
 
 

--- a/tests/unit/lib/observability/xray_traces/test_xray_service_graph_event_puller.py
+++ b/tests/unit/lib/observability/xray_traces/test_xray_service_graph_event_puller.py
@@ -36,7 +36,7 @@ class TestXRayServiceGraphPuller(TestCase):
         patched_utc_to_timestamp.assert_called()
         patched_to_utc.assert_called()
         given_paginator.paginate.assert_called_with(StartTime=start_time, EndTime=end_time)
-        patched_xray_service_graph_event.assrt_called_with({"EndTime": "endtime", "Services": [{"id": 1}]})
+        patched_xray_service_graph_event.assert_called_with({"EndTime": "endtime", "Services": [{"id": 1}]})
         self.consumer.consume.assert_called()
 
     @patch("samcli.lib.observability.xray_traces.xray_service_graph_event_puller.XRayServiceGraphEvent")
@@ -60,7 +60,7 @@ class TestXRayServiceGraphPuller(TestCase):
         patched_utc_to_timestamp.assert_called()
         patched_to_utc.assert_called()
         given_paginator.paginate.assert_called_with(StartTime=start_time, EndTime=end_time)
-        patched_xray_service_graph_event.assrt_called_with({"EndTime": "endtime", "Services": [{"id": 1}]})
+        patched_xray_service_graph_event.assert_called_with({"EndTime": "endtime", "Services": [{"id": 1}]})
         # consumer should only get called once
         self.consumer.consume.assert_called_once()
 


### PR DESCRIPTION
Original PR and discussions: https://github.com/aws/aws-sam-cli/pull/4470

#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
If dynamic imports are used but missed in pyinstaller hidden imports configuration, it will create issues with installers that is created with pyinstaller.

#### How does it address the issue?
If `sam` is executed in development mode (`samdev`) it replaces `import_module` with a proxy method which will analyze every dynamic import and make sure that it is defined in hidden imports.

#### What side effects does this change have?
It shouldn't make any change for `sam` and `sam-nightly` executables since proxy method is only attached if it is running as `samdev` (development mode). 


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
