### PR TITLE
feat: Collect Lambda authorizers in swagger definition

### DIFF
--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -52,7 +52,7 @@ class SwaggerParser:
         Returns
         -------
         dict[str, Authorizer]
-            Description here
+            A map of authorizer names and Authorizer objects found in the body definition
         """
         authorizers: Dict[str, Authorizer] = {}
 
@@ -108,6 +108,19 @@ class SwaggerParser:
         return authorizers
 
     def get_default_authorizer(self, event_type: str) -> Union[str, None]:
+        """
+        Parses the body definition to find root level Authorizer definitions
+
+        Parameters
+        ----------
+        event_type: str
+            String representing the type of API the definition body is defined as
+
+        Returns
+        -------
+        Union[str, None]
+            Returns the name of the authorizer, if there is one defined, otherwise None
+        """
         document_version = self.swagger.get("swagger") or self.swagger.get("openapi") or ""
         authorizers = self.swagger.get("security", [])
 

--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -1,14 +1,23 @@
 """Handles Swagger Parsing"""
 
 import logging
+from typing import List, Union, Dict
 
 from samcli.commands.local.lib.swagger.integration_uri import LambdaUri, IntegrationType
-from samcli.local.apigw.local_apigw_service import Route
+from samcli.local.apigw.local_apigw_service import Route, LambdaAuthorizer, Authorizer
+from samcli.local.apigw.exceptions import (
+    MultipleAuthorizerException,
+    IncorrectOasWithDefaultAuthorizerException,
+    InvalidOasVersion,
+    InvalidSecurityDefinition,
+)
 
 LOG = logging.getLogger(__name__)
 
 
 class SwaggerParser:
+    _AUTHORIZER_KEY = "x-amazon-apigateway-authorizer"
+    _AUTH_KEY = "x-amazon-apigateway-auth"
     _INTEGRATION_KEY = "x-amazon-apigateway-integration"
     _ANY_METHOD_EXTENSION_KEY = "x-amazon-apigateway-any-method"
     _BINARY_MEDIA_TYPES_EXTENSION_KEY = "x-amazon-apigateway-binary-media-types"  # pylint: disable=C0103
@@ -36,7 +45,93 @@ class SwaggerParser:
         """
         return self.swagger.get(self._BINARY_MEDIA_TYPES_EXTENSION_KEY) or []
 
-    def get_routes(self, event_type=Route.API):
+    def get_authorizers(self) -> Dict[str, Authorizer]:
+        """
+        Parse Swagger document and returns a list of Authorizer objects
+
+        Returns
+        -------
+        dict[str, Authorizer]
+            Description here
+        """
+        authorizers: Dict[str, Authorizer] = {}
+
+        authorizer_dict = {}
+        document_version = self.swagger.get("swagger") or self.swagger.get("openapi") or ""
+
+        if document_version.startswith("2."):
+            LOG.debug("Parsing Swagger document using 2.0 specification")
+            authorizer_dict = self.swagger.get("securityDefinitions", {})
+        elif document_version.startswith("3."):
+            LOG.debug("Parsing Swagger document using 3.0 specification")
+            authorizer_dict = self.swagger.get("components", {}).get("securitySchemes", {})
+        else:
+            raise InvalidOasVersion(
+                f"An invalid OpenApi version was detected: '{document_version}', must be one of 2.x or 3.x",
+            )
+
+        for auth_name, properties in authorizer_dict.items():
+            authorizer_object = properties.get(self._AUTHORIZER_KEY)
+
+            if authorizer_object:
+                valid_types = ["token", "request"]
+
+                authorizer_type = authorizer_object.get("type", "").lower()
+                payload_version = authorizer_object.get("authorizerPayloadFormatVersion", "1.0")
+
+                lambda_name = LambdaUri.get_function_name(authorizer_object.get("authorizerUri"))
+
+                if not lambda_name:
+                    LOG.warning(
+                        "Unable to parse authorizerUri '%s' for authorizer '%s', skipping", lambda_name, auth_name
+                    )
+
+                    continue
+
+                # only add authorizer if it is token or request based (not jwt)
+                if authorizer_type in valid_types and lambda_name:
+                    lambda_authorizer = LambdaAuthorizer(
+                        authorizer_name=auth_name,
+                        type=authorizer_type,
+                        payload_version=payload_version,
+                        lambda_name=lambda_name,
+                        identity_sources=[authorizer_object.get("identitySource")],
+                        validation_string=authorizer_object.get("identityValidationExpression"),
+                    )
+
+                    authorizers[auth_name] = lambda_authorizer
+                else:
+                    LOG.info("Lambda authorizer '%s' type '%s' is unsupported, skipping", auth_name, authorizer_type)
+            else:
+                LOG.info("Skip parsing unsupported authorizer %s", auth_name)
+
+        return authorizers
+
+    def get_default_authorizer(self, event_type: str) -> Union[str, None]:
+        document_version = self.swagger.get("swagger") or self.swagger.get("openapi") or ""
+        authorizers = self.swagger.get("security", [])
+
+        if document_version.startswith("3.") and event_type == Route.HTTP:
+            if len(authorizers) > 1:
+                raise MultipleAuthorizerException(
+                    f"There must only be a single authorizer defined for a single route, found '{len(authorizers)}'"
+                )
+
+            if len(authorizers) == 1:
+                auth_name = str(list(authorizers[0])[0])
+
+                LOG.debug("Found default authorizer: %s", auth_name)
+
+                return auth_name
+
+        if authorizers:
+            raise IncorrectOasWithDefaultAuthorizerException(
+                "Root level definition of default authorizers are only supported for OpenApi 3.0"
+            )
+
+        return None
+
+    def get_routes(self, event_type=Route.API) -> List[Route]:
         """
         Parses a swagger document and returns a list of APIs configured in the document.
 
@@ -73,7 +168,6 @@ class SwaggerParser:
 
         for full_path, path_config in paths_dict.items():
             for method, method_config in path_config.items():
-
                 function_name = self._get_integration_function_name(method_config)
                 if not function_name:
                     LOG.debug(
@@ -86,7 +180,34 @@ class SwaggerParser:
                 if method.lower() == self._ANY_METHOD_EXTENSION_KEY:
                     # Convert to a more commonly used method notation
                     method = self._ANY_METHOD
+
                 payload_format_version = self._get_payload_format_version(method_config)
+
+                authorizers = method_config.get("security", None)
+
+                if authorizers is None:
+                    # user has no security defined, set blank to use default
+                    authorizer = ""
+                else:
+                    if not isinstance(authorizers, list):
+                        raise InvalidSecurityDefinition(
+                            "Invalid security definition found, authorizers for "
+                            f"path='{full_path}' method='{method}' must be a list"
+                        )
+
+                    if len(authorizers) > 1:
+                        raise MultipleAuthorizerException(
+                            "There must only be a single authorizer defined "
+                            f"for a single route, found '{len(authorizers)}'"
+                        )
+
+                    if len(authorizers) == 1:
+                        # user has authorizer defined
+                        authorizer = str(list(authorizers[0])[0])
+                    else:
+                        # user has defined empty list, do not set authorizer
+                        authorizer = None
+
                 route = Route(
                     function_name,
                     full_path,
@@ -95,8 +216,10 @@ class SwaggerParser:
                     payload_format_version=payload_format_version,
                     operation_name=method_config.get("operationId"),
                     stack_path=self.stack_path,
+                    authorizer_name=authorizer,
                 )
                 result.append(route)
+
         return result
 
     def _get_integration(self, method_config):

--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -184,6 +184,7 @@ class SwaggerParser:
                 payload_format_version = self._get_payload_format_version(method_config)
 
                 authorizers = method_config.get("security", None)
+                authorizer = None
 
                 if authorizers is None:
                     # user has no security defined, set blank to use default
@@ -198,15 +199,12 @@ class SwaggerParser:
                     if len(authorizers) > 1:
                         raise MultipleAuthorizerException(
                             "There must only be a single authorizer defined "
-                            f"for a single route, found '{len(authorizers)}'"
+                            f"for path='{full_path}' method='{method}', found '{len(authorizers)}'"
                         )
 
                     if len(authorizers) == 1:
                         # user has authorizer defined
                         authorizer = str(list(authorizers[0])[0])
-                    else:
-                        # user has defined empty list, do not set authorizer
-                        authorizer = None
 
                 route = Route(
                     function_name,

--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -122,7 +122,7 @@ class SwaggerParser:
                 validation_expression = None
 
                 LOG.warning(
-                    "Validation expressions is only available on Rest APIs, " "ignoring for Lambda authorizer '%s'",
+                    "Validation expressions is only available on Rest APIs, ignoring for Lambda authorizer '%s'",
                     auth_name,
                 )
 
@@ -178,7 +178,7 @@ class SwaggerParser:
             header_name = properties.get(SwaggerParser._AUTHORIZER_NAME)
 
             if not properties.get(SwaggerParser._AUTHORIZER_IN) == "header" or not header_name:
-                LOG.info(
+                LOG.warning(
                     "Missing properties for Lambda Authorizer '%s', "
                     "property 'in' must be set to 'header' and "
                     "property 'name' must be provided",
@@ -192,7 +192,7 @@ class SwaggerParser:
             identity_source_string = authorizer_object.get(SwaggerParser._AUTHORIZER_IDENTITY_SOURCE)
 
             if not identity_source_string:
-                LOG.info(
+                LOG.warning(
                     "Missing property 'identitySource' in the authorizer integration for Lambda Authorizer '%s'",
                     auth_name,
                 )

--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -234,11 +234,21 @@ class SwaggerParser:
             )
 
         if len(authorizers) == 1:
-            auth_name = str(list(authorizers[0])[0])
+            # user has authorizer defined
+            authorizer_object = authorizers[0]
+            authorizer_object = list(authorizers[0])
 
-            LOG.debug("Found default authorizer: %s", auth_name)
+            # make sure that authorizer actually has keys
+            if len(authorizer_object) != 1:
+                raise InvalidSecurityDefinition(
+                    "Invalid default security definition found, there must " "be an authorizer defined."
+                )
 
-            return auth_name
+            authorizer_name = str(authorizer_object[0])
+
+            LOG.debug("Found default authorizer: %s", authorizer_name)
+
+            return authorizer_name
 
         return None
 

--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -95,56 +95,56 @@ class SwaggerParser:
         for auth_name, properties in authorizer_dict.items():
             authorizer_object = properties.get(self._AUTHORIZER_KEY)
 
-            if authorizer_object:
-                authorizer_type = authorizer_object.get(SwaggerParser._AUTHORIZER_TYPE, "").lower()
-                payload_version = authorizer_object.get(SwaggerParser._AUTHORIZER_PAYLOAD_VERSION, "1.0")
-
-                lambda_name = LambdaUri.get_function_name(authorizer_object.get(SwaggerParser._AUTHORIZER_LAMBDA_URI))
-
-                if not lambda_name:
-                    LOG.warning(
-                        "Unable to parse authorizerUri '%s' for authorizer '%s', skipping", lambda_name, auth_name
-                    )
-
-                    continue
-
-                # only add authorizer if it is Lambda token or request based (not jwt)
-                if authorizer_type in LambdaAuthorizer.VALID_TYPES and lambda_name:
-                    identity_sources = self._get_lambda_identity_sources(
-                        auth_name, authorizer_type, event_type, properties, authorizer_object
-                    )
-
-                    validation_expression = authorizer_object.get(SwaggerParser._AUTHORIZER_LAMBDA_VALIDATION)
-                    if event_type != Route.HTTP:
-                        validation_expression = None
-                        LOG.info(
-                            "Validation expressions is only available on Rest APIs, "
-                            "ignoring for Lambda authorizer '%s'",
-                            auth_name,
-                        )
-
-                    if identity_sources:
-                        lambda_authorizer = LambdaAuthorizer(
-                            authorizer_name=auth_name,
-                            type=authorizer_type,
-                            payload_version=payload_version,
-                            lambda_name=lambda_name,
-                            identity_sources=identity_sources,
-                            validation_string=validation_expression,
-                        )
-
-                        authorizers[auth_name] = lambda_authorizer
-
-                        LOG.info("Parsing Lambda authorizer '%s' type '%s'", auth_name, authorizer_type)
-                    else:
-                        LOG.warning(
-                            "Skip parsing Lambda authorizer '%s', must contain at least valid identity source",
-                            auth_name,
-                        )
-                else:
-                    LOG.warning("Lambda authorizer '%s' type '%s' is unsupported, skipping", auth_name, authorizer_type)
-            else:
+            if not authorizer_object:
                 LOG.warning("Skip parsing unsupported authorizer '%s'", auth_name)
+                continue
+
+            authorizer_type = authorizer_object.get(SwaggerParser._AUTHORIZER_TYPE, "").lower()
+            payload_version = authorizer_object.get(SwaggerParser._AUTHORIZER_PAYLOAD_VERSION, "1.0")
+
+            lambda_name = LambdaUri.get_function_name(authorizer_object.get(SwaggerParser._AUTHORIZER_LAMBDA_URI))
+
+            if not lambda_name:
+                LOG.warning("Unable to parse authorizerUri '%s' for authorizer '%s', skipping", lambda_name, auth_name)
+                continue
+
+            # only add authorizer if it is Lambda token or request based (not jwt)
+            if not authorizer_type in LambdaAuthorizer.VALID_TYPES:
+                LOG.warning("Lambda authorizer '%s' type '%s' is unsupported, skipping", auth_name, authorizer_type)
+                continue
+
+            identity_sources = self._get_lambda_identity_sources(
+                auth_name, authorizer_type, event_type, properties, authorizer_object
+            )
+
+            validation_expression = authorizer_object.get(SwaggerParser._AUTHORIZER_LAMBDA_VALIDATION)
+            if event_type != Route.HTTP:
+                validation_expression = None
+
+                LOG.warning(
+                    "Validation expressions is only available on Rest APIs, " "ignoring for Lambda authorizer '%s'",
+                    auth_name,
+                )
+
+            if not identity_sources:
+                LOG.warning(
+                    "Skip parsing Lambda authorizer '%s', must contain at least valid identity source",
+                    auth_name,
+                )
+                continue
+
+            lambda_authorizer = LambdaAuthorizer(
+                authorizer_name=auth_name,
+                type=authorizer_type,
+                payload_version=payload_version,
+                lambda_name=lambda_name,
+                identity_sources=identity_sources,
+                validation_string=validation_expression,
+            )
+
+            authorizers[auth_name] = lambda_authorizer
+
+            LOG.debug("Parsing Lambda authorizer '%s' type '%s'", auth_name, authorizer_type)
 
         return authorizers
 
@@ -220,23 +220,25 @@ class SwaggerParser:
         document_version = self.swagger.get(SwaggerParser._SWAGGER) or self.swagger.get(SwaggerParser._OPENAPI) or ""
         authorizers = self.swagger.get(SwaggerParser._SWAGGER_SECURITY, [])
 
-        if document_version.startswith(SwaggerParser._3_X_VERSION) and event_type == Route.HTTP:
-            if len(authorizers) > 1:
-                raise MultipleAuthorizerException(
-                    f"There must only be a single authorizer defined for a single route, found '{len(authorizers)}'"
-                )
+        if not authorizers:
+            return None
 
-            if len(authorizers) == 1:
-                auth_name = str(list(authorizers[0])[0])
-
-                LOG.debug("Found default authorizer: %s", auth_name)
-
-                return auth_name
-
-        if authorizers:
+        if not document_version.startswith(SwaggerParser._3_X_VERSION) or not event_type == Route.HTTP:
             raise IncorrectOasWithDefaultAuthorizerException(
                 "Root level definition of default authorizers are only supported for OpenApi 3.0"
             )
+
+        if len(authorizers) > 1:
+            raise MultipleAuthorizerException(
+                f"There must only be a single authorizer defined for a single route, found '{len(authorizers)}'"
+            )
+
+        if len(authorizers) == 1:
+            auth_name = str(list(authorizers[0])[0])
+
+            LOG.debug("Found default authorizer: %s", auth_name)
+
+            return auth_name
 
         return None
 
@@ -293,11 +295,11 @@ class SwaggerParser:
                 payload_format_version = self._get_payload_format_version(method_config)
 
                 authorizers = method_config.get(SwaggerParser._SWAGGER_SECURITY, None)
-                authorizer = None
+                authorizer_name = None
 
                 if authorizers is None:
                     # user has no security defined, set blank to use default
-                    authorizer = ""
+                    authorizer_name = ""
                 else:
                     if not isinstance(authorizers, list):
                         raise InvalidSecurityDefinition(
@@ -313,7 +315,17 @@ class SwaggerParser:
 
                     if len(authorizers) == 1:
                         # user has authorizer defined
-                        authorizer = str(list(authorizers[0])[0])
+                        authorizer_object = authorizers[0]
+                        authorizer_object = list(authorizers[0])
+
+                        # make sure that authorizer actually has keys
+                        if len(authorizer_object) != 1:
+                            raise InvalidSecurityDefinition(
+                                "Invalid security definition found, authorizers for "
+                                f"path='{full_path}' method='{method}' must contain an authorizer"
+                            )
+
+                        authorizer_name = str(authorizer_object[0])
 
                 route = Route(
                     function_name,
@@ -323,7 +335,7 @@ class SwaggerParser:
                     payload_format_version=payload_format_version,
                     operation_name=method_config.get("operationId"),
                     stack_path=self.stack_path,
-                    authorizer_name=authorizer,
+                    authorizer_name=authorizer_name,
                 )
                 result.append(route)
 

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -81,8 +81,8 @@ class ApiCollector:
 
             for route in routes:
                 if route.authorizer_name is None:
-                    LOG.info(
-                        "Linking authorizer skipped, route '%s' has unset all authorizers",
+                    LOG.debug(
+                        "Linking authorizer skipped, route '%s' is set to not use any authorizer.",
                         route.path,
                     )
 

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -95,7 +95,7 @@ class ApiCollector:
                     route.authorizer_name = authorizer_name_lookup
                     route.authorizer_object = authorizer_object
 
-                    LOG.info(
+                    LOG.debug(
                         "Linking authorizer '%s', for route '%s'",
                         route.authorizer_name,
                         route.path,

--- a/samcli/lib/providers/cfn_base_api_provider.py
+++ b/samcli/lib/providers/cfn_base_api_provider.py
@@ -82,7 +82,7 @@ class CfnBaseApiProvider:
         swagger = reader.read()
         parser = SwaggerParser(stack_path, swagger)
 
-        authorizers = parser.get_authorizers()
+        authorizers = parser.get_authorizers(event_type)
         default_authorizer = parser.get_default_authorizer(event_type)
 
         routes = parser.get_routes(event_type)

--- a/samcli/lib/providers/cfn_base_api_provider.py
+++ b/samcli/lib/providers/cfn_base_api_provider.py
@@ -63,7 +63,6 @@ class CfnBaseApiProvider:
         ----------
         stack_path : str
             Path of the stack the resource is located
-
         logical_id : str
             Logical ID of the resource
         body : dict
@@ -82,10 +81,20 @@ class CfnBaseApiProvider:
         reader = SwaggerReader(definition_body=body, definition_uri=uri, working_dir=cwd)
         swagger = reader.read()
         parser = SwaggerParser(stack_path, swagger)
+
+        authorizers = parser.get_authorizers()
+        default_authorizer = parser.get_default_authorizer(event_type)
+
         routes = parser.get_routes(event_type)
+
         LOG.debug("Found '%s' APIs in resource '%s'", len(routes), logical_id)
+        LOG.debug("Found '%s' authorizers in resource '%s'", len(authorizers), logical_id)
 
         collector.add_routes(logical_id, routes)
+        collector.add_authorizers(logical_id, authorizers)
+
+        if default_authorizer:
+            collector.set_default_authorizer(logical_id, default_authorizer)
 
         collector.add_binary_media_types(logical_id, parser.get_binary_media_types())  # Binary media from swagger
         collector.add_binary_media_types(logical_id, binary_media)  # Binary media specified on resource in template

--- a/samcli/local/apigw/exceptions.py
+++ b/samcli/local/apigw/exceptions.py
@@ -1,0 +1,40 @@
+"""
+Exceptions used by API Gateway service
+"""
+from samcli.commands.exceptions import UserException
+
+
+class LambdaResponseParseException(Exception):
+    """
+    An exception raised when we fail to parse the response for Lambda
+    """
+
+
+class PayloadFormatVersionValidateException(Exception):
+    """
+    An exception raised when validation of payload format version fails
+    """
+
+
+class MultipleAuthorizerException(UserException):
+    """
+    An exception raised when user lists more than one Authorizer
+    """
+
+
+class IncorrectOasWithDefaultAuthorizerException(UserException):
+    """
+    An exception raised when the user provides root level Authorizers using the wrong OpenAPI Specification versions
+    """
+
+
+class InvalidOasVersion(UserException):
+    """
+    An exception raised when the user provides an invalid OpenAPI Specificaion version
+    """
+
+
+class InvalidSecurityDefinition(UserException):
+    """
+    An exception raised when the user provides an invalid security definition
+    """

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -42,6 +42,10 @@ class Authorizer:
 
 @dataclass
 class LambdaAuthorizer(Authorizer):
+    TOKEN = "token"
+    REQUEST = "request"
+    VALID_TYPES = [TOKEN, REQUEST]
+
     lambda_name: str
     identity_sources: List[str]
     validation_string: Optional[str] = None

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -1,4 +1,7 @@
 """API Gateway Local Service"""
+# pylint: disable=too-many-lines
+# TODO (lucashuy): this module needs to be refactored
+
 from dataclasses import dataclass
 import io
 import json

--- a/tests/unit/commands/local/lib/swagger/test_parser.py
+++ b/tests/unit/commands/local/lib/swagger/test_parser.py
@@ -466,7 +466,7 @@ class TestSwaggerParser_get_authorizers(TestCase):
         ]
     )
     @patch("samcli.commands.local.lib.swagger.parser.LambdaUri")
-    def test_with_valid_definition(self, swagger_doc, expected_authorizers, mock_lambda_uri):
+    def test_with_valid_lambda_auth_definition(self, swagger_doc, expected_authorizers, mock_lambda_uri):
         mock_lambda_uri.get_function_name.return_value = "arn"
 
         parser = SwaggerParser(Mock(), swagger_doc)
@@ -518,13 +518,13 @@ class TestSwaggerParser_get_authorizers(TestCase):
         ]
     )
     @patch("samcli.commands.local.lib.swagger.parser.LambdaUri")
-    def test_unsupported_authorizers(self, swagger_doc, mock_lambda_uri):
+    def test_unsupported_lambda_authorizers(self, swagger_doc, mock_lambda_uri):
         parser = SwaggerParser(Mock(), swagger_doc)
 
         self.assertEqual(parser.get_authorizers(), {})
 
     @patch("samcli.commands.local.lib.swagger.parser.LambdaUri")
-    def test_invalid_arn(self, mock_lambda_uri):
+    def test_invalid_lambda_auth_arn(self, mock_lambda_uri):
         mock_lambda_uri.get_function_name.return_value = None
 
         swagger_doc = {
@@ -627,6 +627,8 @@ class TestSwaggerParser_get_default_authorizer(TestCase):
         [
             ({"openapi": "3.0", "security": []},),
             ({"swagger": "2.0", "security": []},),
+            ({"openapi": "3.0"},),
+            ({"swagger": "2.0"},),
         ]
     )
     def test_no_default_authorizer_defined(self, swagger):

--- a/tests/unit/commands/local/lib/test_api_collector.py
+++ b/tests/unit/commands/local/lib/test_api_collector.py
@@ -1,0 +1,131 @@
+from unittest import TestCase
+from parameterized import parameterized
+
+from samcli.lib.providers.api_collector import ApiCollector
+from samcli.local.apigw.local_apigw_service import Route, Authorizer
+
+
+class TestApiCollector_linking_authorizer(TestCase):
+    def setUp(self):
+        self.apigw_id = "apigw1"
+
+        self.api_collector = ApiCollector()
+
+    @parameterized.expand(
+        [
+            (  # test link default authorizer
+                [Route(function_name="func1", path="path1", methods=["get"], stack_path="path1", authorizer_name="")],
+                {
+                    "auth1": Authorizer(authorizer_name="auth1", type="token1", payload_version="1.0"),
+                    "auth2": Authorizer(authorizer_name="auth2", type="token2", payload_version="1.0"),
+                },
+                "auth1",
+                [
+                    Route(
+                        function_name="func1",
+                        path="path1",
+                        methods=["get"],
+                        stack_path="path1",
+                        authorizer_name="auth1",
+                        authorizer_object=Authorizer(authorizer_name="auth1", type="token1", payload_version="1.0"),
+                    )
+                ],
+            ),
+            (  # test link non existant default authorizer
+                [Route(function_name="func1", path="path1", methods=["get"], stack_path="path1", authorizer_name="")],
+                {
+                    "auth1": Authorizer(authorizer_name="auth1", type="token1", payload_version="1.0"),
+                    "auth2": Authorizer(authorizer_name="auth2", type="token2", payload_version="1.0"),
+                },
+                None,
+                [
+                    Route(
+                        function_name="func1",
+                        path="path1",
+                        methods=["get"],
+                        stack_path="path1",
+                        authorizer_name=None,
+                        authorizer_object=None,
+                    )
+                ],
+            ),
+            (  # test no authorizer defined in route
+                [Route(function_name="func1", path="path1", methods=["get"], stack_path="path1", authorizer_name=None)],
+                {
+                    "auth1": Authorizer(authorizer_name="auth1", type="token1", payload_version="1.0"),
+                    "auth2": Authorizer(authorizer_name="auth2", type="token2", payload_version="1.0"),
+                },
+                "auth1",
+                [
+                    Route(
+                        function_name="func1",
+                        path="path1",
+                        methods=["get"],
+                        stack_path="path1",
+                        authorizer_name=None,
+                        authorizer_object=None,
+                    )
+                ],
+            ),
+            (  # test linking defined authorizer
+                [
+                    Route(
+                        function_name="func1",
+                        path="path1",
+                        methods=["get"],
+                        stack_path="path1",
+                        authorizer_name="auth2",
+                    )
+                ],
+                {
+                    "auth1": Authorizer(authorizer_name="auth1", type="token1", payload_version="1.0"),
+                    "auth2": Authorizer(authorizer_name="auth2", type="token2", payload_version="1.0"),
+                },
+                "auth1",
+                [
+                    Route(
+                        function_name="func1",
+                        path="path1",
+                        methods=["get"],
+                        stack_path="path1",
+                        authorizer_name="auth2",
+                        authorizer_object=Authorizer(authorizer_name="auth2", type="token2", payload_version="1.0"),
+                    )
+                ],
+            ),
+            (  # test linking unsupported authorizer
+                [
+                    Route(
+                        function_name="func1",
+                        path="path1",
+                        methods=["get"],
+                        stack_path="path1",
+                        authorizer_name="unsupported",
+                    )
+                ],
+                {
+                    "auth1": Authorizer(authorizer_name="auth1", type="token1", payload_version="1.0"),
+                    "auth2": Authorizer(authorizer_name="auth2", type="token2", payload_version="1.0"),
+                },
+                "auth1",
+                [
+                    Route(
+                        function_name="func1",
+                        path="path1",
+                        methods=["get"],
+                        stack_path="path1",
+                        authorizer_name=None,
+                        authorizer_object=None,
+                    )
+                ],
+            ),
+        ]
+    )
+    def test_link_authorizers(self, routes, authorizers, default_authorizer, expected_routes):
+        self.api_collector._route_per_resource[self.apigw_id] = routes
+        self.api_collector._authorizers_per_resources[self.apigw_id] = authorizers
+        self.api_collector._default_authorizer_per_resource[self.apigw_id] = default_authorizer
+
+        self.api_collector._link_authorizers()
+
+        self.assertEqual(self.api_collector._route_per_resource, {self.apigw_id: expected_routes})

--- a/tests/unit/commands/local/lib/test_cfn_api_provider.py
+++ b/tests/unit/commands/local/lib/test_cfn_api_provider.py
@@ -169,6 +169,7 @@ class TestCloudFormationStageValues(TestCase):
                     "Type": "AWS::ApiGateway::RestApi",
                     "Properties": {
                         "Body": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path": {
                                     "get": {
@@ -183,7 +184,7 @@ class TestCloudFormationStageValues(TestCase):
                                         }
                                     }
                                 }
-                            }
+                            },
                         }
                     },
                 },
@@ -211,6 +212,7 @@ class TestCloudFormationStageValues(TestCase):
                     "Type": "AWS::ApiGateway::RestApi",
                     "Properties": {
                         "Body": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path": {
                                     "get": {
@@ -225,7 +227,7 @@ class TestCloudFormationStageValues(TestCase):
                                         }
                                     }
                                 }
-                            }
+                            },
                         }
                     },
                 },
@@ -244,6 +246,7 @@ class TestCloudFormationStageValues(TestCase):
                     "Type": "AWS::ApiGateway::RestApi",
                     "Properties": {
                         "Body": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path": {
                                     "get": {
@@ -271,7 +274,7 @@ class TestCloudFormationStageValues(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         }
                     },
                 }
@@ -964,6 +967,7 @@ class TestCloudFormationWithApiGatewayV2Stage(TestCase):
                     "Type": "AWS::ApiGatewayV2::Api",
                     "Properties": {
                         "Body": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path": {
                                     "get": {
@@ -978,7 +982,7 @@ class TestCloudFormationWithApiGatewayV2Stage(TestCase):
                                         }
                                     }
                                 }
-                            }
+                            },
                         }
                     },
                 },
@@ -1006,6 +1010,7 @@ class TestCloudFormationWithApiGatewayV2Stage(TestCase):
                     "Type": "AWS::ApiGatewayV2::Api",
                     "Properties": {
                         "Body": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path": {
                                     "get": {
@@ -1020,7 +1025,7 @@ class TestCloudFormationWithApiGatewayV2Stage(TestCase):
                                         }
                                     }
                                 }
-                            }
+                            },
                         }
                     },
                 },
@@ -1039,6 +1044,7 @@ class TestCloudFormationWithApiGatewayV2Stage(TestCase):
                     "Type": "AWS::ApiGatewayV2::Api",
                     "Properties": {
                         "Body": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path": {
                                     "get": {
@@ -1066,7 +1072,7 @@ class TestCloudFormationWithApiGatewayV2Stage(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         }
                     },
                 }

--- a/tests/unit/commands/local/lib/test_sam_api_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_api_provider.py
@@ -745,6 +745,7 @@ class TestSamStageValues(TestCase):
                     "Properties": {
                         "StageName": "dev",
                         "DefinitionBody": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path": {
                                     "get": {
@@ -759,7 +760,7 @@ class TestSamStageValues(TestCase):
                                         }
                                     }
                                 }
-                            }
+                            },
                         },
                     },
                 }
@@ -781,6 +782,7 @@ class TestSamStageValues(TestCase):
                         "StageName": "dev",
                         "Variables": {"vis": "data", "random": "test", "foo": "bar"},
                         "DefinitionBody": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path": {
                                     "get": {
@@ -795,7 +797,7 @@ class TestSamStageValues(TestCase):
                                         }
                                     }
                                 }
-                            }
+                            },
                         },
                     },
                 }
@@ -816,6 +818,7 @@ class TestSamStageValues(TestCase):
                 "StageName": "dev",
                 "Variables": {"vis": "data", "random": "test", "foo": "bar"},
                 "DefinitionBody": {
+                    "swagger": "2.0",
                     "paths": {
                         "/path2": {
                             "get": {
@@ -830,7 +833,7 @@ class TestSamStageValues(TestCase):
                                 }
                             }
                         }
-                    }
+                    },
                 },
             },
         }
@@ -841,6 +844,7 @@ class TestSamStageValues(TestCase):
                 "StageName": "Production",
                 "Variables": {"vis": "prod data", "random": "test", "foo": "bar"},
                 "DefinitionBody": {
+                    "swagger": "2.0",
                     "paths": {
                         "/path": {
                             "get": {
@@ -868,7 +872,7 @@ class TestSamStageValues(TestCase):
                                 }
                             }
                         },
-                    }
+                    },
                 },
             },
         }
@@ -900,6 +904,7 @@ class TestSamCors(TestCase):
                         "StageName": "Prod",
                         "Cors": {"AllowOrigin": {"Fn:Sub": "Some string to sub"}},
                         "DefinitionBody": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -925,7 +930,7 @@ class TestSamCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -956,6 +961,7 @@ class TestSamCors(TestCase):
                         "StageName": "Prod",
                         "Cors": "'*'",
                         "DefinitionBody": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -981,7 +987,7 @@ class TestSamCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1017,6 +1023,7 @@ class TestSamCors(TestCase):
                             "MaxAge": "'600'",
                         },
                         "DefinitionBody": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -1042,7 +1049,7 @@ class TestSamCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1080,6 +1087,7 @@ class TestSamCors(TestCase):
                             "MaxAge": "'600'",
                         },
                         "DefinitionBody": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -1105,7 +1113,7 @@ class TestSamCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1283,6 +1291,7 @@ class TestSamCors(TestCase):
                         "StageName": "Prod",
                         "Cors": {"AllowOrigin": "'www.domain.com'"},
                         "DefinitionBody": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path2": {
                                     "get": {
@@ -1297,7 +1306,7 @@ class TestSamCors(TestCase):
                                         }
                                     }
                                 }
-                            }
+                            },
                         },
                     },
                 }
@@ -1331,6 +1340,7 @@ class TestSamCors(TestCase):
                     "Properties": {
                         "StageName": "Prod",
                         "DefinitionBody": {
+                            "swagger": "2.0",
                             "paths": {
                                 "/path2": {
                                     "get": {
@@ -1356,7 +1366,7 @@ class TestSamCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1391,6 +1401,7 @@ class TestSamHttpApiCors(TestCase):
                         "StageName": "Prod",
                         "CorsConfiguration": {"AllowOrigins": {"Fn:Sub": "Some string to sub"}},
                         "DefinitionBody": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -1416,7 +1427,7 @@ class TestSamHttpApiCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1447,6 +1458,7 @@ class TestSamHttpApiCors(TestCase):
                         "StageName": "Prod",
                         "CorsConfiguration": True,
                         "DefinitionBody": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -1472,7 +1484,7 @@ class TestSamHttpApiCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1503,6 +1515,7 @@ class TestSamHttpApiCors(TestCase):
                         "StageName": "Prod",
                         "CorsConfiguration": False,
                         "DefinitionBody": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -1528,7 +1541,7 @@ class TestSamHttpApiCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1561,6 +1574,7 @@ class TestSamHttpApiCors(TestCase):
                             "MaxAge": 600,
                         },
                         "DefinitionBody": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -1586,7 +1600,7 @@ class TestSamHttpApiCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1624,6 +1638,7 @@ class TestSamHttpApiCors(TestCase):
                             "MaxAge": 600,
                         },
                         "DefinitionBody": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path2": {
                                     "post": {
@@ -1649,7 +1664,7 @@ class TestSamHttpApiCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1732,6 +1747,7 @@ class TestSamHttpApiCors(TestCase):
                         "StageName": "Prod",
                         "CorsConfiguration": {"AllowOrigins": ["www.domain.com"]},
                         "DefinitionBody": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path2": {
                                     "get": {
@@ -1746,7 +1762,7 @@ class TestSamHttpApiCors(TestCase):
                                         }
                                     }
                                 }
-                            }
+                            },
                         },
                     },
                 }
@@ -1780,6 +1796,7 @@ class TestSamHttpApiCors(TestCase):
                     "Properties": {
                         "StageName": "Prod",
                         "DefinitionBody": {
+                            "openapi": "3.0",
                             "paths": {
                                 "/path2": {
                                     "get": {
@@ -1805,7 +1822,7 @@ class TestSamHttpApiCors(TestCase):
                                         }
                                     }
                                 },
-                            }
+                            },
                         },
                     },
                 }
@@ -1845,7 +1862,7 @@ def make_swagger(routes, binary_media_types=None):
         Swagger document
 
     """
-    swagger = {"paths": {}}
+    swagger = {"paths": {}, "swagger": "2.0"}
 
     for api in routes:
         swagger["paths"].setdefault(api.path, {})

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -14,10 +14,9 @@ from samcli.lib.providers.provider import Cors
 from samcli.local.apigw.local_apigw_service import (
     LocalApigwService,
     Route,
-    LambdaResponseParseException,
-    PayloadFormatVersionValidateException,
     CatchAllPathConverter,
 )
+from samcli.local.apigw.exceptions import LambdaResponseParseException, PayloadFormatVersionValidateException
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 
 


### PR DESCRIPTION
#### Why is this change necessary?
This change adds the basic foundation for Authorizer support for `start-api`. This PR collects and adds Lambda authorizers that are defined in the body definition for `AWS::Serverless::Api`, and AWS::Serverless::HttpApi` resources.

This change also adds linking of valid Authorizers and those found in the routes.

#### How does it address the issue?
Adds base dataclasses for Authorizers and modifies existing Swagger route collection logic to also collect and link Authorizers.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
