### PR TITLE
chore: fix sync tests by moving default field values into package test

### DIFF
--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -17,7 +17,7 @@ SLEEP = 3
 class PackageIntegBase(TestCase):
     kms_key = None
     ecr_repo_name = None
-    
+
     @classmethod
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -15,6 +15,9 @@ SLEEP = 3
 
 
 class PackageIntegBase(TestCase):
+    kms_key = None
+    ecr_repo_name = None
+    
     @classmethod
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")

--- a/tests/integration/sync/sync_integ_base.py
+++ b/tests/integration/sync/sync_integ_base.py
@@ -43,9 +43,6 @@ class SyncIntegBase(BuildIntegBase, PackageIntegBase):
         self.sns_arn = os.environ.get("AWS_SNS")
         self.stacks = []
         self.s3_prefix = uuid.uuid4().hex
-        # Defining kms key and repo name here to avoid linter error
-        self.kms_key = ""
-        self.ecr_repo_name = ""
         self.dependency_layer = True if self.dependency_layer is None else self.dependency_layer
         super().setUp()
 


### PR DESCRIPTION
Earlier PR (https://github.com/aws/aws-sam-cli/pull/4788/) added default values for `self.ecr_repo_name` and `self.kms_key` in `setUp` method of the sync tests, which overrides the actual values which is set `setUpClass` in `PackageIntegBase` which runs earlier. 

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
