### PR TITLE
feat: read and translate APIGW Stage for Terraform

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
@@ -14,6 +14,7 @@ from samcli.lib.hook.exceptions import PrepareHookException
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.resources import AWS_APIGATEWAY_RESOURCE as CFN_AWS_APIGATEWAY_RESOURCE
 from samcli.lib.utils.resources import AWS_APIGATEWAY_RESTAPI as CFN_AWS_APIGATEWAY_RESTAPI
+from samcli.lib.utils.resources import AWS_APIGATEWAY_STAGE as CFN_AWS_APIGATEWAY_STAGE
 from samcli.lib.utils.resources import AWS_LAMBDA_FUNCTION as CFN_AWS_LAMBDA_FUNCTION
 from samcli.lib.utils.resources import AWS_LAMBDA_LAYERVERSION as CFN_AWS_LAMBDA_LAYER_VERSION
 
@@ -23,6 +24,7 @@ TF_AWS_LAMBDA_LAYER_VERSION = "aws_lambda_layer_version"
 
 TF_AWS_API_GATEWAY_RESOURCE = "aws_api_gateway_resource"
 TF_AWS_API_GATEWAY_REST_API = "aws_api_gateway_rest_api"
+TF_AWS_API_GATEWAY_STAGE = "aws_api_gateway_stage"
 
 
 def _build_code_property(tf_properties: dict, resource: TFResource) -> Any:
@@ -227,6 +229,12 @@ AWS_API_GATEWAY_REST_API_PROPERTY_BUILDER_MAPPING: PropertyBuilderMapping = {
     "BinaryMediaTypes": _get_property_extractor("binary_media_types"),
 }
 
+AWS_API_GATEWAY_STAGE_PROPERTY_BUILDER_MAPPING: PropertyBuilderMapping = {
+    "RestApiId": _get_property_extractor("rest_api_id"),
+    "StageName": _get_property_extractor("stage_name"),
+    "Variables": _get_property_extractor("variables"),
+}
+
 AWS_API_GATEWAY_RESOURCE_PROPERTY_BUILDER_MAPPING: PropertyBuilderMapping = {
     "RestApiId": _get_property_extractor("rest_api_id"),
     "ParentId": _get_property_extractor("parent_id"),
@@ -240,6 +248,9 @@ RESOURCE_TRANSLATOR_MAPPING: Dict[str, ResourceTranslator] = {
     ),
     TF_AWS_API_GATEWAY_REST_API: ResourceTranslator(
         CFN_AWS_APIGATEWAY_RESTAPI, AWS_API_GATEWAY_REST_API_PROPERTY_BUILDER_MAPPING
+    ),
+    TF_AWS_API_GATEWAY_STAGE: ResourceTranslator(
+        CFN_AWS_APIGATEWAY_STAGE, AWS_API_GATEWAY_STAGE_PROPERTY_BUILDER_MAPPING
     ),
     TF_AWS_API_GATEWAY_RESOURCE: ResourceTranslator(
         CFN_AWS_APIGATEWAY_RESOURCE, AWS_API_GATEWAY_RESOURCE_PROPERTY_BUILDER_MAPPING

--- a/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
@@ -9,6 +9,7 @@ from samcli.lib.utils.resources import (
     AWS_LAMBDA_LAYERVERSION,
     AWS_APIGATEWAY_RESOURCE,
     AWS_APIGATEWAY_RESTAPI,
+    AWS_APIGATEWAY_STAGE,
 )
 
 
@@ -37,6 +38,7 @@ class PrepareHookUnitBase(TestCase):
         self.lambda_layer_name = "lambda_layer"
 
         self.apigw_resource_name = "my_resource"
+        self.apigw_stage_name = "my_stage"
         self.apigw_rest_api_name = "my_rest_api"
 
         self.tf_function_common_properties: dict = {
@@ -308,6 +310,11 @@ class PrepareHookUnitBase(TestCase):
             "provider_name": AWS_PROVIDER_NAME,
         }
 
+        self.tf_apigw_stage_common_attributes: dict = {
+            "type": "aws_api_gateway_stage",
+            "provider_name": AWS_PROVIDER_NAME,
+        }
+
         self.tf_apigw_rest_api_common_attributes: dict = {
             "type": "aws_api_gateway_rest_api",
             "provider_name": AWS_PROVIDER_NAME,
@@ -507,6 +514,31 @@ class PrepareHookUnitBase(TestCase):
             "Metadata": {"SamResourceId": f"aws_api_gateway_resource.{self.apigw_resource_name}"},
         }
 
+        self.tf_apigw_stage_properties: dict = {
+            "rest_api_id": "aws_api_gateway_rest_api.MyDemoAPI.id",
+            "stage_name": "test",
+            "variables": {"key1": "value1"},
+        }
+
+        self.expected_cfn_apigw_stage_properties: dict = {
+            "RestApiId": "aws_api_gateway_rest_api.MyDemoAPI.id",
+            "StageName": "test",
+            "Variables": {"key1": "value1"},
+        }
+
+        self.tf_apigw_stage_resource: dict = {
+            **self.tf_apigw_stage_common_attributes,
+            "values": self.tf_apigw_stage_properties,
+            "address": f"aws_api_gateway_stage.{self.apigw_stage_name}",
+            "name": self.apigw_stage_name,
+        }
+
+        self.expected_cfn_apigw_stage_resource: dict = {
+            "Type": AWS_APIGATEWAY_STAGE,
+            "Properties": self.expected_cfn_apigw_stage_properties,
+            "Metadata": {"SamResourceId": f"aws_api_gateway_stage.{self.apigw_stage_name}"},
+        }
+
         self.tf_apigw_rest_api_properties: dict = {
             "name": self.apigw_rest_api_name,
             "body": {
@@ -555,6 +587,7 @@ class PrepareHookUnitBase(TestCase):
                         self.tf_image_package_type_lambda_function_resource,
                         self.tf_apigw_resource_resource,
                         self.tf_apigw_rest_api_resource,
+                        self.tf_apigw_stage_resource,
                     ]
                 }
             }
@@ -567,6 +600,7 @@ class PrepareHookUnitBase(TestCase):
                 f"AwsLambdaFunctionImageFunc{self.mock_logical_id_hash}": self.expected_cfn_image_package_type_lambda_function_resource,
                 f"AwsApiGatewayResourceMyResource{self.mock_logical_id_hash}": self.expected_cfn_apigw_resource,
                 f"AwsApiGatewayRestApiMyRestApi{self.mock_logical_id_hash}": self.expected_cfn_apigw_rest_api,
+                f"AwsApiGatewayStageMyStage{self.mock_logical_id_hash}": self.expected_cfn_apigw_stage_resource,
             },
         }
 

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -8,6 +8,7 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     REMOTE_DUMMY_VALUE,
     AWS_API_GATEWAY_RESOURCE_PROPERTY_BUILDER_MAPPING,
     AWS_API_GATEWAY_REST_API_PROPERTY_BUILDER_MAPPING,
+    AWS_API_GATEWAY_STAGE_PROPERTY_BUILDER_MAPPING,
     TF_AWS_API_GATEWAY_REST_API,
 )
 from samcli.hook_packages.terraform.hooks.prepare.types import (
@@ -1055,6 +1056,12 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
             self.tf_apigw_resource_properties, AWS_API_GATEWAY_RESOURCE_PROPERTY_BUILDER_MAPPING, Mock()
         )
         self.assertEqual(translated_cfn_properties, self.expected_cfn_apigw_resource_properties)
+
+    def test_translating_apigw_stage_resource(self):
+        translated_cfn_properties = _translate_properties(
+            self.tf_apigw_stage_properties, AWS_API_GATEWAY_STAGE_PROPERTY_BUILDER_MAPPING, Mock()
+        )
+        self.assertEqual(translated_cfn_properties, self.expected_cfn_apigw_stage_properties)
 
     def test_translating_apigw_rest_api(self):
         translated_cfn_properties = _translate_properties(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
* Support for APIGW Stage from terraform to CFN.

#### Open Questions?
* Should `deployment_id` be included as well? https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_stage -> deployment_id is marked as required on the terraform docs.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
