### PR TITLE
Fix appveyor canary job uploading test reports

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -352,6 +352,3 @@ for:
       # Smoke tests run in parallel - it runs on both Linux & Windows
       # Presence of the RUN_SMOKE envvar will run the smoke tests
       - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke --json-report --json-report-file=TEST_REPORT-smoke.json}"
-
-artifacts:
-  - path: './TEST_REPORT*.json'

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -170,6 +170,8 @@ build_script:
 
 # Final clean up no matter success or failure
 on_finish:
+  # Upload test reports as artifacts
+  - sh: find "$APPVEYOR_BUILD_FOLDER" -type f -name 'TEST*.json' -print0 | xargs -0 -I '{}' appveyor PushArtifact '{}'
   - sh: 'export AWS_ACCESS_KEY_ID=$CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID'
   - sh: 'export AWS_SECRET_ACCESS_KEY=$CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY'
   - sh: 'export AWS_SESSION_TOKEN=$CI_ACCESS_ROLE_AWS_SESSION_TOKEN'

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -172,6 +172,7 @@ build_script:
 on_finish:
   # Upload test reports as artifacts
   - sh: find "$APPVEYOR_BUILD_FOLDER" -type f -name 'TEST*.json' -print0 | xargs -0 -I '{}' appveyor PushArtifact '{}'
+
   - sh: 'export AWS_ACCESS_KEY_ID=$CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID'
   - sh: 'export AWS_SECRET_ACCESS_KEY=$CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY'
   - sh: 'export AWS_SESSION_TOKEN=$CI_ACCESS_ROLE_AWS_SESSION_TOKEN'
@@ -195,7 +196,7 @@ for:
 
       # Set JAVA_HOME to java11
       - sh: "JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64"
-      - sh: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java11_in_process --json-report --json-report-file=TEST_REPORT-integration-buildcmd-java11"
+      - sh: "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java11_in_process --json-report --json-report-file=TEST_REPORT-integration-buildcmd-java11.json"
 
   # Local ZIP  Terraform Build integ testing
   -

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -286,7 +286,4 @@ for:
 # Uncomment for RDP
 # on_finish:
 #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
-artifacts:
-  - path: './TEST_REPORT*.json'
   

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -123,6 +123,9 @@ install:
 
 # Final clean up no matter success or failure
 on_finish:
+  # Upload test reports as artifacts
+  - ps: Get-ChildItem .\TEST*.json | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
   - ps: "
   If (Test-Path env:BY_CANARY){
     $env:AWS_ACCESS_KEY_ID = $env:CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID;

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 log_cli = 1
 log_cli_level = INFO
-addopts = --maxfail=1000 -rf
+addopts = --maxfail=1000 -ra
 filterwarnings =
     error
     ignore::DeprecationWarning:docker

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 log_cli = 1
 log_cli_level = INFO
-addopts = --maxfail=1000 -ra
+addopts = --maxfail=1000 -rf
 filterwarnings =
     error
     ignore::DeprecationWarning:docker


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
To fix the issue that canary test reports are only uploaded on job succeed

#### How does it address the issue?
Switch to use `on_finish` to upload test reports regardless job succeeds or fails


#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
