### PR TITLE
fix: Revert an integration test change related to permission change revert

### DIFF
--- a/tests/integration/sync/test_sync_adl.py
+++ b/tests/integration/sync/test_sync_adl.py
@@ -133,7 +133,7 @@ class TestSyncAdlWithWatchStartWithNoDependencies(TestSyncWatchBase):
         )
         read_until_string(
             self.watch_process,
-            "\x1b[32mFinished syncing Layer HelloWorldFunction",
+            "\x1b[32mFinished syncing Function Layer Reference Sync HelloWorldFunction.\x1b[0m\n",
             timeout=60,
         )
         lambda_response = json.loads(self._get_lambda_response(lambda_functions[0]))


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N.A.

#### Why is this change necessary?
In https://github.com/aws/aws-sam-cli/pull/4488/files an integration test is updated related to the https://github.com/aws/aws-sam-cli/pull/4485 and https://github.com/aws/aws-sam-cli/pull/4462 changes. However as the mentioned PRs got reverted, this test change was not reverted.

#### How does it address the issue?
Updated the test to restore the test state prior to all the changes.

#### What side effects does this change have?
Not known

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
