### PR TITLE
fix: Pin docker provider version to 2.x

### DIFF
--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/main.tf
@@ -7,10 +7,6 @@ terraform {
   }
 }
 
-provider "docker" {
-  host = "unix:///var/run/docker.sock"
-}
-
 provider "aws" {
     # Make it faster by skipping something
     skip_get_ec2_platforms      = true

--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/main.tf
@@ -1,3 +1,16 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "2.25.0"
+    }
+  }
+}
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}
+
 provider "aws" {
     # Make it faster by skipping something
     skip_get_ec2_platforms      = true

--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/main.tf
@@ -8,10 +8,6 @@ terraform {
   backend "s3" {}
 }
 
-provider "docker" {
-  host = "unix:///var/run/docker.sock"
-}
-
 provider "aws" {
     # Make it faster by skipping something
     skip_get_ec2_platforms      = true

--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/main.tf
@@ -1,5 +1,15 @@
 terraform {
-    backend "s3" {}
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "2.25.0"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
 }
 
 provider "aws" {


### PR DESCRIPTION
#### Why is this change necessary?
Unlocks the integration tests temporarily until https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/398 is resolved. After, this change should be reverted.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
