### PR TITLE
fix: Remove the logic that stores datetime information into packaged ZIP

### DIFF
--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -281,7 +281,7 @@ def make_zip_with_permissions(file_name, source_root, permission_mappers: List[P
                                 info = permission_mapper.apply(info)
                             # ZIP date time can be set to the last time the zip content was modified using this logic.
                             # info.date_time = time.localtime()[0:6]
-            
+
                             # If the date time above is added, the caching logic that compares ZIP files sha will break.
                             # However, without this field, contents of the zip file will have a last modified date 1980
                             # because python's zipfile.ZipInfo is set to: https://docs.python.org/3/library/zipfile.html.

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -283,6 +283,8 @@ def make_zip_with_permissions(file_name, source_root, permission_mappers: List[P
                             # info.date_time = time.localtime()[0:6]
 
                             # If the date time above is added, the caching logic that compares ZIP files sha will break.
+                            # Currently we skip executing sync flows for sam sync command when the logic ZIP hash is
+                            # the same as the remote lambda ZIP hash. A timestamp will make the evaluation always false.
                             # However, without this field, contents of the zip file will have a last modified date 1980
                             # because python's zipfile.ZipInfo is set to: https://docs.python.org/3/library/zipfile.html.
                             zf.writestr(info, file_bytes, compress_type=compression_type)

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -8,7 +8,6 @@ import os
 import re
 import shutil
 import tempfile
-import time
 import zipfile
 from contextlib import contextmanager
 from typing import Callable, Dict, List, Optional, cast
@@ -280,8 +279,12 @@ def make_zip_with_permissions(file_name, source_root, permission_mappers: List[P
                             info.external_attr = os.stat(full_path).st_mode << 16
                             for permission_mapper in permission_mappers:
                                 info = permission_mapper.apply(info)
-                            # Set current time to be the last time the zip content was modified.
-                            info.date_time = time.localtime()[0:6]
+                            # ZIP date time can be set to the last time the zip content was modified using this logic.
+                            # info.date_time = time.localtime()[0:6]
+            
+                            # If the date time above is added, the caching logic that compares ZIP files sha will break.
+                            # However, without this field, contents of the zip file will have a last modified date 1980
+                            # because python's zipfile.ZipInfo is set to: https://docs.python.org/3/library/zipfile.html.
                             zf.writestr(info, file_bytes, compress_type=compression_type)
                         else:
                             zf.write(full_path, relative_path)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
With the latest make ZIP with permission change, we improved ZIP information storage with an additional field `date_time` into the ZIP file. Without this field, the contents of the lambda package will have a default last modified date of 1980. This is the default behaviour from python's zipfile.ZipInfo library: https://docs.python.org/3/library/zipfile.html. However, adding this field is breaking our ZIP hash comparison that sync flow hashing is based upon.

#### Why is this change necessary?
With the date_time, every time we make a package ZIP for lambda functions, the ZIP will have a different hash from the previous package even if the contents of the ZIP did not change. This means the sync flow hash comparison logic for ZIP functions will not work as each time we will generate a ZIP with a new hash.

#### How does it address the issue?
By removing the `date_time` field, the sync flow compare remote caching logic will be restored, we can again skip sync flows that do not change the lambda package ZIP.

#### What side effects does this change have?
The downloaded package will again have some files showing last modified date of 1980.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
