### PR TITLE
fix: Fixed flask request test mocking

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -553,7 +553,7 @@ class LocalApigwService(BaseLocalService):
         Parameters
         ----------
         request: Request
-            Flask request object to get method and endpoint
+            Flask request object containing incoming request variables
         route: Route
             the Route object that contains the Lambda Authorizer definition
 

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -546,12 +546,14 @@ class LocalApigwService(BaseLocalService):
 
         return context.to_dict()
 
-    def _valid_identity_sources(self, route: Route) -> bool:
+    def _valid_identity_sources(self, request: Request, route: Route) -> bool:
         """
         Validates if the route contains all the valid identity sources defined in the route's Lambda Authorizer
 
         Parameters
         ----------
+        request: Request
+            Flask request object to get method and endpoint
         route: Route
             the Route object that contains the Lambda Authorizer definition
 
@@ -654,7 +656,7 @@ class LocalApigwService(BaseLocalService):
             return self.service_response("", headers, 200)
 
         # check for LambdaAuthorizer since that is the only authorizer we currently support
-        if isinstance(lambda_authorizer, LambdaAuthorizer) and not self._valid_identity_sources(route):
+        if isinstance(lambda_authorizer, LambdaAuthorizer) and not self._valid_identity_sources(request, route):
             return ServiceErrorResponses.missing_lambda_auth_identity_sources()
 
         try:

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -586,7 +586,7 @@ class TestApiGatewayService(TestCase):
         route = self.api_gateway_route
         route.authorizer_object = None
 
-        self.assertFalse(self.api_service._valid_identity_sources(route))
+        self.assertFalse(self.api_service._valid_identity_sources(Mock(), route))
 
     @parameterized.expand(
         [
@@ -597,8 +597,10 @@ class TestApiGatewayService(TestCase):
     @patch("samcli.local.apigw.authorizers.lambda_authorizer.LambdaAuthorizer._parse_identity_sources")
     @patch("samcli.local.apigw.authorizers.lambda_authorizer.LambdaAuthorizer.identity_sources")
     @patch("samcli.local.apigw.path_converter.PathConverter.convert_path_to_api_gateway")
+    @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._build_v2_context")
+    @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._build_v1_context")
     def test_valid_identity_sources_id_source(
-        self, is_valid, path_convert_mock, id_source_prop_mock, lambda_auth_parse_mock
+        self, is_valid, v1_mock, v2_mock, path_convert_mock, id_source_prop_mock, lambda_auth_parse_mock
     ):
         route = self.api_gateway_route
         route.authorizer_object = LambdaAuthorizer("", "", "", [], "")
@@ -607,11 +609,7 @@ class TestApiGatewayService(TestCase):
         mocked_id_source_obj.is_valid = Mock(return_value=is_valid)
         route.authorizer_object.identity_sources = [mocked_id_source_obj]
 
-        # create a dummy Flask app to populate the request object with testing data
-        # using Flask's dummy values for request is fine in this context since
-        # the variables are being passed and not validated
-        with flask.Flask(__name__).test_request_context():
-            self.assertEqual(self.api_service._valid_identity_sources(route), is_valid)
+        self.assertEqual(self.api_service._valid_identity_sources(Mock(), route), is_valid)
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     def test_create_method_arn(self, method_endpoint_mock):


### PR DESCRIPTION
#### Why is this change necessary?
At some point, a version bump in our dependencies caused a function call (`werkzeug.urls.url_parse`) to be deprecated. This call is used within the Flask built in test mocking context that was used for one of the tests in SAM CLI, causing the CI workers to fail.

#### How does it address the issue?
Changes the affected SAM CLI function by passing the Flask context as an argument, instead of using the global `request` variable so that it can be mocked out using `pytest`.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
