### PR TITLE
chore: Add 'format' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ black:
 black-check:
 	black --check setup.py samcli tests
 
+format: black
+	ruff samcli --fix
+
 # Verifications to run before sending a pull request
 pr: init dev black-check
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Makes it so that developers only need to use one Makefile target to format code.

#### How does it address the issue?
Adds target

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
