### PR TITLE
Update make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 	# Linter performs static analysis to catch latent bugs
 	pylint --rcfile .pylintrc samcli
 	# mypy performs type check
-	mypy setup.py samcli tests
+	mypy --no-incremental setup.py samcli tests
 
 # Command to run everytime you make changes to verify everything works
 dev: lint test


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A


#### Why is this change necessary?
Since we introduced `ruamel` as a dependency, running `make pr` fails every other time because of an issue in `mypy`
E.g.:
```
tests/unit/lib/sync/flows/test_rest_api_sync_flow.py:1: error: Skipping analyzing 'ruamel': found module but no type hints or library stubs
tests/unit/lib/sync/flows/test_http_api_sync_flow.py:1: error: Skipping analyzing 'ruamel': found module but no type hints or library stubs
tests/unit/lib/sync/flows/test_function_sync_flow.py:1: error: Skipping analyzing 'ruamel': found module but no type hints or library stubs
samcli/lib/sync/flows/zip_function_sync_flow.py:1: error: Skipping analyzing 'ruamel': found module but no type hints or library stubs
```
Issue in `mypy`:
- https://github.com/python/mypy/issues/12664

#### How does it address the issue?
Apply `--no-incredental` as a workaround to not use mypy's cachcing mechanism. So it doesn't hit the error.

#### What side effects does this change have?
`mypy`/`make lint` could run slower since it forces mypy to not use caching.

Note that in our CI/CD jobs, `mypy` is run only once. So we won't have any issue in our CI/CD jobs.
This change helps smoothing the local dev experience a bit because mypy fixes the issue. 

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
