### PR TITLE
fix: move mount with write into try/except block and don't prompt for Image type lambda functions

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -302,8 +302,11 @@ class BuildContext:
                 )
 
                 click.secho(msg, fg="yellow")
+        except FunctionNotFound as function_not_found_ex:
+            raise UserException(
+                str(function_not_found_ex), wrapped_from=function_not_found_ex.__class__.__name__
+            ) from function_not_found_ex
         except (
-            FunctionNotFound,
             UnsupportedRuntimeException,
             BuildError,
             BuildInsideContainerError,

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -312,6 +312,7 @@ class BuildContext:
             BuildInsideContainerError,
             UnsupportedBuilderLibraryVersionError,
             InvalidBuildGraphException,
+            ResourceNotFound,
         ) as ex:
             click.secho("\nBuild Failed", fg="red")
 

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -236,20 +236,20 @@ class BuildContext:
 
         self._stacks = self._handle_build_pre_processing()
 
-        # boolean value indicates if mount with write or not, defaults to READ ONLY
-        mount_with_write = False
-        if self._use_container:
-            if self._mount_with == MountMode.WRITE:
-                mount_with_write = True
-            else:
-                # if self._mount_with is NOT WRITE
-                # check the need of mounting with write permissions and prompt user to enable it if needed
-                mount_with_write = prompt_user_to_enable_mount_with_write_if_needed(
-                    self.get_resources_to_build(),
-                    self.base_dir,
-                )
-
         try:
+            # boolean value indicates if mount with write or not, defaults to READ ONLY
+            mount_with_write = False
+            if self._use_container:
+                if self._mount_with == MountMode.WRITE:
+                    mount_with_write = True
+                else:
+                    # if self._mount_with is NOT WRITE
+                    # check the need of mounting with write permissions and prompt user to enable it if needed
+                    mount_with_write = prompt_user_to_enable_mount_with_write_if_needed(
+                        self.get_resources_to_build(),
+                        self.base_dir,
+                    )
+
             builder = ApplicationBuilder(
                 self.get_resources_to_build(),
                 self.build_dir,
@@ -268,10 +268,7 @@ class BuildContext:
                 build_in_source=self._build_in_source,
                 mount_with_write=mount_with_write,
             )
-        except FunctionNotFound as ex:
-            raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex
 
-        try:
             self._check_exclude_warning()
             self._check_rust_cargo_experimental_flag()
 
@@ -305,8 +302,8 @@ class BuildContext:
                 )
 
                 click.secho(msg, fg="yellow")
-
         except (
+            FunctionNotFound,
             UnsupportedRuntimeException,
             BuildError,
             BuildInsideContainerError,

--- a/samcli/commands/build/utils.py
+++ b/samcli/commands/build/utils.py
@@ -9,6 +9,7 @@ import click
 
 from samcli.lib.build.workflow_config import CONFIG, get_workflow_config
 from samcli.lib.providers.provider import ResourcesToBuildCollector
+from samcli.lib.utils.packagetype import IMAGE
 
 
 class MountMode(Enum):
@@ -53,6 +54,8 @@ def prompt_user_to_enable_mount_with_write_if_needed(
     """
 
     for function in resources_to_build.functions:
+        if function.packagetype == IMAGE:
+            continue
         code_uri = function.codeuri
         if not code_uri:
             continue

--- a/tests/integration/testdata/buildcmd/cdk_v1_synthesized_template_zip_image_functions.json
+++ b/tests/integration/testdata/buildcmd/cdk_v1_synthesized_template_zip_image_functions.json
@@ -82,7 +82,8 @@
           ]
         },
         "Handler": "main.handler",
-        "Runtime": "python3.7"
+        "Runtime": "python3.7",
+        "Timeout": "30"
       },
       "DependsOn": [
         "RandomCitiesFunctionServiceRole4EFB1CF5"

--- a/tests/unit/commands/buildcmd/test_utils.py
+++ b/tests/unit/commands/buildcmd/test_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from samcli.commands.build.utils import prompt_user_to_enable_mount_with_write_if_needed
 from samcli.lib.utils.architecture import X86_64
-from samcli.lib.utils.packagetype import ZIP
+from samcli.lib.utils.packagetype import ZIP, IMAGE
 from samcli.lib.providers.provider import ResourcesToBuildCollector, Function, LayerVersion
 
 
@@ -161,6 +161,55 @@ class TestBuildUtils(TestCase):
         prompt_user_to_enable_mount_with_write_if_needed(resources_to_build, base_dir)
 
         prompt_mock.assert_called()
+
+    @patch("samcli.commands.build.utils.prompt")
+    def test_must_not_prompt_for_image_function(self, prompt_mock):
+        base_dir = "/mybase"
+
+        metadata = {"BuildMethod": "python3.8"}
+        layer1 = LayerVersion(
+            "layer1",
+            codeuri="codeuri",
+            metadata=metadata,
+        )
+        layer2 = LayerVersion(
+            "layer2",
+            codeuri="codeuri",
+            metadata=metadata,
+        )
+
+        function = Function(
+            stack_path="somepath",
+            function_id="function_id",
+            name="logical_id",
+            functionname="function_name",
+            runtime="dotnet6",
+            memory=1234,
+            timeout=12,
+            handler="handler",
+            codeuri="codeuri",
+            environment=None,
+            rolearn=None,
+            layers=[layer1, layer2],
+            events=None,
+            metadata=None,
+            inlinecode=None,
+            imageuri=None,
+            imageconfig=None,
+            packagetype=IMAGE,
+            architectures=[X86_64],
+            codesign_config_arn=None,
+            function_url_config=None,
+            runtime_management_config=None,
+        )
+
+        resources_to_build = ResourcesToBuildCollector()
+        resources_to_build.add_function(function)
+        resources_to_build.add_layers([layer1, layer2])
+
+        prompt_user_to_enable_mount_with_write_if_needed(resources_to_build, base_dir)
+
+        prompt_mock.assert_not_called()
 
     @patch("samcli.commands.build.utils.prompt")
     def test_must_not_prompt(self, prompt_mock):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
- `prompt_user_to_enable_mount_with_write_if_needed` errors are not handled properly
- `prompt_user_to_enable_mount_with_write_if_needed` runs for `Image` type functions which is not needed
- `TestBuildCommand_PythonFunctions_CDK_0_cdk_v1_synthesized_template_zip_image_functions_json::test_cdk_app_with_default_requirements` is failing in Windows due to timeout.


#### How does it address the issue?
- Move `prompt_user_to_enable_mount_with_write_if_needed` into try/except block so that errors will be handled for it
- Don't prompt for the `Image` type functions, since this is only needed for `Zip` ones
- Increase `Timeout` for the function in CDK tests so that timeout will be fixed for Windows tests


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
