### PR TITLE
chore: Added dependabot to the internal PR label workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -25,7 +25,7 @@ jobs:
               'aws-sam-cli-bot',
               'jfuss', 'hoffa', 'awood45', 'aahung', 'hawflau', 'mndeveci', 'ssenchenko',
               'qingchm', 'moelasmar', 'xazhao', 'mildaniel', 'marekaiv', 'torresxb1',
-              'lucashuy', 'hnnasit', 'sriram-mv'
+              'lucashuy', 'hnnasit', 'sriram-mv', 'dependabot'
             ]
             if (maintainers.includes(context.payload.sender.login)) {
               github.rest.issues.addLabels({


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
dependabot PRs are being labelled as external.

#### How does it address the issue?
Adds dependabot to our PR label workflow so that it applies the correct label to it.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
