### PR TITLE
fix: Fix failing tests for image function invoke

### DIFF
--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -149,11 +149,11 @@ class LambdaImage:
         """
         base_image = None
         tag_prefix = ""
-        runtime_image_tag = Runtime.get_image_name_tag(runtime, architecture)
 
         if packagetype == IMAGE:
             base_image = image
         elif packagetype == ZIP:
+            runtime_image_tag = Runtime.get_image_name_tag(runtime, architecture)
             if self.invoke_images:
                 base_image = self.invoke_images.get(function_name, self.invoke_images.get(None))
             if not base_image:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Latest tests for image functions in app templates are failing as a result of the following bug fix: https://github.com/aws/aws-sam-cli/pull/4950. This fix moves the instantiation of `runtime_image_tag` to a broader scope to ensure it's defined before it's used, however this variable shouldn't be instantiated for image type functions.

#### How does it address the issue?
Moves the instantiation of `runtime_image_tag` to a scope where it can be used later but isn't instantiated for image type functions.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
