### PR TITLE
fix: Add default values for init schema test teardown

### DIFF
--- a/tests/integration/init/schemas/schemas_test_data_setup.py
+++ b/tests/integration/init/schemas/schemas_test_data_setup.py
@@ -3,6 +3,7 @@ import time
 import shutil
 import tempfile
 from unittest import TestCase
+from typing import Optional
 
 from boto3.session import Session
 from botocore.exceptions import ClientError
@@ -18,22 +19,20 @@ SLEEP_TIME = 1
 
 
 class SchemaTestDataSetup(TestCase):
-    original_cred_file: str
-    original_config_file: str
-    original_profile: str
-    original_region: str
+    original_cred_file: Optional[str]
+    original_config_file: Optional[str]
+    original_profile: Optional[str]
+    original_region: Optional[str]
+    config_dir: Optional[str]
 
     @classmethod
     def setUpClass(cls):
         env = os.environ
-        if AWS_CONFIG_FILE in env:
-            cls.original_config_file = env[AWS_CONFIG_FILE]
-        if AWS_SHARED_CREDENTIALS_FILE in env:
-            cls.original_cred_file = env[AWS_SHARED_CREDENTIALS_FILE]
-        if AWS_PROFILE in env:
-            cls.original_profile = env[AWS_PROFILE]
-        if AWS_DEFAULT_REGION in env:
-            cls.original_region = env[AWS_DEFAULT_REGION]
+        cls.original_config_file = env[AWS_CONFIG_FILE] if AWS_CONFIG_FILE in env else None
+        cls.original_cred_file = env[AWS_SHARED_CREDENTIALS_FILE] if AWS_SHARED_CREDENTIALS_FILE in env else None
+        cls.original_profile = env[AWS_PROFILE] if AWS_PROFILE in env else None
+        cls.original_region = env[AWS_DEFAULT_REGION] if AWS_DEFAULT_REGION in env else None
+        cls.config_dir = None
 
         session = Session()
         schemas_client = session.client("schemas", region_name=session.region_name)
@@ -86,8 +85,8 @@ eb-app-maven
             del env[AWS_DEFAULT_REGION]
         if self.original_region:
             env[AWS_DEFAULT_REGION] = self.original_region
-
-        shutil.rmtree(self.config_dir, ignore_errors=True)
+        if self.config_dir:
+            shutil.rmtree(self.config_dir, ignore_errors=True)
 
     def _init_custom_config(self, profile, region):
         self.config_dir = tempfile.mkdtemp()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A.

#### Why is this change necessary?
Fixes a failing integration test due to refactoring

#### How does it address the issue?
Adds a default value for teardown fields

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
