### PR TITLE
fix: Fix APIGW V2 context passing

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -712,10 +712,10 @@ class LocalApigwService(BaseLocalService):
         context = lambda_authorizer.get_context(lambda_auth_response)
 
         # payload V2 responses have the passed context under the "lambda" key
-        if route.payload_format_version == "1.0":
-            original_context.update({"authorizer": context})
-        else:
+        if route.event_type == Route.HTTP and route.payload_format_version in [None, "2.0"]:
             original_context.update({"authorizer": {"lambda": context}})
+        else:
+            original_context.update({"authorizer": context})
 
         route_lambda_event.update({"requestContext": original_context})
 

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -708,7 +708,15 @@ class LocalApigwService(BaseLocalService):
 
         # update route context to include any context that may have been passed from authorizer
         original_context = route_lambda_event.get("requestContext", {})
-        original_context.update({"authorizer": lambda_authorizer.get_context(lambda_auth_response)})
+
+        context = lambda_authorizer.get_context(lambda_auth_response)
+
+        # payload V2 responses have the passed context under the "lambda" key
+        if route.payload_format_version == "1.0":
+            original_context.update({"authorizer": context})
+        else:
+            original_context.update({"authorizer": {"lambda": context}})
+
         route_lambda_event.update({"requestContext": original_context})
 
     def _get_current_route(self, flask_request):

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -872,6 +872,20 @@ class TestApiGatewayService(TestCase):
         self.http_service._invoke_parse_lambda_authorizer(auth, {}, route_event, self.http_v2_payload_route)
         self.assertEqual(route_event, {"requestContext": {"authorizer": {"lambda": mock_get_context}}})
 
+    @patch.object(LocalApigwService, "_invoke_lambda_function")
+    @patch.object(LocalApigwService, "_create_method_arn")
+    def test_lambda_authorizer_pass_context_api(self, method_arn_mock, mock_invoke):
+        mock_get_context = Mock()
+        route_event = {}
+
+        auth = LambdaAuthorizer(Mock(), Mock(), "auth_lambda", [], Mock(), Mock(), Mock())
+        auth.is_valid_response = Mock(return_value=True)
+        auth.get_context = Mock(return_value=mock_get_context)
+        self.api_gateway_route.authorizer_object = auth
+
+        self.api_service._invoke_parse_lambda_authorizer(auth, {}, route_event, self.api_gateway_route)
+        self.assertEqual(route_event, {"requestContext": {"authorizer": mock_get_context}})
+
 
 class TestApiGatewayModel(TestCase):
     def setUp(self):

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -858,6 +858,20 @@ class TestApiGatewayService(TestCase):
         result = self.api_service._request_handler()
         self.assertEqual(result, unauth_mock)
 
+    @patch.object(LocalApigwService, "_invoke_lambda_function")
+    @patch.object(LocalApigwService, "_create_method_arn")
+    def test_lambda_authorizer_pass_context_http(self, method_arn_mock, mock_invoke):
+        mock_get_context = Mock()
+        route_event = {}
+
+        auth = LambdaAuthorizer(Mock(), Mock(), "auth_lambda", [], Mock(), Mock(), Mock())
+        auth.is_valid_response = Mock(return_value=True)
+        auth.get_context = Mock(return_value=mock_get_context)
+        self.http_v2_payload_route.authorizer_object = auth
+
+        self.http_service._invoke_parse_lambda_authorizer(auth, {}, route_event, self.http_v2_payload_route)
+        self.assertEqual(route_event, {"requestContext": {"authorizer": {"lambda": mock_get_context}}})
+
 
 class TestApiGatewayModel(TestCase):
     def setUp(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
APIGW payload format version `2.0` passes the context under `{authorizer: {lambda: ...context...}}` instead of `{authorizer: ...context...}`

#### How does it address the issue?
Adds a check for the `2.0` payload format version.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
