### PR TITLE
bug: adding missing MemorySize field to terraform hook

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
@@ -204,6 +204,7 @@ AWS_LAMBDA_FUNCTION_PROPERTY_BUILDER_MAPPING: PropertyBuilderMapping = {
     "Runtime": _get_property_extractor("runtime"),
     "Layers": _get_property_extractor("layers"),
     "Timeout": _get_property_extractor("timeout"),
+    "MemorySize": _get_property_extractor("memory_size"),
     "ImageConfig": _build_lambda_function_image_config_property,
 }
 

--- a/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
@@ -43,6 +43,7 @@ class PrepareHookUnitBase(TestCase):
             "runtime": "python3.7",
             "layers": ["layer_arn1", "layer_arn2"],
             "timeout": 3,
+            "memory_size": 128,
         }
         self.expected_cfn_function_common_properties: dict = {
             "FunctionName": self.zip_function_name,
@@ -53,6 +54,7 @@ class PrepareHookUnitBase(TestCase):
             "Runtime": "python3.7",
             "Layers": ["layer_arn1", "layer_arn2"],
             "Timeout": 3,
+            "MemorySize": 128,
         }
 
         self.tf_image_package_type_function_common_properties: dict = {
@@ -61,6 +63,7 @@ class PrepareHookUnitBase(TestCase):
             "environment": [{"variables": {"foo": "bar", "hello": "world"}}],
             "package_type": "Image",
             "timeout": 3,
+            "memory_size": 128,
         }
         self.expected_cfn_image_package_type_function_common_properties: dict = {
             "FunctionName": self.image_function_name,
@@ -68,6 +71,7 @@ class PrepareHookUnitBase(TestCase):
             "Environment": {"Variables": {"foo": "bar", "hello": "world"}},
             "PackageType": "Image",
             "Timeout": 3,
+            "MemorySize": 128,
         }
 
         self.tf_layer_common_properties: dict = {

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
@@ -250,7 +250,7 @@ class TestPrepareHook(PrepareHookUnitBase):
         resources = {
             "AbsResource1": {
                 "Type": "AWS::Lambda::Function",
-                "Properties": {"Code": abs_path, "Timeout": 10, "Handler": "app.func"},
+                "Properties": {"Code": abs_path, "Timeout": 10, "MemorySize": 128, "Handler": "app.func"},
             },
             "S3Resource1": {
                 "Type": "AWS::Lambda::Function",
@@ -260,12 +260,13 @@ class TestPrepareHook(PrepareHookUnitBase):
                         "S3Key": "s3_key_name",
                     },
                     "Timeout": 10,
+                    "MemorySize": 128,
                     "Handler": "app.func",
                 },
             },
             "RelativeResource1": {
                 "Type": "AWS::Lambda::Function",
-                "Properties": {"Code": relative_path, "Timeout": 10, "Handler": "app.func"},
+                "Properties": {"Code": relative_path, "Timeout": 10, "MemorySize": 128, "Handler": "app.func"},
             },
             "S3Layer": {
                 "Type": "AWS::Lambda::LayerVersion",
@@ -288,13 +289,13 @@ class TestPrepareHook(PrepareHookUnitBase):
             },
             "OtherResource1": {
                 "Type": "AWS::Lambda::NotFunction",
-                "Properties": {"Code": relative_path, "Timeout": 10, "Handler": "app.func"},
+                "Properties": {"Code": relative_path, "Timeout": 10, "MemorySize": 128, "Handler": "app.func"},
             },
         }
         expected_resources = {
             "AbsResource1": {
                 "Type": "AWS::Lambda::Function",
-                "Properties": {"Code": abs_path, "Timeout": 10, "Handler": "app.func"},
+                "Properties": {"Code": abs_path, "Timeout": 10, "MemorySize": 128, "Handler": "app.func"},
             },
             "S3Resource1": {
                 "Type": "AWS::Lambda::Function",
@@ -304,12 +305,13 @@ class TestPrepareHook(PrepareHookUnitBase):
                         "S3Key": "s3_key_name",
                     },
                     "Timeout": 10,
+                    "MemorySize": 128,
                     "Handler": "app.func",
                 },
             },
             "RelativeResource1": {
                 "Type": "AWS::Lambda::Function",
-                "Properties": {"Code": updated_relative_path, "Timeout": 10, "Handler": "app.func"},
+                "Properties": {"Code": updated_relative_path, "Timeout": 10, "MemorySize": 128, "Handler": "app.func"},
             },
             "S3Layer": {
                 "Type": "AWS::Lambda::LayerVersion",
@@ -332,7 +334,7 @@ class TestPrepareHook(PrepareHookUnitBase):
             },
             "OtherResource1": {
                 "Type": "AWS::Lambda::NotFunction",
-                "Properties": {"Code": relative_path, "Timeout": 10, "Handler": "app.func"},
+                "Properties": {"Code": relative_path, "Timeout": 10, "MemorySize": 128, "Handler": "app.func"},
             },
         }
         _update_resources_paths(resources, terraform_application_root)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#4824 

#### Why is this change necessary?
When working with Sam CLI and the new Terraform hook, I noticed that when I create a Lambda function and specify the memory_size in the Terraform resource, this value is not passed to the Lambda function when running locally with sam local invoke. As a result, the Lambda function always runs with the default memory size of 128MB. This causes issues when testing functions that require more than 128MB, as they are killed when the memory usage exceeds that value.

#### How does it address the issue?
To address this issue, I added the missing MemorySize field to the hook property builder. This allows the memory_size value defined in the terraform resource to be passed to the Lambda function, so I can increase the MemorySize as needed.

#### What side effects does this change have?
Not sure

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
