### PR TITLE
Update App Template Commit Hash Update job schedule to every 4 hour

### DIFF
--- a/.github/workflows/update_app_templates_hash.yml
+++ b/.github/workflows/update_app_templates_hash.yml
@@ -2,7 +2,7 @@ name: Update aws/aws-sam-cli with latest commit hash from aws/aws-sam-cli-app-te
 
 on:
   schedule:
-    - cron: "0 * * * *" # run at the top of every hour
+    - cron: "0 0/4 * * *" # run at the top of every 4 hour
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
PR checks take around 1.25hr to finish. If the app template update job keeps running every hour, last jobs will never complete while new push will kick off new jobs.

#### How does it address the issue?
Run it left often. Update to run every 4 hours

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
