### PR TITLE
feat: Add usage disclaimer when starting API with authorizers

### DIFF
--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -4,10 +4,12 @@ routes in a standardized format
 """
 
 import logging
+import os
 from collections import defaultdict
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from samcli.lib.providers.provider import Api, Cors
+from samcli.lib.utils.colors import Colored
 from samcli.local.apigw.authorizers.authorizer import Authorizer
 from samcli.local.apigw.route import Route
 
@@ -102,7 +104,10 @@ class ApiCollector:
                         route.authorizer_name,
                         route.path,
                     )
-                else:
+
+                    continue
+
+                if not authorizer_object and authorizer_name_lookup:
                     route.authorizer_name = None
 
                     LOG.info(
@@ -184,6 +189,14 @@ class ApiCollector:
         api.stage_name = self.stage_name
         api.stage_variables = self.stage_variables
         api.cors = self.cors
+
+        for authorizers in self._authorizers_per_resources.values():
+            if len(authorizers):
+                message = f"{os.linesep}<sample warning message goes here>{os.linesep}"
+                LOG.warning(Colored().yellow(message))
+
+                break
+
         return api
 
     @staticmethod

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -193,10 +193,10 @@ class ApiCollector:
         for authorizers in self._authorizers_per_resources.values():
             if len(authorizers):
                 message = f"""{os.linesep}AWS SAM CLI does not guarantee 100% fidelity between authorizers locally 
-vs authorizers deployed on AWS. Any application critical behavior should
+and authorizers deployed on AWS. Any application critical behavior should
 be validated thoroughly before deploying to production.
 
-Testing application behaviour against authorizers deployed to AWS can be done using the sam sync command.{os.linesep}"""
+Testing application behaviour against authorizers deployed on AWS can be done using the sam sync command.{os.linesep}"""
                 LOG.warning(Colored().yellow(message))
 
                 break

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -192,7 +192,9 @@ class ApiCollector:
 
         for authorizers in self._authorizers_per_resources.values():
             if len(authorizers):
-                message = f"{os.linesep}<sample warning message goes here>{os.linesep}"
+                message = f"""{os.linesep}AWS SAM CLI cannot guarantee one-to-one behaviour of Lambda authorizers 
+locally versus authorizers that are deployed to AWS. Make sure to validate
+any critical behaviour in the cloud before deploying to production.{os.linesep}"""
                 LOG.warning(Colored().yellow(message))
 
                 break

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -192,9 +192,11 @@ class ApiCollector:
 
         for authorizers in self._authorizers_per_resources.values():
             if len(authorizers):
-                message = f"""{os.linesep}AWS SAM CLI cannot guarantee one-to-one behaviour of Lambda authorizers 
-locally versus authorizers that are deployed to AWS. Make sure to validate
-any critical behaviour in the cloud before deploying to production.{os.linesep}"""
+                message = f"""{os.linesep}AWS SAM CLI does not guarantee 100% fidelity between authorizers locally 
+vs authorizers deployed on AWS. Any application critical behavior should
+be validated thoroughly before deploying to production.
+
+Testing application behaviour against authorizers deployed to AWS can be done using the sam sync command.{os.linesep}"""
                 LOG.warning(Colored().yellow(message))
 
                 break


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Adds a disclaimer message to the output of `local start-api` if there are any authorizers that are being used in the template.

![Screen Shot 2023-04-11 at 11 49 51 AM](https://user-images.githubusercontent.com/12496191/231260605-7c7664b0-2f66-4cd1-b15c-a2e7c1448089.png)

This change also fixes some unnecessary log output if there are no authorizers defined in the template by checking to see if a route had an authorizer set in the first place.

#### How does it address the issue?
Adds a log statement at the end of the API collection phase and checks to the warning log for undefined authorizers.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
