### PR TITLE
Print all error name and message in UnhanledException messaging

### DIFF
--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -52,7 +52,8 @@ class UnhandledException(click.ClickException):
             file = click._compat.get_text_stderr()  # pylint: disable=protected-access
 
         tb = "".join(traceback.format_tb(self.__traceback__))
-        click.echo(f"\nTraceback:\n{tb}", file=file, err=True)
+        click.echo(f"\nError: {repr(self._exception)}", file=file, err=True)
+        click.echo(f"Traceback:\n{tb}", file=file, err=True)
 
         encoded_title = quote(f"Bug: {self._command} - {type(self._exception).__name__}")
         lookup_url = self.GH_ISSUE_SEARCH_URL.format(title=encoded_title)

--- a/tests/unit/commands/test_exceptions.py
+++ b/tests/unit/commands/test_exceptions.py
@@ -21,6 +21,7 @@ class TestUnhandledException(TestCase):
 
         output = f.getvalue()
 
+        self.assertIn("Error:", output)
         self.assertIn("Traceback:", output)
         self.assertIn('raise Exception("my_exception")', output)
         self.assertIn(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
To provide more complete info around the unhandled exception

#### How does it address the issue?
Print all the error name and exception. Example:
```

Error: UnsupportedBuilderException("'esbuild1' does not have a supported builder")
Traceback:
  File "/Volumes/workplace/gh/aws-sam-cli/.venv39/lib/python3.9/site-packages/click/core.py", line 1055, in main
.
.
.
    raise UnsupportedBuilderException("'{}' does not have a supported builder".format(specified_workflow))

An unexpected error was encountered while executing "samdev build".
Search for an existing issue:
https://github.com/aws/aws-sam-cli/issues?q=is%3Aissue+is%3Aopen+Bug%3A%20samdev%20build%20-%20UnsupportedBuilderException
Or create a bug report:
https://github.com/aws/aws-sam-cli/issues/new?template=Bug_report.md&title=Bug%3A%20samdev%20build%20-%20UnsupportedBuilderException

```

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
