### PR TITLE
chore: remove duplicated samdev base_command methods in tests

### DIFF
--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -18,7 +18,14 @@ from samcli.lib.utils import osutils
 from samcli.lib.utils.architecture import X86_64, has_runtime_multi_arch_image
 from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 from samcli.yamlhelper import yaml_parse
-from tests.testing_utils import IS_WINDOWS, run_command, SKIP_DOCKER_TESTS, SKIP_DOCKER_MESSAGE, SKIP_DOCKER_BUILD
+from tests.testing_utils import (
+    IS_WINDOWS,
+    run_command,
+    SKIP_DOCKER_TESTS,
+    SKIP_DOCKER_MESSAGE,
+    SKIP_DOCKER_BUILD,
+    get_sam_command,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -28,7 +35,7 @@ class BuildIntegBase(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.cmd = cls.base_command()
+        cls.cmd = get_sam_command()
         integration_dir = Path(__file__).resolve().parents[1]
         cls.test_data_path = str(Path(integration_dir, "testdata", "buildcmd"))
         cls.template_path = str(Path(cls.test_data_path, cls.template)) if cls.template else None
@@ -52,13 +59,6 @@ class BuildIntegBase(TestCase):
         self.custom_build_dir and shutil.rmtree(self.custom_build_dir, ignore_errors=True)
         self.working_dir and shutil.rmtree(self.working_dir, ignore_errors=True)
         self.scratch_dir and shutil.rmtree(self.scratch_dir, ignore_errors=True)
-
-    @classmethod
-    def base_command(cls):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-        return command
 
     def get_command_list(
         self,

--- a/tests/integration/delete/delete_integ_base.py
+++ b/tests/integration/delete/delete_integ_base.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Optional
 from unittest import TestCase
 
+from tests.testing_utils import get_sam_command
+
 
 class DeleteIntegBase(TestCase):
     @classmethod
@@ -15,12 +17,6 @@ class DeleteIntegBase(TestCase):
     def tearDown(self):
         super().tearDown()
 
-    def base_command(self):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-        return command
-
     def get_delete_command_list(
         self,
         stack_name=None,
@@ -32,7 +28,7 @@ class DeleteIntegBase(TestCase):
         s3_bucket=None,
         s3_prefix=None,
     ):
-        command_list = [self.base_command(), "delete"]
+        command_list = [get_sam_command(), "delete"]
 
         # Convert all values as string to make behaviour uniform across platforms
         if stack_name:

--- a/tests/integration/local/generate_event/test_cli_integ.py
+++ b/tests/integration/local/generate_event/test_cli_integ.py
@@ -2,16 +2,11 @@ from unittest import TestCase
 from subprocess import Popen
 import os
 
+from tests.testing_utils import get_sam_command
+
 
 class Test_EventGeneration_Integ(TestCase):
     def test_generate_event_substitution(self):
-        process = Popen([Test_EventGeneration_Integ._get_command(), "local", "generate-event", "s3", "put"])
+        process = Popen([get_sam_command(), "local", "generate-event", "s3", "put"])
         process.communicate()
         self.assertEqual(process.returncode, 0)
-
-    @staticmethod
-    def _get_command():
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-        return command

--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -4,7 +4,7 @@ from unittest import TestCase, skipIf
 from pathlib import Path
 from subprocess import Popen, PIPE, TimeoutExpired
 
-from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS
+from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS, get_sam_command
 
 TIMEOUT = 300
 
@@ -15,7 +15,7 @@ class InvokeIntegBase(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.cmd = cls.base_command()
+        cls.cmd = get_sam_command()
         cls.test_data_path = cls.get_integ_dir().joinpath("testdata")
         if cls.template:
             cls.template_path = str(cls.test_data_path.joinpath("invoke", cls.template))
@@ -26,14 +26,6 @@ class InvokeIntegBase(TestCase):
     @staticmethod
     def get_integ_dir():
         return Path(__file__).resolve().parents[2]
-
-    @classmethod
-    def base_command(cls):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-
-        return command
 
     def get_command_list(
         self,

--- a/tests/integration/local/start_api/start_api_integ_base.py
+++ b/tests/integration/local/start_api/start_api_integ_base.py
@@ -12,7 +12,7 @@ import docker
 from docker.errors import APIError
 
 from tests.integration.local.common_utils import InvalidAddressException, random_port, wait_for_local_process
-from tests.testing_utils import kill_process
+from tests.testing_utils import kill_process, get_sam_command
 from tests.testing_utils import SKIP_DOCKER_MESSAGE, SKIP_DOCKER_TESTS, run_command
 
 LOG = logging.getLogger(__name__)
@@ -53,9 +53,7 @@ class StartApiIntegBaseClass(TestCase):
 
     @classmethod
     def build(cls):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
+        command = get_sam_command()
         command_list = [command, "build"]
         if cls.build_overrides:
             overrides_arg = " ".join(
@@ -82,9 +80,7 @@ class StartApiIntegBaseClass(TestCase):
 
     @classmethod
     def start_api(cls):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
+        command = get_sam_command()
 
         command_list = [command, "local", "start-api", "-t", cls.template, "-p", cls.port]
 

--- a/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
+++ b/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
@@ -17,6 +17,7 @@ from tests.testing_utils import (
     SKIP_DOCKER_MESSAGE,
     run_command,
     kill_process,
+    get_sam_command,
 )
 
 LOG = logging.getLogger(__name__)
@@ -61,15 +62,8 @@ class StartLambdaIntegBaseClass(TestCase):
         cls.start_lambda_with_retry()
 
     @classmethod
-    def base_command(cls):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-        return command
-
-    @classmethod
     def build(cls):
-        command = cls.base_command()
+        command = get_sam_command()
 
         command_list = [command, "build"]
         if cls.build_overrides:
@@ -108,7 +102,7 @@ class StartLambdaIntegBaseClass(TestCase):
         hook_name=None,
         beta_features=None,
     ):
-        command_list = [cls.base_command(), "local", "start-lambda"]
+        command_list = [get_sam_command(), "local", "start-lambda"]
 
         if port:
             command_list += ["-p", port]

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -9,7 +9,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from samcli.lib.bootstrap.companion_stack.data_types import CompanionStack
-from tests.testing_utils import method_to_stack_name
+from tests.testing_utils import method_to_stack_name, get_sam_command
 
 SLEEP = 3
 
@@ -83,13 +83,6 @@ class PackageIntegBase(TestCase):
     def tearDown(self):
         super().tearDown()
 
-    def base_command(self):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-
-        return command
-
     def get_command_list(
         self,
         s3_bucket=None,
@@ -106,7 +99,7 @@ class PackageIntegBase(TestCase):
         image_repositories=None,
         resolve_s3=False,
     ):
-        command_list = [self.base_command(), "package"]
+        command_list = [get_sam_command(), "package"]
 
         if s3_bucket:
             command_list = command_list + ["--s3-bucket", str(s3_bucket)]

--- a/tests/integration/pipeline/base.py
+++ b/tests/integration/pipeline/base.py
@@ -12,15 +12,11 @@ import botocore.exceptions
 from botocore.exceptions import ClientError
 
 from samcli.lib.pipeline.bootstrap.stage import Stage
+from tests.testing_utils import get_sam_command
 
 
 class PipelineBase(TestCase):
-    def base_command(self):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-
-        return command
+    pass
 
 
 class InitIntegBase(PipelineBase):
@@ -45,7 +41,7 @@ class InitIntegBase(PipelineBase):
         super().tearDown()
 
     def get_init_command_list(self, with_bootstrap=False):
-        command_list = [self.base_command(), "pipeline", "init"]
+        command_list = [get_sam_command(), "pipeline", "init"]
         if with_bootstrap:
             command_list.append("--bootstrap")
         return command_list
@@ -105,7 +101,7 @@ class BootstrapIntegBase(PipelineBase):
         image_repository: Optional[str] = None,
         no_confirm_changeset: bool = False,
     ):
-        command_list = [self.base_command(), "pipeline", "bootstrap"]
+        command_list = [get_sam_command(), "pipeline", "bootstrap"]
 
         if no_interactive:
             command_list += ["--no-interactive"]

--- a/tests/integration/pipeline/test_init_command.py
+++ b/tests/integration/pipeline/test_init_command.py
@@ -12,7 +12,7 @@ from samcli.commands.pipeline.init.interactive_init_flow import APP_PIPELINE_TEM
 from samcli.cli.global_config import GlobalConfig
 from tests.integration.pipeline.base import InitIntegBase, BootstrapIntegBase
 from tests.integration.pipeline.test_bootstrap_command import SKIP_BOOTSTRAP_TESTS, CREDENTIAL_PROFILE
-from tests.testing_utils import run_command_with_inputs
+from tests.testing_utils import run_command_with_inputs, get_sam_command
 
 QUICK_START_JENKINS_INPUTS_WITHOUT_AUTO_FILL = [
     "1",  # quick start
@@ -208,7 +208,7 @@ class TestInitWithBootstrap(BootstrapIntegBase):
 
     def setUp(self):
         super().setUp()
-        self.command_list = [self.base_command(), "pipeline", "init", "--bootstrap"]
+        self.command_list = [get_sam_command(), "pipeline", "init", "--bootstrap"]
         generated_jenkinsfile_path = Path("Jenkinsfile")
         self.generated_files.append(generated_jenkinsfile_path)
 

--- a/tests/integration/publish/publish_app_integ_base.py
+++ b/tests/integration/publish/publish_app_integ_base.py
@@ -9,6 +9,8 @@ from unittest import TestCase
 import boto3
 from pathlib import Path
 
+from tests.testing_utils import get_sam_command
+
 S3_SLEEP = 3
 
 
@@ -78,15 +80,8 @@ class PublishAppIntegBase(TestCase):
         for key, value in app_metadata.items():
             self.assertIn('"{}":{}'.format(key, json.dumps(value)), stripped_std_output)
 
-    def base_command(self):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-
-        return command
-
     def get_command_list(self, template_path=None, region=None, profile=None, semantic_version=None):
-        command_list = [self.base_command(), "publish"]
+        command_list = [get_sam_command(), "publish"]
 
         if template_path:
             command_list = command_list + ["-t", str(template_path)]

--- a/tests/integration/root/root_integ_base.py
+++ b/tests/integration/root/root_integ_base.py
@@ -1,6 +1,8 @@
 import os
 from unittest import TestCase
 
+from tests.testing_utils import get_sam_command
+
 
 class RootIntegBase(TestCase):
     def setUp(self):
@@ -9,14 +11,6 @@ class RootIntegBase(TestCase):
     def tearDown(self):
         super().tearDown()
 
-    @staticmethod
-    def base_command():
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-
-        return command
-
     def root_command_list(
         self,
         info=False,
@@ -24,7 +18,7 @@ class RootIntegBase(TestCase):
         version=False,
         _help=False,
     ):
-        command_list = [RootIntegBase.base_command()]
+        command_list = [get_sam_command()]
 
         if info:
             command_list += ["--info"]

--- a/tests/integration/telemetry/integ_base.py
+++ b/tests/integration/telemetry/integ_base.py
@@ -15,7 +15,7 @@ from werkzeug.serving import make_server
 
 from samcli.cli.global_config import GlobalConfig
 from samcli.cli.main import TELEMETRY_PROMPT
-
+from tests.testing_utils import get_sam_command
 
 LOG = logging.getLogger(__name__)
 TELEMETRY_ENDPOINT_PORT = "18298"
@@ -29,7 +29,7 @@ EXPECTED_TELEMETRY_PROMPT = re.sub(r"\n", os.linesep, TELEMETRY_PROMPT)
 class IntegBase(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.cmd = cls.base_command()
+        cls.cmd = get_sam_command()
 
     def setUp(self):
         self.maxDiff = None  # Show full JSON Diff
@@ -40,14 +40,6 @@ class IntegBase(TestCase):
 
     def tearDown(self):
         self.config_dir and shutil.rmtree(self.config_dir)
-
-    @classmethod
-    def base_command(cls):
-        command = "sam"
-        if os.getenv("SAM_CLI_DEV"):
-            command = "samdev"
-
-        return command
 
     def run_cmd(self, cmd_list=None, stdin_data="", optout_envvar_value=None):
         # Any command will work for this test suite

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -11,7 +11,13 @@ from unittest import TestCase
 from unittest.case import skipIf
 
 from parameterized import parameterized
-from tests.testing_utils import RUN_BY_CANARY, RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, run_command
+from tests.testing_utils import (
+    RUN_BY_CANARY,
+    RUNNING_ON_CI,
+    RUNNING_TEST_FOR_MASTER_ON_CI,
+    run_command,
+    get_sam_command,
+)
 
 # Validate tests require credentials and CI/CD will only add credentials to the env if the PR is from the same repo.
 # This is to restrict package tests to run outside of CI/CD, when the branch is not master or tests are not run by Canary
@@ -32,10 +38,6 @@ class TestValidate(TestCase):
             TemplateFileTypes.YAML: re.compile(r"template\.yaml is a valid SAM Template(\r\n)?$"),
         }
 
-    @staticmethod
-    def base_command() -> str:
-        return "samdev" if os.getenv("SAM_CLI_DEV") else "sam"
-
     def command_list(
         self,
         template_file: Optional[Path] = None,
@@ -43,7 +45,7 @@ class TestValidate(TestCase):
         region: Optional[str] = None,
         config_file: Optional[Path] = None,
     ) -> List[str]:
-        command_list = [self.base_command(), "validate"]
+        command_list = [get_sam_command(), "validate"]
         if template_file:
             command_list += ["--template-file", str(template_file)]
         if profile:


### PR DESCRIPTION
Remove duplicated `sam` vs `samdev` assignment in the testing code.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
