### PR TITLE
fix: Split image name from tag before pulling

### DIFF
--- a/samcli/local/docker/manager.py
+++ b/samcli/local/docker/manager.py
@@ -142,7 +142,12 @@ class ContainerManager:
             If the Docker image was not available in the server
         """
         if tag is None:
-            tag = image_name.split(":")[1] if ":" in image_name else "latest"
+            _image_name_split = image_name.split(":")
+            # Separate the image_name from the tag so less forgiving docker clones
+            # (podman) get the image name as the URL they expect. Official docker seems
+            # to clean this up internally.
+            tag = _image_name_split[1] if len(_image_name_split) > 1 else "latest"
+            image_name = _image_name_split[0]
         # use a global lock to get the image lock
         with self._lock:
             image_lock = self._lock_per_image.get(image_name)


### PR DESCRIPTION

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5015

#### Why is this change necessary?
to support `sam build -u` with podman

#### How does it address the issue?
This change fully splits the image name from the tag before pulling. Podman isn't as forgiving as the official docker engine when submitting `"imagename:tag", tag="tag"` to the API

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [n/a] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [n/a] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [n/a] Write/update unit tests
- [n/a] Write/update integration tests
- [n/a] Write/update functional tests if needed
- [x] `make pr` passes
- [n/a] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
