### PR TITLE
bug: Don't set DisableRollback with OnFailure

### DIFF
--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -267,14 +267,8 @@ class DeployContext:
                     if not click.confirm(f"{self.MSG_CONFIRM_CHANGESET}", default=False):
                         return
 
-                # Stop the rollback in the case of DO_NOTHING or if this is a new stack and DELETE is specified
-                # DO_NOTHING behaves the same disable_rollback, they both preserve the current state of the stack
-                do_disable_rollback = (
-                    self.on_failure in [FailureMode.DO_NOTHING, FailureMode.DELETE] or disable_rollback
-                )
-
-                self.deployer.execute_changeset(result["Id"], stack_name, do_disable_rollback)
-                self.deployer.wait_for_execute(stack_name, changeset_type, do_disable_rollback, self.on_failure)
+                self.deployer.execute_changeset(result["Id"], stack_name, disable_rollback)
+                self.deployer.wait_for_execute(stack_name, changeset_type, disable_rollback, self.on_failure)
                 click.echo(self.MSG_EXECUTE_SUCCESS.format(stack_name=stack_name, region=region))
 
             except deploy_exceptions.ChangeEmptyError as ex:

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -691,7 +691,6 @@ class Deployer:
         kwargs = {
             "StackName": stack_name,
         }
-
         current_state = self._get_stack_status(stack_name)
 
         try:
@@ -704,7 +703,7 @@ class Deployer:
 
                 current_state = self._get_stack_status(stack_name)
 
-            failed_states = ["CREATE_FAILED", "UPDATE_FAILED", "ROLLBACK_COMPLETE", "ROLLBACK_FAILED"]
+            failed_states = ["CREATE_FAILED", "ROLLBACK_COMPLETE", "ROLLBACK_FAILED"]
 
             if current_state in failed_states:
                 LOG.info("Stack %s failed to create/update correctly, deleting stack", stack_name)

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -24,20 +24,20 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
 class TestDeploy(DeployIntegBase):
     @classmethod
     def setUpClass(cls):
-        cls.docker_client = docker.from_env()
-        cls.local_images = [
-            ("public.ecr.aws/sam/emulation-python3.8", "latest"),
-        ]
-        # setup some images locally by pulling them.
-        for repo, tag in cls.local_images:
-            cls.docker_client.api.pull(repository=repo, tag=tag)
-            cls.docker_client.api.tag(f"{repo}:{tag}", "emulation-python3.8", tag="latest")
-            cls.docker_client.api.tag(f"{repo}:{tag}", "emulation-python3.8-2", tag="latest")
-            cls.docker_client.api.tag(f"{repo}:{tag}", "colorsrandomfunctionf61b9209", tag="latest")
+        # cls.docker_client = docker.from_env()
+        # cls.local_images = [
+        #     ("public.ecr.aws/sam/emulation-python3.8", "latest"),
+        # ]
+        # # setup some images locally by pulling them.
+        # for repo, tag in cls.local_images:
+        #     cls.docker_client.api.pull(repository=repo, tag=tag)
+        #     cls.docker_client.api.tag(f"{repo}:{tag}", "emulation-python3.8", tag="latest")
+        #     cls.docker_client.api.tag(f"{repo}:{tag}", "emulation-python3.8-2", tag="latest")
+        #     cls.docker_client.api.tag(f"{repo}:{tag}", "colorsrandomfunctionf61b9209", tag="latest")
 
         # setup signing profile arn & name
-        cls.signing_profile_name = os.environ.get("AWS_SIGNING_PROFILE_NAME")
-        cls.signing_profile_version_arn = os.environ.get("AWS_SIGNING_PROFILE_VERSION_ARN")
+        # cls.signing_profile_name = os.environ.get("AWS_SIGNING_PROFILE_NAME")
+        # cls.signing_profile_version_arn = os.environ.get("AWS_SIGNING_PROFILE_VERSION_ARN")
         super().setUpClass()
 
     def setUp(self):
@@ -1303,7 +1303,7 @@ to create a managed default bucket, or run sam deploy --guided",
             bytes(
                 f"Error: Failed to create/update the stack: {stack_name}, Waiter StackCreateComplete failed: "
                 f'Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" '
-                f'we matched expected path: "CREATE_FAILED" at least once',
+                f'we matched expected path: "ROLLBACK_COMPLETE" at least once',
                 encoding="utf-8",
             ),
             stderr,
@@ -1363,7 +1363,7 @@ to create a managed default bucket, or run sam deploy --guided",
             bytes(
                 f"Error: Failed to create/update the stack: {stack_name}, Waiter StackUpdateComplete failed: "
                 f'Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" '
-                f'we matched expected path: "UPDATE_FAILED" at least once',
+                f'we matched expected path: "UPDATE_ROLLBACK_COMPLETE" at least once',
                 encoding="utf-8",
             ),
             stderr,

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -24,20 +24,20 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
 class TestDeploy(DeployIntegBase):
     @classmethod
     def setUpClass(cls):
-        # cls.docker_client = docker.from_env()
-        # cls.local_images = [
-        #     ("public.ecr.aws/sam/emulation-python3.8", "latest"),
-        # ]
-        # # setup some images locally by pulling them.
-        # for repo, tag in cls.local_images:
-        #     cls.docker_client.api.pull(repository=repo, tag=tag)
-        #     cls.docker_client.api.tag(f"{repo}:{tag}", "emulation-python3.8", tag="latest")
-        #     cls.docker_client.api.tag(f"{repo}:{tag}", "emulation-python3.8-2", tag="latest")
-        #     cls.docker_client.api.tag(f"{repo}:{tag}", "colorsrandomfunctionf61b9209", tag="latest")
+        cls.docker_client = docker.from_env()
+        cls.local_images = [
+            ("public.ecr.aws/sam/emulation-python3.8", "latest"),
+        ]
+        # setup some images locally by pulling them.
+        for repo, tag in cls.local_images:
+            cls.docker_client.api.pull(repository=repo, tag=tag)
+            cls.docker_client.api.tag(f"{repo}:{tag}", "emulation-python3.8", tag="latest")
+            cls.docker_client.api.tag(f"{repo}:{tag}", "emulation-python3.8-2", tag="latest")
+            cls.docker_client.api.tag(f"{repo}:{tag}", "colorsrandomfunctionf61b9209", tag="latest")
 
         # setup signing profile arn & name
-        # cls.signing_profile_name = os.environ.get("AWS_SIGNING_PROFILE_NAME")
-        # cls.signing_profile_version_arn = os.environ.get("AWS_SIGNING_PROFILE_VERSION_ARN")
+        cls.signing_profile_name = os.environ.get("AWS_SIGNING_PROFILE_NAME")
+        cls.signing_profile_version_arn = os.environ.get("AWS_SIGNING_PROFILE_VERSION_ARN")
         super().setUpClass()
 
     def setUp(self):

--- a/tests/unit/commands/deploy/test_deploy_context.py
+++ b/tests/unit/commands/deploy/test_deploy_context.py
@@ -268,5 +268,5 @@ class TestSamDeployCommand(TestCase):
             self.deploy_command_context.run()
 
             self.deploy_command_context.deployer.wait_for_execute.assert_called_with(
-                ANY, "CREATE", True, FailureMode.DO_NOTHING
+                ANY, "CREATE", False, FailureMode.DO_NOTHING
             )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#4585 


#### Why is this change necessary?
`--on-failure DELETE` would set `disable-rollback` to True in the `execute-change-set` API call. However, this causes issues when you have replacement updates within your CloudFormation template. Instead, we remove setting `disable-rollback` unless that is explicitly passed in and then allow the deletion of the stack to happen based on the end status of the stack. In talking with with @lucashuy, this seems to align with the original intent.

#### How does it address the issue?
Does what I said above.

#### What side effects does this change have?
In looking at this in depth, I removed the "UPDATE_FAILED" status to trigger a deletion. This doesn't seem like a valid end state in CloudFormation for a stack but assuming a Stack Ends up in this state, it should be recoverable from. The idea behind this was to not accidentally delete a Stack if we are not in one of the states that force a stack deletion (which the others in the list are, see changes for full list).

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
