### PR TITLE
feat: Validate headers against validation expression property

### DIFF
--- a/samcli/local/apigw/authorizers/lambda_authorizer.py
+++ b/samcli/local/apigw/authorizers/lambda_authorizer.py
@@ -87,6 +87,29 @@ class HeaderIdentitySource(IdentitySource):
 
         return str(value) if value else None
 
+    def is_valid(self, **kwargs) -> bool:
+        """
+        Validates whether the required header is present and matches the
+        validation expression, if defined.
+
+        Parameters
+        ----------
+        kwargs: dict
+            Keyword arugments containing the incoming sources and validation expression
+
+        Returns
+        -------
+        bool
+            True if present and valid
+        """
+        identity_source = self.find_identity_value(**kwargs)
+        validation_expression = kwargs.get("validation_expression")
+
+        if validation_expression and identity_source is not None:
+            return re.match(validation_expression, identity_source) is not None
+
+        return identity_source is not None
+
 
 class QueryIdentitySource(IdentitySource):
     def find_identity_value(self, **kwargs) -> Optional[str]:

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -563,6 +563,7 @@ class LocalApigwService(BaseLocalService):
             "querystring": request.query_string.decode("utf-8"),
             "context": context,
             "stageVariables": self.api.stage_variables,
+            "validation_expression": lambda_auth.validation_string,
         }
 
         for validator in identity_sources:

--- a/tests/unit/local/apigw/test_lambda_authorizer.py
+++ b/tests/unit/local/apigw/test_lambda_authorizer.py
@@ -33,6 +33,14 @@ class TestHeaderIdentitySource(TestCase):
 
         self.assertFalse(header_id_source.is_valid(**sources_dict))
 
+    def test_validation_expression_passes(self):
+        id_source = "myheader"
+        args = {"headers": Headers({id_source: "123"}), "validation_expression": "^123$"}
+
+        header_id_source = HeaderIdentitySource(id_source)
+
+        self.assertTrue(header_id_source.is_valid(**args))
+
 
 class TestQueryIdentitySource(TestCase):
     @parameterized.expand(

--- a/tests/unit/local/apigw/test_lambda_authorizer.py
+++ b/tests/unit/local/apigw/test_lambda_authorizer.py
@@ -23,13 +23,14 @@ class TestHeaderIdentitySource(TestCase):
 
     @parameterized.expand(
         [
-            ({"headers": Headers({})}, "test"),  # test empty headers
-            ({}, "test"),  # test no headers
-            ({"headers": Headers({"not here": 123})}, "test"),  # test missing headers
+            ({"headers": Headers({})},),  # test empty headers
+            ({},),  # test no headers
+            ({"headers": Headers({"not here": 123})},),  # test missing headers
+            ({"validation_expression": "^123$"},),  # test no headers, but provided validation
         ]
     )
-    def test_invalid_header_identity_source(self, sources_dict, id_source):
-        header_id_source = HeaderIdentitySource(id_source)
+    def test_invalid_header_identity_source(self, sources_dict):
+        header_id_source = HeaderIdentitySource("test")
 
         self.assertFalse(header_id_source.is_valid(**sources_dict))
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Adds a missing check to validate incoming headers against the validation expression property defined in the template file.

#### How does it address the issue?
Modifies the existing header validator by overriding the parent validation method to also check the expression.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
