### PR TITLE
chore: fix sam local and sam sync integration tests

### DIFF
--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -225,7 +225,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
                 "errorMessage": "Lambda is raising an exception",
                 "errorType": "Exception",
                 "stackTrace": [
-                    ["/var/task/main.py", 51, "raise_exception", 'raise Exception("Lambda is raising an exception")']
+                    '  File "/var/task/main.py", line 51, in raise_exception\n    raise Exception("Lambda is raising an exception")\n'
                 ],
             },
         )

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -145,30 +145,18 @@ class TestSyncCode(TestSyncCodeBase):
             layer_contents = self.get_dependency_layer_contents_from_arn(self.stack_resources, "python", 2)
             self.assertIn("requests", layer_contents)
 
-    @parameterized.expand(
-        [
-            ("layer", "HelloWorldLayer", "HelloWorldFunction", "7"),
-            (
-                "layer_without_build_method",
-                "HelloWorldLayerWithoutBuildMethod",
-                "HelloWorldFunctionWithLayerWithoutBuild",
-                "30",
-            ),
-            ("layer_zip", "HelloWorldPreBuiltZipLayer", "HelloWorldFunctionWithPreBuiltLayer", "50"),
-        ]
-    )
-    def test_sync_code_layer(self, layer_path, layer_logical_id, function_logical_id, expected_value):
-        shutil.rmtree(TestSyncCodeBase.temp_dir.joinpath(layer_path), ignore_errors=True)
+    def test_sync_code_layer(self):
+        shutil.rmtree(TestSyncCodeBase.temp_dir.joinpath("layer"), ignore_errors=True)
         shutil.copytree(
-            self.test_data_path.joinpath(self.folder).joinpath("after").joinpath(layer_path),
-            TestSyncCodeBase.temp_dir.joinpath(layer_path),
+            self.test_data_path.joinpath(self.folder).joinpath("after").joinpath("layer"),
+            TestSyncCodeBase.temp_dir.joinpath("layer"),
         )
         # Run code sync
         sync_command_list = self.get_sync_command_list(
             template_file=TestSyncCodeBase.template_path,
             code=True,
             watch=False,
-            resource_id_list=[layer_logical_id],
+            resource_list=["AWS::Serverless::LayerVersion"],
             dependency_layer=self.dependency_layer,
             stack_name=TestSyncCodeBase.stack_name,
             parameter_overrides="Parameter=Clarity",
@@ -186,10 +174,10 @@ class TestSyncCode(TestSyncCodeBase):
         # Lambda Api call here, which tests both the python function and the layer
         lambda_functions = self.stack_resources.get(AWS_LAMBDA_FUNCTION)
         for lambda_function in lambda_functions:
-            if lambda_function == function_logical_id:
+            if lambda_function == "HelloWorldFunction":
                 lambda_response = json.loads(self._get_lambda_response(lambda_function))
                 self.assertIn("extra_message", lambda_response)
-                self.assertEqual(lambda_response.get("message_from_layer"), expected_value)
+                self.assertEqual(lambda_response.get("message"), "9")
 
     @pytest.mark.flaky(reruns=3)
     def test_sync_function_layer_race_condition(self):
@@ -685,3 +673,63 @@ class TestSyncCodeEsbuildFunctionTemplate(TestSyncCodeBase):
                 lambda_response = json.loads(self._get_lambda_response(lambda_function))
                 self.assertIn("extra_message", lambda_response)
                 self.assertEqual(lambda_response.get("message"), "Hello world!")
+
+
+@skipIf(SKIP_SYNC_TESTS, "Skip sync tests in CI/CD only")
+@parameterized_class(
+    [
+        {"dependency_layer": True, "use_container": True},
+        {"dependency_layer": True, "use_container": False},
+        {"dependency_layer": False, "use_container": False},
+        {"dependency_layer": False, "use_container": True},
+    ]
+)
+class TestSyncLayerCode(TestSyncCodeBase):
+    template = "template-python-code-only-layer.yaml"
+    folder = "code"
+
+    @parameterized.expand(
+        [
+            ("layer", "HelloWorldLayer", "HelloWorldFunction", "7"),
+            (
+                "layer_without_build_method",
+                "HelloWorldLayerWithoutBuildMethod",
+                "HelloWorldFunctionWithLayerWithoutBuild",
+                "30",
+            ),
+            ("layer_zip", "HelloWorldPreBuiltZipLayer", "HelloWorldFunctionWithPreBuiltLayer", "50"),
+        ]
+    )
+    def test_sync_code_layer(self, layer_path, layer_logical_id, function_logical_id, expected_value):
+        shutil.rmtree(TestSyncCodeBase.temp_dir.joinpath(layer_path), ignore_errors=True)
+        shutil.copytree(
+            self.test_data_path.joinpath(self.folder).joinpath("after").joinpath(layer_path),
+            TestSyncCodeBase.temp_dir.joinpath(layer_path),
+        )
+        # Run code sync
+        sync_command_list = self.get_sync_command_list(
+            template_file=TestSyncCodeBase.template_path,
+            code=True,
+            watch=False,
+            resource_id_list=[layer_logical_id],
+            dependency_layer=self.dependency_layer,
+            stack_name=TestSyncCodeBase.stack_name,
+            parameter_overrides="Parameter=Clarity",
+            image_repository=self.ecr_repo_name,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key,
+            tags="integ=true clarity=yes foo_bar=baz",
+            use_container=self.use_container,
+        )
+        sync_process_execute = run_command_with_input(sync_command_list, "y\n".encode())
+        self.assertEqual(sync_process_execute.process.returncode, 0)
+
+        # CFN Api call here to collect all the stack resources
+        self.stack_resources = self._get_stacks(TestSyncCodeBase.stack_name)
+        # Lambda Api call here, which tests both the python function and the layer
+        lambda_functions = self.stack_resources.get(AWS_LAMBDA_FUNCTION)
+        for lambda_function in lambda_functions:
+            if lambda_function == function_logical_id:
+                lambda_response = json.loads(self._get_lambda_response(lambda_function))
+                self.assertIn("extra_message", lambda_response)
+                self.assertEqual(lambda_response.get("message_from_layer"), expected_value)

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -129,7 +129,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.raise_exception
-      Runtime: python3.9
+      Runtime: python3.7
       CodeUri: .
       Timeout: 600
 

--- a/tests/integration/testdata/sync/code/before/template-python-code-only-layer.yaml
+++ b/tests/integration/testdata/sync/code/before/template-python-code-only-layer.yaml
@@ -1,0 +1,74 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 10
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: function/
+      Handler: app.lambda_handler
+      Runtime: python3.7
+      Layers:
+        - Ref: HelloWorldLayer
+      Tracing: Active
+
+  HelloWorldFunctionWithLayerWithoutBuild:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: function/
+      Handler: app.lambda_handler
+      Runtime: python3.7
+      Layers:
+        - Ref: HelloWorldLayerWithoutBuildMethod
+      Tracing: Active
+
+  HelloWorldFunctionWithPreBuiltLayer:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: function/
+      Handler: app.lambda_handler
+      Runtime: python3.7
+      Layers:
+        - Ref: HelloWorldPreBuiltZipLayer
+      Tracing: Active
+
+  HelloWorldLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: HelloWorldLayer
+      Description: Hello World Layer
+      ContentUri: layer/
+      CompatibleRuntimes:
+        - python3.7
+    Metadata:
+      BuildMethod: python3.7
+
+  HelloWorldLayerWithoutBuildMethod:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: HelloWorldLayerWithoutBuild
+      Description: Hello World Layer without BuildMethod
+      ContentUri: layer_without_build_method/
+      CompatibleRuntimes:
+        - python3.7
+
+  HelloWorldPreBuiltZipLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: HelloWorldPreBuiltZipLayer
+      Description: Hello World Layer which is pre-built as ZIP file
+      ContentUri: layer_zip/layer.zip
+      CompatibleRuntimes:
+        - python3.7
+
+  HelloStepFunction:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: statemachine/function.asl.json
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref HelloWorldFunction

--- a/tests/integration/testdata/sync/code/before/template-python.yaml
+++ b/tests/integration/testdata/sync/code/before/template-python.yaml
@@ -16,26 +16,6 @@ Resources:
         - Ref: HelloWorldLayer
       Tracing: Active
 
-  HelloWorldFunctionWithLayerWithoutBuild:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: function/
-      Handler: app.lambda_handler
-      Runtime: python3.7
-      Layers:
-        - Ref: HelloWorldLayerWithoutBuildMethod
-      Tracing: Active
-
-  HelloWorldFunctionWithPreBuiltLayer:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: function/
-      Handler: app.lambda_handler
-      Runtime: python3.7
-      Layers:
-        - Ref: HelloWorldPreBuiltZipLayer
-      Tracing: Active
-
   HelloWorldApi:
     Type: AWS::Serverless::Api
     Properties:
@@ -58,24 +38,6 @@ Resources:
         - python3.7
     Metadata:
       BuildMethod: python3.7
-
-  HelloWorldLayerWithoutBuildMethod:
-    Type: AWS::Serverless::LayerVersion
-    Properties:
-      LayerName: HelloWorldLayerWithoutBuild
-      Description: Hello World Layer without BuildMethod
-      ContentUri: layer_without_build_method/
-      CompatibleRuntimes:
-        - python3.7
-
-  HelloWorldPreBuiltZipLayer:
-    Type: AWS::Serverless::LayerVersion
-    Properties:
-      LayerName: HelloWorldPreBuiltZipLayer
-      Description: Hello World Layer which is pre-built as ZIP file
-      ContentUri: layer_zip/layer.zip
-      CompatibleRuntimes:
-        - python3.7
 
   HelloStepFunction:
     Type: AWS::Serverless::StateMachine

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -120,13 +120,13 @@ def kill_process(process: Popen) -> None:
         raise ValueError(f"Processes: {alive} are still alive.")
 
 
-def read_until_string(process: Popen, expected_output: str, timeout: int = 5) -> None:
+def read_until_string(process: Popen, expected_output: str, timeout: int = 30) -> None:
     """Read output from process until a line equals to expected_output has shown up or reaching timeout.
     Throws TimeoutError if times out
     """
 
     def _compare_output(output, _: List[str]) -> bool:
-        return bool(output == expected_output)
+        return bool(expected_output in output)
 
     try:
         read_until(process, _compare_output, timeout)


### PR DESCRIPTION
Fixes recent issues with integration tests;
- With removal of `python3.6`, we bumped some local tests to use newer python versions but they have different output if an error happens. Updated those tests with expected error message (also verified with error message of actually deployed lambda [see below]).
```
{
    "errorMessage": "Lambda is raising an exception", 
    "errorType": "Exception", 
    "requestId": "6698a3f0-09b6-4ae9-93cb-27882edd5046",
    "stackTrace": ["  File \"/var/task/lambda_function.py\", line 4, in lambda_handler\n    raise Exception(\"Lambda is raising an exception\")\n"]
}
```
- Recently added `sam sync` tests which is related to layers, have added new functions in the test template, which broke the existing tests. Those tests have been moved to its own template and test case.
- Increased default time out for waiting the process output, which should resolve the issues in recent windows tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
