### PR TITLE
fix: update preview runtime warning message and add missing py310 tests

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -35,6 +35,7 @@ environment:
       NOSE_PARAMETERIZED_NO_WARN: 1
       INSTALL_PY_38_PIP: 1
       INSTALL_PY_39_PIP: 1
+      INSTALL_PY_310_PIP: 1
       APPVEYOR_CONSOLE_DISABLE_PTY: true
 
     - PYTHON_HOME: "C:\\Python38-x64"
@@ -44,6 +45,7 @@ environment:
       NOSE_PARAMETERIZED_NO_WARN: 1
       INSTALL_PY_37_PIP: 1
       INSTALL_PY_39_PIP: 1
+      INSTALL_PY_310_PIP: 1
       APPVEYOR_CONSOLE_DISABLE_PTY: true
 
     - PYTHON_HOME: "C:\\Python39-x64"
@@ -53,6 +55,7 @@ environment:
       NOSE_PARAMETERIZED_NO_WARN: 1
       INSTALL_PY_37_PIP: 1
       INSTALL_PY_38_PIP: 1
+      INSTALL_PY_310_PIP: 1
       APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 install:
@@ -87,17 +90,20 @@ install:
   - sh: "sudo apt-get -y install python3.7"
   - sh: "sudo apt-get -y install python3.8"
   - sh: "sudo apt-get -y install python3.9 python3.9-dev python3.9-venv"
+  - sh: "sudo apt-get -y install python3.10 python3.10-dev python3.10-venv"
 
   - sh: "which python3.8"
   - sh: "which python3.7"
   - sh: "which python3.9"
+  - sh: "which python3.10"
 
-  - sh: "PATH=$PATH:/usr/bin/python3.9:/usr/bin/python3.8:/usr/bin/python3.7"
+  - sh: "PATH=$PATH:/usr/bin/python3.9:/usr/bin/python3.8:/usr/bin/python3.7:/usr/bin/python3.10"
   - sh: "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
   - sh: "curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip-36.py"
 
   - sh: "sudo apt-get -y install python3-distutils"
   - sh: "sudo apt-get -y install python3.9-distutils"
+  - ps: "If ($env:INSTALL_PY_310_PIP) {python3.10 get-pip.py --user}"
   - ps: "If ($env:INSTALL_PY_39_PIP) {python3.9 get-pip.py --user}"
   - ps: "If ($env:INSTALL_PY_38_PIP) {python3.8 get-pip.py --user}"
   - ps: "If ($env:INSTALL_PY_37_PIP) {python3.7 get-pip.py --user}"

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -69,7 +69,7 @@ install:
 
   # Make sure the temp directory exists for Python to use.
   - ps: "mkdir -Force C:\\tmp"
-  - 'set PATH=%PYTHON_HOME%;C:\Ruby27-x64\bin;%PATH%;C:\Python37-x64;C:\Python39-x64'
+  - 'set PATH=%PYTHON_HOME%;C:\Ruby27-x64\bin;%PATH%;C:\Python37-x64;C:\Python39-x64;C:\Python310-x64'
   - "echo %PYTHON_HOME%"
   - "echo %PATH%"
   - "python --version"
@@ -84,6 +84,7 @@ install:
   # Install pip for the python versions which is used by the tests
   - "C:\\Python37-x64\\python.exe -m pip install --upgrade pip"
   - "C:\\Python39-x64\\python.exe -m pip install --upgrade pip"
+  - "C:\\Python310-x64\\python.exe -m pip install --upgrade pip"
 
   # Install AWS CLI Globally via pip3
   - "pip install awscli"

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -398,6 +398,7 @@ class TestSkipBuildingFlaggedFunctions(BuildIntegPythonBase):
         ("template.yaml", "Function", True, "python3.7", "Python", False, False, "CodeUri"),
         ("template.yaml", "Function", True, "python3.8", "Python", False, False, "CodeUri"),
         ("template.yaml", "Function", True, "python3.9", "Python", False, False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.10", "Python", False, False, "CodeUri"),
         ("template.yaml", "Function", True, "python3.7", "PythonPEP600", False, False, "CodeUri"),
         ("template.yaml", "Function", True, "python3.8", "PythonPEP600", False, False, "CodeUri"),
         ("template.yaml", "Function", True, "python3.7", "Python", "use_container", False, "CodeUri"),

--- a/tests/unit/commands/package/test_package_context.py
+++ b/tests/unit/commands/package/test_package_context.py
@@ -10,6 +10,7 @@ from samcli.commands.package.exceptions import PackageFailedError
 from samcli.lib.package.artifact_exporter import Template
 from samcli.lib.providers.sam_stack_provider import SamLocalStackProvider
 from samcli.lib.samlib.resource_metadata_normalizer import ResourceMetadataNormalizer
+from samcli.lib.utils.resources import AWS_LAMBDA_FUNCTION, AWS_SERVERLESS_FUNCTION
 
 
 class TestPackageCommand(TestCase):
@@ -156,22 +157,38 @@ class TestPackageCommand(TestCase):
             (
                 "preview_runtime",
                 True,
+                AWS_SERVERLESS_FUNCTION,
             ),
             (
                 "ga_runtime",
                 False,
+                AWS_SERVERLESS_FUNCTION,
+            ),
+             (
+                "preview_runtime",
+                True,
+                AWS_LAMBDA_FUNCTION,
+            ),
+            (
+                "ga_runtime",
+                False,
+                AWS_LAMBDA_FUNCTION,
             ),
         ]
     )
     @patch("samcli.commands.package.package_context.PREVIEW_RUNTIMES", {"preview_runtime"})
-    @patch("samcli.commands.package.package_context.SamFunctionProvider")
     @patch("samcli.commands.package.package_context.click")
-    def test_warn_preview_runtime(self, runtime, should_warn, patched_click, patched_function_provider):
-        function_provider = Mock()
-        patched_function_provider.return_value = function_provider
-        function_provider.get_all.return_value = [Mock(runtime=runtime)]
+    def test_warn_preview_runtime(self, runtime, should_warn, function_type, patched_click):
+        resources = {
+            "MyFunction": {
+                "Type": function_type,
+                "Properties": {
+                    "Runtime": runtime
+                }
+            }
+        }
 
-        self.package_command_context._warn_preview_runtime([Mock()])
+        self.package_command_context._warn_preview_runtime([Mock(resources=resources)])
 
         if should_warn:
             patched_click.secho.assert_called_once()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
- When collecting all functions in a template, `SamFunctionProvider` has side affects which fails during collection of layers.
- `python3.10` was missing in-process build tests

#### How does it address the issue?
- By checking the resources dictionaries rather than collecting them with provider above.
- `python3.10` tests are added into parameterized test annotation


#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
