### PR TITLE
Reduced the length of the cloned app template folder name

### DIFF
--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -34,7 +34,7 @@ MANIFEST_URL = (
     f"https://raw.githubusercontent.com/aws/aws-sam-cli-app-templates/{APP_TEMPLATES_REPO_COMMIT}/manifest-v2.json"
 )
 APP_TEMPLATES_REPO_URL = "https://github.com/aws/aws-sam-cli-app-templates"
-APP_TEMPLATES_REPO_NAME = "aws-sam-cli-app-templates"
+APP_TEMPLATES_REPO_NAME = "tmpl"
 
 
 class InvalidInitTemplateError(UserException):

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -34,7 +34,8 @@ MANIFEST_URL = (
     f"https://raw.githubusercontent.com/aws/aws-sam-cli-app-templates/{APP_TEMPLATES_REPO_COMMIT}/manifest-v2.json"
 )
 APP_TEMPLATES_REPO_URL = "https://github.com/aws/aws-sam-cli-app-templates"
-APP_TEMPLATES_REPO_NAME = "tmpl"
+APP_TEMPLATES_REPO_NAME = "aws-sam-cli-app-templates"
+APP_TEMPLATES_REPO_NAME_WINDOWS = "tmpl"
 
 
 class InvalidInitTemplateError(UserException):
@@ -73,11 +74,17 @@ class InitTemplates:
 
     def clone_templates_repo(self):
         if not self._git_repo.clone_attempted:
+            from platform import system
+
             shared_dir: Path = GlobalConfig().config_dir
+
+            os_name = system().lower()
+            cloned_folder_name = APP_TEMPLATES_REPO_NAME_WINDOWS if os_name == "windows" else APP_TEMPLATES_REPO_NAME
+
             try:
                 self._git_repo.clone(
                     clone_dir=shared_dir,
-                    clone_name=APP_TEMPLATES_REPO_NAME,
+                    clone_name=cloned_folder_name,
                     replace_existing=True,
                     commit=APP_TEMPLATES_REPO_COMMIT,
                 )
@@ -85,7 +92,7 @@ class InitTemplates:
                 raise AppTemplateUpdateException(str(ex)) from ex
             except (OSError, CloneRepoException):
                 LOG.debug("Clone error, attempting to use an old clone from a previous run")
-                expected_previous_clone_local_path: Path = shared_dir.joinpath(APP_TEMPLATES_REPO_NAME)
+                expected_previous_clone_local_path: Path = shared_dir.joinpath(cloned_folder_name)
                 if expected_previous_clone_local_path.exists():
                     self._git_repo.local_path = expected_previous_clone_local_path
 


### PR DESCRIPTION
#### Why is this change necessary?
This is one of the changes being made to help reduce the overall length of cloned app templates to avoid reaching the maximum path length in Windows.

#### How does it address the issue?
Changes the folder name from `aws-sam-cli-app-templates` to `tmpl` for Windows machines.

#### What side effects does this change have?
Existing Windows installations with an `aws-sam-cli-app-templates` folder in their `%appdata%/AWS SAM` directory will have that folder remain there until it is manually deleted.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
