### PR TITLE
fix: the project_type is missed in telemetry data if terraform prepare hook failed

### DIFF
--- a/samcli/cli/context.py
+++ b/samcli/cli/context.py
@@ -152,8 +152,11 @@ class Context:
 
         """
         click_core_ctx = click.get_current_context()
-        if click_core_ctx:
-            return click_core_ctx.template_dict
+        try:
+            if click_core_ctx:
+                return click_core_ctx.template_dict
+        except AttributeError:
+            return None
 
         return None
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Project_type is missed in the telemetry data if terraform prepare hook throws any exception. 


#### Why is this change necessary?
We missed some SAM CLI commands usages to be calculated as part of the terraform usages.

#### How does it address the issue?
If the Terraform prepare hook  failed, the template dictionary will not be populated. so we need to check if the `template_dict` attribute does not exist in the context, we should return None instead of throw exception.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
