### PR TITLE
fix: test_custom_build_image_succeeds build test was failing due log not matching

### DIFF
--- a/samcli/local/docker/manager.py
+++ b/samcli/local/docker/manager.py
@@ -167,7 +167,7 @@ class ContainerManager:
                 raise DockerImagePullFailedException(str(ex)) from ex
 
             # io streams, especially StringIO, work only with unicode strings
-            stream_writer.write("\nFetching {} Docker container image...".format(image_name))
+            stream_writer.write("\nFetching {}:{} Docker container image...".format(image_name, tag))
 
             # Each line contains information on progress of the pull. Each line is a JSON string
             for _ in result_itr:

--- a/tests/unit/local/docker/test_manager.py
+++ b/tests/unit/local/docker/test_manager.py
@@ -221,7 +221,7 @@ class TestContainerManager_pull_image(TestCase):
         stream = io.StringIO()
         pull_result = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
         self.mock_docker_client.api.pull.return_value = pull_result
-        expected_stream_output = "\nFetching {} Docker container image...{}\n".format(
+        expected_stream_output = "\nFetching {}:latest Docker container image...{}\n".format(
             self.image_name, "." * len(pull_result)  # Progress bar will print one dot per response from pull API
         )
 


### PR DESCRIPTION
In #5016, we split the image_name and tag to allow for better support with other docker like systems (podman). The side affect was that, we logged the "image:tag" and asserted that it would be in the logs. Due to the change, the log was changed and caused the test to fail.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None

#### Why is this change necessary?
Failing integration tests

#### How does it address the issue?
Fixes the integration test

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
