### PR TITLE
chore: remove stubber from unit tests

### DIFF
--- a/tests/unit/lib/observability/cw_logs/test_cw_log_puller.py
+++ b/tests/unit/lib/observability/cw_logs/test_cw_log_puller.py
@@ -3,24 +3,23 @@ from datetime import datetime
 from unittest import TestCase
 from unittest.mock import Mock, call, patch, ANY
 
-import botocore.session
-from botocore.stub import Stubber
+from botocore.exceptions import ClientError
 
 from samcli.lib.observability.cw_logs.cw_log_event import CWLogEvent
 from samcli.lib.observability.cw_logs.cw_log_puller import CWLogPuller
 from samcli.lib.utils.time import to_timestamp, to_datetime
 
-LOG_CLIENT = botocore.session.get_session().create_client("logs", region_name="us-east-1")
+
+class CustomResourceNotFoundException(ValueError):
+    pass
 
 
 class TestCWLogPullerBase(TestCase):
 
-    real_client = None
-
     @classmethod
     def setUpClass(cls):
-        cls.real_client = LOG_CLIENT
-        cls.client_stubber = Stubber(cls.real_client)
+        exceptions_mock = Mock(ResourceNotFoundException=CustomResourceNotFoundException)
+        cls.mock_client = Mock(exceptions=exceptions_mock)
 
 
 class TestCWLogPuller_load_time_period(TestCWLogPullerBase):
@@ -30,7 +29,7 @@ class TestCWLogPuller_load_time_period(TestCWLogPullerBase):
         self.timestamp = to_timestamp(datetime.utcnow())
 
         self.consumer = Mock()
-        self.fetcher = CWLogPuller(self.real_client, self.consumer, self.log_group_name)
+        self.fetcher = CWLogPuller(self.mock_client, self.consumer, self.log_group_name)
 
         self.mock_api_response = {
             "events": [
@@ -75,40 +74,35 @@ class TestCWLogPuller_load_time_period(TestCWLogPullerBase):
         ]
 
     def test_must_fetch_logs_for_log_group(self):
-        expected_params = {"logGroupName": self.log_group_name, "interleaved": True}
+        self.mock_client.filter_log_events.return_value = self.mock_api_response
 
-        # Configure the stubber to return the configured response. The stubber also verifies
-        # that input params were provided as expected
-        self.client_stubber.add_response("filter_log_events", self.mock_api_response, expected_params)
+        self.fetcher.load_time_period()
 
-        with self.client_stubber:
-            self.fetcher.load_time_period()
+        self.mock_client.filter_log_events.assert_called_with(logGroupName=self.log_group_name, interleaved=True)
 
-            call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
-            for event in self.expected_events:
-                self.assertIn(event, call_args)
+        call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+        for event in self.expected_events:
+            self.assertIn(event, call_args)
 
     def test_must_fetch_logs_with_all_params(self):
         pattern = "foobar"
         start = datetime.utcnow()
         end = datetime.utcnow()
 
-        expected_params = {
-            "logGroupName": self.log_group_name,
-            "interleaved": True,
-            "startTime": to_timestamp(start),
-            "endTime": to_timestamp(end),
-            "filterPattern": pattern,
-        }
+        self.mock_client.filter_log_events.return_value = self.mock_api_response
 
-        self.client_stubber.add_response("filter_log_events", self.mock_api_response, expected_params)
+        self.fetcher.load_time_period(start_time=start, end_time=end, filter_pattern=pattern)
 
-        with self.client_stubber:
-            self.fetcher.load_time_period(start_time=start, end_time=end, filter_pattern=pattern)
-
-            call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
-            for event in self.expected_events:
-                self.assertIn(event, call_args)
+        self.mock_client.filter_log_events.assert_called_with(
+            logGroupName=self.log_group_name,
+            interleaved=True,
+            startTime=to_timestamp(start),
+            endTime=to_timestamp(end),
+            filterPattern=pattern,
+        )
+        call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+        for event in self.expected_events:
+            self.assertIn(event, call_args)
 
     @patch("samcli.lib.observability.cw_logs.cw_log_puller.LOG")
     def test_must_print_resource_not_found_only_once(self, patched_log):
@@ -116,58 +110,55 @@ class TestCWLogPuller_load_time_period(TestCWLogPullerBase):
         start = datetime.utcnow()
         end = datetime.utcnow()
 
-        expected_params = {
-            "logGroupName": self.log_group_name,
-            "interleaved": True,
-            "startTime": to_timestamp(start),
-            "endTime": to_timestamp(end),
-            "filterPattern": pattern,
-        }
+        self.mock_client.filter_log_events.side_effect = [
+            CustomResourceNotFoundException(),
+            CustomResourceNotFoundException(),
+            self.mock_api_response
+        ]
 
-        self.client_stubber.add_client_error(
-            "filter_log_events", expected_params=expected_params, service_error_code="ResourceNotFoundException"
-        )
-        self.client_stubber.add_client_error(
-            "filter_log_events", expected_params=expected_params, service_error_code="ResourceNotFoundException"
-        )
-        self.client_stubber.add_response("filter_log_events", self.mock_api_response, expected_params)
+        self.assertFalse(self.fetcher._invalid_log_group)
+        self.fetcher.load_time_period(start_time=start, end_time=end, filter_pattern=pattern)
+        self.assertTrue(self.fetcher._invalid_log_group)
+        self.fetcher.load_time_period(start_time=start, end_time=end, filter_pattern=pattern)
+        self.assertTrue(self.fetcher._invalid_log_group)
+        self.fetcher.load_time_period(start_time=start, end_time=end, filter_pattern=pattern)
+        self.assertFalse(self.fetcher._invalid_log_group)
 
-        with self.client_stubber:
-            self.assertFalse(self.fetcher._invalid_log_group)
-            self.fetcher.load_time_period(start_time=start, end_time=end, filter_pattern=pattern)
-            self.assertTrue(self.fetcher._invalid_log_group)
-            self.fetcher.load_time_period(start_time=start, end_time=end, filter_pattern=pattern)
-            self.assertTrue(self.fetcher._invalid_log_group)
-            self.fetcher.load_time_period(start_time=start, end_time=end, filter_pattern=pattern)
-            self.assertFalse(self.fetcher._invalid_log_group)
+        self.mock_client.filter_log_events.assert_called_with(
+            logGroupName=self.log_group_name,
+            interleaved=True,
+            startTime=to_timestamp(start),
+            endTime=to_timestamp(end),
+            filterPattern=pattern,
+        )
 
     def test_must_paginate_using_next_token(self):
         """Make three API calls, first two returns a nextToken and last does not."""
         token = "token"
-        expected_params = {"logGroupName": self.log_group_name, "interleaved": True}
-        expected_params_with_token = {"logGroupName": self.log_group_name, "interleaved": True, "nextToken": token}
 
         mock_response_with_token = copy.deepcopy(self.mock_api_response)
         mock_response_with_token["nextToken"] = token
 
-        # Call 1 returns a token. Also when first call is made, token is **not** passed as API params
-        self.client_stubber.add_response("filter_log_events", mock_response_with_token, expected_params)
-
-        # Call 2 returns a token
-        self.client_stubber.add_response("filter_log_events", mock_response_with_token, expected_params_with_token)
-
-        # Call 3 DOES NOT return a token. This will terminate the loop.
-        self.client_stubber.add_response("filter_log_events", self.mock_api_response, expected_params_with_token)
+        self.mock_client.filter_log_events.side_effect = [
+            mock_response_with_token,
+            mock_response_with_token,
+            self.mock_api_response
+        ]
 
         # Same data was returned in each API call
         expected_events_result = self.expected_events + self.expected_events + self.expected_events
 
-        with self.client_stubber:
-            self.fetcher.load_time_period()
+        self.fetcher.load_time_period()
 
-            call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
-            for event in expected_events_result:
-                self.assertIn(event, call_args)
+        self.mock_client.filter_log_events.assert_has_calls([
+            call(logGroupName=self.log_group_name, interleaved=True),
+            call(logGroupName=self.log_group_name, interleaved=True, nextToken=token),
+            call(logGroupName=self.log_group_name, interleaved=True, nextToken=token)
+        ])
+
+        call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+        for event in expected_events_result:
+            self.assertIn(event, call_args)
 
 
 class TestCWLogPuller_tail(TestCWLogPullerBase):
@@ -180,7 +171,7 @@ class TestCWLogPuller_tail(TestCWLogPullerBase):
 
         self.consumer = Mock()
         self.fetcher = CWLogPuller(
-            self.real_client,
+            self.mock_client,
             self.consumer,
             self.log_group_name,
             max_retries=self.max_retries,
@@ -221,80 +212,66 @@ class TestCWLogPuller_tail(TestCWLogPullerBase):
 
     @patch("samcli.lib.observability.cw_logs.cw_log_puller.time")
     def test_must_tail_logs_with_single_data_fetch(self, time_mock):
-        expected_params = {
-            "logGroupName": self.log_group_name,
-            "interleaved": True,
-            "startTime": 10,
-            "filterPattern": self.filter_pattern,
-        }
-        expected_params_second_try = {
-            "logGroupName": self.log_group_name,
-            "interleaved": True,
-            "startTime": 13,
-            "filterPattern": self.filter_pattern,
-        }
-
-        # first successful return
-        self.client_stubber.add_response("filter_log_events", self.mock_api_response_1, expected_params)
-        # 3 empty returns as the number of max retries
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params_second_try)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params_second_try)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params_second_try)
+        self.mock_client.filter_log_events.side_effect = [
+            # first successful return
+            self.mock_api_response_1,
+            # 3 empty returns as the number of max retries
+            self.mock_api_empty_response,
+            self.mock_api_empty_response,
+            self.mock_api_empty_response,
+        ]
 
         with patch.object(
             self.fetcher, "load_time_period", wraps=self.fetcher.load_time_period
         ) as patched_load_time_period:
-            with self.client_stubber:
-                self.fetcher.tail(
-                    start_time=self.start_time,
-                    filter_pattern=self.filter_pattern,
-                )
+            self.fetcher.tail(
+                start_time=self.start_time,
+                filter_pattern=self.filter_pattern,
+            )
 
-                expected_load_time_period_calls = [
-                    # First fetch returns data
-                    call(self.start_time, filter_pattern=self.filter_pattern),
-                    # Three empty fetches
-                    call(to_datetime(13), filter_pattern=self.filter_pattern),
-                    call(to_datetime(13), filter_pattern=self.filter_pattern),
-                    call(to_datetime(13), filter_pattern=self.filter_pattern),
-                ]
+            self.mock_client.filter_log_events.assert_has_calls([
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=10, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=13, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=13, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=13, filterPattern=self.filter_pattern
+                ),
+            ])
 
-                # One per poll
-                expected_sleep_calls = [call(self.poll_interval) for _ in expected_load_time_period_calls]
+            expected_load_time_period_calls = [
+                # First fetch returns data
+                call(self.start_time, filter_pattern=self.filter_pattern),
+                # Three empty fetches
+                call(to_datetime(13), filter_pattern=self.filter_pattern),
+                call(to_datetime(13), filter_pattern=self.filter_pattern),
+                call(to_datetime(13), filter_pattern=self.filter_pattern),
+            ]
 
-                consumer_call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+            # One per poll
+            expected_sleep_calls = [call(self.poll_interval) for _ in expected_load_time_period_calls]
 
-                self.assertEqual(self.mock_events1, consumer_call_args)
-                self.assertEqual(expected_sleep_calls, time_mock.sleep.call_args_list)
-                self.assertEqual(expected_load_time_period_calls, patched_load_time_period.call_args_list)
+            consumer_call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+
+            self.assertEqual(self.mock_events1, consumer_call_args)
+            self.assertEqual(expected_sleep_calls, time_mock.sleep.call_args_list)
+            self.assertEqual(expected_load_time_period_calls, patched_load_time_period.call_args_list)
 
     @patch("samcli.lib.observability.cw_logs.cw_log_puller.time")
     def test_must_tail_logs_with_multiple_data_fetches(self, time_mock):
-        expected_params = {
-            "logGroupName": self.log_group_name,
-            "interleaved": True,
-            "startTime": 10,
-            "filterPattern": self.filter_pattern,
-        }
-        expected_params_second_try = {
-            "logGroupName": self.log_group_name,
-            "interleaved": True,
-            "startTime": 13,
-            "filterPattern": self.filter_pattern,
-        }
-        expected_params_third_try = {
-            "logGroupName": self.log_group_name,
-            "interleaved": True,
-            "startTime": 15,
-            "filterPattern": self.filter_pattern,
-        }
-
-        self.client_stubber.add_response("filter_log_events", self.mock_api_response_1, expected_params)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params_second_try)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_response_2, expected_params_second_try)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params_third_try)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params_third_try)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params_third_try)
+        self.mock_client.filter_log_events.side_effect = [
+            self.mock_api_response_1,
+            self.mock_api_empty_response,
+            self.mock_api_response_2,
+            self.mock_api_empty_response,
+            self.mock_api_empty_response,
+            self.mock_api_empty_response,
+        ]
 
         expected_load_time_period_calls = [
             # First fetch returns data
@@ -315,14 +292,34 @@ class TestCWLogPuller_tail(TestCWLogPullerBase):
         with patch.object(
             self.fetcher, "load_time_period", wraps=self.fetcher.load_time_period
         ) as patched_load_time_period:
-            with self.client_stubber:
-                self.fetcher.tail(start_time=self.start_time, filter_pattern=self.filter_pattern)
+            self.fetcher.tail(start_time=self.start_time, filter_pattern=self.filter_pattern)
 
-                expected_consumer_call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+            self.mock_client.filter_log_events.assert_has_calls([
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=10, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=13, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=13, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=15, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=15, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=15, filterPattern=self.filter_pattern
+                )
+            ])
 
-                self.assertEqual(self.mock_events1 + self.mock_events2, expected_consumer_call_args)
-                self.assertEqual(expected_load_time_period_calls, patched_load_time_period.call_args_list)
-                self.assertEqual(expected_sleep_calls, time_mock.sleep.call_args_list)
+            expected_consumer_call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+
+            self.assertEqual(self.mock_events1 + self.mock_events2, expected_consumer_call_args)
+            self.assertEqual(expected_load_time_period_calls, patched_load_time_period.call_args_list)
+            self.assertEqual(expected_sleep_calls, time_mock.sleep.call_args_list)
 
     @patch("samcli.lib.observability.cw_logs.cw_log_puller.time")
     def test_without_start_time(self, time_mock):
@@ -332,9 +329,15 @@ class TestCWLogPuller_tail(TestCWLogPullerBase):
             "startTime": 0,
             "filterPattern": self.filter_pattern,
         }
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params)
-        self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params)
+        # self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params)
+        # self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params)
+        # self.client_stubber.add_response("filter_log_events", self.mock_api_empty_response, expected_params)
+
+        self.mock_client.filter_log_events.side_effect = [
+            self.mock_api_empty_response,
+            self.mock_api_empty_response,
+            self.mock_api_empty_response,
+        ]
 
         expected_load_time_period_calls = [
             # Three empty fetches, all with default start time
@@ -349,16 +352,27 @@ class TestCWLogPuller_tail(TestCWLogPullerBase):
         with patch.object(
             self.fetcher, "load_time_period", wraps=self.fetcher.load_time_period
         ) as patched_load_time_period:
-            with self.client_stubber:
-                self.fetcher.tail(
-                    filter_pattern=self.filter_pattern,
-                )
+            self.fetcher.tail(
+                filter_pattern=self.filter_pattern,
+            )
 
-                expected_consumer_call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+            self.mock_client.filter_log_events.assert_has_calls([
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=0, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=0, filterPattern=self.filter_pattern
+                ),
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=0, filterPattern=self.filter_pattern
+                ),
+            ])
 
-                self.assertEqual([], expected_consumer_call_args)
-                self.assertEqual(expected_load_time_period_calls, patched_load_time_period.call_args_list)
-                self.assertEqual(expected_sleep_calls, time_mock.sleep.call_args_list)
+            expected_consumer_call_args = [args[0] for (args, _) in self.consumer.consume.call_args_list]
+
+            self.assertEqual([], expected_consumer_call_args)
+            self.assertEqual(expected_load_time_period_calls, patched_load_time_period.call_args_list)
+            self.assertEqual(expected_sleep_calls, time_mock.sleep.call_args_list)
 
     @patch("samcli.lib.observability.cw_logs.cw_log_puller.time")
     def test_with_throttling(self, time_mock):
@@ -369,10 +383,10 @@ class TestCWLogPuller_tail(TestCWLogPullerBase):
             "filterPattern": self.filter_pattern,
         }
 
-        for _ in range(self.max_retries):
-            self.client_stubber.add_client_error(
-                "filter_log_events", expected_params=expected_params, service_error_code="ThrottlingException"
-            )
+        self.mock_client.filter_log_events.side_effect = [
+            ClientError({"Error": {"Code" : "ThrottlingException"}}, "filter_log_events")
+            for _ in range(self.max_retries)
+        ]
 
         expected_load_time_period_calls = [call(to_datetime(0), filter_pattern=ANY) for _ in range(self.max_retries)]
 
@@ -381,9 +395,15 @@ class TestCWLogPuller_tail(TestCWLogPullerBase):
         with patch.object(
             self.fetcher, "load_time_period", wraps=self.fetcher.load_time_period
         ) as patched_load_time_period:
-            with self.client_stubber:
-                self.fetcher.tail(filter_pattern=self.filter_pattern)
+            self.fetcher.tail(filter_pattern=self.filter_pattern)
 
-                self.consumer.consume.assert_not_called()
-                self.assertEqual(expected_load_time_period_calls, patched_load_time_period.call_args_list)
-                time_mock.sleep.assert_has_calls(expected_time_calls, any_order=True)
+            self.mock_client.filter_log_events.assert_has_calls([
+                call(
+                    logGroupName=self.log_group_name, interleaved=True, startTime=0, filterPattern=self.filter_pattern
+                )
+                for _ in range(self.max_retries)
+            ])
+
+            self.consumer.consume.assert_not_called()
+            self.assertEqual(expected_load_time_period_calls, patched_load_time_period.call_args_list)
+            time_mock.sleep.assert_has_calls(expected_time_calls, any_order=True)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Improve unit tests time to execute (cuts 40s out of 1min40s)

#### How does it address the issue?
Replace boto3 Stubber with Mock's


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
