### PR TITLE
chore: Use utility's yaml parse method in list producer

### DIFF
--- a/samcli/lib/list/resources/resource_mapping_producer.py
+++ b/samcli/lib/list/resources/resource_mapping_producer.py
@@ -4,7 +4,6 @@ The producer for the 'sam list resources' command
 from typing import Any, Dict
 import dataclasses
 import logging
-import yaml
 
 from botocore.exceptions import ClientError, NoCredentialsError, BotoCoreError
 from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
@@ -26,6 +25,7 @@ from samcli.commands.local.cli_common.user_exceptions import InvalidSamTemplateE
 from samcli.commands.exceptions import UserException
 from samcli.commands._utils.template import get_template_data
 from samcli.lib.utils.boto_utils import get_client_error_code
+from samcli.yamlhelper import yaml_parse
 
 
 LOG = logging.getLogger(__name__)
@@ -98,8 +98,7 @@ class ResourceMappingProducer(Producer):
             validator = SamTemplateValidator(
                 template_file_dict, ManagedPolicyLoader(self.iam_client), profile=self.profile, region=self.region
             )
-            translated_dict: dict
-            translated_dict = yaml.load(validator.get_translated_template_if_valid(), Loader=yaml.FullLoader)
+            translated_dict = yaml_parse(validator.get_translated_template_if_valid())
             return translated_dict
         except InvalidSamDocumentException as e:
             raise InvalidSamTemplateException(str(e)) from e

--- a/tests/unit/commands/list/resources/test_resources_context.py
+++ b/tests/unit/commands/list/resources/test_resources_context.py
@@ -415,6 +415,35 @@ class TestGetTranslatedDict(TestCase):
             )
             resource_producer.get_translated_dict(mock_sam_file_reader.return_value)
 
+    @patch("samcli.commands.list.json_consumer.click.echo")
+    @patch("samcli.commands.list.json_consumer.click.get_current_context")
+    @patch("samcli.lib.list.resources.resource_mapping_producer.SamTemplateValidator.get_translated_template_if_valid")
+    @patch("samcli.lib.list.resources.resource_mapping_producer.yaml_parse")
+    @patch("samcli.lib.list.resources.resource_mapping_producer.get_template_data")
+    def test_get_translated_dict_calls_safe_yaml_parse(
+        self,
+        mock_sam_file_reader,
+        mock_yaml_parse,
+        mock_validate_template,
+        patched_click_get_current_context,
+        patched_click_echo,
+    ):
+
+        mock_sam_file_reader.return_value = SAM_FILE_READER_RETURN
+        resource_producer = ResourceMappingProducer(
+            stack_name=None,
+            region=None,
+            profile=None,
+            template_file=None,
+            cloudformation_client=None,
+            iam_client=None,
+            mapper=DataToJsonMapper(),
+            consumer=StringConsumerJsonOutput(),
+        )
+        resource_producer.get_translated_dict(mock_sam_file_reader.return_value)
+
+        mock_yaml_parse.assert_called_once()
+
 
 class TestResourcesInitClients(TestCase):
     @patch("samcli.commands.list.json_consumer.click.echo")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N.A.

#### Why is this change necessary?
The list producer uses yaml.load() method, which should be replaced by safe yaml load.

#### How does it address the issue?
Removes the use of yaml.load() method and use the yaml parse method already created in utilities.

#### What side effects does this change have?
Not known.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
