### PR TITLE
fix: set the deploy delay default value to 5 seconds to match the old experience.

### DIFF
--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -322,8 +322,8 @@ def do_cli(
         ) as package_context:
             package_context.run()
 
-        # 500ms of sleep time between stack checks and describe stack events.
-        DEFAULT_POLL_DELAY = 0.5
+        # 5s of sleep time between stack checks and describe stack events.
+        DEFAULT_POLL_DELAY = 5
         try:
             poll_delay = float(os.getenv("SAM_CLI_POLL_DELAY", str(DEFAULT_POLL_DELAY)))
         except ValueError:

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -345,7 +345,7 @@ class TestDeployCliCommand(TestCase):
                 signing_profiles=self.signing_profiles,
                 use_changeset=self.use_changeset,
                 disable_rollback=True,
-                poll_delay=0.5,
+                poll_delay=5,
                 on_failure=self.on_failure,
             )
 
@@ -489,7 +489,7 @@ class TestDeployCliCommand(TestCase):
                 signing_profiles=self.signing_profiles,
                 use_changeset=self.use_changeset,
                 disable_rollback=True,
-                poll_delay=0.5,
+                poll_delay=5,
                 on_failure=self.on_failure,
             )
 
@@ -640,7 +640,7 @@ class TestDeployCliCommand(TestCase):
             signing_profiles=self.signing_profiles,
             use_changeset=self.use_changeset,
             disable_rollback=True,
-            poll_delay=0.5,
+            poll_delay=5,
             on_failure=self.on_failure,
         )
 
@@ -794,7 +794,7 @@ class TestDeployCliCommand(TestCase):
             signing_profiles=self.signing_profiles,
             use_changeset=self.use_changeset,
             disable_rollback=True,
-            poll_delay=0.5,
+            poll_delay=5,
             on_failure=self.on_failure,
         )
 
@@ -932,7 +932,7 @@ class TestDeployCliCommand(TestCase):
                 signing_profiles=self.signing_profiles,
                 use_changeset=self.use_changeset,
                 disable_rollback=self.disable_rollback,
-                poll_delay=0.5,
+                poll_delay=5,
                 on_failure=self.on_failure,
             )
 
@@ -1008,7 +1008,7 @@ class TestDeployCliCommand(TestCase):
             signing_profiles=self.signing_profiles,
             use_changeset=self.use_changeset,
             disable_rollback=self.disable_rollback,
-            poll_delay=0.5,
+            poll_delay=5,
             on_failure=self.on_failure,
         )
 
@@ -1123,7 +1123,7 @@ class TestDeployCliCommand(TestCase):
             signing_profiles=self.signing_profiles,
             use_changeset=True,
             disable_rollback=self.disable_rollback,
-            poll_delay=0.5,
+            poll_delay=5,
             on_failure=self.on_failure,
         )
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
[#4906](https://github.com/aws/aws-sam-cli/issues/4906)


#### Why is this change necessary?
The customers who use SAM CLI to deploy large templates start to face some issue during the deployment due a change in the default deploy poll delay from 5 seconds to 0.5 seconds, that makes `sam cli` exceeds the number of attempts.


#### How does it address the issue?
Set the default poll delay to 5 seconds instead of 0.5 sec 

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
