### PR TITLE
update app insights template modifier to comply with cfn-lint rules

### DIFF
--- a/samcli/lib/init/template_modifiers/application_insights_template_modifier.py
+++ b/samcli/lib/init/template_modifiers/application_insights_template_modifier.py
@@ -28,7 +28,7 @@ class ApplicationInsightsTemplateModifier(TemplateModifier):
     RESOURCE_GROUP_REF = "ApplicationResourceGroup"
     APPLICATION_INSIGHTS_REF = "ApplicationInsightsMonitoring"
     AUTO_CONFIG_VALUE = "true"
-    RESOURCE_GROUP_NAME = {"Fn::Join": ["", ["ApplicationInsights-SAM-", {"Ref": "AWS::StackName"}]]}
+    RESOURCE_GROUP_NAME = {"Fn::Sub": "ApplicationInsights-SAM-${AWS::StackName}"}
 
     # set ignore aliases to true. This configuration avoids usage yaml aliases which is not parsed by CloudFormation.
     class NonAliasingRTRepresenter(RoundTripRepresenter):
@@ -62,10 +62,9 @@ class ApplicationInsightsTemplateModifier(TemplateModifier):
         appInsightsApplication = {
             self.TYPE_KEY: AWS_APPLICATION_INSIGHTS,
             self.PROPERTIES_KEY: {
-                self.RESOURCE_GROUP_NAME_KEY: self.RESOURCE_GROUP_NAME,
+                self.RESOURCE_GROUP_NAME_KEY: {"Ref": self.RESOURCE_GROUP_REF},
                 self.AUTO_CONFIG_ENABLED_KEY: self.AUTO_CONFIG_VALUE,
             },
-            self.DEPENDS_ON_KEY: self.RESOURCE_GROUP_REF,
         }
 
         self.template[self.RESOURCES_KEY][self.RESOURCE_GROUP_REF] = CommentedMap(resourceGroup)

--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -21,7 +21,7 @@ from samcli.lib.utils.packagetype import IMAGE, ZIP
 from pathlib import Path
 
 from tests.integration.init.test_init_base import InitIntegBase
-from tests.testing_utils import get_sam_command, IS_WINDOWS, RUNNING_ON_APPVEYOR
+from tests.testing_utils import get_sam_command, IS_WINDOWS, RUNNING_ON_APPVEYOR, run_command
 
 TIMEOUT = 300
 
@@ -382,6 +382,7 @@ class TestBasicInitCommand(TestCase):
 
             self.assertEqual(process.returncode, 0)
             self.assertTrue(Path(temp, "sam-app").is_dir())
+            self._assert_template_with_cfn_lint(Path(temp, "sam-app"))
 
     def test_init_command_passes_with_disabled_tracing(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -411,6 +412,7 @@ class TestBasicInitCommand(TestCase):
 
             self.assertEqual(process.returncode, 0)
             self.assertTrue(Path(temp, "sam-app").is_dir())
+            self._assert_template_with_cfn_lint(Path(temp, "sam-app"))
 
     def test_init_command_passes_with_enabled_application_insights(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -440,6 +442,7 @@ class TestBasicInitCommand(TestCase):
 
             self.assertEqual(process.returncode, 0)
             self.assertTrue(Path(temp, "sam-app").is_dir())
+            self._assert_template_with_cfn_lint(Path(temp, "sam-app"))
 
     def test_init_command_passes_with_disabled_application_insights(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -469,6 +472,17 @@ class TestBasicInitCommand(TestCase):
 
             self.assertEqual(process.returncode, 0)
             self.assertTrue(Path(temp, "sam-app").is_dir())
+            self._assert_template_with_cfn_lint(Path(temp, "sam-app"))
+
+    def _assert_template_with_cfn_lint(self, cwd):
+        """Assert if the generated project passes cfn-lint"""
+        cmd_list = [
+            get_sam_command(),
+            "validate",
+            "--lint",
+        ]
+        result = run_command(cmd_list, cwd=cwd)
+        self.assertEqual(result.process.returncode, 0)
 
 
 MISSING_REQUIRED_PARAM_MESSAGE = """Error: Missing required parameters, with --no-interactive set.

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -56,6 +56,9 @@ def method_to_stack_name(method_name):
 
 def run_command(command_list, cwd=None, env=None, timeout=TIMEOUT) -> CommandResult:
     LOG.info("Running command: %s", " ".join(command_list))
+    LOG.info("cwd:             %s", cwd)
+    LOG.info("env:             %s", env)
+    LOG.info("timeout:         %s", timeout)
     process_execute = Popen(command_list, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE)
     try:
         stdout_data, stderr_data = process_execute.communicate(timeout=timeout)

--- a/tests/unit/lib/init/test_application_insights_template_modifier.py
+++ b/tests/unit/lib/init/test_application_insights_template_modifier.py
@@ -148,12 +148,7 @@ class TestTemplateModifier(TestCase):
                                         (
                                             "Properties",
                                             {
-                                                "Name": {
-                                                    "Fn::Join": [
-                                                        "",
-                                                        ["ApplicationInsights-SAM-", {"Ref": "AWS::StackName"}],
-                                                    ]
-                                                },
+                                                "Name": {"Fn::Sub": "ApplicationInsights-SAM-${AWS::StackName}"},
                                                 "ResourceQuery": {"Type": "CLOUDFORMATION_STACK_1_0"},
                                             },
                                         ),
@@ -168,16 +163,10 @@ class TestTemplateModifier(TestCase):
                                         (
                                             "Properties",
                                             {
-                                                "ResourceGroupName": {
-                                                    "Fn::Join": [
-                                                        "",
-                                                        ["ApplicationInsights-SAM-", {"Ref": "AWS::StackName"}],
-                                                    ]
-                                                },
+                                                "ResourceGroupName": {"Ref": "ApplicationResourceGroup"},
                                                 "AutoConfigurationEnabled": "true",
                                             },
                                         ),
-                                        ("DependsOn", "ApplicationResourceGroup"),
                                     ]
                                 ),
                             ),


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#4695 

#### Why is this change necessary?
After running `sam init`, the resulting template should pass `cfn-lint` by default.

#### How does it address the issue?
- Update App Insights Template Modifier to comply with cfn-lint rules
- Update integration tests to assert with cfn lint for both app insight templates and x-ray tracing templates

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
