### PR TITLE
feat: Update translator to use new managed policy map

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ jmespath~=0.10.0
 ruamel_yaml==0.17.21
 PyYAML>=5.4.1,==5.*
 cookiecutter~=2.1.1
-aws-sam-translator==1.60.1
+aws-sam-translator==1.61.0
 #docker minor version updates can include breaking changes. Auto update micro version only.
 docker~=4.2.0
 dateparser~=1.0

--- a/samcli/lib/translate/sam_template_validator.py
+++ b/samcli/lib/translate/sam_template_validator.py
@@ -7,6 +7,7 @@ import logging
 from boto3.session import Session
 from samtranslator.parser import parser
 from samtranslator.public.exceptions import InvalidDocumentException
+from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
 from samtranslator.translator.translator import Translator
 
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
@@ -18,7 +19,7 @@ LOG = logging.getLogger(__name__)
 
 
 class SamTemplateValidator:
-    def __init__(self, sam_template, managed_policy_loader, profile=None, region=None):
+    def __init__(self, sam_template, managed_policy_loader: ManagedPolicyLoader, profile=None, region=None):
         """
         Construct a SamTemplateValidator
 
@@ -54,10 +55,9 @@ class SamTemplateValidator:
         InvalidSamDocumentException
              If the template is not valid, an InvalidSamDocumentException is raised
         """
-        managed_policy_map = self.managed_policy_loader.load()
 
         sam_translator = Translator(
-            managed_policy_map=managed_policy_map,
+            managed_policy_map=None,
             sam_parser=self.sam_parser,
             plugins=[],
             boto_session=self.boto3_session,
@@ -67,13 +67,19 @@ class SamTemplateValidator:
         self._replace_local_image()
 
         try:
-            template = sam_translator.translate(sam_template=self.sam_template, parameter_values={})
+            template = sam_translator.translate(
+                sam_template=self.sam_template, parameter_values={}, get_managed_policy_map=self._get_managed_policy_map
+            )
             LOG.debug("Translated template is:\n%s", yaml_dump(template))
             return yaml_dump(template)
         except InvalidDocumentException as e:
             raise InvalidSamDocumentException(
                 functools.reduce(lambda message, error: message + " " + str(error), e.causes, str(e))
             ) from e
+
+    @functools.lru_cache(maxsize=None)
+    def _get_managed_policy_map(self):
+        return self.managed_policy_loader.load()
 
     def _replace_local_codeuri(self):
         """

--- a/samcli/lib/translate/sam_template_validator.py
+++ b/samcli/lib/translate/sam_template_validator.py
@@ -3,6 +3,7 @@ Library for Validating Sam Templates
 """
 import functools
 import logging
+from typing import Dict, cast
 
 from boto3.session import Session
 from samtranslator.parser import parser
@@ -78,8 +79,17 @@ class SamTemplateValidator:
             ) from e
 
     @functools.lru_cache(maxsize=None)
-    def _get_managed_policy_map(self):
-        return self.managed_policy_loader.load()
+    def _get_managed_policy_map(self) -> Dict[str, str]:
+        """
+        Helper function for getting managed policies and caching them.
+        Used by the transform for loading policies.
+
+        Returns
+        -------
+        Dict[str, str]
+            Dictionary containing the policy map
+        """
+        return cast(Dict[str, str], self.managed_policy_loader.load())
 
     def _replace_local_codeuri(self):
         """

--- a/tests/unit/commands/list/resources/test_resources_context.py
+++ b/tests/unit/commands/list/resources/test_resources_context.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from samtranslator.model.exceptions import ExceptionWithMessage
-from unittest.mock import patch, call, Mock
+from unittest.mock import patch, call, Mock, ANY
 from botocore.exceptions import ClientError, EndpointConnectionError, NoCredentialsError, BotoCoreError
 from samtranslator.translator.arn_generator import NoRegionFound
 
@@ -212,11 +212,13 @@ class TestResourceMappingProducerProduce(TestCase):
             validator.get_translated_template_if_valid()
 
         sam_translator.assert_called_once_with(
-            managed_policy_map={"policy": "SomePolicy"}, sam_parser=parser, plugins=[], boto_session=boto_session_mock
+            managed_policy_map=None, sam_parser=parser, plugins=[], boto_session=boto_session_mock
         )
 
         boto_session_patch.assert_called_once_with(profile_name=None, region_name=None)
-        translate_mock.translate.assert_called_once_with(sam_template=template, parameter_values={})
+        translate_mock.translate.assert_called_once_with(
+            sam_template=template, parameter_values={}, get_managed_policy_map=ANY
+        )
         sam_parser.Parser.assert_called_once()
 
     @patch("samcli.commands.list.json_consumer.click.echo")

--- a/tests/unit/commands/validate/lib/test_sam_template_validator.py
+++ b/tests/unit/commands/validate/lib/test_sam_template_validator.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, ANY
 
 from samtranslator.model import InvalidResourceException
 
@@ -36,9 +36,11 @@ class TestSamTemplateValidator(TestCase):
 
         boto_session_patch.assert_called_once_with(profile_name="profile", region_name="region")
         sam_translator.assert_called_once_with(
-            managed_policy_map={"policy": "SomePolicy"}, sam_parser=parser, plugins=[], boto_session=boto_session_mock
+            managed_policy_map=None, sam_parser=parser, plugins=[], boto_session=boto_session_mock
         )
-        translate_mock.translate.assert_called_once_with(sam_template=template, parameter_values={})
+        translate_mock.translate.assert_called_once_with(
+            sam_template=template, parameter_values={}, get_managed_policy_map=ANY
+        )
         sam_parser.Parser.assert_called_once()
 
     @patch("samcli.lib.translate.sam_template_validator.Session")
@@ -67,11 +69,13 @@ class TestSamTemplateValidator(TestCase):
             validator.get_translated_template_if_valid()
 
         sam_translator.assert_called_once_with(
-            managed_policy_map={"policy": "SomePolicy"}, sam_parser=parser, plugins=[], boto_session=boto_session_mock
+            managed_policy_map=None, sam_parser=parser, plugins=[], boto_session=boto_session_mock
         )
 
         boto_session_patch.assert_called_once_with(profile_name=None, region_name=None)
-        translate_mock.translate.assert_called_once_with(sam_template=template, parameter_values={})
+        translate_mock.translate.assert_called_once_with(
+            sam_template=template, parameter_values={}, get_managed_policy_map=ANY
+        )
         sam_parser.Parser.assert_called_once()
 
     def test_init(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#4858 

#### Why is this change necessary?
Makes use of the new SAM-T feature in version 1.61.0 to call Translator with `get_managed_policy_map` parameter and cache policies, speeding up any calls to the transform.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
