### PR TITLE
Fix printing exception message for Unhandled Exception

### DIFF
--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -52,7 +52,8 @@ class UnhandledException(click.ClickException):
             file = click._compat.get_text_stderr()  # pylint: disable=protected-access
 
         tb = "".join(traceback.format_tb(self.__traceback__))
-        click.echo(f"\nTraceback:\n{tb}", file=file, err=True)
+        click.echo(f"\nError: {repr(self._exception)}", file=file, err=True)
+        click.echo(f"Traceback:\n{tb}", file=file, err=True)
 
         encoded_title = quote(f"Bug: {self._command} - {type(self._exception).__name__}")
         lookup_url = self.GH_ISSUE_SEARCH_URL.format(title=encoded_title)

--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -52,7 +52,7 @@ class UnhandledException(click.ClickException):
             file = click._compat.get_text_stderr()  # pylint: disable=protected-access
 
         tb = "".join(traceback.format_tb(self.__traceback__))
-        click.echo(f"\nError: {repr(self._exception)}", file=file, err=True)
+        click.echo(f"\nError: {self._exception}", file=file, err=True)
         click.echo(f"Traceback:\n{tb}", file=file, err=True)
 
         encoded_title = quote(f"Bug: {self._command} - {type(self._exception).__name__}")

--- a/tests/unit/commands/test_exceptions.py
+++ b/tests/unit/commands/test_exceptions.py
@@ -21,6 +21,7 @@ class TestUnhandledException(TestCase):
 
         output = f.getvalue()
 
+        self.assertIn("Error:", output)
         self.assertIn("Traceback:", output)
         self.assertIn('raise Exception("my_exception")', output)
         self.assertIn(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
To match previous behavior in terms of the exception message being printed. (should print `str(ex)` instead of `repr(ex)`)

#### How does it address the issue?
change `repr` to `str`

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
