### PR TITLE
Handle non changeset error while waiting for chageset

### DIFF
--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -314,19 +314,22 @@ class Deployer:
             waiter.wait(ChangeSetName=changeset_id, StackName=stack_name, WaiterConfig=waiter_config)
         except botocore.exceptions.WaiterError as ex:
             resp = ex.last_response
-            status = resp["Status"]
-            reason = resp["StatusReason"]
+            if "Status" in resp and "StatusReason" in resp:
+                status = resp["Status"]
+                reason = resp["StatusReason"]
 
-            if (
-                status == "FAILED"
-                and "The submitted information didn't contain changes." in reason
-                or "No updates are to be performed" in reason
-            ):
-                raise deploy_exceptions.ChangeEmptyError(stack_name=stack_name)
+                if (
+                    status == "FAILED"
+                    and "The submitted information didn't contain changes." in reason
+                    or "No updates are to be performed" in reason
+                ):
+                    raise deploy_exceptions.ChangeEmptyError(stack_name=stack_name)
 
-            raise ChangeSetError(
-                stack_name=stack_name, msg="ex: {0} Status: {1}. Reason: {2}".format(ex, status, reason)
-            ) from ex
+                raise ChangeSetError(stack_name=stack_name, msg=f"ex: {ex} Status: {status}. Reason: {reason}") from ex
+
+            # Not a changeset error, re-raising
+            LOG.debug("Failed while waiting for changeset: %s", ex)
+            raise ex
 
     def execute_changeset(self, changeset_id, stack_name, disable_rollback):
         """

--- a/tests/unit/lib/deploy/test_deployer.py
+++ b/tests/unit/lib/deploy/test_deployer.py
@@ -380,6 +380,25 @@ class TestDeployer(CustomTestCase):
         with self.assertRaises(ChangeSetError):
             self.deployer.wait_for_changeset("test-id", "test-stack")
 
+    def test_wait_for_changeset_exception_NonChangeSetError(self):
+        self.deployer._client.get_waiter = MagicMock(
+            return_value=MockChangesetWaiter(
+                ex=WaiterError(
+                    name="wait_for_changeset",
+                    reason="unit-test",
+                    last_response={
+                        "Error": {
+                            "Type": "Sender",
+                            "Code": "AccessDenied",
+                            "Message": "not authorized to perform: cloudformation:DescribeChangeSet",
+                        }
+                    },
+                )
+            )
+        )
+        with self.assertRaises(WaiterError):
+            self.deployer.wait_for_changeset("test-id", "test-stack")
+
     def test_execute_changeset(self):
         self.deployer.execute_changeset("id", "test", True)
         self.deployer._client.execute_change_set.assert_called_with(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#4813 

#### Why is this change necessary?
Error handling was not catered for non-changeset error

#### How does it address the issue?
re-raise the waiter exception if it doesn't contain info about the changeset. so the generic error handler will handle it as SDKError

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
