### PR TITLE
feat: make layer version optional for function layer ref sync flow

### DIFF
--- a/samcli/lib/sync/flows/function_sync_flow.py
+++ b/samcli/lib/sync/flows/function_sync_flow.py
@@ -1,4 +1,5 @@
 """Base SyncFlow for Lambda Function"""
+from abc import ABC
 from enum import Enum
 import logging
 
@@ -21,7 +22,7 @@ LOG = logging.getLogger(__name__)
 FUNCTION_SLEEP = 1  # used to wait for lambda function last update to be successful
 
 
-class FunctionSyncFlow(SyncFlow):
+class FunctionSyncFlow(SyncFlow, ABC):
     _function_identifier: str
     _function_provider: SamFunctionProvider
     _function: Function

--- a/samcli/lib/sync/flows/generic_api_sync_flow.py
+++ b/samcli/lib/sync/flows/generic_api_sync_flow.py
@@ -1,5 +1,6 @@
 """SyncFlow interface for HttpApi and RestApi"""
 import logging
+from abc import ABC
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
@@ -15,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
 LOG = logging.getLogger(__name__)
 
 
-class GenericApiSyncFlow(SyncFlow):
+class GenericApiSyncFlow(SyncFlow, ABC):
     """SyncFlow interface for HttpApi and RestApi"""
 
     _api_client: Any

--- a/tests/unit/lib/sync/flows/test_layer_sync_flow.py
+++ b/tests/unit/lib/sync/flows/test_layer_sync_flow.py
@@ -2,6 +2,7 @@ import base64
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch, call, ANY, mock_open, PropertyMock
 
+from parameterized import parameterized
 
 from samcli.lib.sync.exceptions import MissingPhysicalResourceError, NoLayerVersionsFoundError
 from samcli.lib.sync.flows.function_sync_flow import wait_for_function_update_complete
@@ -10,6 +11,7 @@ from samcli.lib.sync.flows.layer_sync_flow import (
     FunctionLayerReferenceSync,
     LayerSyncFlowSkipBuildDirectory,
     LayerSyncFlowSkipBuildZipFile,
+    get_latest_layer_version,
 )
 from samcli.lib.sync.sync_flow import SyncFlow, ApiCallTypes
 
@@ -124,7 +126,8 @@ class TestLayerSyncFlow(TestCase):
         self.layer_sync_flow._get_lock_chain.return_value.__enter__.assert_called_once()
         self.layer_sync_flow._get_lock_chain.return_value.__exit__.assert_called_once()
 
-    def test_compare_remote(self):
+    @patch("samcli.lib.sync.flows.layer_sync_flow.get_latest_layer_version")
+    def test_compare_remote(self, patched_get_latest_layer_version):
         given_lambda_client = Mock()
         self.layer_sync_flow._lambda_client = given_lambda_client
 
@@ -134,15 +137,14 @@ class TestLayerSyncFlow(TestCase):
 
         self.layer_sync_flow._local_sha = base64.b64decode(given_sha256).hex()
 
-        with patch.object(self.layer_sync_flow, "_get_latest_layer_version") as patched_get_latest_layer_version:
-            given_layer_name = Mock()
-            given_latest_layer_version = Mock()
-            self.layer_sync_flow._layer_arn = given_layer_name
-            patched_get_latest_layer_version.return_value = given_latest_layer_version
+        given_layer_name = Mock()
+        given_latest_layer_version = Mock()
+        self.layer_sync_flow._layer_arn = given_layer_name
+        patched_get_latest_layer_version.return_value = given_latest_layer_version
 
-            compare_result = self.layer_sync_flow.compare_remote()
+        compare_result = self.layer_sync_flow.compare_remote()
 
-            self.assertTrue(compare_result)
+        self.assertTrue(compare_result)
 
     def test_sync(self):
         with patch.object(self.layer_sync_flow, "_publish_new_layer_version") as patched_publish_new_layer_version:
@@ -319,10 +321,8 @@ class TestLayerSyncFlow(TestCase):
         given_layer_name = Mock()
         given_lambda_client = Mock()
         given_lambda_client.list_layer_versions.return_value = {"LayerVersions": [{"Version": given_version}]}
-        self.layer_sync_flow._lambda_client = given_lambda_client
-        self.layer_sync_flow._layer_arn = given_layer_name
 
-        latest_layer_version = self.layer_sync_flow._get_latest_layer_version()
+        latest_layer_version = get_latest_layer_version(given_lambda_client, given_layer_name)
 
         given_lambda_client.list_layer_versions.assert_called_with(LayerName=given_layer_name)
         self.assertEqual(latest_layer_version, given_version)
@@ -331,11 +331,9 @@ class TestLayerSyncFlow(TestCase):
         given_layer_name = Mock()
         given_lambda_client = Mock()
         given_lambda_client.list_layer_versions.return_value = {"LayerVersions": []}
-        self.layer_sync_flow._lambda_client = given_lambda_client
-        self.layer_sync_flow._layer_arn = given_layer_name
 
         with self.assertRaises(NoLayerVersionsFoundError):
-            self.layer_sync_flow._get_latest_layer_version()
+            get_latest_layer_version(given_lambda_client, given_layer_name)
 
     def test_equality_keys(self):
         self.assertEqual(self.layer_sync_flow._equality_keys(), self.layer_identifier)
@@ -435,6 +433,19 @@ class TestFunctionLayerReferenceSync(TestCase):
 
     def test_gather_dependencies(self):
         self.assertEqual(self.function_layer_sync.gather_dependencies(), [])
+
+    @parameterized.expand([(1,), (None,)])
+    @patch("samcli.lib.sync.flows.layer_sync_flow.get_latest_layer_version")
+    def test_gather_resources(self, layer_version, patched_get_latest_layer_version):
+        self.function_layer_sync._new_layer_version = layer_version
+        self.function_layer_sync._lambda_client = Mock()
+
+        self.function_layer_sync.gather_resources()
+
+        if layer_version:
+            patched_get_latest_layer_version.assert_not_called()
+        else:
+            patched_get_latest_layer_version.assert_called_once()
 
 
 class TestLayerSyncFlowSkipBuild(TestCase):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Some sync flows have dependencies which should be run once the flow is completed. But there is an edge case where user kills the process in between execution of a parent sync flow vs the dependent one. 

#### How does it address the issue?
This is preparation of the issue above, which will let to instantiate the `FunctionLayerReferenceSync` with optional `new_layer_version` parameter so that we can still queue this sync flow even the layer code haven't changed (by comparing the remote hashes).


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
