### PR TITLE
feat: Invoke Lambda authorizer

### DIFF
--- a/samcli/local/apigw/authorizers/lambda_authorizer.py
+++ b/samcli/local/apigw/authorizers/lambda_authorizer.py
@@ -5,16 +5,13 @@ import json
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qsl
 
 from samcli.commands.local.lib.validators.identity_source_validator import IdentitySourceValidator
-from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.apigw.authorizers.authorizer import Authorizer
 from samcli.local.apigw.exceptions import InvalidLambdaAuthorizerResponse, InvalidSecurityDefinition
 from samcli.local.apigw.route import Route
-from samcli.local.services.base_local_service import LambdaOutputParser
 
 _RESPONSE_PRINCIPAL_ID = "principalId"
 _RESPONSE_CONTEXT = "context"
@@ -299,15 +296,6 @@ class LambdaAuthorizer(Authorizer):
                     self._identity_sources.append(identity_source_validator)
 
                     break
-
-    def invoke_lambda_function(self, invoke_context, event, stderr) -> str:
-        with BytesIO() as stdout:
-            stdout_writer = StreamWriter(stdout, auto_flush=True)
-
-            invoke_context(self.lambda_name, event, stdout=stdout_writer, stderr=stderr)
-            lambda_response, _ = LambdaOutputParser.get_lambda_output(stdout)
-
-            return lambda_response
 
     def is_valid_response(self, response: str, method_arn: str) -> bool:
         """

--- a/samcli/local/apigw/authorizers/lambda_authorizer.py
+++ b/samcli/local/apigw/authorizers/lambda_authorizer.py
@@ -356,7 +356,7 @@ class LambdaAuthorizer(Authorizer):
         all_statements = policy_document.get(_RESPONSE_IAM_STATEMENT)
         if not all_statements or not isinstance(all_statements, list) or not len(all_statements) > 0:
             raise InvalidLambdaAuthorizerResponse(
-                f"Authorizer {self.authorizer_name} contains an invalid {_RESPONSE_IAM_STATEMENT}"
+                f"Authorizer {self.authorizer_name} contains an invalid " f"or missing {_RESPONSE_IAM_STATEMENT}"
             )
 
         for statement in all_statements:
@@ -442,10 +442,10 @@ class LambdaAuthorizer(Authorizer):
 
         Returns
         -------
-        dict
+        Dict[str, Any]
             The built authorizer context object
         """
         built_context = response.get(_RESPONSE_CONTEXT, {})
         built_context[_RESPONSE_PRINCIPAL_ID] = response.get(_RESPONSE_PRINCIPAL_ID)
 
-        return built_context
+        return built_context  # type: ignore

--- a/samcli/local/apigw/authorizers/lambda_authorizer.py
+++ b/samcli/local/apigw/authorizers/lambda_authorizer.py
@@ -524,7 +524,6 @@ class LambdaAuthorizerIAMPolicyValidator:
                     f"Authorizer '{auth_name}' policy document must be a list of objects"
                 )
 
-
             for prop_name, validator in validators.items():
                 if not validator.is_valid(statement):
                     raise InvalidLambdaAuthorizerResponse(

--- a/samcli/local/apigw/authorizers/lambda_authorizer.py
+++ b/samcli/local/apigw/authorizers/lambda_authorizer.py
@@ -446,6 +446,10 @@ class LambdaAuthorizer(Authorizer):
             The built authorizer context object
         """
         built_context = response.get(_RESPONSE_CONTEXT, {})
-        built_context[_RESPONSE_PRINCIPAL_ID] = response.get(_RESPONSE_PRINCIPAL_ID)
+
+        principal_id = response.get(_RESPONSE_PRINCIPAL_ID)
+        if principal_id:
+            # only V1 response contains this ID in the output
+            built_context[_RESPONSE_PRINCIPAL_ID] = principal_id
 
         return built_context  # type: ignore

--- a/samcli/local/apigw/event_constructor.py
+++ b/samcli/local/apigw/event_constructor.py
@@ -3,7 +3,6 @@ Lambda event construction and generation
 """
 
 import base64
-import json
 import logging
 from datetime import datetime
 from time import time
@@ -88,9 +87,9 @@ def construct_v1_event(
         stage_variables=stage_variables,
     )
 
-    event_str = json.dumps(event.to_dict(), sort_keys=True)
-    LOG.debug("Constructed String representation of Event to invoke Lambda. Event: %s", event_str)
-    return event_str
+    event_dict = event.to_dict()
+    LOG.debug("Constructed Event 1.0 to invoke Lambda. Event: %s", event_dict)
+    return event_dict
 
 
 def construct_v2_event_http(
@@ -159,9 +158,9 @@ def construct_v2_event_http(
         stage_variables=stage_variables,
     )
 
-    event_str = json.dumps(event.to_dict())
-    LOG.debug("Constructed String representation of Event Version 2.0 to invoke Lambda. Event: %s", event_str)
-    return event_str
+    event_dict = event.to_dict()
+    LOG.debug("Constructed Event Version 2.0 to invoke Lambda. Event: %s", event_dict)
+    return event_dict
 
 
 def _query_string_params(flask_request):

--- a/samcli/local/apigw/event_constructor.py
+++ b/samcli/local/apigw/event_constructor.py
@@ -90,7 +90,7 @@ def construct_v1_event(
 
     event_dict = event.to_dict()
     LOG.debug("Constructed Event 1.0 to invoke Lambda. Event: %s", event_dict)
-    return event_dict
+    return event_dict  # type: ignore
 
 
 def construct_v2_event_http(
@@ -161,7 +161,7 @@ def construct_v2_event_http(
 
     event_dict = event.to_dict()
     LOG.debug("Constructed Event Version 2.0 to invoke Lambda. Event: %s", event_dict)
-    return event_dict
+    return event_dict  # type: ignore
 
 
 def _query_string_params(flask_request):

--- a/samcli/local/apigw/event_constructor.py
+++ b/samcli/local/apigw/event_constructor.py
@@ -6,6 +6,7 @@ import base64
 import logging
 from datetime import datetime
 from time import time
+from typing import Any, Dict
 
 from samcli.local.apigw.path_converter import PathConverter
 from samcli.local.events.api_event import (
@@ -22,7 +23,7 @@ LOG = logging.getLogger(__name__)
 
 def construct_v1_event(
     flask_request, port, binary_types, stage_name=None, stage_variables=None, operation_name=None
-) -> str:
+) -> Dict[str, Any]:
     """
     Helper method that constructs the Event to be passed to Lambda
 
@@ -31,7 +32,7 @@ def construct_v1_event(
     :param binary_types: list of binary types
     :param stage_name: Optional, the stage name string
     :param stage_variables: Optional, API Gateway Stage Variables
-    :return: String representing the event
+    :return: JSON object
     """
 
     identity = ContextIdentity(source_ip=flask_request.remote_addr)
@@ -101,7 +102,7 @@ def construct_v2_event_http(
     route_key=None,
     request_time_epoch=int(time()),
     request_time=datetime.utcnow().strftime("%d/%b/%Y:%H:%M:%S +0000"),
-) -> str:
+) -> Dict[str, Any]:
     """
     Helper method that constructs the Event 2.0 to be passed to Lambda
 
@@ -113,7 +114,7 @@ def construct_v2_event_http(
     :param stage_name: Optional, the stage name string
     :param stage_variables: Optional, API Gateway Stage Variables
     :param route_key: Optional, the route key for the route
-    :return: String representing the event
+    :return: JSON object
     """
     method = flask_request.method
 

--- a/samcli/local/apigw/event_constructor.py
+++ b/samcli/local/apigw/event_constructor.py
@@ -90,7 +90,7 @@ def construct_v1_event(
 
     event_dict = event.to_dict()
     LOG.debug("Constructed Event 1.0 to invoke Lambda. Event: %s", event_dict)
-    return event_dict  # type: ignore
+    return event_dict
 
 
 def construct_v2_event_http(
@@ -161,7 +161,7 @@ def construct_v2_event_http(
 
     event_dict = event.to_dict()
     LOG.debug("Constructed Event Version 2.0 to invoke Lambda. Event: %s", event_dict)
-    return event_dict  # type: ignore
+    return event_dict
 
 
 def _query_string_params(flask_request):

--- a/samcli/local/apigw/exceptions.py
+++ b/samcli/local/apigw/exceptions.py
@@ -38,3 +38,9 @@ class InvalidSecurityDefinition(UserException):
     """
     An exception raised when the user provides an invalid security definition
     """
+
+
+class InvalidLambdaAuthorizerResponse(UserException):
+    """
+    An exception raised when a Lambda authorizer returns an invalid response format
+    """

--- a/samcli/local/apigw/exceptions.py
+++ b/samcli/local/apigw/exceptions.py
@@ -44,3 +44,9 @@ class InvalidLambdaAuthorizerResponse(UserException):
     """
     An exception raised when a Lambda authorizer returns an invalid response format
     """
+
+
+class AuthorizerUnauthorizedRequest(UserException):
+    """
+    An exception raised when the request is not authorized by the authorizer
+    """

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -660,7 +660,7 @@ class LocalApigwService(BaseLocalService):
 
                 # update route context to include any context that may have been passed from authorizer
                 original_context = route_lambda_event.get("requestContext", {})
-                original_context.update({"authorizer": LambdaAuthorizer.get_context(lambda_auth_response)})
+                original_context.update({"authorizer": lambda_authorizer.get_context(lambda_auth_response)})
                 route_lambda_event.update({"requestContext": original_context})
 
             # invoke the route's Lambda function

--- a/samcli/local/apigw/service_error_responses.py
+++ b/samcli/local/apigw/service_error_responses.py
@@ -8,11 +8,26 @@ class ServiceErrorResponses:
     _MISSING_AUTHENTICATION = {"message": "Missing Authentication Token"}
     _LAMBDA_FAILURE = {"message": "Internal server error"}
     _MISSING_LAMBDA_AUTH_IDENTITY_SOURCES = {"message": "Unauthorized"}
+    _LAMBDA_AUTHORIZER_NOT_AUTHORIZED = {"message": "User is not authorized to access this resource"}
 
     HTTP_STATUS_CODE_501 = 501
     HTTP_STATUS_CODE_502 = 502
     HTTP_STATUS_CODE_403 = 403
     HTTP_STATUS_CODE_401 = 401
+
+    @staticmethod
+    def lambda_authorizer_unauthorized() -> Response:
+        """
+        Constructs a Flask response for when a route invokes a Lambda Authorizer, but
+        is the identity sources provided are not authorized for that method
+
+        Returns
+        -------
+        Response
+            A Flask Response object
+        """
+        response_data = jsonify(ServiceErrorResponses._LAMBDA_AUTHORIZER_NOT_AUTHORIZED)
+        return make_response(response_data, ServiceErrorResponses.HTTP_STATUS_CODE_403)
 
     @staticmethod
     def missing_lambda_auth_identity_sources() -> Response:

--- a/samcli/local/events/api_event.py
+++ b/samcli/local/events/api_event.py
@@ -219,11 +219,14 @@ class ApiGatewayLambdaEvent:
         self.path = path
         self.is_base_64_encoded = is_base_64_encoded
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         """
         Constructs an dictionary representation of the ApiGatewayLambdaEvent Object to be used in serializing to JSON
 
-        :return: dict representing the object
+        Returns
+        -------
+        Dict[str, Any]
+            Dict representing the object
         """
         request_context_dict = {}
         if self.request_context:
@@ -428,12 +431,15 @@ class ApiGatewayV2LambdaEvent:
         self.is_base_64_encoded = is_base_64_encoded
         self.stage_variables = stage_variables
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         """
         Constructs an dictionary representation of the ApiGatewayLambdaEvent
         Version 2 Object to be used in serializing to JSON
 
-        :return: dict representing the object
+        Returns
+        -------
+        Dict[str, Any]
+            Dict representing the object
         """
         request_context_dict = {}
         if self.request_context:

--- a/tests/unit/local/apigw/test_event_constructor.py
+++ b/tests/unit/local/apigw/test_event_constructor.py
@@ -72,9 +72,7 @@ class TestService_construct_event(TestCase):
         self.assertIsInstance(request_time_epoch, int)
 
     def test_construct_event_with_data(self):
-        actual_event_str = construct_v1_event(self.request_mock, 3000, binary_types=[])
-
-        actual_event_json = json.loads(actual_event_str)
+        actual_event_json = construct_v1_event(self.request_mock, 3000, binary_types=[])
         self.validate_request_context_and_remove_request_time_data(actual_event_json)
 
         self.assertEqual(actual_event_json["body"], self.expected_dict["body"])
@@ -82,8 +80,7 @@ class TestService_construct_event(TestCase):
     def test_construct_event_no_data(self):
         self.request_mock.get_data.return_value = None
 
-        actual_event_str = construct_v1_event(self.request_mock, 3000, binary_types=[])
-        actual_event_json = json.loads(actual_event_str)
+        actual_event_json = construct_v1_event(self.request_mock, 3000, binary_types=[])
         self.validate_request_context_and_remove_request_time_data(actual_event_json)
 
         self.assertEqual(actual_event_json["body"], None)
@@ -97,8 +94,7 @@ class TestService_construct_event(TestCase):
 
         self.request_mock.get_data.return_value = binary_body
 
-        actual_event_str = construct_v1_event(self.request_mock, 3000, binary_types=[])
-        actual_event_json = json.loads(actual_event_str)
+        actual_event_json = construct_v1_event(self.request_mock, 3000, binary_types=[])
         self.validate_request_context_and_remove_request_time_data(actual_event_json)
 
         self.assertEqual(actual_event_json["body"], base64_body)
@@ -254,7 +250,7 @@ class TestService_construct_event_http(TestCase):
         self.expected_dict = json.loads(expected)
 
     def test_construct_event_with_data(self):
-        actual_event_str = construct_v2_event_http(
+        actual_event_dict = construct_v2_event_http(
             self.request_mock,
             3000,
             binary_types=[],
@@ -262,9 +258,6 @@ class TestService_construct_event_http(TestCase):
             request_time_epoch=self.request_time_epoch,
             request_time=self.request_time,
         )
-        print("DEBUG: json.loads(actual_event_str)", json.loads(actual_event_str))
-        print("DEBUG: self.expected_dict", self.expected_dict)
-        actual_event_dict = json.loads(actual_event_str)
         self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
@@ -273,7 +266,7 @@ class TestService_construct_event_http(TestCase):
         self.request_mock.get_data.return_value = None
         self.expected_dict["body"] = None
 
-        actual_event_str = construct_v2_event_http(
+        actual_event_dict = construct_v2_event_http(
             self.request_mock,
             3000,
             binary_types=[],
@@ -281,7 +274,6 @@ class TestService_construct_event_http(TestCase):
             request_time_epoch=self.request_time_epoch,
             request_time=self.request_time,
         )
-        actual_event_dict = json.loads(actual_event_str)
         self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)
@@ -306,7 +298,7 @@ class TestService_construct_event_http(TestCase):
         self.expected_dict["isBase64Encoded"] = True
         self.maxDiff = None
 
-        actual_event_str = construct_v2_event_http(
+        actual_event_dict = construct_v2_event_http(
             self.request_mock,
             3000,
             binary_types=[],
@@ -314,7 +306,6 @@ class TestService_construct_event_http(TestCase):
             request_time_epoch=self.request_time_epoch,
             request_time=self.request_time,
         )
-        actual_event_dict = json.loads(actual_event_str)
         self.assertEqual(len(actual_event_dict["requestContext"]["requestId"]), 36)
         actual_event_dict["requestContext"]["requestId"] = ""
         self.assertEqual(actual_event_dict, self.expected_dict)

--- a/tests/unit/local/apigw/test_lambda_authorizer.py
+++ b/tests/unit/local/apigw/test_lambda_authorizer.py
@@ -1,3 +1,4 @@
+import json
 from unittest import TestCase
 from unittest.mock import Mock, patch
 from parameterized import parameterized
@@ -247,7 +248,7 @@ class TestLambdaAuthorizer(TestCase):
         expected = context.copy()
         expected["principalId"] = principal_id
 
-        result = LambdaAuthorizer.get_context(input)
+        result = LambdaAuthorizer(Mock(), Mock(), Mock(), [], Mock()).get_context(json.dumps(input))
 
         self.assertEqual(result, expected)
 

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -222,12 +222,14 @@ class TestApiGatewayService(TestCase):
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._generate_lambda_event")
     def test_api_options_request_must_invoke_lambda(self, generate_mock, request_mock):
+        generate_mock.return_value = {}
         make_response_mock = Mock()
 
         self.api_service.service_response = make_response_mock
         self.api_service._get_current_route = MagicMock()
         self.api_service._get_current_route.return_value.methods = ["OPTIONS"]
         self.api_service._get_current_route.return_value.payload_format_version = "1.0"
+        self.api_service._get_current_route.return_value.authorizer_object = None
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
@@ -247,12 +249,14 @@ class TestApiGatewayService(TestCase):
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._generate_lambda_event")
     def test_http_options_request_must_invoke_lambda(self, generate_mock, request_mock):
+        generate_mock.return_value = {}
         make_response_mock = Mock()
 
         self.http_service.service_response = make_response_mock
         self.http_service._get_current_route = MagicMock()
         self.http_service._get_current_route.return_value.methods = ["OPTIONS"]
         self.http_service._get_current_route.return_value.payload_format_version = "1.0"
+        self.http_service._get_current_route.return_value.authorizer_object = None
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
@@ -275,11 +279,13 @@ class TestApiGatewayService(TestCase):
     def test_request_handler_returns_process_stdout_when_making_response(
         self, generate_mock, lambda_output_parser_mock, request_mock
     ):
+        generate_mock.return_value = {}
         make_response_mock = Mock()
         request_mock.return_value = ("test", "test")
         self.api_service.service_response = make_response_mock
         current_route = Mock()
         current_route.payload_format_version = "2.0"
+        current_route.authorizer_object = None
         self.api_service._get_current_route = MagicMock()
         self.api_service._get_current_route.return_value = current_route
         current_route.methods = []
@@ -307,12 +313,14 @@ class TestApiGatewayService(TestCase):
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._generate_lambda_event")
     def test_request_handler_returns_make_response(self, generate_mock, request_mock):
+        generate_mock.return_value = {}
         make_response_mock = Mock()
 
         self.api_service.service_response = make_response_mock
         self.api_service._get_current_route = MagicMock()
         self.api_service._get_current_route.methods = []
         self.api_service._get_current_route.return_value.payload_format_version = "1.0"
+        self.api_service._get_current_route.return_value.authorizer_object = None
 
         parse_output_mock = Mock()
         parse_output_mock.return_value = ("status_code", Headers({"headers": "headers"}), "body")
@@ -407,9 +415,11 @@ class TestApiGatewayService(TestCase):
     def test_request_handles_error_when_invoke_cant_find_function(
         self, generate_mock, service_error_responses_patch, request_mock
     ):
+        generate_mock.return_value = {}
         not_found_response_mock = Mock()
         self.api_service._get_current_route = MagicMock()
         self.api_service._get_current_route.return_value.payload_format_version = "2.0"
+        self.api_service._get_current_route.return_value.authorizer_object = None
         self.api_service._get_current_route.methods = []
 
         service_error_responses_patch.lambda_not_found_response.return_value = not_found_response_mock
@@ -426,9 +436,11 @@ class TestApiGatewayService(TestCase):
     def test_request_handles_error_when_invoke_function_with_inline_code(
         self, generate_mock, service_error_responses_patch, request_mock
     ):
+        generate_mock.return_value = {}
         not_implemented_response_mock = Mock()
         self.api_service._get_current_route = MagicMock()
         self.api_service._get_current_route.return_value.payload_format_version = "2.0"
+        self.api_service._get_current_route.return_value.authorizer_object = None
         self.api_service._get_current_route.methods = []
 
         service_error_responses_patch.not_implemented_locally.return_value = not_implemented_response_mock
@@ -455,6 +467,7 @@ class TestApiGatewayService(TestCase):
     def test_request_handler_errors_when_parse_lambda_output_raises_keyerror(
         self, generate_mock, service_error_responses_patch, request_mock
     ):
+        generate_mock.return_value = {}
         parse_output_mock = Mock()
         parse_output_mock.side_effect = LambdaResponseParseException()
         self.api_service._parse_v1_payload_format_lambda_output = parse_output_mock
@@ -466,6 +479,7 @@ class TestApiGatewayService(TestCase):
         self.api_service._get_current_route = MagicMock()
         self.api_service._get_current_route.methods = []
         self.api_service._get_current_route.return_value.payload_format_version = "1.0"
+        self.api_service._get_current_route.return_value.authorizer_object = None
 
         request_mock.return_value = ("test", "test")
         result = self.api_service._request_handler()
@@ -487,11 +501,13 @@ class TestApiGatewayService(TestCase):
     def test_request_handler_errors_when_unable_to_read_binary_data(
         self, generate_mock, service_error_responses_patch, request_mock
     ):
+        generate_mock.return_value = {}
         _construct_event = Mock()
         _construct_event.side_effect = UnicodeDecodeError("utf8", b"obj", 1, 2, "reason")
         self.api_service._get_current_route = MagicMock()
         self.api_service._get_current_route.methods = []
         self.api_service._get_current_route.return_value.payload_format_version = "1.0"
+        self.api_service._get_current_route.return_value.authorizer_object = None
 
         failure_mock = Mock()
         service_error_responses_patch.lambda_failure_response.return_value = failure_mock
@@ -597,7 +613,7 @@ class TestApiGatewayService(TestCase):
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     def test_create_method_arn(self, method_endpoint_mock):
-        method_endpoint_mock.return_value = ("method", "endpoint")
+        method_endpoint_mock.return_value = ("method", "/endpoint")
 
         expected_method_arn = "arn:aws:execute-api:us-east-1:123456789012:1234567890/None/method/endpoint"
 
@@ -675,7 +691,7 @@ class TestApiGatewayService(TestCase):
         method_arn_mock,
         method_endpoints_mock,
     ):
-        original = json.dumps({"existing": "value"})
+        original = {"existing": "value"}
         payload_version = "2.0"
         method_arn = "arn"
 
@@ -717,7 +733,7 @@ class TestApiGatewayService(TestCase):
 
         method_arn_mock.return_value = method_arn
         method_endpoints_mock.return_value = ("method", "endpoint")
-        generate_lambda_mock.return_value = json.dumps(original)
+        generate_lambda_mock.return_value = original
         build_v2_mock.return_value = {}
         build_v1_mock.return_value = {}
 

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -787,6 +787,7 @@ class TestApiGatewayService(TestCase):
         # create mock authorizer
         auth = LambdaAuthorizer(Mock(), Mock(), "auth_lambda", [], Mock(), Mock(), Mock())
         auth.is_valid_response = Mock(return_value=True)
+        auth.get_context = Mock(return_value={})
         self.api_gateway_route.authorizer_object = auth
 
         # get api service to return mocked route containing authorizer


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
This adds the logic required to invoke a Lambda authorizer before the route's Lambda function and passes any context from the authorizer to the route. We also validate the response from the authorizer to make sure that the request is indeed valid and allowed.

#### How does it address the issue?
Updates our Lambda invocation to be a method so that we can reuse it for both authorizers and routes. Adds some event manipulation to append the required keys to pass along context.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
