### PR TITLE
fix: telemetry for Abort

### DIFF
--- a/samcli/lib/init/__init__.py
+++ b/samcli/lib/init/__init__.py
@@ -123,9 +123,8 @@ def generate_project(
 
     except UnknownRepoType as e:
         raise InvalidLocationError(template=params["template"]) from e
-    except CookiecutterException as e:
-        raise GenerateProjectFailedError(project=name, provider_error=e) from e
-
+    except (CookiecutterException, OSError) as e:
+        raise GenerateProjectFailedError(project=name if name else "", provider_error=e) from e
     except TypeError as ex:
         LOG.debug("Error from cookiecutter: %s", ex)
 

--- a/samcli/lib/telemetry/metric.py
+++ b/samcli/lib/telemetry/metric.py
@@ -143,19 +143,21 @@ def track_command(func):
                 # re-raise here to handle exception captured in context and not run func()
                 raise ctx.exception
 
-            # Execute the function and capture return value. This is returned back by the wrapper
+            # Execute the function and capture return value. This is returned by the wrapper
             # First argument of all commands should be the Context
             return_value = func(*args, **kwargs)
         except (
             UserException,
+            click.Abort,
             click.BadOptionUsage,
             click.BadArgumentUsage,
             click.BadParameter,
             click.UsageError,
         ) as ex:
-            # Capture exception information and re-raise it later so we can first send metrics.
+            # Capture exception information and re-raise it later,
+            # so metrics can be sent.
             exception = ex
-            # TODO (hawflau): review exitcode meaning. We now understand exitcode 1 as errors fixable by users.
+            # NOTE(sriram-mv): Set exit code to 1 if deemed to be user fixable error.
             exit_code = 1
             if hasattr(ex, "wrapped_from") and ex.wrapped_from:
                 exit_reason = ex.wrapped_from

--- a/tests/integration/init/test_init_base.py
+++ b/tests/integration/init/test_init_base.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from tests.testing_utils import get_sam_command
+
+
+class InitIntegBase(TestCase):
+
+    BINARY_READY_WAIT_TIME = 5
+
+    def get_command(
+        self,
+    ):
+        command_list = [get_sam_command(), "init"]
+        return command_list

--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -1,3 +1,4 @@
+import platform
 import time
 import signal
 
@@ -956,7 +957,7 @@ class TestInitCommand(InitIntegBase):
         time.sleep(self.BINARY_READY_WAIT_TIME)
 
         # Send SIGINT signal
-        process_execute.send_signal(signal.SIGINT)
+        process_execute.send_signal(signal.CTRL_C_EVENT if platform.system().lower() == "windows" else signal.SIGINT)
         process_execute.wait()
         # Process should exit gracefully with an exit code of 1.
         self.assertEqual(process_execute.returncode, 1)

--- a/tests/unit/lib/init/test_init.py
+++ b/tests/unit/lib/init/test_init.py
@@ -179,6 +179,32 @@ class TestInit(TestCase):
 
         self.assertEqual(expected_msg, str(ctx.exception))
 
+    @patch("samcli.lib.init.cookiecutter")
+    def test_when_generate_project_with_invalid_zip_location(self, cookiecutter_patch):
+        # INVALID ZIP PATH
+        invalid_zip_path = Path("invalid_dir").joinpath("invalid.zip")
+
+        # GIVEN generate_project fails to create a project
+        ex = OSError(f"No such file or directory: {str(invalid_zip_path)}")
+        cookiecutter_patch.side_effect = ex
+
+        expected_msg = str(GenerateProjectFailedError(project=self.name, provider_error=ex))
+
+        # WHEN the --location is not a valid local zip path
+        # THEN we should receive a GenerateProjectFailedError Exception
+        with self.assertRaises(GenerateProjectFailedError) as ctx:
+            generate_project(
+                location=invalid_zip_path,
+                runtime=self.runtime,
+                package_type=ZIP,
+                dependency_manager=self.dependency_manager,
+                output_dir=self.output_dir,
+                name=self.name,
+                no_input=self.no_input,
+            )
+
+        self.assertEqual(expected_msg, str(ctx.exception))
+
     @patch("samcli.lib.init.DefaultSamconfig")
     @patch("samcli.lib.init.Path.is_file")
     def test_create_default_samconfig(self, is_file_mock, samconfig_mock):

--- a/tests/unit/lib/telemetry/test_metric.py
+++ b/tests/unit/lib/telemetry/test_metric.py
@@ -186,6 +186,7 @@ class TestTrackCommand(TestCase):
             (click.BadArgumentUsage("Wrong argument usage"), "BadArgumentUsage", 1),
             (click.BadParameter("Bad param"), "BadParameter", 1),
             (click.UsageError("UsageError"), "UsageError", 1),
+            (click.Abort("Abort"), "Abort", 1),
         ]
     )
     @patch("samcli.lib.telemetry.metric.Context")


### PR DESCRIPTION
- Add Abort as an exit code that's no longer classified as 255
- Add OSError to the catch blocks for `sam init` such that a non existent zip location does not cause the cli to crash.

```bash
sam init --location /path/to/template.zip 

Error: An error occurred while generating this project : [Errno 2] No such file or directory: '/path/to/template.zip' 
```

Before it used to crash with a traceback.

#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
* Change is necessary for better telemetry numbers and also allowing for tracebacks to not appear on keyboard interrupts.

#### How does it address the issue?
* No more crashes due to interrupts

#### What side effects does this change have?
* N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
