### PR TITLE
feat: Only stream command output to stdout

### DIFF
--- a/samcli/commands/list/cli_common/options.py
+++ b/samcli/commands/list/cli_common/options.py
@@ -34,9 +34,15 @@ def output_option(f):
     return output_click_option()(f)
 
 
+STACK_NAME_WARNING_MESSAGE = (
+    "The --stack-name options was not provided, displaying only local template data. "
+    "To see data about deployed resources, provide the corresponding stack name."
+)
+
+
 def stack_name_not_provided_message():
     click.secho(
         fg="yellow",
-        message="The --stack-name options was not provided, displaying only local template data. "
-        "To see data about deployed resources, provide the corresponding stack name.",
+        message=STACK_NAME_WARNING_MESSAGE,
+        err=True,
     )

--- a/tests/unit/commands/list/test_options.py
+++ b/tests/unit/commands/list/test_options.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from samcli.commands.list.cli_common.options import stack_name_not_provided_message, STACK_NAME_WARNING_MESSAGE
+
+
+class TestCommonOptions(TestCase):
+    @patch("samcli.commands.list.cli_common.options.click")
+    def test_echoes_warning_messages(self, mock_click):
+        stack_name_not_provided_message()
+        mock_click.secho.assert_called_once_with(
+            fg="yellow",
+            message=STACK_NAME_WARNING_MESSAGE,
+            err=True,
+        )


### PR DESCRIPTION
Since `sam list` is a command that can be used programmatically with the `json` output format, we should reserve the `stdout` stream to be exclusively the output of the command, similar to how `sam local invoke` works today. 

This PR changes the warning message to use `stderr` instead.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
