### PR TITLE
chore: fix `sam logs` APIGW tests by making more calls before pulling the logs

### DIFF
--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -23,6 +23,7 @@ from tests.testing_utils import (
 )
 
 LOG = logging.getLogger(__name__)
+APIGW_REQUESTS_TO_WARM_UP = 20
 
 
 class LogsIntegTestCases(LogsIntegBase):
@@ -118,8 +119,10 @@ class LogsIntegTestCases(LogsIntegBase):
         # apigw name in output section doesn't have forward slashes
         apigw_name_from_output = apigw_name.replace("/", "")
         apigw_url = f"{self._get_output_value(apigw_name_from_output)}{path}"
-        apigw_result = requests.get(apigw_url)
-        LOG.info("APIGW result %s", apigw_result)
+        # make couple of requests to warm-up APIGW to write its logs to CW
+        for i in range(APIGW_REQUESTS_TO_WARM_UP):
+            apigw_result = requests.get(apigw_url)
+            LOG.info("APIGW result %s", apigw_result)
         cmd_list = self.get_logs_command_list(self.stack_name, name=apigw_name)
         self._check_logs(cmd_list, [f"HTTP Method: GET, Resource Path: /{path}"])
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
When running `sam logs` tests for APIGW, we make one API call and verify the logs of it. But for some cases, it doesn't fill-up the buffer therefore the logs were never delivered CW and causes the test to fail.

#### How does it address the issue?
With this change, we are making couple of calls before checking the logs of them.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
