### PR TITLE
chore: Refactor the linking algorithm to be more generic

### DIFF
--- a/samcli/hook_packages/terraform/designs/resource_linking_generalized.md
+++ b/samcli/hook_packages/terraform/designs/resource_linking_generalized.md
@@ -1,0 +1,163 @@
+# Resource Linking
+
+After translating a resource from Terraform to CloudFormation, 
+that resource often needs to be linked to another based on a field.
+
+For example, AWS Lambda Functions are linked to AWS Lambda Layers through the 
+`Layers` property of a Lambda Function.
+
+E.g.
+```yaml
+Resources:
+  AwsLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: s3_lambda_function
+      Code: function.zip
+      Handler: app.lambda_handler
+      PackageType: Zip
+      Runtime: python3.8
+      Layers:
+      - Ref: AwsLambdaLayerVersion
+  AwsLambdaLayerVersion:
+    Type: AWS::Lambda::LayerVersion
+    Properties:
+      LayerName: lambda_layer1
+      CompatibleRuntimes:
+      - python3.8
+      Content: layer.zip
+```
+
+In this case, the function will be defined as the `source` resource and the layer
+as the `destination` resource. The `Layers` field links to the destination resource 
+using a CloudFormation intrinsic function `!Ref`, and points to the Lambda Layer Arn.
+
+Today, the linking logic is specific to Functions and Layers. The section below proposes
+a method of generalization to make the linking of two resources more extensible and easier to implement.
+
+## Proposed Solution
+Currently, the linking design is functional and passes certain required parameters from 
+the translation function to a specific Function to Layer linking function. Since the fields required to link any two resources primarily the same, they can be abstracted away to a data class
+that will house them.
+
+```python
+@dataclass
+class ResourceLinkingPair:
+    source_resource_cfn_resource: Dict[str, List]
+    source_resource_tf_config: Dict[str, TFResource]
+    destination_resource_tf: Dict[str, Dict]
+    intrinsic_type: LinkerIntrinsics
+    cfn_intrinsic_attribute: Optional[str]
+    source_link_field_name: str
+    terraform_resource_type_prefix: str
+    linking_exceptions: ResourcePairLinkingExceptions
+```
+
+- `source_resource_cfn_resource` this the CFN representation of the resource to which the linked resource will be added
+- `source_resource_tf_config` the Terraform configuration object for the source resource
+- `destination_resource_tf` the destination resources' Terraform planned values (not the configuration object)
+- `intrinsic_type` the CFN intrinsic on which to link (`Ref` or `GetAtt`)
+- `cfn_intrinsic_attribute` in the case of `GetAtt`, the resource attribute to link to (should be None for `Ref`)
+- `source_link_field_name` the name in the source CFN resource to add the linked resource to
+- `terraform_resource_type_prefix` the Terraform resource type prefix used for finding all resource of that type
+- `linking_exceptions` these are exceptions that need to be created with messages specific to the resource linking pair to be used
+by the `ResourceLinker`. With specific exception types, metric data can be collected specific to the resources being linked.
+
+```python
+class ResourcePairLinkingExceptions:
+    multiple_resource_linking_exception: Type[UserException]
+    local_variable_linking_exception: Type[UserException]
+```
+
+
+Only the first three fields are computed, and need to be collected the same way they are today, when parsing the Terraform modules.
+E.g. collecting the Lambda function `source_resource_cfn_resource` and `source_resource_tf_config` looks like this:
+```python
+if resource_type == TF_AWS_LAMBDA_FUNCTION:
+    resolved_config_address = _get_configuration_address(resource_full_address)
+    matched_lambdas = source_resource_cfn_resource.get(resolved_config_address, [])
+    matched_lambdas.append(translated_resource)
+    source_resource_cfn_resource[resolved_config_address] = matched_lambdas
+    source_resource_tf_config[resolved_config_address] = config_resource
+```
+
+and on the destination Layer resource, collecting the `destination_resource_tf`
+```python
+if resource_type == TF_AWS_LAMBDA_LAYER_VERSION:
+    destination_resource_tf[logical_id] = resource
+```
+
+After collecting those three fields, a `ResourceLinkingPair` object can be instantiated.
+
+Once all `ResourceLinkingPair` objects have been created, a list of these objects can be passed to the `ResourceLinker`.
+```python
+class ResourceLinker:
+    _resource_pairs: List[ResourceLinkingPair]
+
+    def link_resources(self):
+        """
+        Iterate through all of the ResourceLinkingPair items and link the
+        corresponding source resource to destination resource
+        """
+
+    def _update_mapped_parent_resource_with_resolved_child_resources(self, destination_resources: List):
+        """
+        Set the resolved destination resource list to the mapped source resources.
+
+        Parameters
+        ----------
+        destination_resources: List
+            The resolved destination resource values that will be used as a value for the mapped CFN resource attribute.
+        """
+
+    def _process_reference_resource_value(self, resolved_destination_resource: ResolvedReference):
+        """
+        Process the a reference destination resource value of type ResolvedReference.
+
+        Parameters
+        ----------
+        resolved_destination_resource: ResolvedReference
+            The resolved destination resource reference.
+
+        Returns
+        -------
+        List[Dict[str, str]]
+            The resolved values that will be used as a value for the mapped CFN resource attribute.
+        """
+
+    def _process_resolved_resources(self, resolved_destination_resource: List[Union[ConstantValue, ResolvedReference]]):
+        """
+        Process the resolved destination resources.
+
+        Parameters
+        ----------
+        resolved_destination_resource: List[Union[ConstantValue, ResolvedReference]]
+            The resolved destination resources to be processed for the input source resource.
+
+        Returns
+        --------
+        List[Dict[str, str]]:
+            The list of destination resources after processing
+        """
+```
+
+The `ResourceLinker` contains a public `link_resources` method to begin execution of the resource linking. The methods 
+shown in the class are all generalized versions of the existing Function to Layer linking functions that exist today.
+
+`link_resources` &larr; `_link_lambda_function_to_layer`, `_link_lambda_functions_to_layers`
+`_update_mapped_parent_resource_with_resolved_child_resources` &larr; `_update_mapped_lambda_function_with_resolved_layers`
+`_process_reference_resource_value` &larr; `_process_reference_layer_value`
+`_process_resolved_resources` &larr; `_process_resolved_layers` 
+
+To generalize these functions: 
+- All instances of hard-coded properties need to be replaced with the corresponding values
+defined in the `ResourceLinkingPair` instance
+- Exception messages should be updated to be more generic
+- The `_update_mapped_parent_resource_with_resolved_child_resources` method should be updated to support writing other intrinsic types.
+
+
+### Adding New Resource Links
+With the proposed change, creating a new link between two resources will include:
+1. Collecting the three required fields (`source_resource_cfn_resource`, `source_resource_tf_config` and `destination_resource_tf`)
+2. Creating a `ResourceLinkingPair` instance
+3. Appending the `ResourceLinkingPair` to the list of pairs

--- a/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
@@ -17,38 +17,50 @@ class InvalidResourceLinkingException(UserException):
         UserException.__init__(self, msg)
 
 
-class OneResourceLimitationException(UserException):
+class OneResourceLinkingLimitationException(UserException):
     fmt = (
-        "AWS SAM CLI could not process a Terraform project that contains Lambda functions that are linked to more "
-        "than one lambda layer. Layer(s) defined by {layers_list} could not be linked to lambda function {function_id}."
-        "{line_sep}Related issue: {issue_link}."
+        "AWS SAM CLI could not process a Terraform project that contains a source resource that is linked to more "
+        "than one destination resource. Destination resource(s) defined by {dest_resource_list} could not be linked to "
+        "source resource {source_resource_id}.{line_sep}Related issue: {issue_link}."
     )
 
-    def __init__(self, layers_list, function_id):
+    def __init__(self, dest_resource_list, source_resource_id):
         msg = self.fmt.format(
-            layers_list=layers_list,
-            function_id=function_id,
+            dest_resource_list=dest_resource_list,
+            source_resource_id=source_resource_id,
             issue_link=ONE_LAMBDA_LAYER_LINKING_ISSUE_LINK,
             line_sep=os.linesep,
         )
         UserException.__init__(self, msg)
 
 
+class OneLambdaLayerLinkingLimitationException(OneResourceLinkingLimitationException):
+    """
+    Exception specific for Lambda function linking to more than one layer
+    """
+
+
 class LocalVariablesLinkingLimitationException(UserException):
     fmt = (
-        "AWS SAM CLI could not process a Terraform project that uses local variables to define the Lambda functions "
-        "layers. Layer(s) defined by {local_variable_reference} could not be linked to lambda function {function_id}."
-        "{line_sep}Related issue: {issue_link}."
+        "AWS SAM CLI could not process a Terraform project that uses local variables to define linked resources. "
+        "Destination resource(s) defined by {local_variable_reference} could not be linked to destination "
+        "resource {dest_resource_list}.{line_sep}Related issue: {issue_link}."
     )
 
-    def __init__(self, local_variable_reference, function_id):
+    def __init__(self, local_variable_reference, dest_resource_list):
         msg = self.fmt.format(
             local_variable_reference=local_variable_reference,
-            function_id=function_id,
+            dest_resource_list=dest_resource_list,
             issue_link=LOCAL_VARIABLES_SUPPORT_ISSUE_LINK,
             line_sep=os.linesep,
         )
         UserException.__init__(self, msg)
+
+
+class FunctionLayerLocalVariablesLinkingLimitationException(LocalVariablesLinkingLimitationException):
+    """
+    Exception specific for Lambda function linking to a layer defined as a local
+    """
 
 
 class InvalidSamMetadataPropertiesException(UserException):

--- a/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
@@ -17,7 +17,7 @@ class InvalidResourceLinkingException(UserException):
         UserException.__init__(self, msg)
 
 
-class OneLambdaLayerLinkingLimitationException(UserException):
+class OneResourceLimitationException(UserException):
     fmt = (
         "AWS SAM CLI could not process a Terraform project that contains Lambda functions that are linked to more "
         "than one lambda layer. Layer(s) defined by {layers_list} could not be linked to lambda function {function_id}."

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -215,7 +215,9 @@ class ResourceLinker:
                     cfn_source_resource,
                 )
                 dest_arn = (
-                    self._resource_pair.destination_resource_tf[dest_resource["Ref"]].get("values", {}).get("arn")
+                    self._resource_pair.destination_resource_tf.get(dest_resource.get("Ref"))
+                    .get("values", {})
+                    .get("arn")
                 )
 
                 # The resolved dest resource is a reference to a dest resource

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -215,7 +215,7 @@ class ResourceLinker:
                     cfn_source_resource,
                 )
                 dest_arn = (
-                    self._resource_pair.destination_resource_tf.get(dest_resource.get("Ref"))
+                    self._resource_pair.destination_resource_tf.get(dest_resource.get("Ref"), {})
                     .get("values", {})
                     .get("arn")
                 )

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Type, Union
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     InvalidResourceLinkingException,
     LocalVariablesLinkingLimitationException,
-    OneResourceLimitationException,
+    OneResourceLinkingLimitationException,
 )
 from samcli.hook_packages.terraform.hooks.prepare.types import (
     ConstantValue,
@@ -38,7 +38,7 @@ class LinkerIntrinsics(Enum):
 
 @dataclass
 class ResourcePairExceptions:
-    multiple_resource_linking_exception: Type[OneResourceLimitationException]
+    multiple_resource_linking_exception: Type[OneResourceLinkingLimitationException]
     local_variable_linking_exception: Type[LocalVariablesLinkingLimitationException]
 
 

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -215,7 +215,7 @@ class ResourceLinker:
                     cfn_source_resource,
                 )
                 dest_arn = (
-                    self._resource_pair.destination_resource_tf[dest_resource[self._resource_pair.intrinsic_type.value]]
+                    self._resource_pair.destination_resource_tf[dest_resource["Ref"]]
                     .get("values", {})
                     .get("arn")
                 )
@@ -316,7 +316,7 @@ class ResourceLinker:
                 )
             else:
                 tf_dest_resource_full_address = (
-                    f"{self._resource_pair.terraform_resource_type_prefix}" f"{tf_dest_res_name}"
+                    f"{self._resource_pair.terraform_resource_type_prefix}{tf_dest_res_name}"
                 )
             cfn_dest_resource_logical_id = build_cfn_logical_id(tf_dest_resource_full_address)
             LOG.debug(
@@ -333,7 +333,7 @@ class ResourceLinker:
                     "The resource referred by %s can be found in the mapped destination resources",
                     resolved_destination_resource.value,
                 )
-                dest_resources.append({self._resource_pair.intrinsic_type.value: cfn_dest_resource_logical_id})
+                dest_resources.append({"Ref": cfn_dest_resource_logical_id})
             return dest_resources
         # it means the source resource is referring to a wrong destination resource type
         LOG.debug(

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -4,8 +4,11 @@ e.g. linking layers to functions
 """
 import logging
 import re
-from typing import Dict, List, Optional, Union
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Type, Union
 
+from samcli.commands.exceptions import UserException
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     InvalidResourceLinkingException,
     LocalVariablesLinkingLimitationException,
@@ -27,6 +30,78 @@ DATA_RESOURCE_ADDRESS_PREFIX = "data."
 
 LOG = logging.getLogger(__name__)
 COMPILED_REGULAR_EXPRESSION = re.compile(r"\[[^\[\]]*\]")
+
+
+class LinkerIntrinsics(Enum):
+    Ref = "Ref"
+    GetAtt = "GetAtt"
+
+
+class ResourcePairLinkingExceptions:
+    multiple_resource_linking_exception: Type[UserException]
+    local_variable_linking_exception: Type[UserException]
+
+
+@dataclass
+class ResourceLinkingPair:
+    source_resource_cfn_resource: Dict[str, List]
+    source_resource_tf_config: Dict[str, TFResource]
+    destination_resource_tf: Dict[str, Dict]
+    intrinsic_type: LinkerIntrinsics
+    cfn_intrinsic_attribute: Optional[str]
+    source_link_field_name: str
+    terraform_resource_type_prefix: str
+    linking_exceptions: ResourcePairLinkingExceptions
+
+
+class ResourceLinker:
+    _resource_pairs: List[ResourceLinkingPair]
+
+    def link_resources(self):
+        """
+        Iterate through all of the ResourceLinkingPair items and link the
+        corresponding source resource to destination resource
+        """
+
+    def _update_mapped_parent_resource_with_resolved_child_resources(self, destination_resources: List):
+        """
+        Set the resolved destination resource list to the mapped source resources.
+
+        Parameters
+        ----------
+        destination_resources: List
+            The resolved destination resource values that will be used as a value for the mapped CFN resource attribute.
+        """
+
+    def _process_reference_resource_value(self, resolved_destination_resource: ResolvedReference):
+        """
+        Process the a reference destination resource value of type ResolvedReference.
+
+        Parameters
+        ----------
+        resolved_destination_resource: ResolvedReference
+            The resolved destination resource reference.
+
+        Returns
+        -------
+        List[Dict[str, str]]
+            The resolved values that will be used as a value for the mapped CFN resource attribute.
+        """
+
+    def _process_resolved_resources(self, resolved_destination_resource: List[Union[ConstantValue, ResolvedReference]]):
+        """
+        Process the resolved destination resources.
+
+        Parameters
+        ----------
+        resolved_destination_resource: List[Union[ConstantValue, ResolvedReference]]
+            The resolved destination resources to be processed for the input source resource.
+
+        Returns
+        --------
+        List[Dict[str, str]]:
+            The list of destination resources after processing
+        """
 
 
 def _build_module(

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -215,9 +215,7 @@ class ResourceLinker:
                     cfn_source_resource,
                 )
                 dest_arn = (
-                    self._resource_pair.destination_resource_tf[dest_resource["Ref"]]
-                    .get("values", {})
-                    .get("arn")
+                    self._resource_pair.destination_resource_tf[dest_resource["Ref"]].get("values", {}).get("arn")
                 )
 
                 # The resolved dest resource is a reference to a dest resource

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -12,7 +12,7 @@ from samcli.commands.exceptions import UserException
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     InvalidResourceLinkingException,
     LocalVariablesLinkingLimitationException,
-    OneLambdaLayerLinkingLimitationException,
+    OneResourceLimitationException,
 )
 from samcli.hook_packages.terraform.hooks.prepare.types import (
     ConstantValue,
@@ -37,8 +37,9 @@ class LinkerIntrinsics(Enum):
     GetAtt = "GetAtt"
 
 
-class ResourcePairLinkingExceptions:
-    multiple_resource_linking_exception: Type[UserException]
+@dataclass
+class ResourcePairExceptions:
+    multiple_resource_linking_exception: Type[OneResourceLimitationException]
     local_variable_linking_exception: Type[UserException]
 
 
@@ -50,45 +51,82 @@ class ResourceLinkingPair:
     intrinsic_type: LinkerIntrinsics
     cfn_intrinsic_attribute: Optional[str]
     source_link_field_name: str
+    terraform_link_field_name: str
     terraform_resource_type_prefix: str
-    linking_exceptions: ResourcePairLinkingExceptions
+    linking_exceptions: ResourcePairExceptions
 
 
 class ResourceLinker:
-    _resource_pairs: List[ResourceLinkingPair]
+    _resource_pair: ResourceLinkingPair
+
+    def __init__(self, resource_pair):
+        self._resource_pair = resource_pair
 
     def link_resources(self):
         """
-        Iterate through all of the ResourceLinkingPair items and link the
-        corresponding source resource to destination resource
+        Validate the ResourceLinkingPair object and link the corresponding source resource to destination resource
         """
+        for config_address, resource in self._resource_pair.source_resource_tf_config.items():
+            if config_address in self._resource_pair.source_resource_cfn_resource:
+                LOG.debug("Linking destination resource for source resource: %s", resource.full_address)
+                self._handle_linking(
+                    resource,
+                    self._resource_pair.source_resource_cfn_resource[config_address],
+                )
 
-    def _update_mapped_parent_resource_with_resolved_child_resources(self, destination_resources: List):
+    def _handle_linking(self, source_tf_resource: TFResource, cfn_source_resources: List[Dict]) -> None:
         """
-        Set the resolved destination resource list to the mapped source resources.
+        Resolve the destinations resource for the input source configuration resource,
+        and then update the equivalent cfn source resource list.
+        The source resource configuration resource in Terraform can match
+        multiple actual resources in case if it was defined using count or for_each pattern.
 
         Parameters
         ----------
-        destination_resources: List
-            The resolved destination resource values that will be used as a value for the mapped CFN resource attribute.
+        source_tf_resource: TFResource
+            The source resource Terraform configuration resource
+
+        cfn_source_resources: List[Dict]
+            A list of mapped source resources that are equivalent to the input terraform configuration source resource
         """
 
-    def _process_reference_resource_value(self, resolved_destination_resource: ResolvedReference):
-        """
-        Process the a reference destination resource value of type ResolvedReference.
+        LOG.debug(
+            "Link resource configuration %s that has these instances %s.",
+            source_tf_resource.full_address,
+            cfn_source_resources,
+        )
+        resolved_dest_resources = _resolve_resource_attribute(
+            source_tf_resource, self._resource_pair.terraform_link_field_name
+        )
+        LOG.debug(
+            "The resolved destination resources for source resource %s are %s",
+            source_tf_resource.full_address,
+            resolved_dest_resources,
+        )
+        dest_resources = self._process_resolved_resources(source_tf_resource, resolved_dest_resources)
 
-        Parameters
-        ----------
-        resolved_destination_resource: ResolvedReference
-            The resolved destination resource reference.
+        # The agreed limitation to support only 1 destination resource.
+        if len(dest_resources) > 1:
+            LOG.debug(
+                "AWS SAM CLI does not support mapping the source resources %s to more than one destination resource.",
+                source_tf_resource.full_address,
+            )
+            raise self._resource_pair.linking_exceptions.multiple_resource_linking_exception(
+                dest_resources, source_tf_resource.full_address
+            )
+        if not dest_resources:
+            LOG.debug(
+                "There are destination resources defined for for the source resource %s",
+                source_tf_resource.full_address,
+            )
+        else:
+            self._update_mapped_parent_resource_with_resolved_child_resources(cfn_source_resources, dest_resources)
 
-        Returns
-        -------
-        List[Dict[str, str]]
-            The resolved values that will be used as a value for the mapped CFN resource attribute.
-        """
-
-    def _process_resolved_resources(self, resolved_destination_resource: List[Union[ConstantValue, ResolvedReference]]):
+    def _process_resolved_resources(
+        self,
+        source_tf_resource: TFResource,
+        resolved_destination_resource: List[Union[ConstantValue, ResolvedReference]],
+    ):
         """
         Process the resolved destination resources.
 
@@ -102,6 +140,175 @@ class ResourceLinker:
         List[Dict[str, str]]:
             The list of destination resources after processing
         """
+        LOG.debug(
+            "Map the resolved destination resources %s to configuration source resource %s.",
+            resolved_destination_resource,
+            source_tf_resource.full_address,
+        )
+        destination_resources = []
+        does_refer_to_constant_values = False
+        does_refer_to_data_sources = False
+        for resolved_dest_resource in resolved_destination_resource:
+            # Skip ConstantValue destination reference, as it will be already handled by terraform plan command.
+            if isinstance(resolved_dest_resource, ConstantValue):
+                does_refer_to_constant_values = True
+            elif isinstance(resolved_dest_resource, ResolvedReference):
+                processed_dest_resources = self._process_reference_resource_value(
+                    source_tf_resource, resolved_dest_resource
+                )
+                if not processed_dest_resources:
+                    does_refer_to_data_sources = True
+                destination_resources += processed_dest_resources
+
+        if (does_refer_to_constant_values or does_refer_to_data_sources) and len(destination_resources) > 0:
+            LOG.debug(
+                "Source resource %s to is referring to destination resource using an "
+                "expression mixing between constant value or data "
+                "sources and other resources references. AWS SAM CLI "
+                "could not determine this source resources destination.",
+                source_tf_resource.full_address,
+            )
+            raise self._resource_pair.linking_exceptions.multiple_resource_linking_exception(
+                resolved_destination_resource, source_tf_resource.full_address
+            )
+
+        return destination_resources
+
+    def _update_mapped_parent_resource_with_resolved_child_resources(
+        self, cfn_source_resources: List[Dict], destination_resources: List
+    ):
+        """
+        Set the resolved destination resource list to the mapped source resources.
+
+        Parameters
+        ----------
+        destination_resources: List
+            The resolved destination resource values that will be used as a value for the mapped CFN resource attribute.
+        """
+        LOG.debug("Set the resolved layers %s to the cfn functions %s", destination_resources, cfn_source_resources)
+        for cfn_func in cfn_source_resources:
+            LOG.debug("Process the Lambda function %s", cfn_func)
+            # Add the resolved layers list as it is to the mapped function that does not have any layers defined
+            if not cfn_func["Properties"].get("Layers"):
+                LOG.debug("The Lambda function %s does not have any layers defined.", cfn_func)
+                cfn_func["Properties"]["Layers"] = destination_resources
+                continue
+
+            # Check if the the mapped function layers list contains any
+            # arn value for one of the resolved layers to replace it.
+            for layer in destination_resources:
+                # resolve the layer arn string to check if it is already there in the CFN func layer property
+                # layer logical id will be always in tf_layers, as we
+                # do not consider the references to layers that does not
+                # exist in the tf_layers list as it means that this layer will not be created.
+                LOG.debug("Check if the layer %s is already defined in function % layers.", layer, cfn_func)
+                layer_arn = self._resource_pair.destination_resource_tf[layer["Ref"]].get("values", {}).get("arn")
+
+                # The resolved layer is a reference to a layers which is not applied yet, so there is no ARN value yet.
+                if not layer_arn:
+                    LOG.debug("The layer %s is not applied yet, and does not have ARN property.", layer)
+                    cfn_func["Properties"]["Layers"].append(layer)
+                    continue
+
+                # try to find a layer arn that equals the resolved layer arn so we can replace it with Ref value.
+                try:
+                    layer_index = cfn_func["Properties"].get("Layers", []).index(layer_arn)
+                    LOG.debug(
+                        "The layer %s has the arn value %s that exists in function %s layers.",
+                        layer,
+                        layer_arn,
+                        cfn_func,
+                    )
+                    cfn_func["Properties"]["Layers"][layer_index] = layer
+                except ValueError:
+                    # there is no matching layer ARN.
+                    LOG.debug(
+                        "The layer %s has the arn value %s that does not exist in function %s layers.",
+                        layer,
+                        layer_arn,
+                        cfn_func,
+                    )
+                    cfn_func["Properties"]["Layers"].append(layer)
+
+    def _process_reference_resource_value(
+        self, source_tf_resource: TFResource, resolved_destination_resource: ResolvedReference
+    ):
+        """
+        Process the a reference destination resource value of type ResolvedReference.
+
+        Parameters
+        ----------
+        resolved_destination_resource: ResolvedReference
+            The resolved destination resource reference.
+
+        Returns
+        -------
+        List[Dict[str, str]]
+            The resolved values that will be used as a value for the mapped CFN resource attribute.
+        """
+        LOG.debug("Process the reference layer %s.", resolved_destination_resource.value)
+        # skip processing the data source block, as it should be mapped while executing the terraform plan command.
+        if resolved_destination_resource.value.startswith(DATA_RESOURCE_ADDRESS_PREFIX):
+            LOG.debug(
+                "Skip processing the reference layer %s, as it is referring to a data resource",
+                resolved_destination_resource.value,
+            )
+            return []
+
+        # resolved reference is a local variable
+        if resolved_destination_resource.value.startswith(TERRAFORM_LOCAL_VARIABLES_ADDRESS_PREFIX):
+            LOG.debug("AWS SAM CLI could not process the Local variables %s", resolved_destination_resource.value)
+            raise LocalVariablesLinkingLimitationException(
+                resolved_destination_resource.value, source_tf_resource.full_address
+            )
+
+        # Valid Layer resource
+        if resolved_destination_resource.value.startswith(LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX):
+            LOG.debug("Process the Layer version resource %s", resolved_destination_resource.value)
+            if not resolved_destination_resource.value.endswith("arn"):
+                LOG.debug(
+                    "The used property in reference %s is not an ARN property", resolved_destination_resource.value
+                )
+                raise InvalidResourceLinkingException(
+                    f"Could not use the value {resolved_destination_resource.value} as a Layer for lambda function "
+                    f"{source_tf_resource.full_address}. Lambda Function Layer value should refer to valid "
+                    f"lambda layer ARN property"
+                )
+
+            tf_layer_res_name = resolved_destination_resource.value[
+                len(LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX) : -len(".arn")
+            ]
+            if resolved_destination_resource.module_address:
+                tf_layer_full_address = (
+                    f"{resolved_destination_resource.module_address}.{LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX}"
+                    f"{tf_layer_res_name}"
+                )
+            else:
+                tf_layer_full_address = f"{LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX}{tf_layer_res_name}"
+            cfn_layer_logical_id = build_cfn_logical_id(tf_layer_full_address)
+            LOG.debug(
+                "The logical id of the resource referred by %s is %s",
+                resolved_destination_resource.value,
+                cfn_layer_logical_id,
+            )
+
+            # validate that the found layer is in mapped layers resources, which means that it is created.
+            # The resource can be defined in the TF plan configuration, but will not be created.
+            layers = []
+            if cfn_layer_logical_id in self._resource_pair.destination_resource_tf:
+                LOG.debug(
+                    "The resource referred by %s can be found in the mapped layers resources",
+                    resolved_destination_resource.value,
+                )
+                layers.append({"Ref": cfn_layer_logical_id})
+            return layers
+        # it means the Lambda function is referring to a wrong layer resource type
+        LOG.debug("The used reference %s is not a Layer Version resource.", resolved_destination_resource.value)
+        raise InvalidResourceLinkingException(
+            f"Could not use the value {resolved_destination_resource.value} as a Layer for lambda function "
+            f"{source_tf_resource.full_address}. Lambda Function Layer value should refer to valid lambda layer ARN "
+            f"property"
+        )
 
 
 def _build_module(
@@ -639,234 +846,3 @@ def _resolve_resource_attribute(
         else:
             results.append(ResolvedReference(reference, resource.module.full_address))
     return results
-
-
-def _link_lambda_function_to_layer(
-    function_tf_resource: TFResource, cfn_functions: List[Dict], tf_layers: Dict[str, Dict]
-) -> None:
-    """
-    Resolve the lambda layer for the input lambda function configuration resource, and then update the equivalent cfn
-    lambda functions list.
-    The Lambda configuration resource in Terraform can match multiple actual resources in case if it was defined using
-    count or for_each pattern.
-
-    Parameters
-    ----------
-    function_tf_resource: TFResource
-        The input lambda function terraform configuration resource
-
-    cfn_functions: List[Dict]
-        A list of mapped lambda functions that are equivalent to the input terraform configuration lambda function
-
-    tf_layers: Dict[str, Dict]
-        Dictionary of all actual terraform layers resources (not configuration resources). The dictionary's key is the
-        calculated logical id for each resource
-    """
-
-    LOG.debug(
-        "Link function configuration %s layer that has these instances %s.",
-        function_tf_resource.full_address,
-        cfn_functions,
-    )
-    resolved_layers = _resolve_resource_attribute(function_tf_resource, "layers")
-    LOG.debug("The resolved layers for function %s are %s", function_tf_resource.full_address, resolved_layers)
-    layers = _process_resolved_layers(function_tf_resource, resolved_layers, tf_layers)
-
-    # The agreed limitation to support only 1 lambda layer reference.
-    if len(layers) > 1:
-        LOG.debug(
-            "AWS SAM CLI does not support mapping the lambda function %s to more than one layer.",
-            function_tf_resource.full_address,
-        )
-        raise OneLambdaLayerLinkingLimitationException(layers, function_tf_resource.full_address)
-    if not layers:
-        LOG.debug("There are no layers defined for lambda function %s", function_tf_resource.full_address)
-    else:
-        _update_mapped_lambda_function_with_resolved_layers(cfn_functions, layers, tf_layers)
-
-
-def _process_resolved_layers(
-    function_tf_resource: TFResource,
-    resolved_layers: List[Union[ConstantValue, ResolvedReference]],
-    tf_layers: Dict[str, Dict],
-) -> List[Dict[str, str]]:
-    """
-    Process the resolved layers.
-
-    Parameters
-    ----------
-    function_tf_resource: TFResource
-        The input lambda function terraform configuration resource
-
-    resolved_layers: List[Union[ConstantValue, ResolvedReference]]
-        The resolved layers to be processed for the input lambda function.
-
-    tf_layers: Dict[str, Dict]
-        Dictionary of all actual terraform layers resources (not configuration resources). The dictionary's key is the
-        calculated logical id for each resource
-
-    Returns
-    --------
-    List[Dict[str, str]]:
-        The list of layers after processing
-
-    """
-    LOG.debug(
-        "Map the resolved layers %s to configuration function %s.", resolved_layers, function_tf_resource.full_address
-    )
-    layers = []
-    does_refer_to_constant_values = False
-    does_refer_to_data_sources = False
-    for resolved_layer in resolved_layers:
-        # Skip ConstantValue layers reference, as it will be already handled by terraform plan command.
-        if isinstance(resolved_layer, ConstantValue):
-            does_refer_to_constant_values = True
-        elif isinstance(resolved_layer, ResolvedReference):
-            processed_layers = _process_reference_layer_value(function_tf_resource, resolved_layer, tf_layers)
-            if not processed_layers:
-                does_refer_to_data_sources = True
-            layers += processed_layers
-
-    if (does_refer_to_constant_values or does_refer_to_data_sources) and len(layers) > 0:
-        LOG.debug(
-            "Lambda function %s to is referring to layers using an expression mixing between constant value or data "
-            "sources and other resources references. AWS SAM CLI could not determine this lambda functions layers.",
-            function_tf_resource.full_address,
-        )
-        raise OneLambdaLayerLinkingLimitationException(resolved_layers, function_tf_resource.full_address)
-
-    return layers
-
-
-def _process_reference_layer_value(
-    function_tf_resource: TFResource, resolved_layer: ResolvedReference, tf_layers: Dict[str, Dict]
-) -> List[Dict[str, str]]:
-    """
-    Process the layer value of type ResolvedReference.
-
-    Parameters
-    ----------
-    function_tf_resource: TFResource
-        The input lambda function terraform configuration resource
-
-    resolved_layer: ResolvedReference
-        The layer reference.
-
-    tf_layers: Dict[str, Dict]
-        Dictionary of all actual terraform layers resources (not configuration resources). The dictionary's key is the
-        calculated logical id for each resource
-
-    Returns
-    -------
-    List[Dict[str, str]]
-        The resolved layers values that will be used as a value for the mapped CFN function Layers attribute.
-
-    """
-    LOG.debug("Process the reference layer %s.", resolved_layer.value)
-    # skip processing the data source block, as it should be mapped while executing the terraform plan command.
-    if resolved_layer.value.startswith(DATA_RESOURCE_ADDRESS_PREFIX):
-        LOG.debug("Skip processing the reference layer %s, as it is referring to a data resource", resolved_layer.value)
-        return []
-
-    # resolved reference is a local variable
-    if resolved_layer.value.startswith(TERRAFORM_LOCAL_VARIABLES_ADDRESS_PREFIX):
-        LOG.debug("AWS SAM CLI could not process the Local variables %s", resolved_layer.value)
-        raise LocalVariablesLinkingLimitationException(resolved_layer.value, function_tf_resource.full_address)
-
-    # Valid Layer resource
-    if resolved_layer.value.startswith(LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX):
-        LOG.debug("Process the Layer version resource %s", resolved_layer.value)
-        if not resolved_layer.value.endswith("arn"):
-            LOG.debug("The used property in reference %s is not an ARN property", resolved_layer.value)
-            raise InvalidResourceLinkingException(
-                f"Could not use the value {resolved_layer.value} as a Layer for lambda function "
-                f"{function_tf_resource.full_address}. Lambda Function Layer value should refer to valid "
-                f"lambda layer ARN property"
-            )
-
-        tf_layer_res_name = resolved_layer.value[len(LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX) : -len(".arn")]
-        if resolved_layer.module_address:
-            tf_layer_full_address = (
-                f"{resolved_layer.module_address}.{LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX}" f"{tf_layer_res_name}"
-            )
-        else:
-            tf_layer_full_address = f"{LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX}{tf_layer_res_name}"
-        cfn_layer_logical_id = build_cfn_logical_id(tf_layer_full_address)
-        LOG.debug("The logical id of the resource referred by %s is %s", resolved_layer.value, cfn_layer_logical_id)
-
-        # validate that the found layer is in mapped layers resources, which means that it is created.
-        # The resource can be defined in the TF plan configuration, but will not be created.
-        layers = []
-        if cfn_layer_logical_id in tf_layers:
-            LOG.debug("The resource referred by %s can be found in the mapped layers resources", resolved_layer.value)
-            layers.append({"Ref": cfn_layer_logical_id})
-        return layers
-    # it means the Lambda function is referring to a wrong layer resource type
-    LOG.debug("The used reference %s is not a Layer Version resource.", resolved_layer.value)
-    raise InvalidResourceLinkingException(
-        f"Could not use the value {resolved_layer.value} as a Layer for lambda function "
-        f"{function_tf_resource.full_address}. Lambda Function Layer value should refer to valid lambda layer ARN "
-        f"property"
-    )
-
-
-def _update_mapped_lambda_function_with_resolved_layers(
-    cfn_functions: List[Dict],
-    layers: List[Dict[str, str]],
-    tf_layers: Dict[str, Dict],
-) -> None:
-    """
-    Set The resolved layers list to the mapped lambda functions.
-
-    Parameters
-    ----------
-    cfn_functions: List[Dict]
-        A list of mapped lambda functions that are equivalent to the input terraform configuration lambda function
-
-    layers: List
-        The resolved layers values that will be used as a value for the mapped CFN function Layers attribute.
-
-    tf_layers: Dict[str, Dict]
-        Dictionary of all actual terraform layers resources (not configuration resources). The dictionary's key is the
-        calculated logical id for each resource
-    """
-    LOG.debug("Set the resolved layers %s to the cfn functions %s", layers, cfn_functions)
-    for cfn_func in cfn_functions:
-        LOG.debug("Process the Lambda function %s", cfn_func)
-        # Add the resolved layers list as it is to the mapped function that does not have any layers defined
-        if not cfn_func["Properties"].get("Layers"):
-            LOG.debug("The Lambda function %s does not have any layers defined.", cfn_func)
-            cfn_func["Properties"]["Layers"] = layers
-            continue
-
-        # Check if the the mapped function layers list contains any arn value for one of the resolved layers to replace
-        # it.
-        for layer in layers:
-            # resolve the layer arn string to check if it is already there in the CFN func layer property
-            # layer logical id will be always in tf_layers, as we do not consider the references to layers that does not
-            # exist in the tf_layers list as it means that this layer will not be created.
-            LOG.debug("Check if the layer %s is already defined in function % layers.", layer, cfn_func)
-            layer_arn = tf_layers[layer["Ref"]].get("values", {}).get("arn")
-
-            # The resolved layer is a reference to a layers which is not applied yet, so there is no ARN value yet.
-            if not layer_arn:
-                LOG.debug("The layer %s is not applied yet, and does not have ARN property.", layer)
-                cfn_func["Properties"]["Layers"].append(layer)
-                continue
-
-            # try to find a layer arn that equals the resolved layer arn so we can replace it with Ref value.
-            try:
-                layer_index = cfn_func["Properties"].get("Layers", []).index(layer_arn)
-                LOG.debug(
-                    "The layer %s has the arn value %s that exists in function %s layers.", layer, layer_arn, cfn_func
-                )
-                cfn_func["Properties"]["Layers"][layer_index] = layer
-            except ValueError:
-                # there is no matching layer ARN.
-                LOG.debug(
-                    "The layer %s has the arn value %s that does not exist in function %s layers.",
-                    layer,
-                    layer_arn,
-                    cfn_func,
-                )
-                cfn_func["Properties"]["Layers"].append(layer)

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Type, Union
 
-from samcli.commands.exceptions import UserException
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     InvalidResourceLinkingException,
+    LocalVariablesLinkingLimitationException,
     OneResourceLimitationException,
 )
 from samcli.hook_packages.terraform.hooks.prepare.types import (
@@ -39,7 +39,7 @@ class LinkerIntrinsics(Enum):
 @dataclass
 class ResourcePairExceptions:
     multiple_resource_linking_exception: Type[OneResourceLimitationException]
-    local_variable_linking_exception: Type[UserException]
+    local_variable_linking_exception: Type[LocalVariablesLinkingLimitationException]
 
 
 @dataclass
@@ -131,6 +131,8 @@ class ResourceLinker:
 
         Parameters
         ----------
+        source_tf_resource: TFResource
+            The source Terraform resource.
         resolved_destination_resource: List[Union[ConstantValue, ResolvedReference]]
             The resolved destination resources to be processed for the input source resource.
 
@@ -181,6 +183,8 @@ class ResourceLinker:
 
         Parameters
         ----------
+        cfn_source_resources: TFResource
+            The source CloudFormation resource to be updated.
         destination_resources: List
             The resolved destination resource values that will be used as a value for the mapped CFN resource attribute.
         """
@@ -261,6 +265,8 @@ class ResourceLinker:
 
         Parameters
         ----------
+        source_tf_resource: TFResource
+            The source Terraform resource.
         resolved_destination_resource: ResolvedReference
             The resolved destination resource reference.
 

--- a/samcli/hook_packages/terraform/hooks/prepare/translate.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/translate.py
@@ -14,8 +14,8 @@ from samcli.hook_packages.terraform.hooks.prepare.constants import (
 )
 from samcli.hook_packages.terraform.hooks.prepare.enrich import enrich_resources_and_generate_makefile
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
-    LocalVariablesLinkingLimitationException,
-    OneResourceLimitationException,
+    FunctionLayerLocalVariablesLinkingLimitationException,
+    OneLambdaLayerLinkingLimitationException,
 )
 from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     REMOTE_DUMMY_VALUE,
@@ -427,8 +427,8 @@ def _link_lambda_functions_to_layers(
         calculated logical id for each resource
     """
     exceptions = ResourcePairExceptions(
-        multiple_resource_linking_exception=OneResourceLimitationException,
-        local_variable_linking_exception=LocalVariablesLinkingLimitationException,
+        multiple_resource_linking_exception=OneLambdaLayerLinkingLimitationException,
+        local_variable_linking_exception=FunctionLayerLocalVariablesLinkingLimitationException,
     )
     resource_linking_pair = ResourceLinkingPair(
         source_resource_cfn_resource=lambda_funcs_conf_cfn_resources,

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -7,14 +7,13 @@ from uuid import uuid4
 from parameterized import parameterized
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     InvalidResourceLinkingException,
-    OneLambdaLayerLinkingLimitationException,
+    OneResourceLimitationException,
     LocalVariablesLinkingLimitationException,
     ONE_LAMBDA_LAYER_LINKING_ISSUE_LINK,
     LOCAL_VARIABLES_SUPPORT_ISSUE_LINK,
 )
 
 from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
-    ResolvedReference,
     _clean_references_list,
     _get_configuration_address,
     _resolve_module_output,
@@ -27,10 +26,11 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     _build_module_resources_from_configuration,
     _build_module_variables_from_configuration,
     _resolve_resource_attribute,
-    _link_lambda_function_to_layer,
-    _process_resolved_layers,
-    _process_reference_layer_value,
-    _update_mapped_lambda_function_with_resolved_layers,
+    ResourceLinkingPair,
+    ResourcePairExceptions,
+    LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX,
+    LinkerIntrinsics,
+    ResourceLinker,
 )
 from samcli.hook_packages.terraform.hooks.prepare.types import (
     ConstantValue,
@@ -1058,217 +1058,237 @@ class TestResourceLinking(TestCase):
         results = _resolve_resource_attribute(resource, "Layers")
         self.assertEqual(len(results), 0)
 
-    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._resolve_resource_attribute")
-    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_resolved_layers")
-    @patch(
-        "samcli.hook_packages.terraform.hooks.prepare.resource_linking."
-        "_update_mapped_lambda_function_with_resolved_layers"
-    )
-    def test_link_lambda_function_to_layer_valid_scenario(
-        self,
-        update_mapped_lambda_function_with_resolved_layers_mock,
-        process_resolved_layers_mock,
-        resolve_resource_attribute_mock,
-    ):
-        cfn_functions = Mock()
-        tf_layers = Mock()
-        layers = [Mock()]
-        process_resolved_layers_mock.return_value = layers
-        resolved_layers = Mock()
-        resolve_resource_attribute_mock.return_value = resolved_layers
 
+class TestResourceLinker(TestCase):
+    def setUp(self) -> None:
+        self.linker_exceptions = ResourcePairExceptions(
+            multiple_resource_linking_exception=OneResourceLimitationException,
+            local_variable_linking_exception=LocalVariablesLinkingLimitationException,
+        )
+        self.sample_resource_linking_pair = ResourceLinkingPair(
+            source_resource_cfn_resource=Mock(),
+            source_resource_tf_config=Mock(),
+            destination_resource_tf=Mock(),
+            intrinsic_type=LinkerIntrinsics.Ref,
+            cfn_intrinsic_attribute=None,
+            source_link_field_name="Layers",
+            terraform_link_field_name="layers",
+            terraform_resource_type_prefix=LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX,
+            linking_exceptions=self.linker_exceptions,
+        )
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._resolve_resource_attribute")
+    def test_handle_linking_valid_scenario(self, resolve_resource_attribute_mock):
+        source_resources = Mock()
+        dest_resources = [Mock()]
         resource = Mock()
-        _link_lambda_function_to_layer(resource, cfn_functions, tf_layers)
+
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+
+        resolved_dest_resources = Mock()
+        resolve_resource_attribute_mock.return_value = resolved_dest_resources
+
+        resource_linker._process_resolved_resources = Mock()
+        resource_linker._process_resolved_resources.return_value = dest_resources
+
+        resource_linker._update_mapped_parent_resource_with_resolved_child_resources = Mock()
+
+        resource_linker._handle_linking(resource, source_resources)
+
+        resource_linker._process_resolved_resources.assert_called_with(resource, resolved_dest_resources)
+        resource_linker._update_mapped_parent_resource_with_resolved_child_resources.assert_called_with(
+            source_resources, dest_resources
+        )
         resolve_resource_attribute_mock.assert_called_with(resource, "layers")
-        process_resolved_layers_mock.assert_called_with(resource, resolved_layers, tf_layers)
-        update_mapped_lambda_function_with_resolved_layers_mock.assert_called_with(cfn_functions, layers, tf_layers)
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._resolve_resource_attribute")
-    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_resolved_layers")
-    @patch(
-        "samcli.hook_packages.terraform.hooks.prepare.resource_linking."
-        "_update_mapped_lambda_function_with_resolved_layers"
-    )
-    def test_link_lambda_function_to_layer_more_than_one_layer_limitation(
-        self,
-        update_mapped_lambda_function_with_resolved_layers_mock,
-        process_resolved_layers_mock,
-        resolve_resource_attribute_mock,
-    ):
-        cfn_functions = Mock()
-        tf_layers = Mock()
-        layers = ["layer2.arn", {"Ref": "layer1_logical_id"}]
-        process_resolved_layers_mock.return_value = layers
-        resolved_layers = [ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")]
-        resolve_resource_attribute_mock.return_value = resolved_layers
+    def test_handle_linking_multiple_destinations_exception(self, resolve_resource_attribute_mock):
+        source_resources = Mock()
+        dest_resources = ["layer2.arn", {"Ref": "layer1_logical_id"}]
+
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+
+        resource_linker._process_resolved_resources = Mock()
+        resource_linker._process_resolved_resources.return_value = dest_resources
+
+        resource_linker._update_mapped_parent_resource_with_resolved_child_resources = Mock()
+
+        resolved_destination_resources = [ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")]
+        resolve_resource_attribute_mock.return_value = resolved_destination_resources
+
         resource = Mock()
         resource.full_address = "func_full_address"
         expected_exception = (
             "AWS SAM CLI could not process a Terraform project that contains Lambda functions that are linked to more than "
-            f"one lambda layer. Layer(s) defined by {layers} could not be linked to lambda function func_full_address."
+            f"one lambda layer. Layer(s) defined by {dest_resources} could not be linked to lambda function func_full_address."
             f"{os.linesep}Related issue: {ONE_LAMBDA_LAYER_LINKING_ISSUE_LINK}."
         )
-        with self.assertRaises(OneLambdaLayerLinkingLimitationException) as exc:
-            _link_lambda_function_to_layer(resource, cfn_functions, tf_layers)
+        with self.assertRaises(OneResourceLimitationException) as exc:
+            resource_linker._handle_linking(resource, source_resources)
         self.assertEqual(exc.exception.args[0], expected_exception)
 
-    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
-    def test_process_resolved_layers_constant_only(
-        self,
-        process_reference_layer_value_mock,
-    ):
-        tf_layers = Mock()
+    def test_process_resolved_resources_constant_only(self):
         resource = Mock()
-        constant_value_resolved_layer = ConstantValue("layer1.arn")
-        resolved_layers = [constant_value_resolved_layer]
-        layers = _process_resolved_layers(resource, resolved_layers, tf_layers)
-        self.assertEqual(layers, [])
-        process_reference_layer_value_mock.assert_not_called()
 
-    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
-    def test_process_resolved_layers_references_only(
-        self,
-        process_reference_layer_value_mock,
-    ):
-        tf_layers = Mock()
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._process_reference_resource_value = Mock()
+
+        constant_value_resolved_resource = ConstantValue("layer1.arn")
+        resolved_resources = [constant_value_resolved_resource]
+
+        destination_resources = resource_linker._process_resolved_resources(resource, resolved_resources)
+
+        self.assertEqual(destination_resources, [])
+        resource_linker._process_reference_resource_value.assert_not_called()
+
+    def test_process_resolved_resources_references_only(self):
         resource = Mock()
+
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._process_reference_resource_value = Mock()
+
         reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")
-        resolved_layers = [reference_resolved_layer]
-        process_reference_layer_value_mock.return_value = [{"Ref": "Layer1LogicalId"}]
-        layers = _process_resolved_layers(resource, resolved_layers, tf_layers)
-        self.assertEqual(layers, [{"Ref": "Layer1LogicalId"}])
-        process_reference_layer_value_mock.assert_called_with(resource, reference_resolved_layer, tf_layers)
+        resolved_resources = [reference_resolved_layer]
+        resource_linker._process_reference_resource_value = Mock()
+        resource_linker._process_reference_resource_value.return_value = [{"Ref": "Layer1LogicalId"}]
 
-    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
-    def test_process_resolved_layers_mixed_constant_and_references(
-        self,
-        process_reference_layer_value_mock,
-    ):
-        tf_layers = Mock()
+        destination_resources = resource_linker._process_resolved_resources(resource, resolved_resources)
+
+        self.assertEqual(destination_resources, [{"Ref": "Layer1LogicalId"}])
+        resource_linker._process_reference_resource_value.assert_called_with(resource, reference_resolved_layer)
+
+    def test_process_resolved_resources_mixed_constant_and_references(self):
         resource = Mock()
         resource.full_address = "func_full_address"
-        constant_value_resolved_layer = ConstantValue("layer1.arn")
-        reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")
-        resolved_layers = [reference_resolved_layer, constant_value_resolved_layer]
-        process_reference_layer_value_mock.return_value = [{"Ref": "Layer1LogicalId"}]
+
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._process_reference_resource_value = Mock()
+
+        constant_value_resolved_resource = ConstantValue("layer1.arn")
+        reference_resolved_resource = ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")
+        resolved_resources = [reference_resolved_resource, constant_value_resolved_resource]
+        resource_linker._process_reference_resource_value.return_value = [{"Ref": "Layer1LogicalId"}]
         expected_exception = (
             "AWS SAM CLI could not process a Terraform project that contains Lambda functions that are linked to more "
-            f"than one lambda layer. Layer(s) defined by {resolved_layers} could not be linked to lambda function "
+            f"than one lambda layer. Layer(s) defined by {resolved_resources} could not be linked to lambda function "
             f"func_full_address.{os.linesep}Related issue: {ONE_LAMBDA_LAYER_LINKING_ISSUE_LINK}."
         )
-        with self.assertRaises(OneLambdaLayerLinkingLimitationException) as exc:
-            _process_resolved_layers(resource, resolved_layers, tf_layers)
+        with self.assertRaises(OneResourceLimitationException) as exc:
+            resource_linker._process_resolved_resources(resource, resolved_resources)
         self.assertEqual(exc.exception.args[0], expected_exception)
-        process_reference_layer_value_mock.assert_called_with(resource, reference_resolved_layer, tf_layers)
+        resource_linker._process_reference_resource_value.assert_called_with(resource, reference_resolved_resource)
 
-    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._process_reference_layer_value")
-    def test_process_resolved_layers_mixed_data_sources_and_references(
-        self,
-        process_reference_layer_value_mock,
-    ):
-        tf_layers = Mock()
+    def test_process_resolved_resources_mixed_data_sources_and_references(self):
         resource = Mock()
         resource.full_address = "func_full_address"
-        data_resources_resolved_layer = ResolvedReference("data.aws_region.current.name", "module.layer1")
-        reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")
-        resolved_layers = [reference_resolved_layer, data_resources_resolved_layer]
-        process_reference_layer_value_mock.side_effect = [[{"Ref": "Layer1LogicalId"}], []]
+
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._process_reference_resource_value = Mock()
+
+        data_resources_resolved_resources = ResolvedReference("data.aws_region.current.name", "module.layer1")
+        reference_resolved_resources = ResolvedReference("aws_lambda_layer_version.layer1.arn", "module.layer1")
+        resolved_resources = [reference_resolved_resources, data_resources_resolved_resources]
+        resource_linker._process_reference_resource_value.side_effect = [[{"Ref": "Layer1LogicalId"}], []]
+
         expected_exception = (
             "AWS SAM CLI could not process a Terraform project that contains Lambda functions that are linked to more "
-            f"than one lambda layer. Layer(s) defined by {resolved_layers} could not be linked to lambda function "
+            f"than one lambda layer. Layer(s) defined by {resolved_resources} could not be linked to lambda function "
             f"func_full_address.{os.linesep}Related issue: {ONE_LAMBDA_LAYER_LINKING_ISSUE_LINK}."
         )
-        with self.assertRaises(OneLambdaLayerLinkingLimitationException) as exc:
-            _process_resolved_layers(resource, resolved_layers, tf_layers)
+        with self.assertRaises(OneResourceLimitationException) as exc:
+            resource_linker._process_resolved_resources(resource, resolved_resources)
         self.assertEqual(exc.exception.args[0], expected_exception)
-        process_reference_layer_value_mock.assert_has_calls(
+        resource_linker._process_reference_resource_value.assert_has_calls(
             [
-                call(resource, reference_resolved_layer, tf_layers),
-                call(resource, data_resources_resolved_layer, tf_layers),
+                call(resource, reference_resolved_resources),
+                call(resource, data_resources_resolved_resources),
             ]
         )
 
-    def test_process_reference_layer_value_data_resource_reference(self):
-        reference_resolved_layer = ResolvedReference("data.aws_lambda_layer_version.layer1", "module.layer1")
+    def test_process_reference_resource_value_data_resource_reference(self):
+        reference_resolved_resource = ResolvedReference("data.aws_lambda_layer_version.layer1", "module.layer1")
         resource = Mock()
-        tf_layers = Mock()
-        layers = _process_reference_layer_value(resource, reference_resolved_layer, tf_layers)
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        layers = resource_linker._process_reference_resource_value(resource, reference_resolved_resource)
         self.assertEqual(len(layers), 0)
 
-    def test_process_reference_layer_value_reference_to_local_variables(self):
-        reference_resolved_layer = ResolvedReference("local.layer_arn", "module.layer1")
+    def test_process_reference_resource_value_reference_to_local_variables(self):
+        reference_resolved_resources = ResolvedReference("local.layer_arn", "module.layer1")
         resource = Mock()
         resource.full_address = "func_full_address"
-        tf_layers = Mock()
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
         expected_exception = (
             "AWS SAM CLI could not process a Terraform project that uses local variables to define the Lambda functions "
             "layers. Layer(s) defined by local.layer_arn could not be linked to lambda function func_full_address."
             f"{os.linesep}Related issue: {LOCAL_VARIABLES_SUPPORT_ISSUE_LINK}."
         )
         with self.assertRaises(LocalVariablesLinkingLimitationException) as exc:
-            _process_reference_layer_value(resource, reference_resolved_layer, tf_layers)
+            resource_linker._process_reference_resource_value(resource, reference_resolved_resources)
         self.assertEqual(exc.exception.args[0], expected_exception)
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking.build_cfn_logical_id")
-    def test_process_reference_layer_value_reference_to_an_exist_layer_resource(self, build_cfn_logical_id_mock):
+    def test_process_reference_resource_value_reference_to_an_existing_layer_resource(self, build_cfn_logical_id_mock):
         build_cfn_logical_id_mock.return_value = "layer1LogicalId"
         reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer.arn", "module.layer1")
         resource = Mock()
-        tf_layers = {"layer1LogicalId": Mock()}
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._resource_pair.destination_resource_tf = {"layer1LogicalId": Mock()}
 
-        layers = _process_reference_layer_value(resource, reference_resolved_layer, tf_layers)
-        self.assertEqual(len(layers), 1)
-        self.assertEqual(layers[0], {"Ref": "layer1LogicalId"})
+        resources = resource_linker._process_reference_resource_value(resource, reference_resolved_layer)
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0], {"Ref": "layer1LogicalId"})
         build_cfn_logical_id_mock.assert_called_with("module.layer1.aws_lambda_layer_version.layer")
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking.build_cfn_logical_id")
-    def test_process_reference_layer_value_reference_to_non_exist_layer_resource(self, build_cfn_logical_id_mock):
+    def test_process_reference_resource_value_reference_to_non_exist_layer_resource(self, build_cfn_logical_id_mock):
         build_cfn_logical_id_mock.return_value = "layer1LogicalId"
-        reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer.arn", None)
+        reference_resolved_resources = ResolvedReference("aws_lambda_layer_version.layer.arn", None)
         resource = Mock()
-        tf_layers = {"layer2LogicalId": Mock()}
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._resource_pair.destination_resource_tf = {"layer2LogicalId": Mock()}
 
-        layers = _process_reference_layer_value(resource, reference_resolved_layer, tf_layers)
-        self.assertEqual(len(layers), 0)
+        resources = resource_linker._process_reference_resource_value(resource, reference_resolved_resources)
+        self.assertEqual(len(resources), 0)
         build_cfn_logical_id_mock.assert_called_with("aws_lambda_layer_version.layer")
 
     def test_process_reference_layer_value_reference_to_not_layer_resource_arn_property(self):
-        reference_resolved_layer = ResolvedReference("aws_lambda_layer_version.layer.name", None)
+        reference_resolved_resource = ResolvedReference("aws_lambda_layer_version.layer.name", None)
         resource = Mock()
         resource.full_address = "func_full_address"
-        tf_layers = Mock()
         expected_exception = (
             f"An error occurred when attempting to link two resources: Could not use the value "
-            f"aws_lambda_layer_version.layer.name as a Layer for lambda function func_full_address. Lambda Function "
-            f"Layer value should refer to valid lambda layer ARN property"
+            f"aws_lambda_layer_version.layer.name as a destination resource for the source "
+            f"resource func_full_address. The source resource value should refer to valid destination "
+            f"resource ARN property."
         )
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
         with self.assertRaises(InvalidResourceLinkingException) as exc:
-            _process_reference_layer_value(resource, reference_resolved_layer, tf_layers)
+            resource_linker._process_reference_resource_value(resource, reference_resolved_resource)
         self.assertEqual(exc.exception.args[0], expected_exception)
 
-    def test_process_reference_layer_value_reference_to_not_layer_resource(self):
-        reference_resolved_layer = ResolvedReference("aws_lambda_layer_version2.layer.arn", None)
+    def test_process_reference_resource_value_reference_to_invalid_destination_resource(self):
+        reference_resolved_resource = ResolvedReference("aws_lambda_layer_version2.layer.arn", None)
         resource = Mock()
         resource.full_address = "func_full_address"
-        tf_layers = Mock()
         expected_exception = (
             f"An error occurred when attempting to link two resources: Could not use the value "
-            f"aws_lambda_layer_version2.layer.arn as a Layer for lambda function func_full_address. Lambda Function "
-            f"Layer value should refer to valid lambda layer ARN property"
+            f"aws_lambda_layer_version2.layer.arn as a destination for the source resource func_full_address. "
+            f"The source resource value should refer to valid destination ARN property."
         )
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
         with self.assertRaises(InvalidResourceLinkingException) as exc:
-            _process_reference_layer_value(resource, reference_resolved_layer, tf_layers)
+            resource_linker._process_reference_resource_value(resource, reference_resolved_resource)
         self.assertEqual(exc.exception.args[0], expected_exception)
 
     def test_update_mapped_lambda_function_with_resolved_layers(self):
-        cfn_functions = [
+        cfn_source_resources = [
             {"Type": "AWS::Lambda::Function", "Properties": {"Code": "/path/code1", "Runtime": "Python3.8"}},
             {
                 "Type": "AWS::Lambda::Function",
                 "Properties": {"Code": "/path/code2", "Runtime": "Python3.8", "Layers": ["layer3.arn", "layer1.arn"]},
             },
         ]
-        tf_layers = {
+        tf_destination_resources = {
             "layer1_logical_id": {
                 "address": "aws_lambda_layer_version.layer1",
                 "type": "aws_lambda_layer_version",
@@ -1304,10 +1324,71 @@ class TestResourceLinking(TestCase):
                 },
             },
         }
-        layers = [{"Ref": "layer1_logical_id"}, {"Ref": "layer3_logical_id"}]
-        _update_mapped_lambda_function_with_resolved_layers(cfn_functions, layers, tf_layers)
-        self.assertEqual(cfn_functions[0]["Properties"]["Layers"], layers)
+        destination_resources = [{"Ref": "layer1_logical_id"}, {"Ref": "layer3_logical_id"}]
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._resource_pair.destination_resource_tf = tf_destination_resources
+        resource_linker._update_mapped_parent_resource_with_resolved_child_resources(
+            cfn_source_resources, destination_resources
+        )
+        self.assertEqual(cfn_source_resources[0]["Properties"]["Layers"], destination_resources)
         self.assertEqual(
-            cfn_functions[1]["Properties"]["Layers"],
+            cfn_source_resources[1]["Properties"]["Layers"],
             ["layer3.arn", {"Ref": "layer1_logical_id"}, {"Ref": "layer3_logical_id"}],
+        )
+
+    def test_link_resources(self):
+        source_config_resources = {
+            "aws_lambda_function.remote_lambda_code": [
+                {
+                    "Type": "AWS::Lambda::Function",
+                    "Properties": {
+                        "FunctionName": "s3_remote_lambda_function",
+                        "Code": {"S3Bucket": "lambda_code_bucket", "S3Key": "remote_lambda_code_key"},
+                        "Handler": "app.lambda_handler",
+                        "PackageType": "Zip",
+                        "Runtime": "python3.8",
+                        "Timeout": 3,
+                    },
+                    "Metadata": {"SamResourceId": "aws_lambda_function.remote_lambda_code", "SkipBuild": True},
+                }
+            ],
+            "aws_lambda_function.root_lambda": [
+                {
+                    "Type": "AWS::Lambda::Function",
+                    "Properties": {
+                        "FunctionName": "root_lambda",
+                        "Code": "HelloWorldFunction.zip",
+                        "Handler": "app.lambda_handler",
+                        "PackageType": "Zip",
+                        "Runtime": "python3.8",
+                        "Timeout": 3,
+                    },
+                    "Metadata": {"SamResourceId": "aws_lambda_function.root_lambda", "SkipBuild": True},
+                }
+            ],
+        }
+        resources = {
+            "aws_lambda_function.remote_lambda_code": TFResource(
+                "aws_lambda_function.remote_lambda_code", "", None, {}
+            ),
+            "aws_lambda_function.root_lambda": TFResource("aws_lambda_function.root_lambda", "", None, {}),
+        }
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._resource_pair.source_resource_cfn_resource = source_config_resources
+        resource_linker._resource_pair.source_resource_tf_config = resources
+        resource_linker._handle_linking = Mock()
+
+        resource_linker.link_resources()
+
+        resource_linker._handle_linking.assert_has_calls(
+            [
+                call(
+                    resources["aws_lambda_function.remote_lambda_code"],
+                    source_config_resources.get("aws_lambda_function.remote_lambda_code"),
+                ),
+                call(
+                    resources["aws_lambda_function.root_lambda"],
+                    source_config_resources.get("aws_lambda_function.root_lambda"),
+                ),
+            ]
         )

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -3,8 +3,8 @@ import copy
 from unittest.mock import Mock, call, patch, MagicMock
 
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
-    OneResourceLimitationException,
-    LocalVariablesLinkingLimitationException,
+    OneLambdaLayerLinkingLimitationException,
+    FunctionLayerLocalVariablesLinkingLimitationException,
 )
 from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     LinkerIntrinsics,
@@ -770,8 +770,8 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         }
         _link_lambda_functions_to_layers(resources, lambda_funcs_config_resources, terraform_layers_resources)
         mock_resource_linking_exceptions.assert_called_once_with(
-            multiple_resource_linking_exception=OneResourceLimitationException,
-            local_variable_linking_exception=LocalVariablesLinkingLimitationException,
+            multiple_resource_linking_exception=OneLambdaLayerLinkingLimitationException,
+            local_variable_linking_exception=FunctionLayerLocalVariablesLinkingLimitationException,
         )
         mock_resource_linking_pair.assert_called_once_with(
             source_resource_cfn_resource=lambda_funcs_config_resources,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
To make the resource linking for Terraform resources more extensible to resources beyond functions and layers. This will allow for quicker additions of linking two resources based on a given field.

#### How does it address the issue?
Implements the resource linker generalization strategy defined in: https://github.com/aws/aws-sam-cli/pull/5039

##### Note: This PR should not include any functional changes. The changes should only be encapsulating the existing logic in the classes defined in the design. It should not change or add any new behaviour.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
