### PR TITLE
 ci: add feat* rule to run github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - develop
-      - "feat/*"
+      - "feat*"
   merge_group:
     types: [ checks_requested ]
     branches:
       - develop
-      - "feat/*"
+      - "feat*"
 
 jobs:
   run-workflow:


### PR DESCRIPTION
Enable GHA CI jobs to run against `develop` and `feat*` branches.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
