### PR TITLE
fix: relax IAM Policy Document structure requirements

### DIFF
--- a/tests/unit/local/apigw/test_lambda_authorizer.py
+++ b/tests/unit/local/apigw/test_lambda_authorizer.py
@@ -387,6 +387,36 @@ class TestLambdaAuthorizer(TestCase):
                 },
                 True,
             ),
+            (  # resource as string
+                {
+                    "principalId": "123",
+                    "policyDocument": {
+                        "Statement": [
+                            {
+                                "Action": "execute-api:Invoke",
+                                "Effect": "Allow",
+                                "Resource": "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/hello",
+                            }
+                        ]
+                    },
+                },
+                True,
+            ),
+            (  # action as list
+                {
+                    "principalId": "123",
+                    "policyDocument": {
+                        "Statement": [
+                            {
+                                "Action": ["execute-api:Invoke"],
+                                "Effect": "Allow",
+                                "Resource": "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/hello",
+                            }
+                        ]
+                    },
+                },
+                True,
+            ),
         ]
     )
     def test_validate_is_resource_authorized(self, response, expected_result):
@@ -458,17 +488,42 @@ class TestLambdaAuthorizerIamPolicyValidator(TestCase):
                 {"principalId": "123", "policyDocument": {"Statement": [{"Action": "execute-api:Invoke"}]}},
                 "Authorizer 'my auth' policy document contains an invalid 'Effect'",
             ),
-            (  # statement resource not a list
-                {
-                    "principalId": "123",
-                    "policyDocument": {
-                        "Statement": [{"Action": "execute-api:Invoke", "Effect": "Allow", "Resource": "not list"}]
-                    },
-                },
-                "Authorizer 'my auth' policy document contains an invalid 'Resource'",
-            ),
         ]
     )
     def test_validate_validate_statement_raises(self, response, message):
         with self.assertRaisesRegex(InvalidLambdaAuthorizerResponse, message):
             LambdaAuthorizerIAMPolicyValidator.validate_statement("my auth", response)
+
+    @parameterized.expand(
+        [
+            (  # default
+                {
+                    "principalId": "123",
+                    "policyDocument": {
+                        "Statement": [{"Action": "execute-api:Invoke", "Effect": "Allow", "Resource": ["arn"]}]
+                    },
+                },
+            ),
+            (  # statement resource as string
+                {
+                    "principalId": "123",
+                    "policyDocument": {
+                        "Statement": [{"Action": "execute-api:Invoke", "Effect": "Allow", "Resource": "arn"}]
+                    },
+                },
+            ),
+            (  # statement action as list
+                {
+                    "principalId": "123",
+                    "policyDocument": {
+                        "Statement": [{"Action": ["execute-api:Invoke"], "Effect": "Allow", "Resource": ["arn"]}]
+                    },
+                },
+            ),
+        ]
+    )
+    def test_validate_validate_statement_does_not_raise(self, response):
+        try:
+            LambdaAuthorizerIAMPolicyValidator.validate_statement("my auth", response)
+        except InvalidLambdaAuthorizerResponse as e:
+            self.fail(f"validate statement raised unexpectedly: {e.message}")


### PR DESCRIPTION
This patch makes the lambda authorizer expect some valid statements in an IAM Policy Document that were not allowed before. Specifically, it is now allowed to use:

* single resource string instead of list; and
* action list instead of single string.

#### Which issue(s) does this change fix?
#5072, #5083


#### Why is this change necessary?

The current implementation does not allow some valid API Policy Documents as the response from the authorizer lambda. It will always lead to an authorization failure.


#### How does it address the issue?

* Update the validator to not consider these documents to be invalid.
* Update the logic that checks the contents to handle these values properly.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [X] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [X] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [X] Write/update integration tests -- _(in this case, I believe integration tests should not be necessary)_
- [X] Write/update functional tests if needed
- [X] `make pr` passes
- [X] `make update-reproducible-reqs` if dependencies were changed
- [X] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
