### PR TITLE
fix: Only print console message if enableSimpleResponses is defined

### DIFF
--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -137,14 +137,20 @@ class SwaggerParser:
                 )
 
             enable_simple_response = authorizer_object.get(SwaggerParser._AUTHORIZER_SIMPLE_RESPONSES, False)
-            if event_type != Route.HTTP or payload_version != LambdaAuthorizer.PAYLOAD_V2 and enable_simple_response:
+
+            if (
+                event_type != Route.HTTP
+                or payload_version != LambdaAuthorizer.PAYLOAD_V2
+                or not isinstance(enable_simple_response, bool)
+            ):
                 enable_simple_response = False
 
-                LOG.warning(
-                    "Simple responses are only available on HTTP APIs with payload version "
-                    "2.0, ignoring for Lambda authorizer '%s'",
-                    auth_name,
-                )
+                if authorizer_object.get(SwaggerParser._AUTHORIZER_SIMPLE_RESPONSES) is not None:
+                    LOG.warning(
+                        "Simple responses are only available on HTTP APIs with payload version "
+                        "2.0, ignoring for Lambda authorizer '%s'",
+                        auth_name,
+                    )
 
             if not identity_sources:
                 LOG.warning(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Previously, the "simple response only available on HTTP APIs" message was being logged to the terminal even if simple responses was never defined in the template.

#### How does it address the issue?
Encases the `if` statement in a `None` check to only print if the property was defined. This PR also adds a typing check to the property, defaulting to `False` if an invalid type was defined.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
