### PR TITLE
fix: Use python3.7 template in E2E tests

### DIFF
--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -16,7 +16,7 @@ from tests.end_to_end.test_stages import (
     DefaultSyncStage,
     BaseValidator,
 )
-from tests.testing_utils import CommandResult, RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
+from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
 
 # Deploy tests require credentials and CI/CD will only add credentials to the env if the PR is from the same repo.
 # This is to restrict package tests to run outside of CI/CD, when the branch is not master or tests are not run by Canary
@@ -60,7 +60,7 @@ class StackOutputsValidator(BaseValidator):
     ("runtime", "dependency_manager"),
     [
         ("go1.x", "mod"),
-        ("python3.9", "pip"),
+        ("python3.7", "pip"),
     ],
 )
 class TestHelloWorldDefaultEndToEnd(EndToEndBase):
@@ -91,7 +91,7 @@ class TestHelloWorldDefaultEndToEnd(EndToEndBase):
     ("runtime", "dependency_manager"),
     [
         ("go1.x", "mod"),
-        ("python3.9", "pip"),
+        ("python3.7", "pip"),
     ],
 )
 class TestHelloWorldDefaultSyncEndToEnd(EndToEndBase):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
E2E test for Python are failing since our environment uses Python 3.7 but generated template is for Python3.9, resulting in the build stage not working.

#### How does it address the issue?
Changes the Python version in the test cases to 3.7 to match the environment.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
