### PR TITLE
perf: caching for reading template file

### DIFF
--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -1,10 +1,10 @@
 """
 Utilities to manipulate template
 """
-from functools import lru_cache
 import itertools
 import os
 import pathlib
+from functools import lru_cache
 
 import jmespath
 import yaml

--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -1,6 +1,7 @@
 """
 Utilities to manipulate template
 """
+from functools import lru_cache
 import itertools
 import os
 import pathlib
@@ -30,6 +31,7 @@ class TemplateFailedParsingException(UserException):
     pass
 
 
+@lru_cache
 def get_template_data(template_file):
     """
     Read the template file, parse it as JSON/YAML and return the template as a dictionary.


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/3442


#### Why is this change necessary?
* Prevent repeated reloads from template file into in-memory representation.

#### How does it address the issue?
* cuts the load times by a factor of 50% on deploys.

#### What side effects does this change have?
* @mndeveci does this affect `sam sync` ?

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
