### PR TITLE
Move up BuildFunctionRuntime Event to track failed builds by runtime

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -258,12 +258,12 @@ class BuildContext:
         try:
             self._check_exclude_warning()
 
+            for f in self.get_resources_to_build().functions:
+                EventTracker.track_event("BuildFunctionRuntime", f.runtime)
+
             build_result = builder.build()
 
             self._handle_build_post_processing(builder, build_result)
-
-            for f in self.get_resources_to_build().functions:
-                EventTracker.track_event("BuildFunctionRuntime", f.runtime)
 
             click.secho("\nBuild Succeeded", fg="green")
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
The inability to match the runtime, such as 'provided.al2' to failed builds.


#### Why is this change necessary?
So that the runtime of failed builds can be correlated by request ID

#### How does it address the issue?
It moves the EventTracker before the build happens, so if the build fails, the EventTracker has already run

#### What side effects does this change have?
There could be something today that assumes that BuildFunctionRuntime means the build was successful, which will no longer be the case.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
