### PR TITLE
fix: Fix S3 bucket policy issue for sam pipeline

### DIFF
--- a/samcli/lib/pipeline/bootstrap/stage_resources.yaml
+++ b/samcli/lib/pipeline/bootstrap/stage_resources.yaml
@@ -231,6 +231,9 @@ Resources:
     DeletionPolicy: "Retain"
     Properties:
       AccessControl: "LogDeliveryWrite"
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership:  ObjectWriter
       Tags:
         - Key: ManagedStackSource
           Value: AwsSamCli


### PR DESCRIPTION
#### Which issue(s) does this change fix?
`sam pipeline bootstrap` is broken because of a S3 [security change](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/)

The default value of `ObjectOwnership` becomes `BucketOwnerEnforced` which has conflicts with `AccessControl` property. Hence the deployment will fail.


#### Why is this change necessary?


#### How does it address the issue?

Specify `ObjectOwnership` to `ObjectWriter` so that it doesn't have conflicts with `AccessControl`


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
