### PR TITLE
fix: relax the version constraint on `cfn-lint`

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,4 +29,4 @@ regex==2021.9.30
 tzlocal==3.0
 
 #Adding cfn-lint dependency for SAM validate
-cfn-lint==0.72.2
+cfn-lint~=0.72


### PR DESCRIPTION
- `cfn-lint` still depends on `aws-sam-translator`. The latest setup.py on `cfn-lint` says >=1.56.0 (https://github.com/aws-cloudformation/cfn-lint/blob/main/setup.py#L46)
- current `aws-sam-translator` version on `aws-sam-cli` is 1.57.0
- with current version setting, cfn-lint is free to upgrade in all > =0.72 till it reaches a 1.0 release.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
