### PR TITLE
chore: update pytest plugins

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,11 +17,11 @@ types-setuptools==65.4.0.0
 
 # Test requirements
 pytest==7.2.2
-parameterized==0.7.4
-pytest-xdist==2.1.0
-pytest-forked==1.3.0
-pytest-timeout==1.4.2
-pytest-rerunfailures==11.1.1
+parameterized==0.8.1
+pytest-xdist==3.2.0
+pytest-forked==1.6.0
+pytest-timeout==2.1.0
+pytest-rerunfailures==11.1.2
 pytest-json-report==1.5.0
 filelock==3.9.0
 

--- a/tests/unit/lib/sync/test_watch_manager.py
+++ b/tests/unit/lib/sync/test_watch_manager.py
@@ -67,8 +67,9 @@ class TestWatchManager(TestCase):
         sync_flow_factory_mock.return_value.load_physical_id_mapping.assert_called_once_with()
         trigger_factory_mock.assert_called_once_with(stacks, path_mock.return_value)
 
+    @patch("samcli.lib.sync.watch_manager.LOG")
     @patch("samcli.lib.sync.watch_manager.get_all_resource_ids")
-    def test_add_code_triggers(self, get_all_resource_ids_mock):
+    def test_add_code_triggers(self, get_all_resource_ids_mock, patched_log):
         resource_ids = [MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock()]
         get_all_resource_ids_mock.return_value = resource_ids
 


### PR DESCRIPTION
We recently updated pytest to a newer version, which seems like not working well with existing plugin versions that we have. This PR is targeting to fix it by updating those plugins to the newer versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
