### PR TITLE
fix: catch all boto errors and exit gracefully

### DIFF
--- a/samcli/commands/_utils/command_exception_handler.py
+++ b/samcli/commands/_utils/command_exception_handler.py
@@ -5,11 +5,59 @@ which will end exeecution gracefully
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
 
-from botocore.exceptions import ClientError, NoRegionError
+from botocore.exceptions import BotoCoreError, ClientError, NoRegionError
 
 from samcli.commands._utils.parameterized_option import parameterized_option
-from samcli.commands.exceptions import CredentialsError, RegionError
+from samcli.commands.exceptions import CredentialsError, RegionError, SDKError
 from samcli.lib.utils.boto_utils import get_client_error_code
+
+
+class CustomExceptionHandler:
+    def __init__(self, custom_exception_handler_mapping):
+        self.custom_exception_handler_mapping = custom_exception_handler_mapping
+
+    def get_handler(self, exception_type: type):
+        return self.custom_exception_handler_mapping.get(exception_type)
+
+
+class GenericExceptionHandler:
+    def __init__(self, generic_exception_handler_mapping):
+        self.generic_exception_handler_mapping = generic_exception_handler_mapping
+
+    def get_handler(self, exception_type: type):
+        for common_exception, common_exception_handler in self.generic_exception_handler_mapping.items():
+            if issubclass(exception_type, common_exception):
+                return common_exception_handler
+
+
+def _handle_no_region_error(ex: NoRegionError) -> None:
+    raise RegionError(
+        "No region information found. Please provide --region parameter or configure default region settings."
+    )
+
+
+def _handle_client_errors(ex: ClientError) -> None:
+    error_code = get_client_error_code(ex)
+
+    if error_code in ("ExpiredToken", "ExpiredTokenException"):
+        raise CredentialsError(
+            "Your credential configuration is invalid or has expired token value. \nFor more information please "
+            "visit: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html"
+        )
+
+    raise ex
+
+
+def _catch_all_boto_errors(ex: BotoCoreError) -> None:
+    raise SDKError(str(ex)) from ex
+
+
+CUSTOM_EXCEPTION_HANDLER_MAPPING: Dict[Any, Callable] = {
+    NoRegionError: _handle_no_region_error,
+    ClientError: _handle_client_errors,
+}
+
+GENERIC_EXCEPTION_HANDLER_MAPPING: Dict[Any, Callable] = {BotoCoreError: _catch_all_boto_errors}
 
 
 @parameterized_option
@@ -31,10 +79,15 @@ def command_exception_handler(f, additional_mapping: Optional[Dict[Any, Callable
                 if exception_handler:
                     exception_handler(ex)
 
-                # if no custom handling defined search for default handlers
-                exception_handler = COMMON_EXCEPTION_HANDLER_MAPPING.get(exception_type)
-                if exception_handler:
-                    exception_handler(ex)
+                # if no custom handling defined search for default handlers under pre-defined
+                # custom and generic handlers.
+                for exception_handler in [
+                    CustomExceptionHandler(CUSTOM_EXCEPTION_HANDLER_MAPPING),
+                    GenericExceptionHandler(GENERIC_EXCEPTION_HANDLER_MAPPING),
+                ]:
+                    handler = exception_handler.get_handler(exception_type)
+                    if handler:
+                        handler(ex)
 
                 # if no handler defined, raise the exception
                 raise ex
@@ -42,29 +95,3 @@ def command_exception_handler(f, additional_mapping: Optional[Dict[Any, Callable
         return wrapper_command_exception_handler
 
     return decorator_command_exception_handler(f)
-
-
-def _handle_no_region_error(ex: NoRegionError) -> None:
-    raise RegionError(
-        "No region information found. Please provide --region parameter or configure default region settings. "
-        "\nFor more information please visit https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/"
-        "setup-credentials.html#setup-credentials-setting-region"
-    )
-
-
-def _handle_client_errors(ex: ClientError) -> None:
-    error_code = get_client_error_code(ex)
-
-    if error_code in ("ExpiredToken", "ExpiredTokenException"):
-        raise CredentialsError(
-            "Your credential configuration is invalid or has expired token value. \nFor more information please "
-            "visit: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html"
-        )
-
-    raise ex
-
-
-COMMON_EXCEPTION_HANDLER_MAPPING: Dict[Any, Callable] = {
-    NoRegionError: _handle_no_region_error,
-    ClientError: _handle_client_errors,
-}

--- a/samcli/commands/delete/command.py
+++ b/samcli/commands/delete/command.py
@@ -8,6 +8,7 @@ from typing import Optional
 import click
 
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
+from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.lib.utils.version_checker import check_newer_version
 
 SHORT_HELP = "Delete an AWS SAM application and the artifacts created by sam deploy."
@@ -83,6 +84,7 @@ LOG = logging.getLogger(__name__)
 @pass_context
 @check_newer_version
 @print_cmdline_args
+@command_exception_handler
 def cli(ctx, stack_name: str, config_file: str, config_env: str, no_prompts: bool, s3_bucket: str, s3_prefix: str):
     """
     `sam delete` command entry point

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -10,6 +10,7 @@ from samcli.cli.cli_config_file import TomlProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.cdk_support_decorators import unsupported_command_cdk
 from samcli.commands._utils.click_mutex import ClickMutex
+from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands._utils.options import (
     capabilities_option,
     force_upload_option,
@@ -155,6 +156,7 @@ LOG = logging.getLogger(__name__)
 @check_newer_version
 @print_cmdline_args
 @unsupported_command_cdk(alternative_command="cdk deploy")
+@command_exception_handler
 def cli(
     ctx,
     template_file,

--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -74,6 +74,12 @@ class CredentialsError(UserException):
     """
 
 
+class SDKError(UserException):
+    """
+    Exception class when there are generic Boto Errors.
+    """
+
+
 class SchemasApiException(UserException):
     """
     Exception class to wrap all Schemas APIs exceptions.

--- a/samcli/commands/package/command.py
+++ b/samcli/commands/package/command.py
@@ -6,6 +6,7 @@ import click
 from samcli.cli.cli_config_file import TomlProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.cdk_support_decorators import unsupported_command_cdk
+from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands._utils.options import (
     force_upload_option,
     image_repositories_option,
@@ -85,6 +86,7 @@ The following resources and their property locations are supported.
 @track_template_warnings([CodeDeployWarning.__name__, CodeDeployConditionWarning.__name__])
 @print_cmdline_args
 @unsupported_command_cdk(alternative_command="cdk deploy")
+@command_exception_handler
 def cli(
     ctx,
     template_file,

--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -10,6 +10,7 @@ import click
 from samcli.cli.cli_config_file import TomlProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.click_mutex import ClickMutex
+from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands.pipeline.bootstrap.oidc_config import (
     BitbucketOidcConfig,
     GitHubOidcConfig,
@@ -21,7 +22,6 @@ from samcli.lib.config.samconfig import SamConfig
 from samcli.lib.telemetry.metric import track_command
 from samcli.lib.utils.version_checker import check_newer_version
 
-from ..._utils.command_exception_handler import command_exception_handler
 from .guided_context import BITBUCKET, GITHUB_ACTIONS, GITLAB, IAM, OPEN_ID_CONNECT
 
 SHORT_HELP = "Generates the required AWS resources to connect your CI/CD system."

--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -21,6 +21,7 @@ from samcli.lib.config.samconfig import SamConfig
 from samcli.lib.telemetry.metric import track_command
 from samcli.lib.utils.version_checker import check_newer_version
 
+from ..._utils.command_exception_handler import command_exception_handler
 from .guided_context import BITBUCKET, GITHUB_ACTIONS, GITLAB, IAM, OPEN_ID_CONNECT
 
 SHORT_HELP = "Generates the required AWS resources to connect your CI/CD system."
@@ -177,6 +178,7 @@ OPENID_CONNECT = "OpenID Connect (OIDC)"
 @track_command
 @check_newer_version
 @print_cmdline_args
+@command_exception_handler
 def cli(
     ctx: Any,
     interactive: bool,

--- a/samcli/commands/pipeline/init/cli.py
+++ b/samcli/commands/pipeline/init/cli.py
@@ -8,6 +8,7 @@ import click
 from samcli.cli.cli_config_file import TomlProvider, configuration_option
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.cli.main import pass_context
+from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands.pipeline.init.interactive_init_flow import InteractiveInitFlow
 from samcli.lib.telemetry.metric import track_command
 
@@ -33,6 +34,7 @@ file generation process, or refer to resources you have previously created with 
 @cli_framework_options
 @pass_context
 @track_command  # pylint: disable=R0914
+@command_exception_handler
 def cli(ctx: Any, config_env: Optional[str], config_file: Optional[str], bootstrap: bool) -> None:
     """
     `sam pipeline init` command entry point

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -10,6 +10,7 @@ from serverlessrepo.publish import CREATE_APPLICATION
 from samcli.cli.cli_config_file import TomlProvider, configuration_option
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
+from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands._utils.options import template_common_option
 from samcli.commands._utils.template import TemplateFailedParsingException, TemplateNotFoundException, get_template_data
 from samcli.lib.telemetry.metric import track_command
@@ -52,6 +53,7 @@ SEMANTIC_VERSION = "SemanticVersion"
 @track_command
 @check_newer_version
 @print_cmdline_args
+@command_exception_handler
 def cli(
     ctx,
     template_file,

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -11,6 +11,7 @@ from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.commands._utils.cdk_support_decorators import unsupported_command_cdk
 from samcli.commands._utils.click_mutex import ClickMutex
+from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands._utils.constants import (
     DEFAULT_BUILD_DIR,
     DEFAULT_BUILD_DIR_WITH_AUTO_DEPENDENCY_LAYER,
@@ -154,6 +155,7 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
 @check_newer_version
 @print_cmdline_args
 @unsupported_command_cdk()
+@command_exception_handler
 def cli(
     ctx: Context,
     template_file: str,

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -13,6 +13,7 @@ from samcli.cli.context import Context
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.commands._utils.cdk_support_decorators import unsupported_command_cdk
+from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands._utils.options import template_option_without_build
 from samcli.commands.exceptions import LinterRuleMatchedException
 from samcli.lib.telemetry.event import EventTracker
@@ -37,6 +38,7 @@ from samcli.lib.utils.version_checker import check_newer_version
 @check_newer_version
 @print_cmdline_args
 @unsupported_command_cdk(alternative_command="cdk doctor")
+@command_exception_handler
 def cli(ctx, template_file, config_file, config_env, lint):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing

--- a/tests/unit/commands/_utils/test_command_exception_handler.py
+++ b/tests/unit/commands/_utils/test_command_exception_handler.py
@@ -4,7 +4,11 @@ from unittest import TestCase
 from botocore.exceptions import NoRegionError, ClientError, NoCredentialsError
 from parameterized import parameterized
 
-from samcli.commands._utils.command_exception_handler import command_exception_handler
+from samcli.commands._utils.command_exception_handler import (
+    command_exception_handler,
+    CustomExceptionHandler,
+    GenericExceptionHandler,
+)
 from samcli.commands.exceptions import RegionError, CredentialsError, UserException, SDKError
 
 
@@ -85,3 +89,21 @@ class TestCommandExceptionHandlerWithCustomHandler(TestCase):
 
         with self.assertRaises(CustomUserException):
             command_with_custom_exception_handler(_proxy_custom_exception)
+
+
+class TestCustomExceptionHandler(TestCase):
+    def test_custom_exception_handler(self):
+        custom_exception_handler = CustomExceptionHandler({CustomException: _custom_handler})
+
+        self.assertEqual(custom_exception_handler.get_handler(CustomException), _custom_handler)
+
+
+class TestGenericExceptionHandler(TestCase):
+    def test_generc_exception_handler(self):
+        def _generic_handler():
+            pass
+
+        generic_exception_handler = GenericExceptionHandler({Exception: _generic_handler})
+
+        # CustomException is a subclass of Exception
+        self.assertEqual(generic_exception_handler.get_handler(CustomException), _generic_handler)

--- a/tests/unit/commands/_utils/test_command_exception_handler.py
+++ b/tests/unit/commands/_utils/test_command_exception_handler.py
@@ -1,11 +1,11 @@
 from typing import Callable
 from unittest import TestCase
 
-from botocore.exceptions import NoRegionError, ClientError
+from botocore.exceptions import NoRegionError, ClientError, NoCredentialsError
 from parameterized import parameterized
 
 from samcli.commands._utils.command_exception_handler import command_exception_handler
-from samcli.commands.exceptions import RegionError, CredentialsError, UserException
+from samcli.commands.exceptions import RegionError, CredentialsError, UserException, SDKError
 
 
 @command_exception_handler
@@ -27,6 +27,13 @@ class TestCommandExceptionHandler(TestCase):
 
         with self.assertRaises(RegionError):
             echo_command(_proxy_function_that_raises_region_error)
+
+    def test_generic_sdk_error(self):
+        def _proxy_function_that_raises_generic_boto_error():
+            raise NoCredentialsError()
+
+        with self.assertRaises(SDKError):
+            echo_command(_proxy_function_that_raises_generic_boto_error)
 
     @parameterized.expand([("ExpiredToken",), ("ExpiredTokenException",)])
     def test_expired_token_error(self, error_code):


### PR DESCRIPTION
- DO NOT CRASH THE CLI on sdk errors. Showcase the error message.

#### Why is this change necessary?
* Do not crash the CLI and report a traceback on developer environment related issues/api calls related issues.

#### How does it address the issue?
* catch and handle the exception appropriately and exit with an exit code 1. Showcase the exception message as well.

#### What side effects does this change have?
* N/A (Better UX?)


### BEFORE

![Screen Shot 2023-02-28 at 5 41 57 PM](https://user-images.githubusercontent.com/3770774/222023080-7533fb40-51f4-43b3-bee9-617e423f65a4.png)

... Above is not even the full traceback. 
### AFTER
![Screen Shot 2023-02-28 at 5 41 26 PM](https://user-images.githubusercontent.com/3770774/222023089-5df3d069-0201-406b-b9aa-31cf7c40a693.png)


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
