### PR TITLE
ci: fix canary failures

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -296,7 +296,7 @@ for:
 
     test_script:
       - "pip install -e \".[dev]\""
-      - sh: "pytest -vv tests/integration/delete --json-report --json-report-file=TEST_REPORT-integration-delete.json"
+      - sh: "pytest -vv tests/integration/delete -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-delete.json"
 
   # Integ testing sync
   -

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -285,7 +285,7 @@ for:
 
     test_script:
       - "pip install -e \".[dev]\""
-      - sh: "pytest -vv tests/integration/package --json-report --json-report-file=TEST_REPORT-integration-package.json"
+      - sh: "pytest -vv tests/integration/package -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package.json"
 
   # Integ testing delete
   -

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -227,7 +227,7 @@ for:
       - "git --version"
       - "venv\\Scripts\\activate"
       - "docker system prune -a -f"
-      - ps: "pytest -vv tests/integration/package --json-report --json-report-file=TEST_REPORT-integration-package.json"
+      - ps: "pytest -vv tests/integration/package -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package.json"
 
   # Integ testing delete
   - matrix:

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -239,7 +239,7 @@ for:
       - "git --version"
       - "venv\\Scripts\\activate"
       - "docker system prune -a -f"
-      - ps: "pytest -vv tests/integration/delete --json-report --json-report-file=TEST_REPORT-integration-delete.json"
+      - ps: "pytest -vv tests/integration/delete -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-delete.json"
 
   # Integ testing sync
   - matrix:

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -38,4 +38,5 @@ SAM_CLI_HIDDEN_IMPORTS = list(samcli_modules) + [
     "pkg_resources.py2_warn",
     "aws_lambda_builders.workflows",
     "configparser",
+    "dateparser",
 ]

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -954,7 +954,7 @@ class ApplicationBuilder:
         except Exception:
             # Invalid JSON is produced as an output only when the builder process crashed for some reason.
             # Report this as a crash
-            LOG.error("Builder crashed: {}", stdout_data)
+            LOG.error("Builder crashed: %s", stdout_data)
             raise
 
         if "error" in response:

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -954,7 +954,7 @@ class ApplicationBuilder:
         except Exception:
             # Invalid JSON is produced as an output only when the builder process crashed for some reason.
             # Report this as a crash
-            LOG.debug("Builder crashed")
+            LOG.error("Builder crashed: {}", stdout_data)
             raise
 
         if "error" in response:

--- a/tests/integration/buildcmd/test_build_terraform_applications.py
+++ b/tests/integration/buildcmd/test_build_terraform_applications.py
@@ -267,7 +267,7 @@ class TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend(Bu
             f"https://aws.amazon.com/service-terms/.{os.linesep}"
         )
         self.assertNotRegex(stdout.decode("utf-8"), terraform_beta_feature_prompted_text)
-        self.assertTrue(stderr.decode("utf-8").startswith(Colored().yellow(experimental_warning)))
+        self.assertIn(Colored().yellow(experimental_warning), stderr.decode("utf-8"))
         LOG.info("sam build stdout: %s", stdout.decode("utf-8"))
         LOG.info("sam build stderr: %s", stderr.decode("utf-8"))
         self.assertEqual(return_code, 0)

--- a/tests/integration/local/start_lambda/test_start_lambda_terraform_applications.py
+++ b/tests/integration/local/start_lambda/test_start_lambda_terraform_applications.py
@@ -390,7 +390,7 @@ class TestLocalStartLambdaTerraformApplicationWithBetaFeatures(StartLambdaTerraf
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_function_and_warning_message_is_printed(self):
-        self.assertTrue(self.start_lambda_process_error.startswith(Colored().yellow(EXPERIMENTAL_WARNING)))
+        self.assertIn(Colored().yellow(EXPERIMENTAL_WARNING), self.start_lambda_process_error)
 
 
 class TestLocalStartLambdaTerraformApplicationWithExperimentalPromptNo(StartLambdaTerraformApplicationIntegBase):


### PR DESCRIPTION
- Change terraform tests to `assertIn` certain text is printed.
- Run `package` tests in parallel (which speeds up 10mins per package test group [~40mins in total])
- Run `delete` tests in parallel (which speeds up 8mins per delete test group [~32mins in total])
- Add `dateparser` to hidden imports which was caught by newly added pyinstaller checks (I am in between whether we should add this as exclusion to the dynamic import validation that we added)


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
