### PR TITLE
fix: Fix failing list tests on Windows

### DIFF
--- a/tests/integration/list/endpoints/endpoints_integ_base.py
+++ b/tests/integration/list/endpoints/endpoints_integ_base.py
@@ -25,3 +25,19 @@ class EndpointsIntegBase(ListIntegBase):
             command_list += ["--help"]
 
         return command_list
+
+    def assert_endpoints(self, endpoints, logical_id, physical_id, cloud_endpoints, methods):
+        resource = self._find_resource(endpoints, logical_id)
+        if not resource:
+            raise AssertionError(f"Couldn't find endpoint with corresponding logical id {logical_id}")
+        self.assertRegex(resource.get("PhysicalResourceId", ""), physical_id)
+        self.assertEqual(resource.get("Methods", []), methods)
+        self._assert_cloud_endpoints(resource, cloud_endpoints)
+
+    def _assert_cloud_endpoints(self, resource, cloud_endpoints):
+        deployed_endpoint = resource.get("CloudEndpoint")
+        if isinstance(cloud_endpoints, str):
+            self.assertRegex(deployed_endpoint, cloud_endpoints)
+            return
+        for deployed, expected in zip(deployed_endpoint, cloud_endpoints):
+            self.assertRegex(deployed, expected)

--- a/tests/integration/list/endpoints/test_endpoints_command.py
+++ b/tests/integration/list/endpoints/test_endpoints_command.py
@@ -44,9 +44,7 @@ class TestEndpoints(DeployIntegBase, EndpointsIntegBase):
         command_result = run_command(cmdlist, cwd=self.working_dir)
         command_output = json.loads(command_result.stdout.decode())
         self.assertEqual(len(command_output), 3)
-        self.assert_endpoints(
-            command_output, "HelloWorldFunction", "-", "-", "-"
-        )
+        self.assert_endpoints(command_output, "HelloWorldFunction", "-", "-", "-")
         self.assert_endpoints(
             command_output,
             "ServerlessRestApi",

--- a/tests/integration/list/list_integ_base.py
+++ b/tests/integration/list/list_integ_base.py
@@ -1,3 +1,5 @@
+import re
+
 import os
 from unittest import TestCase
 from pathlib import Path
@@ -34,3 +36,11 @@ class ListIntegBase(TestCase):
     @classmethod
     def base_command(cls):
         return get_sam_command()
+
+    @staticmethod
+    def _find_resource(resources, logical_id):
+        for resource in resources:
+            resource_logical_id = resource.get("LogicalResourceId", "")
+            if resource_logical_id == logical_id or re.match(logical_id, resource_logical_id):
+                return resource
+        return None

--- a/tests/integration/list/resources/resources_integ_base.py
+++ b/tests/integration/list/resources/resources_integ_base.py
@@ -25,3 +25,9 @@ class ResourcesIntegBase(ListIntegBase):
             command_list += ["--help"]
 
         return command_list
+
+    def assert_resource(self, resources, logical_id, physical_id):
+        resource = self._find_resource(resources, logical_id)
+        if not resource:
+            raise AssertionError(f"Couldn't find resource with corresponding logical id {logical_id}")
+        self.assertRegex(resource.get("PhysicalResourceId", ""), physical_id)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Some `sam list` integration tests have been failing on Windows since they hard-code line endings.

#### How does it address the issue?
Refactored the tests to not need specific strings, instead it validates JSON properties.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
