### PR TITLE
fix(list): Handle Stacks with >100 resources

### DIFF
--- a/tests/unit/commands/list/resources/test_resources_context.py
+++ b/tests/unit/commands/list/resources/test_resources_context.py
@@ -606,9 +606,7 @@ class TestGetResourcesInfo(TestCase):
         mock_cfn_client = Mock()
         paginator_mock = Mock()
         mock_cfn_client.get_paginator.return_value = paginator_mock
-        paginator_mock.paginate.return_value = [{
-            "StackResourceSummaries": [{"StackName": "sam-app-hello"}]
-        }]
+        paginator_mock.paginate.return_value = [{"StackResourceSummaries": [{"StackName": "sam-app-hello"}]}]
         mock_get_translated_dict.return_value = TRANSLATED_DICT_RETURN
 
         mock_sam_file_reader.return_value = SAM_FILE_READER_RETURN

--- a/tests/unit/commands/list/resources/test_resources_context.py
+++ b/tests/unit/commands/list/resources/test_resources_context.py
@@ -465,16 +465,17 @@ class TestGetResourcesInfo(TestCase):
     @patch("samcli.commands.list.json_consumer.click.get_current_context")
     @patch("samcli.lib.list.resources.resource_mapping_producer.get_template_data")
     @patch("samcli.lib.list.resources.resource_mapping_producer.ResourceMappingProducer.get_translated_dict")
-    @patch("samcli.commands.list.cli_common.list_common_context.get_boto_client_provider_with_config")
     def test_clienterror_stack_does_not_exist_in_region(
         self,
-        mock_client_provider,
         mock_get_translated_dict,
         mock_sam_file_reader,
         patched_click_get_current_context,
         patched_click_echo,
     ):
-        mock_client_provider.return_value.return_value.describe_stack_resources.side_effect = ClientError(
+        mock_cfn_client = Mock()
+        paginator_mock = Mock()
+        mock_cfn_client.get_paginator.return_value = paginator_mock
+        paginator_mock.paginate.side_effect = ClientError(
             {"Error": {"Code": "ValidationError", "Message": "Stack with id test does not exist"}}, "DescribeStacks"
         )
         mock_get_translated_dict.return_value = TRANSLATED_DICT_RETURN
@@ -486,7 +487,7 @@ class TestGetResourcesInfo(TestCase):
                 region="us-east-1",
                 profile=None,
                 template_file=None,
-                cloudformation_client=mock_client_provider.return_value.return_value,
+                cloudformation_client=mock_cfn_client,
                 iam_client=None,
                 mapper=None,
                 consumer=None,
@@ -497,16 +498,17 @@ class TestGetResourcesInfo(TestCase):
     @patch("samcli.commands.list.json_consumer.click.get_current_context")
     @patch("samcli.lib.list.resources.resource_mapping_producer.get_template_data")
     @patch("samcli.lib.list.resources.resource_mapping_producer.ResourceMappingProducer.get_translated_dict")
-    @patch("samcli.commands.list.cli_common.list_common_context.get_boto_client_provider_with_config")
     def test_botocoreerror_invalid_region(
         self,
-        mock_client_provider,
         mock_get_translated_dict,
         mock_sam_file_reader,
         patched_click_get_current_context,
         patched_click_echo,
     ):
-        mock_client_provider.return_value.return_value.describe_stack_resources.side_effect = EndpointConnectionError(
+        mock_cfn_client = Mock()
+        paginator_mock = Mock()
+        mock_cfn_client.get_paginator.return_value = paginator_mock
+        paginator_mock.paginate.side_effect = EndpointConnectionError(
             endpoint_url="https://cloudformation.test.amazonaws.com/"
         )
         mock_get_translated_dict.return_value = TRANSLATED_DICT_RETURN
@@ -518,7 +520,7 @@ class TestGetResourcesInfo(TestCase):
                 region="us-east-1",
                 profile=None,
                 template_file=None,
-                cloudformation_client=mock_client_provider.return_value.return_value,
+                cloudformation_client=mock_cfn_client,
                 iam_client=None,
                 mapper=None,
                 consumer=None,
@@ -529,16 +531,17 @@ class TestGetResourcesInfo(TestCase):
     @patch("samcli.commands.list.json_consumer.click.get_current_context")
     @patch("samcli.lib.list.resources.resource_mapping_producer.get_template_data")
     @patch("samcli.lib.list.resources.resource_mapping_producer.ResourceMappingProducer.get_translated_dict")
-    @patch("samcli.commands.list.cli_common.list_common_context.get_boto_client_provider_with_config")
     def test_clienterror_token_error(
         self,
-        mock_client_provider,
         mock_get_translated_dict,
         mock_sam_file_reader,
         patched_click_get_current_context,
         patched_click_echo,
     ):
-        mock_client_provider.return_value.return_value.describe_stack_resources.side_effect = ClientError(
+        mock_cfn_client = Mock()
+        paginator_mock = Mock()
+        mock_cfn_client.get_paginator.return_value = paginator_mock
+        paginator_mock.paginate.side_effect = ClientError(
             {"Error": {"Code": "ExpiredToken", "Message": "The security token included in the request is expired"}},
             "DescribeStacks",
         )
@@ -551,7 +554,7 @@ class TestGetResourcesInfo(TestCase):
                 region="us-east-1",
                 profile=None,
                 template_file=None,
-                cloudformation_client=mock_client_provider.return_value.return_value,
+                cloudformation_client=mock_cfn_client,
                 iam_client=None,
                 mapper=None,
                 consumer=None,
@@ -562,16 +565,17 @@ class TestGetResourcesInfo(TestCase):
     @patch("samcli.commands.list.json_consumer.click.get_current_context")
     @patch("samcli.lib.list.resources.resource_mapping_producer.get_template_data")
     @patch("samcli.lib.list.resources.resource_mapping_producer.ResourceMappingProducer.get_translated_dict")
-    @patch("samcli.commands.list.cli_common.list_common_context.get_boto_client_provider_with_config")
     def test_stack_resource_not_in_response(
         self,
-        mock_client_provider,
         mock_get_translated_dict,
         mock_sam_file_reader,
         patched_click_get_current_context,
         patched_click_echo,
     ):
-        mock_client_provider.return_value.return_value.describe_stack_resources.return_value = {}
+        mock_cfn_client = Mock()
+        paginator_mock = Mock()
+        mock_cfn_client.get_paginator.return_value = paginator_mock
+        paginator_mock.paginate.return_value = {}
         mock_get_translated_dict.return_value = TRANSLATED_DICT_RETURN
 
         mock_sam_file_reader.return_value = SAM_FILE_READER_RETURN
@@ -580,7 +584,7 @@ class TestGetResourcesInfo(TestCase):
             region="us-east-1",
             profile=None,
             template_file=None,
-            cloudformation_client=mock_client_provider.return_value.return_value,
+            cloudformation_client=mock_cfn_client,
             iam_client=None,
             mapper=None,
             consumer=None,
@@ -592,18 +596,19 @@ class TestGetResourcesInfo(TestCase):
     @patch("samcli.commands.list.json_consumer.click.get_current_context")
     @patch("samcli.lib.list.resources.resource_mapping_producer.get_template_data")
     @patch("samcli.lib.list.resources.resource_mapping_producer.ResourceMappingProducer.get_translated_dict")
-    @patch("samcli.commands.list.cli_common.list_common_context.get_boto_client_provider_with_config")
     def test_stack_resource_in_response(
         self,
-        mock_client_provider,
         mock_get_translated_dict,
         mock_sam_file_reader,
         patched_click_get_current_context,
         patched_click_echo,
     ):
-        mock_client_provider.return_value.return_value.describe_stack_resources.return_value = {
-            "StackResources": [{"StackName": "sam-app-hello"}]
-        }
+        mock_cfn_client = Mock()
+        paginator_mock = Mock()
+        mock_cfn_client.get_paginator.return_value = paginator_mock
+        paginator_mock.paginate.return_value = [{
+            "StackResourceSummaries": [{"StackName": "sam-app-hello"}]
+        }]
         mock_get_translated_dict.return_value = TRANSLATED_DICT_RETURN
 
         mock_sam_file_reader.return_value = SAM_FILE_READER_RETURN
@@ -612,7 +617,7 @@ class TestGetResourcesInfo(TestCase):
             region="us-east-1",
             profile=None,
             template_file=None,
-            cloudformation_client=mock_client_provider.return_value.return_value,
+            cloudformation_client=mock_cfn_client,
             iam_client=None,
             mapper=None,
             consumer=None,


### PR DESCRIPTION
Previously, we were using `describe_stack_resources` to get all the Resources from a Stack. However, this will only ever return the first 100 resources (per API docs). Instead, we move to using the `list_stack_resources` paginator (per API docs). This allows us to get all the resources within a stack. The response is different from `describe_stack_resources` and `list_stack_resources` but the difference is not meaningful for the current implementation.

As apart of this, I updated the unit tests. Previously, we were using another class to get a CFN Client to mock. Instead of mocking out a file that is not used within the `resource_mapping_producer.py`, I remove that and mocked out the `cfn_client` directly. This makes the tests easier to follow and removes unneeded mocking of classes/methods that are not used within the implementation.

#### Which issue(s) does this change fix?
#4909

#### Why is this change necessary?
Fixes github issues linked.

#### How does it address the issue?
See above commit details

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
