### PR TITLE
fix: Create cache dir before attempting to lock it

### DIFF
--- a/tests/end_to_end/end_to_end_base.py
+++ b/tests/end_to_end/end_to_end_base.py
@@ -1,5 +1,8 @@
+import os
+
 from typing import List
 
+from samcli.cli.global_config import GlobalConfig
 from tests.end_to_end.test_stages import EndToEndBaseStage
 from tests.integration.delete.delete_integ_base import DeleteIntegBase
 from tests.integration.init.test_init_base import InitIntegBase
@@ -20,6 +23,13 @@ class EndToEndBase(InitIntegBase, StackOutputsIntegBase, DeleteIntegBase, SyncIn
     def setUp(self):
         super().setUp()
         self.stacks = []
+        self.config_file_dir = GlobalConfig().config_dir
+        self._create_config_dir()
+
+    def _create_config_dir(self):
+        # Init tests will lock the config dir, ensure it exists before obtaining a lock
+        if not self.config_file_dir.is_dir():
+            os.mkdir(self.config_file_dir)
 
     @staticmethod
     def _run_tests(stages: List[EndToEndBaseStage]):

--- a/tests/end_to_end/test_stages.py
+++ b/tests/end_to_end/test_stages.py
@@ -8,8 +8,6 @@ from pathlib import Path
 import os
 
 from samcli.cli.global_config import GlobalConfig
-from tests.end_to_end.end_to_end_context import EndToEndTestContext
-from tests.testing_utils import CommandResult, run_command, run_command_with_input
 from filelock import FileLock
 from tests.end_to_end.end_to_end_context import EndToEndTestContext
 from tests.testing_utils import CommandResult, run_command, run_command_with_input
@@ -51,7 +49,6 @@ class DefaultInitStage(EndToEndBaseStage):
             # Need to lock the config file so that the several processes don't
             # attempt to write to it at the same time when caching init templates.
             command_result = run_command(self.command_list, cwd=self.test_context.working_directory)
-        command_result = run_command(self.command_list, cwd=self.test_context.working_directory)
         self._delete_default_samconfig()
         return command_result
 


### PR DESCRIPTION
#### Why is this change necessary?
E2E tests fail when the cache directory doesn't already exist since they attempt to acquire a lock with it.

#### How does it address the issue?
Ensures directory is creating before attempting to acquire the lock.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
