### PR TITLE
fix: run managed stack tests sequentially & suppress rustup output

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -99,7 +99,7 @@ install:
   - sh: "terraform -version"
 
   # install Rust
-  - sh: "curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL https://sh.rustup.rs | sh -s -- --default-toolchain none -y"
+  - sh: "curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL https://sh.rustup.rs | sh -s -- --default-toolchain none -y > /dev/null 2>&1"
   - sh: "source $HOME/.cargo/env"
   - sh: "rustup toolchain install stable --profile minimal --no-self-update"
   - sh: "rustup default stable"
@@ -264,7 +264,7 @@ for:
 
     test_script:
       - "pip install -e \".[dev]\""
-      - sh: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
+      - sh: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --dist=loadgroup --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
 
   # Integ testing package
   -

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -254,7 +254,7 @@ for:
       - "git --version"
       - "venv\\Scripts\\activate"
       - "docker system prune -a -f"
-      - ps: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
+      - ps: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --dist=loadgroup --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
 
   # Integ testing package
   - matrix:

--- a/tests/integration/deploy/test_managed_stack_deploy.py
+++ b/tests/integration/deploy/test_managed_stack_deploy.py
@@ -2,6 +2,7 @@ import os
 from unittest import skipIf
 
 import boto3
+import pytest
 from botocore.exceptions import ClientError
 from parameterized import parameterized
 
@@ -16,7 +17,7 @@ PYTHON_VERSION = os.environ.get("PYTHON_VERSION", "0.0.0")
 # This is to restrict package tests to run outside of CI/CD, when the branch is not master or tests are not run by Canary
 SKIP_MANAGED_STACK_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_BY_CANARY
 # Limits the managed stack tests to be run on a single python version to avoid CI race conditions
-IS_TARGETTED_PYTHON_VERSION = PYTHON_VERSION.startswith("3.7")
+IS_TARGETTED_PYTHON_VERSION = PYTHON_VERSION.startswith("3.8")
 
 CFN_PYTHON_VERSION_SUFFIX = PYTHON_VERSION.replace(".", "-")
 # Set region for managed stacks to be in a different region than the ones in deploy
@@ -24,6 +25,7 @@ DEFAULT_REGION = "us-west-2"
 
 
 @skipIf(SKIP_MANAGED_STACK_TESTS or not IS_TARGETTED_PYTHON_VERSION, "Skip managed stack tests in CI/CD only")
+@pytest.mark.xdist_group(name="managed_stack")
 class TestManagedStackDeploy(DeployIntegBase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
- Tests in `test_managed_stack_deploy.py` clashing each other when we run them in parallel. Switched to use `--dist=loadgroup` and marked the tests with `@pytest.mark.xdist_group(name="managed_stack")` so that each test will run in the same thread sequentially.
- Updated same tests to only run in `python3.8` instead of `python3.7`
- Suppressed `rustup` output to fix issue which causes workers to stall.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
