### PR TITLE
fix: Return non-zero exit code on lint failures

### DIFF
--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -139,3 +139,9 @@ class InvalidStackNameException(UserException):
     """
     Value provided to --stack-name is invalid
     """
+
+
+class LinterRuleMatchedException(UserException):
+    """
+    The linter matched a rule meaning that the template linting failed
+    """

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -162,3 +162,4 @@ class TestValidate(TestCase):
         )
 
         self.assertIn(warning_message, output)
+        self.assertEqual(command_result.process.returncode, 1)

--- a/tests/unit/commands/validate/test_cli.py
+++ b/tests/unit/commands/validate/test_cli.py
@@ -6,7 +6,7 @@ from botocore.exceptions import NoCredentialsError
 
 from cfnlint.core import CfnLintExitException, InvalidRegionException  # type: ignore
 
-from samcli.commands.exceptions import UserException
+from samcli.commands.exceptions import UserException, LinterRuleMatchedException
 from samcli.commands.local.cli_common.user_exceptions import SamTemplateNotFoundException, InvalidSamTemplateException
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.validate.validate import do_cli, _read_sam_file, _lint
@@ -124,5 +124,19 @@ class TestValidateCli(TestCase):
         template_path = "path_to_template"
 
         with patch("samcli.lib.telemetry.event.EventTracker.track_event") as track_patch:
-            _lint(ctx=ctx_lint_mock(debug=False, region="region"), template=template_path)
+            with self.assertRaises(LinterRuleMatchedException):
+                _lint(ctx=ctx_lint_mock(debug=False, region="region"), template=template_path)
             track_patch.assert_called_with("UsedFeature", "CFNLint")
+
+    @patch("cfnlint.core.get_args_filenames")
+    @patch("cfnlint.core.get_matches")
+    @patch("samcli.commands.validate.validate.click")
+    def test_linter_raises_exception_if_matches_found(self, click_patch, matches_patch, args_patch):
+        template_path = "path_to_template"
+        args_patch.return_value = ("A", "B", Mock())
+        matches_patch.return_value = ["Failed rule A", "Failed rule B"]
+        with self.assertRaises(LinterRuleMatchedException) as ex:
+            _lint(ctx=ctx_lint_mock(debug=False, region="region"), template=template_path)
+        self.assertEqual(
+            ex.exception.message, "Linting failed. At least one linting rule was matched to the provided template."
+        )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#4649


#### Why is this change necessary?
Currently, `sam validate --lint` returns a 0 return code even if lint errors occurred.

#### How does it address the issue?
Raises an exception if any lint rules matched, which will propagate up and will exit the process with a return code of 1. 

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
