### PR TITLE
test: Add end2end test for package and local

### DIFF
--- a/tests/end_to_end/end_to_end_base.py
+++ b/tests/end_to_end/end_to_end_base.py
@@ -9,7 +9,6 @@ from tests.integration.init.test_init_base import InitIntegBase
 from tests.integration.local.invoke.invoke_integ_base import InvokeIntegBase
 from tests.integration.sync.sync_integ_base import SyncIntegBase
 from tests.integration.list.stack_outputs.stack_outputs_integ_base import StackOutputsIntegBase
-import boto3
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -27,8 +26,6 @@ class EndToEndBase(InitIntegBase, StackOutputsIntegBase, DeleteIntegBase, SyncIn
         self.stacks = []
         self.config_file_dir = GlobalConfig().config_dir
         self._create_config_dir()
-        self._session = boto3.session.Session()
-        self.s3_client = self._session.client("s3")
 
     def _create_config_dir(self):
         # Init tests will lock the config dir, ensure it exists before obtaining a lock

--- a/tests/end_to_end/end_to_end_base.py
+++ b/tests/end_to_end/end_to_end_base.py
@@ -64,7 +64,6 @@ class EndToEndBase(InitIntegBase, StackOutputsIntegBase, DeleteIntegBase, SyncIn
 
     def _get_package_command(self, s3_prefix, use_json=False, output_template_file=None):
         return PackageIntegBase.get_command_list(
-            self,
             s3_bucket=self.s3_bucket.name,
             s3_prefix=s3_prefix,
             use_json=use_json,

--- a/tests/end_to_end/end_to_end_base.py
+++ b/tests/end_to_end/end_to_end_base.py
@@ -61,8 +61,14 @@ class EndToEndBase(InitIntegBase, StackOutputsIntegBase, DeleteIntegBase, SyncIn
             s3_bucket=self.s3_bucket.name,
         )
 
-    def _get_package_command(self, s3_prefix):
-        return DeleteIntegBase.get_command_list(self, s3_bucket=self.s3_bucket.name, s3_prefix=s3_prefix)
+    def _get_package_command(self, s3_prefix, use_json=False, output_template_file=None):
+        return DeleteIntegBase.get_command_list(
+            self,
+            s3_bucket=self.s3_bucket.name,
+            s3_prefix=s3_prefix,
+            use_json=use_json,
+            output_template_file=output_template_file,
+        )
 
     def _get_local_command(self, function_name):
         return InvokeIntegBase.get_minimal_local_invoke_command_list(function_to_invoke=function_name)

--- a/tests/end_to_end/end_to_end_base.py
+++ b/tests/end_to_end/end_to_end_base.py
@@ -6,6 +6,7 @@ from samcli.cli.global_config import GlobalConfig
 from tests.end_to_end.test_stages import EndToEndBaseStage
 from tests.integration.delete.delete_integ_base import DeleteIntegBase
 from tests.integration.init.test_init_base import InitIntegBase
+from tests.integration.package.package_integ_base import PackageIntegBase
 from tests.integration.local.invoke.invoke_integ_base import InvokeIntegBase
 from tests.integration.sync.sync_integ_base import SyncIntegBase
 from tests.integration.list.stack_outputs.stack_outputs_integ_base import StackOutputsIntegBase
@@ -62,7 +63,7 @@ class EndToEndBase(InitIntegBase, StackOutputsIntegBase, DeleteIntegBase, SyncIn
         )
 
     def _get_package_command(self, s3_prefix, use_json=False, output_template_file=None):
-        return DeleteIntegBase.get_command_list(
+        return PackageIntegBase.get_command_list(
             self,
             s3_bucket=self.s3_bucket.name,
             s3_prefix=s3_prefix,
@@ -71,7 +72,7 @@ class EndToEndBase(InitIntegBase, StackOutputsIntegBase, DeleteIntegBase, SyncIn
         )
 
     def _get_local_command(self, function_name):
-        return InvokeIntegBase.get_minimal_local_invoke_command_list(function_to_invoke=function_name)
+        return InvokeIntegBase.get_command_list(function_to_invoke=function_name)
 
     def _get_delete_command(self, stack_name):
         return self.get_delete_command_list(stack_name=stack_name, region=self.region_name, no_prompts=True)

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -9,7 +9,7 @@ from tests.end_to_end.end_to_end_base import EndToEndBase
 from tests.end_to_end.end_to_end_context import EndToEndTestContext
 from tests.end_to_end.test_stages import (
     DefaultInitStage,
-    DownloadPackagedZipFunctionStage,
+    PackageDownloadZipFunctionStage,
     DefaultRemoteInvokeStage,
     DefaultDeleteStage,
     EndToEndBaseStage,
@@ -49,11 +49,6 @@ class RemoteInvokeValidator(BaseValidator):
     def validate(self, command_result: CommandResult):
         self.assertEqual(command_result.process.get("StatusCode"), 200)
         self.assertEqual(command_result.process.get("FunctionError", ""), "")
-
-
-class DownloadPackagedZipValidator(BaseValidator):
-    def validate(self, command_result: CommandResult):
-        self.assertEqual(command_result.stdout, "Packaged zip file downloaded")
 
 
 class StackOutputsValidator(BaseValidator):
@@ -126,8 +121,9 @@ class TestHelloWorldZipPackagePermissionsEndToEnd(EndToEndBase):
             stages = [
                 DefaultInitStage(InitValidator(e2e_context), e2e_context, init_command_list, self.app_name),
                 EndToEndBaseStage(BuildValidator(e2e_context), e2e_context, build_command_list),
-                EndToEndBaseStage(BaseValidator(e2e_context), e2e_context, package_command_list),
-                DownloadPackagedZipFunctionStage(DownloadPackagedZipValidator(e2e_context), e2e_context, function_name),
+                PackageDownloadZipFunctionStage(
+                    BaseValidator(e2e_context), e2e_context, package_command_list, function_name
+                ),
                 EndToEndBaseStage(LocalInvokeValidator(e2e_context), e2e_context, local_command_list),
             ]
             self._run_tests(stages)

--- a/tests/end_to_end/test_stages.py
+++ b/tests/end_to_end/test_stages.py
@@ -97,7 +97,7 @@ class DownloadPackagedZipFunctionStage(EndToEndBaseStage):
         self.s3_client = self._session.client("s3")
 
     def run_stage(self) -> CommandResult:
-        built_function_path = Path(self.test_context.project_directory) / ".aws-sam/build" / self.function_name
+        built_function_path = Path(self.test_context.project_directory) / ".aws-sam" / "build" / self.function_name
         zip_file_path = built_function_path / "zipped_function.zip"
         packaged_template = {}
         with open(self.test_context.project_directory + "/packaged_template.json", "r") as json_file:

--- a/tests/end_to_end/test_stages.py
+++ b/tests/end_to_end/test_stages.py
@@ -100,7 +100,7 @@ class DownloadPackagedZipFunctionStage(EndToEndBaseStage):
         built_function_path = Path(self.test_context.project_directory) / ".aws-sam" / "build" / self.function_name
         zip_file_path = built_function_path / "zipped_function.zip"
         packaged_template = {}
-        with open(self.test_context.project_directory + "/packaged_template.json", "r") as json_file:
+        with open(Path(self.test_context.project_directory) / "packaged_template.json", "r") as json_file:
             packaged_template = json.load(json_file)
 
         zipped_fn_s3_loc = (

--- a/tests/integration/local/invoke/invoke_cdk_templates.py
+++ b/tests/integration/local/invoke/invoke_cdk_templates.py
@@ -22,7 +22,7 @@ class TestCDKSynthesizedTemplate(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returncode_is_zero(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "helloworld-serverless-function", event_path=self.event_path, template_path=self.template_path
         )
         stdout, _, return_code = self.run_command(command_list)
@@ -31,7 +31,7 @@ class TestCDKSynthesizedTemplate(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_utf8_event(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "helloworld-serverless-function", event_path=self.event_utf8_path, template_path=self.template_path
         )
         stdout, _, return_code = self.run_command(command_list)
@@ -40,7 +40,7 @@ class TestCDKSynthesizedTemplate(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_expected_results(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "helloworld-serverless-function", event_path=self.event_path, template_path=self.template_path
         )
 
@@ -51,7 +51,7 @@ class TestCDKSynthesizedTemplate(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_timeout_set(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "timeout-function", event_path=self.event_path, template_path=self.template_path
         )
 
@@ -78,7 +78,7 @@ class TestCDKSynthesizedTemplate(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_vars(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "custom-env-vars-function", event_path=self.event_path, template_path=self.template_path
         )
 
@@ -89,7 +89,7 @@ class TestCDKSynthesizedTemplate(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_when_function_writes_stdout(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "write-to-stdout-function", event_path=self.event_path, template_path=self.template_path
         )
 
@@ -101,7 +101,7 @@ class TestCDKSynthesizedTemplate(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_expected_result_when_no_event_given(self):
-        command_list = self.get_command_list("echo-event-function", template_path=self.template_path)
+        command_list = InvokeIntegBase.get_command_list("echo-event-function", template_path=self.template_path)
 
         stdout, _, return_code = self.run_command(command_list)
 
@@ -112,7 +112,7 @@ class TestCDKSynthesizedTemplate(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_parameters_overrides(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "echo-env-with-parameters",
             event_path=self.event_path,
             parameter_overrides={"MyRuntimeVersion": "v0", "TimeOut": "100"},
@@ -165,7 +165,7 @@ class TestCDKSynthesizedTemplatesImageFunctions(InvokeIntegBase):
     def test_build_and_invoke_image_function(self, function_name):
         # Set the function name to be removed during teardown
         self.teardown_function_name = function_name
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke=function_name, template_path=self.template_path
         )
         stdout, _, return_code = self.run_command(local_invoke_command_list)
@@ -178,7 +178,7 @@ class TestCDKSynthesizedTemplatesImageFunctions(InvokeIntegBase):
         self.assertEqual(response, expected_response)
 
     def test_invoke_with_utf8_event(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "StandardFunctionConstructZipFunction", template_path=self.template_path, event_path=self.event_utf8_path
         )
         stdout, _, return_code = self.run_command(command_list)
@@ -214,7 +214,7 @@ class TestRuntimeFunctionConstructs(InvokeIntegBase):
 
     @parameterized.expand(["NodeJsFunction", "PythonFunction", "GoFunction", "FunctionBundledAssets"])
     def test_runtime_function_construct(self, function_name):
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke=function_name, template_path=self.template_path
         )
         stdout, _, return_code = self.run_command(local_invoke_command_list)
@@ -235,7 +235,7 @@ class TestCDKLayerVersion(TestLayerVersionBase):
 
     def test_reference_of_layer_version(self):
         function_identifier = "sample-function"
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_identifier,
             template_path=self.template_path,
             no_event=True,

--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -27,8 +27,8 @@ class InvokeIntegBase(TestCase):
     def get_integ_dir():
         return Path(__file__).resolve().parents[2]
 
+    @staticmethod
     def get_command_list(
-        self,
         function_to_invoke,
         template_path=None,
         event_path=None,
@@ -43,7 +43,7 @@ class InvokeIntegBase(TestCase):
         hook_name=None,
         beta_features=None,
     ):
-        command_list = [self.cmd, "local", "invoke", function_to_invoke]
+        command_list = [get_sam_command(), "local", "invoke", function_to_invoke]
 
         if template_path:
             command_list = command_list + ["-t", template_path]

--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -117,12 +117,3 @@ class InvokeIntegBase(TestCase):
         except TimeoutExpired:
             process.kill()
             raise
-
-    @staticmethod
-    def get_minimal_local_invoke_command_list(function_to_invoke=None):
-        command_list = [get_sam_command(), "local", "invoke"]
-
-        if function_to_invoke:
-            command_list = command_list + [function_to_invoke]
-
-        return command_list

--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -117,3 +117,12 @@ class InvokeIntegBase(TestCase):
         except TimeoutExpired:
             process.kill()
             raise
+
+    @staticmethod
+    def get_minimal_local_invoke_command_list(function_to_invoke=None):
+        command_list = [get_sam_command(), "local", "invoke"]
+
+        if function_to_invoke:
+            command_list = command_list + [function_to_invoke]
+
+        return command_list

--- a/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
+++ b/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
@@ -36,7 +36,7 @@ class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
     @pytest.mark.timeout(timeout=300, method="thread")
     @parameterized.expand([param("Go1xFunction"), param("Java8Function")])
     def test_runtime_zip(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.events_file_path
         )
 
@@ -53,7 +53,7 @@ class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
 
     @pytest.mark.timeout(timeout=300, method="thread")
     def test_custom_provided_runtime(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "CustomBashFunction", template_path=self.template_path, event_path=self.events_file_path
         )
 

--- a/tests/integration/local/invoke/test_integration_cli_images.py
+++ b/tests/integration/local/invoke/test_integration_cli_images.py
@@ -52,7 +52,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returncode_is_zero(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -74,7 +74,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_execpted_results(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path
         )
 
@@ -90,7 +90,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_of_lambda_function(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -106,7 +106,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_of_lambda_function_with_function_name_override(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "func-name-override", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -125,7 +125,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_timeout_set(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path
         )
 
@@ -156,7 +156,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_vars(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoCustomEnvVarFunction",
             template_path=self.template_path,
             event_path=self.event_path,
@@ -175,7 +175,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
     @parameterized.expand([("EchoCustomEnvVarWithFunctionNameDefinedFunction"), ("customname")])
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_vars_with_functionname_defined(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path
         )
 
@@ -191,7 +191,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
     @parameterized.expand([("EchoGlobalCustomEnvVarFunction")])
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_global_env_vars_function(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path
         )
 
@@ -206,7 +206,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_when_function_writes_stdout(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "WriteToStdoutFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -225,7 +225,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_when_function_writes_stderr(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "WriteToStderrFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -242,7 +242,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_expected_result_when_no_event_given(self):
-        command_list = self.get_command_list("EchoEventFunction", template_path=self.template_path)
+        command_list = InvokeIntegBase.get_command_list("EchoEventFunction", template_path=self.template_path)
         process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
@@ -257,7 +257,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_using_parameters(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters",
             template_path=self.template_path,
             event_path=self.event_path,
@@ -291,7 +291,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
     def test_invoke_with_env_using_parameters_with_custom_region(self):
         custom_region = "my-custom-region"
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path, region=custom_region
         )
 
@@ -314,7 +314,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
         secret = "secret"
         session = "session"
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -343,7 +343,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_docker_network_of_host(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction",
             template_path=self.template_path,
             event_path=self.event_path,
@@ -362,7 +362,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
     @pytest.mark.flaky(reruns=3)
     @skipIf(IS_WINDOWS, "The test hangs on Windows due to trying to attach to a non-existing network")
     def test_invoke_with_docker_network_of_host_in_env_var(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -382,7 +382,9 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_sam_template_file_env_var_set(self):
-        command_list = self.get_command_list("HelloWorldFunctionInNonDefaultTemplate", event_path=self.event_path)
+        command_list = InvokeIntegBase.get_command_list(
+            "HelloWorldFunctionInNonDefaultTemplate", event_path=self.event_path
+        )
 
         self.test_data_path.joinpath("invoke", "sam-template-image.yaml")
         env = os.environ.copy()
@@ -400,7 +402,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello world"')
 
     def test_invoke_with_error_during_image_build(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "ImageDoesntExistFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -465,7 +467,7 @@ class TestDeleteOldRapidImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_building_new_rapid_image_removes_old_rapid_images(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -492,7 +494,7 @@ class TestDeleteOldRapidImages(InvokeIntegBase):
         ):
             print(log)
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -516,7 +518,7 @@ class TestDeleteOldRapidImages(InvokeIntegBase):
             ):
                 print(log)
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -34,7 +34,7 @@ TIMEOUT = 300
 class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returncode_is_zero(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -50,7 +50,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     # https://github.com/aws/aws-sam-cli/issues/2494
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_utf8_event(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_utf8_path
         )
 
@@ -65,7 +65,9 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_function_with_metadata(self):
-        command_list = self.get_command_list("FunctionWithMetadata", template_path=self.template_path, no_event=True)
+        command_list = InvokeIntegBase.get_command_list(
+            "FunctionWithMetadata", template_path=self.template_path, no_event=True
+        )
 
         process = Popen(command_list, stdout=PIPE)
         try:
@@ -87,7 +89,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_execpted_results(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path
         )
 
@@ -103,7 +105,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_of_lambda_function(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -119,7 +121,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_of_lambda_function_with_function_name_override(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "func-name-override", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -138,7 +140,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_timeout_set(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path
         )
 
@@ -169,7 +171,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_vars(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoCustomEnvVarFunction",
             template_path=self.template_path,
             event_path=self.event_path,
@@ -188,7 +190,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     @parameterized.expand([("EchoCustomEnvVarWithFunctionNameDefinedFunction"), ("customname")])
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_vars_with_functionname_defined(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path
         )
 
@@ -204,7 +206,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     @parameterized.expand([("EchoGlobalCustomEnvVarFunction")])
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_global_env_vars_function(self, function_name):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path
         )
 
@@ -219,7 +221,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_invoke_image_provided(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction",
             template_path=self.template_path,
             event_path=self.event_path,
@@ -238,7 +240,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_when_function_writes_stdout(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "WriteToStdoutFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -257,7 +259,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_when_function_writes_stderr(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "WriteToStderrFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -276,7 +278,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_expected_result_when_no_event_given(self):
-        command_list = self.get_command_list("EchoEventFunction", template_path=self.template_path)
+        command_list = InvokeIntegBase.get_command_list("EchoEventFunction", template_path=self.template_path)
         process = Popen(command_list, stdout=PIPE)
         try:
             stdout, _ = process.communicate(timeout=TIMEOUT)
@@ -291,7 +293,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_using_parameters(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters",
             template_path=self.template_path,
             event_path=self.event_path,
@@ -326,7 +328,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     def test_invoke_with_env_using_parameters_with_custom_region(self):
         custom_region = "my-custom-region"
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path, region=custom_region
         )
 
@@ -349,7 +351,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
         secret = "secret"
         session = "session"
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -378,7 +380,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_docker_network_of_host(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction",
             template_path=self.template_path,
             event_path=self.event_path,
@@ -397,7 +399,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     @pytest.mark.flaky(reruns=3)
     @skipIf(IS_WINDOWS, "The test hangs on Windows due to trying to attach to a non-existing network")
     def test_invoke_with_docker_network_of_host_in_env_var(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -417,7 +419,9 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_sam_template_file_env_var_set(self):
-        command_list = self.get_command_list("HelloWorldFunctionInNonDefaultTemplate", event_path=self.event_path)
+        command_list = InvokeIntegBase.get_command_list(
+            "HelloWorldFunctionInNonDefaultTemplate", event_path=self.event_path
+        )
 
         self.test_data_path.joinpath("invoke", "sam-template.yaml")
         env = os.environ.copy()
@@ -439,7 +443,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     def test_skip_pull_image_in_env_var(self):
         docker.from_env().api.pull("lambci/lambda:python3.7")
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -460,7 +464,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     @skipIf(SKIP_LAYERS_TESTS, "Skip layers tests in Appveyor only")
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_expected_results_from_git_function(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "GitLayerFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -478,7 +482,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
     @skipIf(SKIP_LAYERS_TESTS, "Skip layers tests in Appveyor only")
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_expected_results_from_git_function_with_parameters(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "GitLayerFunctionParameters",
             template_path=self.template_path,
             event_path=self.event_path,
@@ -501,7 +505,7 @@ class TestSamInstrinsicsAndPlugins(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_resolve_instrincs_which_runs_plugins(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -532,7 +536,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         custom_config = self._create_config_file(profile)
         custom_cred = self._create_cred_file(profile)
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -572,7 +576,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         custom_config = self._create_config_file(profile)
         custom_cred = self._create_cred_file(profile)
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -608,7 +612,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         custom_config = self._create_config_file("custom")
         custom_cred = self._create_cred_file("custom")
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path, profile="custom"
         )
 
@@ -648,7 +652,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
 
         custom_cred = self._create_cred_file("custom")
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -757,7 +761,7 @@ class TestLayerVersion(TestLayerVersionBase):
         ]
     )
     def test_reference_of_layer_version(self, function_logical_id):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_logical_id,
             template_path=self.template_path,
             no_event=True,
@@ -781,7 +785,7 @@ class TestLayerVersion(TestLayerVersionBase):
 
     @parameterized.expand([("OneLayerVersionServerlessFunction"), ("OneLayerVersionLambdaFunction")])
     def test_download_one_layer(self, function_logical_id):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_logical_id,
             template_path=self.template_path,
             no_event=True,
@@ -807,7 +811,7 @@ class TestLayerVersion(TestLayerVersionBase):
         layer_name = self.layer_utils.generate_layer_name()
         self.layer_utils.upsert_layer(layer_name=layer_name, ref_layer_name="ChangedLayerArn", layer_zip="layer1.zip")
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_logical_id,
             template_path=self.template_path,
             no_event=True,
@@ -832,7 +836,7 @@ class TestLayerVersion(TestLayerVersionBase):
             layer_name=layer_name, ref_layer_name="ChangedLayerArn", layer_zip="changedlayer1.zip"
         )
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_logical_id,
             template_path=self.template_path,
             no_event=True,
@@ -856,7 +860,7 @@ class TestLayerVersion(TestLayerVersionBase):
     @parameterized.expand([("TwoLayerVersionServerlessFunction"), ("TwoLayerVersionLambdaFunction")])
     @pytest.mark.flaky(reruns=3)
     def test_download_two_layers(self, function_logical_id):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_logical_id,
             template_path=self.template_path,
             no_event=True,
@@ -880,7 +884,7 @@ class TestLayerVersion(TestLayerVersionBase):
         self.assertEqual(process_stdout, expected_output)
 
     def test_caching_two_layers(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "TwoLayerVersionServerlessFunction",
             template_path=self.template_path,
             no_event=True,
@@ -899,7 +903,7 @@ class TestLayerVersion(TestLayerVersionBase):
         self.assertEqual(2, len(os.listdir(str(self.layer_cache))))
 
     def test_caching_two_layers_with_layer_cache_env_set(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "TwoLayerVersionServerlessFunction",
             template_path=self.template_path,
             no_event=True,
@@ -927,7 +931,7 @@ class TestLocalZipLayerVersion(InvokeIntegBase):
     def test_local_zip_layers(
         self,
     ):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "OneLayerVersionServerlessFunction",
             template_path=self.template_path,
             no_event=True,
@@ -959,7 +963,7 @@ class TestLayerVersionThatDoNotCreateCache(InvokeIntegBase):
             self.layer_utils.layers_meta[0].layer_name, "non_existent_layer"
         )
 
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "LayerVersionDoesNotExistFunction",
             template_path=self.template_path,
             no_event=True,
@@ -983,7 +987,7 @@ class TestLayerVersionThatDoNotCreateCache(InvokeIntegBase):
         self.layer_utils.delete_layers()
 
     def test_account_does_not_exist_for_layer(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "LayerVersionAccountDoesNotExistFunction",
             template_path=self.template_path,
             no_event=True,
@@ -1014,7 +1018,7 @@ class TestBadLayerVersion(InvokeIntegBase):
     region = "us-west-2"
 
     def test_unresolved_layer_due_to_bad_instrinsic(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "LayerBadInstrinsic",
             template_path=self.template_path,
             no_event=True,
@@ -1050,7 +1054,7 @@ class TestInvokeWithFunctionFullPathToAvoidAmbiguity(InvokeIntegBase):
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_function_name_will_call_functions_in_top_level_stacks(self, function_identifier, expected):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             function_identifier, template_path=self.template_path, event_path=self.event_path
         )
 
@@ -1068,7 +1072,7 @@ class TestInvokeWithFunctionFullPathToAvoidAmbiguity(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_function_full_path_will_call_functions_in_specified_stack(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "SubApp/SubSubApp/FunctionA", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -1086,7 +1090,7 @@ class TestInvokeWithFunctionFullPathToAvoidAmbiguity(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_non_existent_function_full_path(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "SubApp/SubSubApp/Function404", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -1108,7 +1112,7 @@ class TestInvokeFunctionWithInlineCode(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returncode_is_zero(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "NoInlineCodeServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 
@@ -1123,7 +1127,7 @@ class TestInvokeFunctionWithInlineCode(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_inline_code_function(self):
-        command_list = self.get_command_list(
+        command_list = InvokeIntegBase.get_command_list(
             "InlineCodeServerlessFunction", template_path=self.template_path, event_path=self.event_path
         )
 

--- a/tests/integration/local/invoke/test_invoke_cdk_templates_with_function_id.py
+++ b/tests/integration/local/invoke/test_invoke_cdk_templates_with_function_id.py
@@ -26,7 +26,7 @@ class TestCDKSynthesizedTemplatesFunctionIdentifies(InvokeIntegBase):
         self.teardown_function_name = logical_id
         function_identifiers = [function_name, logical_id, function_id]
         for identifier in function_identifiers:
-            local_invoke_command_list = self.get_command_list(
+            local_invoke_command_list = InvokeIntegBase.get_command_list(
                 function_to_invoke=identifier, template_path=self.template_path
             )
             stdout, _, return_code = self.run_command(local_invoke_command_list)
@@ -46,7 +46,7 @@ class TestCDKSynthesizedTemplatesNestedFunctionIdentifies(InvokeIntegBase):
     @pytest.mark.flaky(reruns=0)
     def test_invoke_function_with_unique_function_id(self, function_id_part, logical_id):
         self.teardown_function_name = [logical_id]
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke=function_id_part, template_path=self.template_path
         )
         stdout, _, return_code = self.run_command(local_invoke_command_list)
@@ -66,7 +66,7 @@ class TestCDKSynthesizedTemplatesNestedFunctionIdentifies(InvokeIntegBase):
         self, duplicated_function_id, expected_logical_id, not_invoked_logical_id
     ):
         self.teardown_function_name = [expected_logical_id, not_invoked_logical_id]
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke=duplicated_function_id, template_path=self.template_path
         )
         stdout, _, return_code = self.run_command(local_invoke_command_list)

--- a/tests/integration/local/invoke/test_invoke_terraform_applications.py
+++ b/tests/integration/local/invoke/test_invoke_terraform_applications.py
@@ -75,7 +75,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
     @parameterized.expand(functions)
     @pytest.mark.flaky(reruns=3)
     def test_invoke_function(self, function_name):
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke=function_name, hook_name="terraform", beta_features=True
         )
         stdout, _, return_code = self.run_command(local_invoke_command_list)
@@ -103,7 +103,9 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
         with open(samconfig_toml_path, "wb") as file:
             file.writelines(samconfig_lines)
 
-        local_invoke_command_list = self.get_command_list(function_to_invoke=function_name, hook_name="terraform")
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
+            function_to_invoke=function_name, hook_name="terraform"
+        )
         stdout, _, return_code = self.run_command(local_invoke_command_list)
 
         # Get the response without the sam-cli prompts that proceed it
@@ -128,7 +130,9 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
         environment_variables = os.environ.copy()
         environment_variables["SAM_CLI_BETA_TERRAFORM_SUPPORT"] = "1"
 
-        local_invoke_command_list = self.get_command_list(function_to_invoke=function_name, hook_name="terraform")
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
+            function_to_invoke=function_name, hook_name="terraform"
+        )
         stdout, _, return_code = self.run_command(local_invoke_command_list, env=environment_variables)
 
         # Get the response without the sam-cli prompts that proceed it
@@ -144,7 +148,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_function_get_experimental_prompted(self):
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke="s3_lambda_function", hook_name="terraform"
         )
         stdout, stderr, return_code = self.run_command(local_invoke_command_list, input=b"Y\n\n")
@@ -169,7 +173,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_function_with_beta_feature_expect_warning_message(self):
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke="s3_lambda_function", hook_name="terraform", beta_features=True
         )
         stdout, stderr, return_code = self.run_command(local_invoke_command_list)
@@ -194,7 +198,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_function_get_experimental_prompted_input_no(self):
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke="s3_lambda_function", hook_name="terraform"
         )
         stdout, stderr, return_code = self.run_command(local_invoke_command_list, input=b"N\n\n")
@@ -215,7 +219,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
         self.assertEqual(return_code, 0)
 
     def test_invalid_hook_name(self):
-        local_invoke_command_list = self.get_command_list("func", hook_name="tf")
+        local_invoke_command_list = InvokeIntegBase.get_command_list("func", hook_name="tf")
         _, stderr, return_code = self.run_command(local_invoke_command_list)
 
         process_stderr = stderr.strip()
@@ -226,7 +230,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
         self.assertNotEqual(return_code, 0)
 
     def test_invoke_terraform_with_no_beta_feature_option(self):
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke="func", hook_name="terraform", beta_features=False
         )
         _, stderr, return_code = self.run_command(local_invoke_command_list)
@@ -248,7 +252,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
         with open(samconfig_toml_path, "wb") as file:
             file.writelines(samconfig_lines)
 
-        local_invoke_command_list = self.get_command_list(function_to_invoke="func", hook_name="terraform")
+        local_invoke_command_list = InvokeIntegBase.get_command_list(function_to_invoke="func", hook_name="terraform")
         _, stderr, return_code = self.run_command(local_invoke_command_list)
 
         process_stderr = stderr.strip()
@@ -267,7 +271,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
         environment_variables = os.environ.copy()
         environment_variables["SAM_CLI_BETA_TERRAFORM_SUPPORT"] = "False"
 
-        local_invoke_command_list = self.get_command_list(function_to_invoke="func", hook_name="terraform")
+        local_invoke_command_list = InvokeIntegBase.get_command_list(function_to_invoke="func", hook_name="terraform")
         _, stderr, return_code = self.run_command(local_invoke_command_list, env=environment_variables)
 
         process_stderr = stderr.strip()
@@ -278,7 +282,9 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
         self.assertEqual(return_code, 0)
 
     def test_invalid_coexist_parameters(self):
-        local_invoke_command_list = self.get_command_list("func", hook_name="terraform", template_path="template.yaml")
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
+            "func", hook_name="terraform", template_path="template.yaml"
+        )
         _, stderr, return_code = self.run_command(local_invoke_command_list)
 
         process_stderr = stderr.strip()
@@ -435,7 +441,7 @@ class TestInvokeTerraformApplicationWithLayersWithoutBuild(InvokeTerraformApplic
     @parameterized.expand(functions)
     @pytest.mark.flaky(reruns=3)
     def test_invoke_function(self, function_name, expected_output):
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke=function_name, hook_name="terraform", beta_features=True
         )
         stdout, _, return_code = self.run_command(local_invoke_command_list, env=self._add_tf_project_variables())
@@ -467,7 +473,7 @@ class TestInvalidTerraformApplicationThatReferToS3BucketNotCreatedYet(InvokeTerr
     @pytest.mark.flaky(reruns=3)
     def test_invoke_function(self):
         function_name = "aws_lambda_function.function"
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke=function_name, hook_name="terraform", beta_features=True
         )
         _, stderr, return_code = self.run_command(local_invoke_command_list)
@@ -524,7 +530,7 @@ class TestInvokeTerraformApplicationWithLocalImageUri(InvokeTerraformApplication
     @parameterized.expand(functions)
     @pytest.mark.flaky(reruns=3)
     def test_invoke_image_function(self, function_name):
-        local_invoke_command_list = self.get_command_list(
+        local_invoke_command_list = InvokeIntegBase.get_command_list(
             function_to_invoke=function_name,
             hook_name="terraform",
             event_path=self.event_path,

--- a/tests/integration/local/invoke/test_with_credentials.py
+++ b/tests/integration/local/invoke/test_with_credentials.py
@@ -11,7 +11,7 @@ SKIP_CREDENTIALS_TESTS = IS_WINDOWS or RUNNING_ON_CI or not RUN_BY_CANARY
 
 class CredentialsTestBase(InvokeIntegBase):
     def invoke_functions_and_validate(self, function_name):
-        local_invoke_command_list = self.get_command_list(function_to_invoke=function_name)
+        local_invoke_command_list = InvokeIntegBase.get_command_list(function_to_invoke=function_name)
         stdout, _, returncode = self.run_command(local_invoke_command_list)
         self.assertEqual(returncode, 0)
         self.assertTrue((b'"statusCode": 200' in stdout) or (b'"statusCode":200' in stdout))

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -83,8 +83,8 @@ class PackageIntegBase(TestCase):
         self.s3_prefix = uuid.uuid4().hex
         super().setUp()
 
+    @staticmethod
     def get_command_list(
-        self,
         s3_bucket=None,
         template=None,
         template_file=None,

--- a/tests/integration/package/test_package_command_image.py
+++ b/tests/integration/package/test_package_command_image.py
@@ -52,7 +52,7 @@ class TestPackageImage(PackageIntegBase):
     )
     def test_package_template_without_image_repository(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(template=template_path)
+        command_list = PackageIntegBase.get_command_list(template=template_path)
 
         process = Popen(command_list, stdout=PIPE, stderr=PIPE)
         try:
@@ -75,7 +75,7 @@ class TestPackageImage(PackageIntegBase):
     )
     def test_package_template_with_image_repository(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(image_repository=self.ecr_repo_name, template=template_path)
+        command_list = PackageIntegBase.get_command_list(image_repository=self.ecr_repo_name, template=template_path)
 
         process = Popen(command_list, stdout=PIPE)
         try:
@@ -98,7 +98,7 @@ class TestPackageImage(PackageIntegBase):
     )
     def test_package_template_with_image_repositories(self, resource_id, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             image_repositories=f"{resource_id}={self.ecr_repo_name}", template=template_path
         )
 
@@ -128,7 +128,7 @@ class TestPackageImage(PackageIntegBase):
     )
     def test_package_template_with_image_repositories_nested_stack(self, resource_id, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             image_repositories=f"{resource_id}={self.ecr_repo_name}", template=template_path, resolve_s3=True
         )
 
@@ -152,7 +152,7 @@ class TestPackageImage(PackageIntegBase):
     )
     def test_package_template_with_non_ecr_repo_uri_image_repository(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             image_repository="non-ecr-repo-uri", template=template_path, resolve_s3=True
         )
 
@@ -176,7 +176,9 @@ class TestPackageImage(PackageIntegBase):
     )
     def test_package_template_and_s3_bucket(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(s3_bucket=self.s3_bucket, s3_prefix=self.s3_prefix, template=template_path)
+        command_list = PackageIntegBase.get_command_list(
+            s3_bucket=self.s3_bucket, s3_prefix=self.s3_prefix, template=template_path
+        )
 
         process = Popen(command_list, stdout=PIPE, stderr=PIPE)
         try:
@@ -200,7 +202,7 @@ class TestPackageImage(PackageIntegBase):
             # Closes the NamedTemporaryFile as on Windows NT or later, NamedTemporaryFile cannot be opened twice.
             packaged_file.close()
 
-            command_list = self.get_command_list(
+            command_list = PackageIntegBase.get_command_list(
                 image_repository=self.ecr_repo_name,
                 template=template_path,
                 resolve_s3=True,
@@ -245,7 +247,7 @@ class TestPackageImage(PackageIntegBase):
         template_file = os.path.join("deep-nested-image", "template.yaml")
 
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             image_repository=self.ecr_repo_name, resolve_s3=True, template=template_path, force_upload=True
         )
 

--- a/tests/integration/package/test_package_command_zip.py
+++ b/tests/integration/package/test_package_command_zip.py
@@ -28,7 +28,7 @@ class TestPackageZip(PackageIntegBase):
     @parameterized.expand(["aws-serverless-function.yaml", "cdk_v1_synthesized_template_zip_functions.json"])
     def test_package_template_flag(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template=template_path
         )
 
@@ -50,7 +50,7 @@ class TestPackageZip(PackageIntegBase):
     )
     def test_package_nested_template(self, template_file, uploading_count):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template=template_path, force_upload=True
         )
 
@@ -92,7 +92,7 @@ class TestPackageZip(PackageIntegBase):
     )
     def test_package_barebones(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template_file=template_path
         )
 
@@ -107,7 +107,7 @@ class TestPackageZip(PackageIntegBase):
         self.assertIn("{bucket_name}".format(bucket_name=self.s3_bucket.name), process_stdout.decode("utf-8"))
 
     def test_package_without_required_args(self):
-        command_list = self.get_command_list()
+        command_list = PackageIntegBase.get_command_list()
 
         process = Popen(command_list, stdout=PIPE)
         try:
@@ -144,7 +144,7 @@ class TestPackageZip(PackageIntegBase):
     )
     def test_package_with_prefix(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, template_file=template_path, s3_prefix=self.s3_prefix
         )
 
@@ -189,7 +189,7 @@ class TestPackageZip(PackageIntegBase):
         template_path = self.test_data_path.joinpath(template_file)
 
         with tempfile.NamedTemporaryFile(delete=False) as output_template:
-            command_list = self.get_command_list(
+            command_list = PackageIntegBase.get_command_list(
                 s3_bucket=self.s3_bucket.name,
                 template_file=template_path,
                 s3_prefix=self.s3_prefix,
@@ -243,7 +243,7 @@ class TestPackageZip(PackageIntegBase):
         template_path = self.test_data_path.joinpath(template_file)
 
         with tempfile.NamedTemporaryFile(delete=False) as output_template:
-            command_list = self.get_command_list(
+            command_list = PackageIntegBase.get_command_list(
                 s3_bucket=self.s3_bucket.name,
                 template_file=template_path,
                 s3_prefix=self.s3_prefix,
@@ -300,7 +300,7 @@ class TestPackageZip(PackageIntegBase):
         with tempfile.NamedTemporaryFile(delete=False) as output_template:
             # Upload twice and see the string to have packaged artifacts both times.
             for _ in range(2):
-                command_list = self.get_command_list(
+                command_list = PackageIntegBase.get_command_list(
                     s3_bucket=self.s3_bucket.name,
                     template_file=template_path,
                     s3_prefix=self.s3_prefix,
@@ -355,7 +355,7 @@ class TestPackageZip(PackageIntegBase):
         template_path = self.test_data_path.joinpath(template_file)
 
         with tempfile.NamedTemporaryFile(delete=False) as output_template:
-            command_list = self.get_command_list(
+            command_list = PackageIntegBase.get_command_list(
                 s3_bucket=self.s3_bucket.name,
                 template_file=template_path,
                 s3_prefix=self.s3_prefix,
@@ -411,7 +411,7 @@ class TestPackageZip(PackageIntegBase):
         template_path = self.test_data_path.joinpath(template_file)
 
         with tempfile.NamedTemporaryFile(delete=False) as output_template:
-            command_list = self.get_command_list(
+            command_list = PackageIntegBase.get_command_list(
                 s3_bucket=self.s3_bucket.name,
                 template_file=template_path,
                 s3_prefix=self.s3_prefix,
@@ -466,7 +466,7 @@ class TestPackageZip(PackageIntegBase):
         template_path = self.test_data_path.joinpath(template_file)
 
         with tempfile.NamedTemporaryFile(delete=False) as output_template:
-            command_list = self.get_command_list(
+            command_list = PackageIntegBase.get_command_list(
                 template_file=template_path,
                 s3_prefix=self.s3_prefix,
                 output_template_file=output_template.name,
@@ -497,7 +497,7 @@ class TestPackageZip(PackageIntegBase):
         template_path = self.test_data_path.joinpath("aws-serverless-function.yaml")
 
         with tempfile.NamedTemporaryFile(delete=False) as output_template:
-            command_list = self.get_command_list(
+            command_list = PackageIntegBase.get_command_list(
                 template_file=template_path,
                 s3_prefix=self.s3_prefix,
                 output_template_file=output_template.name,
@@ -534,7 +534,7 @@ class TestPackageZip(PackageIntegBase):
     )
     def test_package_with_warning_template(self, template_file, warning_keyword):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template=template_path
         )
 
@@ -564,7 +564,7 @@ class TestPackageZip(PackageIntegBase):
         template_file = os.path.join("deep-nested", "template.yaml")
 
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template=template_path, force_upload=True
         )
 
@@ -608,7 +608,7 @@ class TestPackageZip(PackageIntegBase):
         template_file = os.path.join("stackset", "template.yaml")
 
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template=template_path, force_upload=True
         )
 
@@ -651,7 +651,7 @@ class TestPackageZip(PackageIntegBase):
         template_file = os.path.join("stackset", "nested-template.yaml")
 
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template=template_path, force_upload=True
         )
 
@@ -686,7 +686,7 @@ class TestPackageZip(PackageIntegBase):
     @parameterized.expand(["aws-serverless-function-cdk.yaml", "cdk_v1_synthesized_template_zip_functions.json"])
     def test_package_logs_warning_for_cdk_project(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        command_list = self.get_command_list(
+        command_list = PackageIntegBase.get_command_list(
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template_file=template_path
         )
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?

#### Why is this change necessary?
SAM CLI 1.67.0 changed the permissions of the packaged zip file which could not be invoked locally as well. Testing the cloud packaged zip file by invoking it locally to ensure it has the right permissions.

Verified sam local invoke throws permission error with SAM CLI 1.67.0 after running sam package.

#### How does it address the issue?
The new end to end test ensures the packaged function has the correct permissions and can be invoked using sam local.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
