### PR TITLE
Adding app composer link and validate --lint option to recommended next commands in sam init

### DIFF
--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -270,10 +270,12 @@ def _generate_from_use_case(
     )
 
     click.echo(summary_msg)
+    app_composer_link = "https://console.aws.amazon.com/composer/home"
     command_suggestions = generate_next_command_recommendation(
         [
+            ("Visually build with AWS Application Composer", f"{app_composer_link}"), 
             ("Create pipeline", f"cd {name} && sam pipeline init --bootstrap"),
-            ("Validate SAM template", f"cd {name} && sam validate"),
+            ("Validate SAM template", f"cd {name} && sam validate --lint"),
             ("Test Function in the Cloud", f"cd {name} && sam sync --stack-name {{stack-name}} --watch"),
         ]
     )


### PR DESCRIPTION
Hello, please review but do not merge yet, as I have not completely tested this yet. 

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
n/a 

#### Why is this change necessary?
Giving developers a quick link to App Composer through init flow

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
