### PR TITLE
If a function is created without an architecture on an arm host assume arm

### DIFF
--- a/samcli/commands/init/init_flow_helpers.py
+++ b/samcli/commands/init/init_flow_helpers.py
@@ -4,8 +4,9 @@ Init flow based helper functions
 import logging
 import functools
 import re
+from platform import machine
 
-from samcli.lib.utils.architecture import X86_64
+from samcli.lib.utils.architecture import X86_64, ARM64
 from samcli.local.common.runtime_template import INIT_RUNTIMES, is_custom_runtime, LAMBDA_IMAGES_RUNTIMES_MAP
 
 LOG = logging.getLogger(__name__)
@@ -165,4 +166,7 @@ def get_architectures(architecture):
     """
     Returns list of architecture value based on the init input value
     """
-    return [X86_64] if architecture is None else [architecture]
+    if architecture is not None:
+        return [architecture]
+
+    return [ARM64] if machine() in ("arm64", "aarch64") else [X86_64]

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 import requests
 from pathlib import Path
+from platform import machine
 from typing import Dict, Any
 from unittest import TestCase
 from unittest.mock import patch, ANY
@@ -31,6 +32,8 @@ from samcli.lib.utils import osutils
 from samcli.lib.utils.git_repo import GitRepo
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.architecture import X86_64, ARM64
+
+default_arch = ARM64 if machine() in ("arm64", "aarch64") else X86_64
 
 
 class MockInitTemplates:
@@ -926,7 +929,7 @@ Y
                 "AWS_Schema_source": "aws.autoscaling",
                 "AWS_Schema_detail_type": "aws.autoscaling response",
                 "AWS_Schema_root": "schemas.aws.AWSAPICallViaCloudTrail",
-                "architectures": {"value": [X86_64]},
+                "architectures": {"value": [default_arch]},
             },
             False,
             False,
@@ -997,7 +1000,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "java8", "architectures": {"value": [X86_64]}},
+            {"project_name": "test-project", "runtime": "java8", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -1144,7 +1147,7 @@ us-east-1
                 "AWS_Schema_source": "aws.autoscaling",
                 "AWS_Schema_detail_type": "aws.autoscaling response",
                 "AWS_Schema_root": "schemas.aws.AWSAPICallViaCloudTrail",
-                "architectures": {"value": [X86_64]},
+                "architectures": {"value": [default_arch]},
             },
             False,
             False,
@@ -1398,7 +1401,7 @@ Y
                 "AWS_Schema_source": "aws.autoscaling",
                 "AWS_Schema_detail_type": "aws.autoscaling response",
                 "AWS_Schema_root": "schemas.aws.AWSAPICallViaCloudTrail",
-                "architectures": {"value": [X86_64]},
+                "architectures": {"value": [default_arch]},
             },
             False,
             False,
@@ -2023,7 +2026,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "python3.9", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "python3.9", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -2112,7 +2115,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -2388,7 +2391,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -2601,7 +2604,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -2692,7 +2695,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -2775,7 +2778,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -2864,7 +2867,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "provided.al2", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "provided.al2", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -2945,7 +2948,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "provided.al2", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "provided.al2", "architectures": {"value": [default_arch]}},
             False,
             False,
         )
@@ -3030,7 +3033,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": [default_arch]}},
             True,
             False,
         )
@@ -3115,7 +3118,7 @@ test-project
             ".",
             "test-project",
             True,
-            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": ["x86_64"]}},
+            {"project_name": "test-project", "runtime": "java11", "architectures": {"value": [default_arch]}},
             False,
             True,
         )


### PR DESCRIPTION
If someone is running the sam cli on an Arm host, assume they actually want an arm-based function if none is provided

#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
It's not necessary, but today if someone runs the sam cli and doesn't specify the architecture they can create a function they can't locally test. 

#### How does it address the issue?
It detects the architecture of the host and defaults the cli to create a function of that type if none is specified

#### What side effects does this change have?
It changes behavior of the command line options defaults which previously always defaulted to x86

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [NA] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [NA] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [NA] Write/update integration tests
- [NA] Write/update functional tests if needed
- [X] `make pr` passes
- [NA] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
