### PR TITLE
feat: Add warning about not providing stack name option

### DIFF
--- a/samcli/commands/list/cli_common/options.py
+++ b/samcli/commands/list/cli_common/options.py
@@ -32,3 +32,11 @@ def output_click_option():
 
 def output_option(f):
     return output_click_option()(f)
+
+
+def stack_name_not_provided_message():
+    click.secho(
+        fg="yellow",
+        message="The --stack-name options was not provided, displaying only local template data. "
+        "To see data about deployed resources, provide the corresponding stack name.",
+    )

--- a/samcli/commands/list/endpoints/command.py
+++ b/samcli/commands/list/endpoints/command.py
@@ -5,7 +5,7 @@ Sets up the cli for resources
 import click
 
 from samcli.commands._utils.command_exception_handler import command_exception_handler
-from samcli.commands.list.cli_common.options import stack_name_option, output_option
+from samcli.commands.list.cli_common.options import stack_name_option, output_option, stack_name_not_provided_message
 from samcli.cli.main import pass_context, common_options, aws_creds_options, print_cmdline_args
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.lib.telemetry.metric import track_command
@@ -49,4 +49,6 @@ def do_cli(stack_name, output, region, profile, template_file):
     with EndpointsContext(
         stack_name=stack_name, output=output, region=region, profile=profile, template_file=template_file
     ) as endpoints_context:
+        if not stack_name:
+            stack_name_not_provided_message()
         endpoints_context.run()

--- a/samcli/commands/list/resources/command.py
+++ b/samcli/commands/list/resources/command.py
@@ -5,7 +5,7 @@ Sets up the cli for resources
 import click
 
 from samcli.commands._utils.command_exception_handler import command_exception_handler
-from samcli.commands.list.cli_common.options import stack_name_option, output_option
+from samcli.commands.list.cli_common.options import stack_name_option, output_option, stack_name_not_provided_message
 from samcli.cli.main import pass_context, common_options, aws_creds_options, print_cmdline_args
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.lib.telemetry.metric import track_command
@@ -49,4 +49,6 @@ def do_cli(stack_name, output, region, profile, template_file):
     with ResourcesContext(
         stack_name=stack_name, output=output, region=region, profile=profile, template_file=template_file
     ) as resources_context:
+        if not stack_name:
+            stack_name_not_provided_message()
         resources_context.run()

--- a/tests/unit/commands/list/endpoints/test_cli.py
+++ b/tests/unit/commands/list/endpoints/test_cli.py
@@ -11,9 +11,10 @@ class TestCli(TestCase):
         self.profile = None
         self.template_file = None
 
+    @patch("samcli.commands.list.endpoints.command.stack_name_not_provided_message")
     @patch("samcli.commands.list.endpoints.command.click")
     @patch("samcli.commands.list.endpoints.endpoints_context.EndpointsContext")
-    def test_cli_base_command(self, mock_endpoints_context, mock_endpoints_click):
+    def test_cli_base_command(self, mock_endpoints_context, mock_endpoints_click, mock_stack_name_not_provided):
         context_mock = Mock()
         mock_endpoints_context.return_value.__enter__.return_value = context_mock
         do_cli(
@@ -34,3 +35,19 @@ class TestCli(TestCase):
 
         context_mock.run.assert_called_with()
         self.assertEqual(context_mock.run.call_count, 1)
+        mock_stack_name_not_provided.assert_not_called()
+
+    @patch("samcli.commands.list.endpoints.command.stack_name_not_provided_message")
+    @patch("samcli.commands.list.endpoints.command.click")
+    @patch("samcli.commands.list.endpoints.endpoints_context.EndpointsContext")
+    def test_warns_user_stack_name_not_provided(
+        self, mock_resources_context, mock_resources_click, mock_stack_name_not_provided
+    ):
+        do_cli(
+            stack_name=None,
+            output=self.output,
+            region=self.region,
+            profile=self.profile,
+            template_file=self.template_file,
+        )
+        mock_stack_name_not_provided.assert_called_once()

--- a/tests/unit/commands/list/resources/test_cli.py
+++ b/tests/unit/commands/list/resources/test_cli.py
@@ -11,9 +11,10 @@ class TestCli(TestCase):
         self.profile = None
         self.template_file = None
 
+    @patch("samcli.commands.list.resources.command.stack_name_not_provided_message")
     @patch("samcli.commands.list.resources.command.click")
     @patch("samcli.commands.list.resources.resources_context.ResourcesContext")
-    def test_cli_base_command(self, mock_resources_context, mock_resources_click):
+    def test_cli_base_command(self, mock_resources_context, mock_resources_click, mock_stack_name_not_provided):
         context_mock = Mock()
         mock_resources_context.return_value.__enter__.return_value = context_mock
         do_cli(
@@ -34,3 +35,19 @@ class TestCli(TestCase):
 
         context_mock.run.assert_called_with()
         self.assertEqual(context_mock.run.call_count, 1)
+        mock_stack_name_not_provided.assert_not_called()
+
+    @patch("samcli.commands.list.resources.command.stack_name_not_provided_message")
+    @patch("samcli.commands.list.resources.command.click")
+    @patch("samcli.commands.list.resources.resources_context.ResourcesContext")
+    def test_warns_user_stack_name_not_provided(
+        self, mock_resources_context, mock_resources_click, mock_stack_name_not_provided
+    ):
+        do_cli(
+            stack_name=None,
+            output=self.output,
+            region=self.region,
+            profile=self.profile,
+            template_file=self.template_file,
+        )
+        mock_stack_name_not_provided.assert_called_once()


### PR DESCRIPTION
Adds a warning message if a `--stack-name` option isn't provided explaining that the `sam list` command is acting only on the local template and not deployed resources. Applicable to `sam list resources` and `sam list endpoints`.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
