### PR TITLE
feat: Add threshold to the number of code syncs that trigger skip infra sync

### DIFF
--- a/samcli/lib/sync/infra_sync_executor.py
+++ b/samcli/lib/sync/infra_sync_executor.py
@@ -155,24 +155,24 @@ class InfraSyncExecutor:
         # Will not combine the comparisons in order to save operation cost
         if first_sync:
             # Reminder: Add back after sync infra skip ready for release
-            try:
-                if self._auto_skip_infra_sync(
-                    self._package_context.output_template_file,
-                    self._package_context.template_file,
-                    self._deploy_context.stack_name,
-                ):
-                    # We have a threshold on number of sync flows we initiate
-                    # If higher than the threshold, we perform infra sync to improve performance
-                    if len(self.code_sync_resources) < SYNC_FLOW_THRESHOLD:
-                        LOG.info("Template haven't been changed since last deployment, skipping infra sync...")
-                        return InfraSyncResult(False, self.code_sync_resources)
-                    else:
-                        LOG.info("The number of resources that needs an update exceeds %s, \
-an infra sync will be executed for an CloudFormation deployment to improve performance", SYNC_FLOW_THRESHOLD)
-            except Exception:
-                LOG.debug(
-                    "Could not skip infra sync by comparing to a previously deployed template, starting infra sync"
-                )
+            #             try:
+            #                 if self._auto_skip_infra_sync(
+            #                     self._package_context.output_template_file,
+            #                     self._package_context.template_file,
+            #                     self._deploy_context.stack_name,
+            #                 ):
+            #                     # We have a threshold on number of sync flows we initiate
+            #                     # If higher than the threshold, we perform infra sync to improve performance
+            #                     if len(self.code_sync_resources) < SYNC_FLOW_THRESHOLD:
+            #                         LOG.info("Template haven't been changed since last deployment, skipping infra sync...")
+            #                         return InfraSyncResult(False, self.code_sync_resources)
+            #                     else:
+            #                         LOG.info("The number of resources that needs an update exceeds %s, \
+            # an infra sync will be executed for an CloudFormation deployment to improve performance", SYNC_FLOW_THRESHOLD)
+            #             except Exception:
+            #                 LOG.debug(
+            #                     "Could not skip infra sync by comparing to a previously deployed template, starting infra sync"
+            #                 )
             pass
 
         self._deploy_context.run()

--- a/samcli/lib/sync/infra_sync_executor.py
+++ b/samcli/lib/sync/infra_sync_executor.py
@@ -155,24 +155,28 @@ class InfraSyncExecutor:
         # Will not combine the comparisons in order to save operation cost
         if first_sync:
             # Reminder: Add back after sync infra skip ready for release
-            #             try:
-            #                 if self._auto_skip_infra_sync(
-            #                     self._package_context.output_template_file,
-            #                     self._package_context.template_file,
-            #                     self._deploy_context.stack_name,
-            #                 ):
-            #                     # We have a threshold on number of sync flows we initiate
-            #                     # If higher than the threshold, we perform infra sync to improve performance
-            #                     if len(self.code_sync_resources) < SYNC_FLOW_THRESHOLD:
-            #                         LOG.info("Template haven't been changed since last deployment, skipping infra sync...")
-            #                         return InfraSyncResult(False, self.code_sync_resources)
-            #                     else:
-            #                         LOG.info("The number of resources that needs an update exceeds %s, \
-            # an infra sync will be executed for an CloudFormation deployment to improve performance", SYNC_FLOW_THRESHOLD)
-            #             except Exception:
-            #                 LOG.debug(
-            #                     "Could not skip infra sync by comparing to a previously deployed template, starting infra sync"
-            #                 )
+            # try:
+            #     if self._auto_skip_infra_sync(
+            #         self._package_context.output_template_file,
+            #         self._package_context.template_file,
+            #         self._deploy_context.stack_name,
+            #     ):
+            #         We have a threshold on number of sync flows we initiate
+            #         If higher than the threshold, we perform infra sync to improve performance
+            #         if len(self.code_sync_resources) < SYNC_FLOW_THRESHOLD:
+            #             pass
+            #             LOG.info("Template haven't been changed since last deployment, skipping infra sync...")
+            #             return InfraSyncResult(False, self.code_sync_resources)
+            #         else:
+            #             LOG.info(
+            #             "The number of resources that needs an update exceeds %s, \
+            #             an infra sync will be executed for an CloudFormation deployment to improve performance",
+            #             SYNC_FLOW_THRESHOLD)
+            #             pass
+            # except Exception:
+            #     LOG.debug(
+            #         "Could not skip infra sync by comparing to a previously deployed template, starting infra sync"
+            #     )
             pass
 
         self._deploy_context.run()

--- a/tests/unit/lib/sync/test_infra_sync_executor.py
+++ b/tests/unit/lib/sync/test_infra_sync_executor.py
@@ -36,6 +36,29 @@ class TestInfraSyncExecutor(TestCase):
         # Reminder: Add back after sync infra skip ready for release
         # self.assertEqual(executed, not auto_skip_infra_sync)
 
+    @patch("samcli.lib.sync.infra_sync_executor.SYNC_FLOW_THRESHOLD", 1)
+    @patch("samcli.lib.sync.infra_sync_executor.InfraSyncExecutor._auto_skip_infra_sync")
+    @patch("samcli.lib.sync.infra_sync_executor.Session")
+    def test_execute_infra_sync_exceed_threshold(self, session_mock, auto_skip_infra_sync_mock):
+
+        infra_sync_executor = InfraSyncExecutor(self.build_context, self.package_context, self.deploy_context)
+        auto_skip_infra_sync_mock.return_value = True
+        infra_sync_executor._code_sync_resources = {"Function"}
+
+        infra_sync_result = infra_sync_executor.execute_infra_sync(True)
+
+        executed = infra_sync_result.infra_sync_executed
+        code_sync_resources = infra_sync_result.code_sync_resources
+
+        self.build_context.set_up.assert_called_once()
+        self.build_context.run.assert_called_once()
+        self.package_context.run.assert_called_once()
+
+        self.deploy_context.run.assert_called_once()
+        self.assertEqual(code_sync_resources, set())
+
+        self.assertEqual(executed, True)
+
     @patch("samcli.lib.sync.infra_sync_executor.is_local_path")
     @patch("samcli.lib.sync.infra_sync_executor.get_template_data")
     @patch("samcli.lib.sync.infra_sync_executor.Session")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A.

#### Why is this change necessary?
When the number of resources that needs a code sync exceeds a threshold value (currently 50), it's not likely that skipping infra sync and queuing up related code syncs improve the execution speed.

#### How does it address the issue?
Add a threshold check to prevent skip infra sync if the number of required code sync resources exceed the threshold

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
