### PR TITLE
fix: set lint on validate to be default

### DIFF
--- a/samcli/lib/init/default_samconfig.py
+++ b/samcli/lib/init/default_samconfig.py
@@ -41,6 +41,7 @@ class DefaultSamconfig:
             ),
             Default(writing_type=WritingType.ZIP, key="cached", value=True, command=["build"]),
             Default(writing_type=WritingType.Both, key="parallel", value=True, command=["build"]),
+            Default(writing_type=WritingType.Both, key="lint", value=True, command=["validate"]),
             Default(writing_type=WritingType.Both, key="capabilities", value="CAPABILITY_IAM", command=["deploy"]),
             Default(writing_type=WritingType.Both, key="confirm_changeset", value=True, command=["deploy"]),
             # NOTE(sriram-mv): Template is still uploaded to s3 regardless of Package Type.

--- a/tests/unit/lib/init/test_default_samconfig.py
+++ b/tests/unit/lib/init/test_default_samconfig.py
@@ -56,6 +56,7 @@ class TestDefaultSamconfig(TestCase):
             [
                 call(cmd_names=["global"], section="parameters", key="stack_name", value="sam-app"),
                 call(cmd_names=["build"], section="parameters", key="parallel", value=True),
+                call(cmd_names=["validate"], section="parameters", key="lint", value=True),
                 call(cmd_names=["deploy"], section="parameters", key="resolve_s3", value=True),
                 call(cmd_names=["package"], section="parameters", key="resolve_s3", value=True),
                 call(cmd_names=["deploy"], section="parameters", key="capabilities", value="CAPABILITY_IAM"),
@@ -83,6 +84,7 @@ class TestDefaultSamconfig(TestCase):
         default_config._config.put.assert_has_calls(
             [
                 call(cmd_names=["global"], section="parameters", key="stack_name", value="sam-app"),
+                call(cmd_names=["validate"], section="parameters", key="lint", value=True),
                 call(cmd_names=["build"], section="parameters", key="parallel", value=True),
                 call(cmd_names=["deploy"], section="parameters", key="resolve_image_repos", value=True),
                 call(cmd_names=["deploy"], section="parameters", key="capabilities", value="CAPABILITY_IAM"),


### PR DESCRIPTION
- sam validate will use cfn-lint by default when running the interactive init flow.

#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
* as part of engaging the right defaults with applications initialized with sam init, the default samconfig.toml should have validate with `cfn-lint` turned on.

#### How does it address the issue?
* turn on `lint` on `sam validate` to be True

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
