### PR TITLE
fix: accept pipe as config file

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -133,7 +133,11 @@ def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx,
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
     # If --config-file is an absolute path, use it, if not, start from config_dir
     config_file_path = config_file if os.path.isabs(config_file) else os.path.join(config_dir, config_file)
-    if config_file and config_file != DEFAULT_CONFIG_FILE_NAME and not Path(config_file_path).absolute().is_file():
+    if (
+        config_file
+        and config_file != DEFAULT_CONFIG_FILE_NAME
+        and not (Path(config_file_path).absolute().is_file() or Path(config_file_path).absolute().is_fifo())
+    ):
         error_msg = f"Config file {config_file} does not exist or could not be read!"
         LOG.debug(error_msg)
         raise ConfigException(error_msg)

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -133,15 +133,14 @@ def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx,
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
     # If --config-file is an absolute path, use it, if not, start from config_dir
     config_file_path = config_file if os.path.isabs(config_file) else os.path.join(config_dir, config_file)
-    if config_file != DEFAULT_CONFIG_FILE_NAME:
-        try:
-            fd = os.open(config_file_path, os.O_RDONLY | os.O_NONBLOCK)
-        except Exception as exc:
-            error_msg = f"Config file {config_file} does not exist or could not be read!"
-            LOG.debug(error_msg)
-            raise ConfigException(error_msg) from exc
-        else:
-            os.close(fd)
+    if (
+        config_file
+        and config_file != DEFAULT_CONFIG_FILE_NAME
+        and not (Path(config_file_path).absolute().is_file() or Path(config_file_path).absolute().is_fifo())
+    ):
+        error_msg = f"Config file {config_file} does not exist or could not be read!"
+        LOG.debug(error_msg)
+        raise ConfigException(error_msg)
 
     config = get_ctx_defaults(
         cmd_name,

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -133,14 +133,15 @@ def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx,
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
     # If --config-file is an absolute path, use it, if not, start from config_dir
     config_file_path = config_file if os.path.isabs(config_file) else os.path.join(config_dir, config_file)
-    if (
-        config_file
-        and config_file != DEFAULT_CONFIG_FILE_NAME
-        and not (Path(config_file_path).absolute().is_file() or Path(config_file_path).absolute().is_fifo())
-    ):
-        error_msg = f"Config file {config_file} does not exist or could not be read!"
-        LOG.debug(error_msg)
-        raise ConfigException(error_msg)
+    if config_file != DEFAULT_CONFIG_FILE_NAME:
+        try:
+            fd = os.open(config_file_path, os.O_RDONLY | os.O_NONBLOCK)
+        except Exception as exc:
+            error_msg = f"Config file {config_file} does not exist or could not be read!"
+            LOG.debug(error_msg)
+            raise ConfigException(error_msg) from exc
+        else:
+            os.close(fd)
 
     config = get_ctx_defaults(
         cmd_name,

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -85,6 +85,7 @@ class TestCliConfiguration(TestCase):
         self.param = MagicMock()
         self.value = MagicMock()
         self.config_file = "otherconfig.toml"
+        self.config_file_pipe = "config"
 
     class Dummy:
         pass
@@ -154,6 +155,39 @@ class TestCliConfiguration(TestCase):
                 param=self.param,
                 value=self.value,
             )
+        self.assertEqual(self.saved_callback.call_count, 1)
+        for arg in [self.ctx, self.param, DEFAULT_ENV]:
+            self.assertIn(arg, self.saved_callback.call_args[0])
+        self.assertNotIn(self.value, self.saved_callback.call_args[0])
+
+    def test_callback_with_config_file_from_pipe(self):
+        mock_context1 = MockContext(info_name="sam", parent=None)
+        mock_context2 = MockContext(info_name="local", parent=mock_context1)
+        mock_context3 = MockContext(info_name="start-api", parent=mock_context2)
+        self.ctx.parent = mock_context3
+        self.ctx.info_name = "test_info"
+        # Create a temporary directory.
+        temp_dir = tempfile.mkdtemp()
+        # Create a new config file path that is one layer above the temporary directory.
+        config_file_pipe_path = Path(temp_dir).parent.joinpath(self.config_file_pipe)
+        try:
+            # Create a new pipe
+            os.mkfifo(config_file_pipe_path)
+            # Set the `samconfig_dir` to be temporary directory that was created.
+            setattr(self.ctx, "samconfig_dir", temp_dir)
+            # set a relative path for the config file from `samconfig_dir`.
+            self.ctx.params = {"config_file": os.path.join("..", self.config_file_pipe)}
+            configuration_callback(
+                cmd_name=self.cmd_name,
+                option_name=self.option_name,
+                saved_callback=self.saved_callback,
+                provider=self.provider,
+                ctx=self.ctx,
+                param=self.param,
+                value=self.value,
+            )
+        finally:
+            os.remove(config_file_pipe_path)
         self.assertEqual(self.saved_callback.call_count, 1)
         for arg in [self.ctx, self.param, DEFAULT_ENV]:
             self.assertIn(arg, self.saved_callback.call_args[0])

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -2,12 +2,14 @@ import os
 import tempfile
 
 from pathlib import Path
-from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest import TestCase, skipIf
+from unittest.mock import MagicMock, patch
 
 from samcli.commands.exceptions import ConfigException
 from samcli.cli.cli_config_file import TomlProvider, configuration_option, configuration_callback, get_ctx_defaults
 from samcli.lib.config.samconfig import DEFAULT_ENV
+
+from tests.testing_utils import IS_WINDOWS
 
 
 class MockContext:
@@ -160,6 +162,7 @@ class TestCliConfiguration(TestCase):
             self.assertIn(arg, self.saved_callback.call_args[0])
         self.assertNotIn(self.value, self.saved_callback.call_args[0])
 
+    @skipIf(IS_WINDOWS, "os.mkfifo doesn't exist on windows")
     def test_callback_with_config_file_from_pipe(self):
         mock_context1 = MockContext(info_name="sam", parent=None)
         mock_context2 = MockContext(info_name="local", parent=mock_context1)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#4875 

#### Why is this change necessary?
This change is necessary so that users can use a pipe with `--config-file` option.

#### How does it address the issue?
It refactors the checks on user provided configuration file paths in order to explicitly allow pipes. 

#### What side effects does this change have?
I believe that there are no side effects.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
