### PR TITLE
Loosen cfn-lint version to support patch/minor upgrades

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,4 +29,4 @@ regex==2021.9.30
 tzlocal==3.0
 
 #Adding cfn-lint dependency for SAM validate
-cfn-lint==0.72.2
+cfn-lint>=0.72.2,==0.*


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
New releases of `aws-sam-cli` are downgrading `cfn-lint` to `0.72.2`.

#### How does it address the issue?
This change allows any version of `cfn-lint` greater than `0.72.2` less than <1.0 to be supported

#### What side effects does this change have?
`cfn-lint` will be upgraded on new `aws-sam-cli` releases

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
