### PR TITLE
chore: fix canary failures which extends from deploy class

### DIFF
--- a/tests/integration/delete/delete_integ_base.py
+++ b/tests/integration/delete/delete_integ_base.py
@@ -1,21 +1,14 @@
-import os
 from pathlib import Path
-from typing import Optional
-from unittest import TestCase
 
+from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.testing_utils import get_sam_command
 
 
-class DeleteIntegBase(TestCase):
+class DeleteIntegBase(DeployIntegBase):
     @classmethod
     def setUpClass(cls):
         cls.delete_test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "delete")
-
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
+        super().setUpClass()
 
     def get_delete_command_list(
         self,

--- a/tests/integration/delete/test_delete_command.py
+++ b/tests/integration/delete/test_delete_command.py
@@ -1,21 +1,15 @@
 import os
-import shutil
-import tempfile
 import time
-import uuid
-import pytest
-from pathlib import Path
 from unittest import skipIf
+
 import boto3
 import docker
-from botocore.config import Config
-from parameterized import parameterized
+import pytest
 from botocore.exceptions import ClientError
+from parameterized import parameterized
 
-from samcli.lib.bootstrap.bootstrap import SAM_CLI_STACK_NAME
-from samcli.lib.config.samconfig import DEFAULT_CONFIG_FILE_NAME
-from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.integration.delete.delete_integ_base import DeleteIntegBase
+from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.integration.package.package_integ_base import PackageIntegBase
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
 from tests.testing_utils import run_command, run_command_with_input
@@ -28,7 +22,7 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
 
 
 @skipIf(SKIP_DELETE_TESTS, "Skip delete tests in CI/CD only")
-class TestDelete(PackageIntegBase, DeployIntegBase, DeleteIntegBase):
+class TestDelete(DeleteIntegBase):
     @classmethod
     def setUpClass(cls):
         cls.docker_client = docker.from_env()
@@ -38,10 +32,7 @@ class TestDelete(PackageIntegBase, DeployIntegBase, DeleteIntegBase):
         # setup some images locally by pulling them.
         for repo, tag in cls.local_images:
             cls.docker_client.api.pull(repository=repo, tag=tag)
-
-        PackageIntegBase.setUpClass()
-        DeployIntegBase.setUpClass()
-        DeleteIntegBase.setUpClass()
+        super().setUpClass()
 
     def setUp(self):
         # Save reference to session object to get region_name

--- a/tests/integration/deploy/deploy_integ_base.py
+++ b/tests/integration/deploy/deploy_integ_base.py
@@ -6,6 +6,8 @@ from enum import Enum, auto
 
 import boto3
 from botocore.config import Config
+
+from tests.integration.package.package_integ_base import PackageIntegBase
 from tests.testing_utils import get_sam_command, run_command, run_command_with_input
 
 
@@ -15,7 +17,7 @@ class ResourceType(Enum):
     IAM_ROLE = auto()
 
 
-class DeployIntegBase(TestCase):
+class DeployIntegBase(PackageIntegBase):
     def setUp(self):
         super().setUp()
         self.left_over_resources = {
@@ -26,7 +28,8 @@ class DeployIntegBase(TestCase):
         # make temp directory and move all test files into there for each test run
         original_test_data_path = self.test_data_path
         self.test_data_path = Path(tempfile.mkdtemp())
-        shutil.copytree(original_test_data_path, self.test_data_path, dirs_exist_ok=True)
+        shutil.rmtree(self.test_data_path) # copytree call below fails if root folder present, delete it first
+        shutil.copytree(original_test_data_path, self.test_data_path)
 
     def tearDown(self):
         shutil.rmtree(self.test_data_path)

--- a/tests/integration/deploy/deploy_integ_base.py
+++ b/tests/integration/deploy/deploy_integ_base.py
@@ -1,12 +1,12 @@
 import shutil
 import tempfile
 from pathlib import Path
-from unittest import TestCase
 from enum import Enum, auto
 
 import boto3
 from botocore.config import Config
 
+from samcli.lib.bootstrap.bootstrap import SAM_CLI_STACK_NAME
 from tests.integration.package.package_integ_base import PackageIntegBase
 from tests.testing_utils import get_sam_command, run_command, run_command_with_input
 
@@ -28,10 +28,27 @@ class DeployIntegBase(PackageIntegBase):
         # make temp directory and move all test files into there for each test run
         original_test_data_path = self.test_data_path
         self.test_data_path = Path(tempfile.mkdtemp())
-        shutil.rmtree(self.test_data_path) # copytree call below fails if root folder present, delete it first
+
+        # copytree call below fails if root folder present, delete it first
+        shutil.rmtree(self.test_data_path, ignore_errors=True)
         shutil.copytree(original_test_data_path, self.test_data_path)
 
+        self.cfn_client = boto3.client("cloudformation")
+        self.ecr_client = boto3.client("ecr")
+        self.stacks = []
+
     def tearDown(self):
+        for stack in self.stacks:
+            # because of the termination protection, do not delete aws-sam-cli-managed-default stack
+            stack_name = stack["name"]
+            if stack_name != SAM_CLI_STACK_NAME:
+                region = stack.get("region")
+                cfn_client = (
+                    self.cfn_client if not region else boto3.client("cloudformation", config=Config(region_name=region))
+                )
+                ecr_client = self.ecr_client if not region else boto3.client("ecr", config=Config(region_name=region))
+                self._delete_companion_stack(cfn_client, ecr_client, self._stack_name_to_companion_stack(stack_name))
+                cfn_client.delete_stack(StackName=stack_name)
         shutil.rmtree(self.test_data_path)
         super().tearDown()
         self.delete_s3_buckets()

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -24,7 +24,7 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
 
 
 @skipIf(SKIP_DEPLOY_TESTS, "Skip deploy tests in CI/CD only")
-class TestDeploy(PackageIntegBase, DeployIntegBase):
+class TestDeploy(DeployIntegBase):
     @classmethod
     def setUpClass(cls):
         cls.docker_client = docker.from_env()
@@ -41,16 +41,14 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # setup signing profile arn & name
         cls.signing_profile_name = os.environ.get("AWS_SIGNING_PROFILE_NAME")
         cls.signing_profile_version_arn = os.environ.get("AWS_SIGNING_PROFILE_VERSION_ARN")
-        PackageIntegBase.setUpClass()
-        DeployIntegBase.setUpClass()
+        super().setUpClass()
 
     def setUp(self):
         self.cfn_client = boto3.client("cloudformation")
         self.ecr_client = boto3.client("ecr")
         self.sns_arn = os.environ.get("AWS_SNS")
         self.stacks = []
-        PackageIntegBase.setUp(self)
-        DeployIntegBase.setUp(self)
+        super().setUp()
 
     def tearDown(self):
         for stack in self.stacks:

--- a/tests/integration/deploy/test_managed_stack_deploy.py
+++ b/tests/integration/deploy/test_managed_stack_deploy.py
@@ -9,7 +9,6 @@ from parameterized import parameterized
 from samcli.lib.bootstrap.bootstrap import SAM_CLI_STACK_NAME
 from samcli.lib.config.samconfig import DEFAULT_CONFIG_FILE_NAME
 from tests.integration.deploy.deploy_integ_base import DeployIntegBase
-from tests.integration.package.package_integ_base import PackageIntegBase
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
 
 PYTHON_VERSION = os.environ.get("PYTHON_VERSION", "0.0.0")
@@ -26,11 +25,7 @@ DEFAULT_REGION = "us-west-2"
 
 
 @skipIf(SKIP_MANAGED_STACK_TESTS or not IS_TARGETTED_PYTHON_VERSION, "Skip managed stack tests in CI/CD only")
-class TestManagedStackDeploy(PackageIntegBase, DeployIntegBase):
-    @classmethod
-    def setUpClass(cls):
-        PackageIntegBase.setUpClass()
-        DeployIntegBase.setUpClass()
+class TestManagedStackDeploy(DeployIntegBase):
 
     def setUp(self):
         self.cfn_client = boto3.client("cloudformation", region_name=DEFAULT_REGION)
@@ -41,8 +36,7 @@ class TestManagedStackDeploy(PackageIntegBase, DeployIntegBase):
         self._delete_managed_stack(self.cfn_client, self.s3_client, DEFAULT_REGION)
         self.assertFalse(self._does_stack_exist(self.cfn_client, SAM_CLI_STACK_NAME))
 
-        PackageIntegBase.setUp(self)
-        DeployIntegBase.setUp(self)
+        super().setUp()
 
     def tearDown(self):
         for stack in self.stacks:
@@ -56,8 +50,7 @@ class TestManagedStackDeploy(PackageIntegBase, DeployIntegBase):
 
         self._delete_managed_stack(self.cfn_client, self.s3_client, DEFAULT_REGION)
         self.assertFalse(self._does_stack_exist(self.cfn_client, SAM_CLI_STACK_NAME))
-        DeployIntegBase.tearDown(self)
-        PackageIntegBase.tearDown(self)
+        super().tearDown()
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_managed_stack_creation_resolve_s3(self, template_file):

--- a/tests/integration/deploy/test_managed_stack_deploy.py
+++ b/tests/integration/deploy/test_managed_stack_deploy.py
@@ -25,7 +25,6 @@ DEFAULT_REGION = "us-west-2"
 
 @skipIf(SKIP_MANAGED_STACK_TESTS or not IS_TARGETTED_PYTHON_VERSION, "Skip managed stack tests in CI/CD only")
 class TestManagedStackDeploy(DeployIntegBase):
-
     def setUp(self):
         super().setUp()
         self.s3_client = boto3.client("s3", region_name=DEFAULT_REGION)

--- a/tests/integration/list/endpoints/test_endpoints_command.py
+++ b/tests/integration/list/endpoints/test_endpoints_command.py
@@ -1,31 +1,23 @@
 import os
-import time
 import boto3
 import json
 from unittest import skipIf
-from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.integration.list.endpoints.endpoints_integ_base import EndpointsIntegBase
 from samcli.commands.list.endpoints.command import HELP_TEXT
 from tests.testing_utils import CI_OVERRIDE, RUN_BY_CANARY
 from tests.testing_utils import run_command, run_command_with_input, method_to_stack_name
 
-CFN_SLEEP = 3
 CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".", "-")
 
 
 @skipIf(
     (not RUN_BY_CANARY and not CI_OVERRIDE),
-    "Skip Terraform test cases unless running in CI",
+    "Skip List test cases unless running in CI",
 )
-class TestEndpoints(DeployIntegBase, EndpointsIntegBase):
-    @classmethod
-    def setUpClass(cls):
-        DeployIntegBase.setUpClass()
-        EndpointsIntegBase.setUpClass()
+class TestEndpoints(EndpointsIntegBase):
 
     def setUp(self):
         self.cf_client = boto3.client("cloudformation")
-        time.sleep(CFN_SLEEP)
         super().setUp()
 
     def test_endpoints_help_message(self):

--- a/tests/integration/list/endpoints/test_endpoints_command.py
+++ b/tests/integration/list/endpoints/test_endpoints_command.py
@@ -15,7 +15,6 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
     "Skip List test cases unless running in CI",
 )
 class TestEndpoints(EndpointsIntegBase):
-
     def test_endpoints_help_message(self):
         cmdlist = self.get_endpoints_command_list(help=True)
         command_result = run_command(cmdlist)

--- a/tests/integration/list/endpoints/test_endpoints_command.py
+++ b/tests/integration/list/endpoints/test_endpoints_command.py
@@ -16,10 +16,6 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
 )
 class TestEndpoints(EndpointsIntegBase):
 
-    def setUp(self):
-        self.cf_client = boto3.client("cloudformation")
-        super().setUp()
-
     def test_endpoints_help_message(self):
         cmdlist = self.get_endpoints_command_list(help=True)
         command_result = run_command(cmdlist)
@@ -60,6 +56,8 @@ class TestEndpoints(EndpointsIntegBase):
         run_command_with_input(
             deploy_command_list, "{}\n{}\nY\nY\nY\nY\nY\nY\n\n\nY\n".format(stack_name, region).encode()
         )
+        self.stacks.append({"name": stack_name})
+
         cmdlist = self.get_endpoints_command_list(
             stack_name=stack_name, output="json", region=region, template_file=template_path
         )

--- a/tests/integration/list/list_integ_base.py
+++ b/tests/integration/list/list_integ_base.py
@@ -1,17 +1,19 @@
 import re
 
 import os
-from unittest import TestCase
 from pathlib import Path
 import uuid
 import shutil
 import tempfile
+
+from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.testing_utils import get_sam_command
 
 
-class ListIntegBase(TestCase):
+class ListIntegBase(DeployIntegBase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.cmd = cls.base_command()
         cls.list_test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "list")
 

--- a/tests/integration/list/resources/test_resources_command.py
+++ b/tests/integration/list/resources/test_resources_command.py
@@ -1,31 +1,23 @@
 import os
-import time
 import boto3
 import json
 from unittest import skipIf
-from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.integration.list.resources.resources_integ_base import ResourcesIntegBase
 from samcli.commands.list.resources.command import HELP_TEXT
 from tests.testing_utils import CI_OVERRIDE, RUN_BY_CANARY
 from tests.testing_utils import run_command, run_command_with_input, method_to_stack_name
 
-CFN_SLEEP = 3
 CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".", "-")
 
 
 @skipIf(
     (not RUN_BY_CANARY and not CI_OVERRIDE),
-    "Skip Terraform test cases unless running in CI",
+    "Skip List test cases unless running in CI",
 )
-class TestResources(DeployIntegBase, ResourcesIntegBase):
-    @classmethod
-    def setUpClass(cls):
-        DeployIntegBase.setUpClass()
-        ResourcesIntegBase.setUpClass()
+class TestResources(ResourcesIntegBase):
 
     def setUp(self):
         self.cf_client = boto3.client("cloudformation")
-        time.sleep(CFN_SLEEP)
         super().setUp()
 
     def test_resources_help_message(self):

--- a/tests/integration/list/resources/test_resources_command.py
+++ b/tests/integration/list/resources/test_resources_command.py
@@ -69,6 +69,8 @@ class TestResources(ResourcesIntegBase):
         run_command_with_input(
             deploy_command_list, "{}\n{}\nY\nY\nY\nY\nY\n\n\nY\n".format(stack_name, region).encode()
         )
+        self.stacks.append({"name": stack_name})
+
         cmdlist = self.get_resources_command_list(
             stack_name=stack_name, region=region, output="json", template_file=template_path
         )

--- a/tests/integration/list/resources/test_resources_command.py
+++ b/tests/integration/list/resources/test_resources_command.py
@@ -15,7 +15,6 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
     "Skip List test cases unless running in CI",
 )
 class TestResources(ResourcesIntegBase):
-
     def setUp(self):
         self.cf_client = boto3.client("cloudformation")
         super().setUp()

--- a/tests/integration/list/stack_outputs/test_stack_outputs_command.py
+++ b/tests/integration/list/stack_outputs/test_stack_outputs_command.py
@@ -42,6 +42,8 @@ class TestStackOutputs(StackOutputsIntegBase):
         run_command_with_input(
             deploy_command_list, "{}\n{}\nY\nY\nY\nY\nY\n\n\nY\n".format(stack_name, region).encode()
         )
+        self.stacks.append({"name": stack_name})
+
         cmdlist = self.get_stack_outputs_command_list(stack_name=stack_name, region=region, output="json")
         command_result = run_command(cmdlist, cwd=self.working_dir)
         outputs = json.loads(command_result.stdout.decode())
@@ -79,6 +81,8 @@ class TestStackOutputs(StackOutputsIntegBase):
         run_command_with_input(
             deploy_command_list, "{}\n{}\nY\nY\nY\nY\nY\n\n\nY\n".format(stack_name, region).encode()
         )
+        self.stacks.append({"name": stack_name})
+
         cmdlist = self.get_stack_outputs_command_list(stack_name=stack_name, region=region, output="json")
         command_result = run_command(cmdlist, cwd=self.working_dir)
         expected_output = (

--- a/tests/integration/list/stack_outputs/test_stack_outputs_command.py
+++ b/tests/integration/list/stack_outputs/test_stack_outputs_command.py
@@ -16,7 +16,6 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
     "Skip List test cases unless running in CI",
 )
 class TestStackOutputs(StackOutputsIntegBase):
-
     def setUp(self):
         self.cf_client = boto3.client("cloudformation")
         super().setUp()

--- a/tests/integration/list/stack_outputs/test_stack_outputs_command.py
+++ b/tests/integration/list/stack_outputs/test_stack_outputs_command.py
@@ -1,32 +1,24 @@
 import os
-import time
 import boto3
 import json
 from unittest import skipIf
 
-from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.integration.list.stack_outputs.stack_outputs_integ_base import StackOutputsIntegBase
 from samcli.commands.list.stack_outputs.command import HELP_TEXT
 from tests.testing_utils import CI_OVERRIDE, RUN_BY_CANARY
 from tests.testing_utils import run_command, run_command_with_input, method_to_stack_name
 
-CFN_SLEEP = 3
 CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".", "-")
 
 
 @skipIf(
     (not RUN_BY_CANARY and not CI_OVERRIDE),
-    "Skip Terraform test cases unless running in CI",
+    "Skip List test cases unless running in CI",
 )
-class TestStackOutputs(DeployIntegBase, StackOutputsIntegBase):
-    @classmethod
-    def setUpClass(cls):
-        DeployIntegBase.setUpClass()
-        StackOutputsIntegBase.setUpClass()
+class TestStackOutputs(StackOutputsIntegBase):
 
     def setUp(self):
         self.cf_client = boto3.client("cloudformation")
-        time.sleep(CFN_SLEEP)
         super().setUp()
 
     def test_stack_outputs_help_message(self):


### PR DESCRIPTION
- `dir_exists_ok` is added in python3.8 to `shutil.copytree` method. Replaced that with alternative approach (delete the target parent folder before starting the copy operation).
- Moved stack deletion logic into `DeployIntegBase` class so that other test classes (like `sam list` tests) can use it to cleanup stacks once tests are completed
- Removed multiple inheritance in some test classes to make implementation more straight forward.

Tested by running deploy, delete and list tests which extends from changed files below.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
