### PR TITLE
remove dotnet5 support

### DIFF
--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -98,7 +98,6 @@ SUPPORTED_DEP_MANAGERS: List[str] = list(
 INIT_RUNTIMES = [
     # dotnetcore runtimes in descending order
     "dotnet6",
-    "dotnet5.0",
     "dotnetcore3.1",
     "go1.x",
     # java runtimes in descending order
@@ -126,7 +125,6 @@ INIT_RUNTIMES = [
 
 LAMBDA_IMAGES_RUNTIMES_MAP = {
     "dotnet6": "amazon/dotnet6-base",
-    "dotnet5.0": "amazon/dotnet5.0-base",
     "dotnetcore3.1": "amazon/dotnetcore3.1-base",
     "go1.x": "amazon/go1.x-base",
     "go (provided.al2)": "amazon/go-provided.al2-base",

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -2118,7 +2118,7 @@ test-project
 
     def test_must_return_runtime_from_base_image_name(self):
         base_images = [
-            "amazon/dotnet5.0-base",
+            "amazon/dotnet6-base",
             "amazon/dotnetcore3.1-base",
             "amazon/go1.x-base",
             "amazon/java11-base",
@@ -2129,7 +2129,7 @@ test-project
         ]
 
         expected_runtime = [
-            "dotnet5.0",
+            "dotnet6",
             "dotnetcore3.1",
             "go1.x",
             "java11",

--- a/tests/unit/commands/init/test_non_interactive_mode.py
+++ b/tests/unit/commands/init/test_non_interactive_mode.py
@@ -25,7 +25,7 @@ class TestNonInteractiveMode(TestCase):
     @patch("samcli.commands.init.command.click.get_current_context")
     def test_non_interactive_mode_with_non_java_image(self, mocked_ctx):
         mocked_ctx.return_value = Mock(
-            params={"no_interactive": True, "package_type": IMAGE, "base_image": "amazon/dotnet5.0"}
+            params={"no_interactive": True, "package_type": IMAGE, "base_image": "amazon/dotnet6-base"}
         )
 
         mocked_func = Mock()


### PR DESCRIPTION
Complementing to: https://github.com/aws/aws-sam-cli-app-templates/pull/410
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Remove dotnet5 image templates since [the language reached its EOL](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/).

AWS Lambda does not support dotnet5 as native runtime, it is only supported via Image type lambda function. This PR removes `sam local` related functionality from this code base.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
