### PR TITLE
fix: bring back validate resource parameter

### DIFF
--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -135,6 +135,7 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
     "--resource",
     multiple=True,
     cls=ReplaceHelpSummaryOption,
+    type=click.Choice(SyncCodeResources.values(), case_sensitive=True),
     replace_help_option="--resource RESOURCE",
     help=f"Sync code for all resources of the given resource type. Accepted values are {SyncCodeResources.values()}",
 )

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -276,26 +276,6 @@ class TestSyncCode(TestSyncCodeBase):
         state_machine = self.stack_resources.get(AWS_STEPFUNCTIONS_STATEMACHINE)[0]
         self.assertEqual(self._get_sfn_response(state_machine), '"World 2"')
 
-    def test_sync_code_invalid_resource_type(self):
-        sync_command_list = self.get_sync_command_list(
-            template_file=TestSyncCodeBase.template_path,
-            code=True,
-            watch=False,
-            resource_list=["AWS::Serverless::InvalidResource"],
-            stack_name=TestSyncCodeBase.stack_name,
-            parameter_overrides="Parameter=Clarity",
-            image_repository=self.ecr_repo_name,
-            s3_prefix=self.s3_prefix,
-            kms_key_id=self.kms_key,
-            tags="integ=true clarity=yes foo_bar=baz",
-        )
-        sync_process_execute = run_command_with_input(sync_command_list, "y\n".encode())
-        self.assertEqual(sync_process_execute.process.returncode, 2)
-        self.assertIn(
-            "Error: Invalid value for '--resource': 'AWS::Serverless::InvalidResource' is not one of",
-            str(sync_process_execute.stderr),
-        )
-
 
 @skipIf(SKIP_SYNC_TESTS, "Skip sync tests in CI/CD only")
 class TestSyncCodeDotnetFunctionTemplate(TestSyncCodeBase):

--- a/tests/unit/commands/sync/test_command.py
+++ b/tests/unit/commands/sync/test_command.py
@@ -2,10 +2,13 @@ import itertools
 import os
 from unittest import TestCase
 from unittest.mock import ANY, MagicMock, Mock, patch
+
+from click.testing import CliRunner
 from parameterized import parameterized
 
 from samcli.commands.sync.command import (
     do_cli,
+    cli as sync_cli,
     execute_code_sync,
     execute_watch,
     check_enable_dependency_layer,
@@ -779,3 +782,12 @@ class TestDisableADL(TestCase):
             build_context_mock, package_context_mock, deploy_context_mock, sync_context_mock
         )
         infra_sync_executor_mock.execute_infra_sync.assert_called_once()
+
+    def test_invalid_resource_type(self):
+        cli_runner = CliRunner()
+        invoke_result = cli_runner.invoke(sync_cli, ["--resource", "AWS::Serverless::InvalidResource"])
+        self.assertEqual(invoke_result.exit_code, 2)
+        self.assertIn(
+            "Error: Invalid value for '--resource': 'AWS::Serverless::InvalidResource' is not one of",
+            invoke_result.output
+        )

--- a/tests/unit/commands/sync/test_command.py
+++ b/tests/unit/commands/sync/test_command.py
@@ -789,5 +789,5 @@ class TestDisableADL(TestCase):
         self.assertEqual(invoke_result.exit_code, 2)
         self.assertIn(
             "Error: Invalid value for '--resource': 'AWS::Serverless::InvalidResource' is not one of",
-            invoke_result.output
+            invoke_result.output,
         )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?
Bring back `--resource` parameter validation which was accidentally removed in https://github.com/aws/aws-sam-cli/pull/4849

#### How does it address the issue?
Adding back the validation and also moving the tests to unit so that we can run them with PR checks.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
