### PR TITLE
test: Disable running the Java build test cases in windows.

### DIFF
--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -771,6 +771,10 @@ class TestBuildCommand_Java(BuildIntegJavaBase):
         )
 
 
+@skipIf(
+    (IS_WINDOWS and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
 class TestBuildCommand_Java_With_Specified_Architecture(BuildIntegJavaBase):
     template = "template_with_architecture.yaml"
     EXPECTED_FILES_PROJECT_MANIFEST_GRADLE = {"aws", "lib", "META-INF"}


### PR DESCRIPTION
#### Why is this change necessary?
Revert back to disable executing the `tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_Java_With_Specified_Architecture` test cases in windows to fix the Timed Out issue in the Appveyor canaries.

https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-windows/build/job/2c9nkyujp57la9au#L10284 

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
