### PR TITLE
fix: Hard fail deploy if can't determine if the stack exists

### DIFF
--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -124,7 +124,7 @@ class Deployer:
             if "Stack with id {0} does not exist".format(stack_name) in str(e):
                 LOG.debug("Stack with id %s does not exist", stack_name)
                 return False
-            
+
             LOG.debug("Unknown ClientError recieved: %s. Cannont determine if stack exists.", str(e))
             raise DeployFailedError(stack_name=stack_name, msg=str(e)) from e
         except botocore.exceptions.BotoCoreError as e:

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -124,7 +124,9 @@ class Deployer:
             if "Stack with id {0} does not exist".format(stack_name) in str(e):
                 LOG.debug("Stack with id %s does not exist", stack_name)
                 return False
-            return None
+            
+            LOG.debug("Unknown ClientError recieved: %s. Cannont determine if stack exists.", str(e))
+            raise DeployFailedError(stack_name=stack_name, msg=str(e)) from e
         except botocore.exceptions.BotoCoreError as e:
             # If there are credentials, environment errors,
             # catch that and throw a deploy failed error.

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -125,7 +125,7 @@ class Deployer:
                 LOG.debug("Stack with id %s does not exist", stack_name)
                 return False
 
-            LOG.debug("Unknown ClientError recieved: %s. Cannont determine if stack exists.", str(e))
+            LOG.debug("Unknown ClientError recieved: %s. Cannot determine if stack exists.", str(e))
             raise DeployFailedError(stack_name=stack_name, msg=str(e)) from e
         except botocore.exceptions.BotoCoreError as e:
             # If there are credentials, environment errors,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
We had a report that sometimes `sam deploy` can fail with a validation Error from CFN. The only path that this might be caused by is returning None if we get a ClientError from boto3. So I added additionally logging and a hard fail if we cannot determine if the Stack Exists. This ensures `sam deploy` will create the correct change set type (create or update) depending on if the stack exists.

#### How does it address the issue?
Raises a DeployError when we cannot determine if the Stack exists

#### What side effects does this change have?
This might fail stacks more often for customers if ClientErrors are thrown. I think this is acceptable because right now we are purely guessing at if the stack exists. Returning `None` is the same as saying the stack doesn't exist which may or may  not be true.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
