### PR TITLE
chore: Remove unnecessary samtranslator import "IS_STR"

### DIFF
--- a/samcli/lib/samlib/wrapper.py
+++ b/samcli/lib/samlib/wrapper.py
@@ -20,7 +20,6 @@ from samtranslator.model.exceptions import (
     InvalidResourceException,
     InvalidEventException,
 )
-from samtranslator.model.types import IS_STR
 from samtranslator.plugins import LifeCycleEvents
 from samtranslator.sdk.resource import SamResource, SamResourceType
 from samtranslator.translator.translator import prepare_plugins
@@ -92,7 +91,7 @@ class SamTranslatorWrapper:
 
             def patched_func(self):
                 if self.condition:
-                    if not IS_STR(self.condition, should_raise=False):
+                    if not isinstance(self.condition, str):
                         raise InvalidDocumentException(
                             [InvalidTemplateException("Every Condition member must be a string.")]
                         )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?

To decouple samtranslator. It is just a simple type check, no need to import a helper function for that. 

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
