### PR TITLE
chore: consolidate env vars and set the ones recommended by AppVeyor

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -25,35 +25,21 @@ environment:
   AWS_S3: 'AWS_S3_TESTING'
   AWS_ECR: 'AWS_ECR_TESTING'
   CARGO_LAMBDA_VERSION: "v0.17.1"
- 
+  PYTHON_ARCH: '64'
+  NOSE_PARAMETERIZED_NO_WARN: 1
+  APPVEYOR_CONSOLE_DISABLE_PTY: false
+  APPVEYOR_DETAILED_SHELL_LOGGING: true
+
   matrix:
 
     - PYTHON_HOME: "$HOME/venv3.7/bin"
       PYTHON_VERSION: '3.7'
-      PYTHON_ARCH: '64'
-      NOSE_PARAMETERIZED_NO_WARN: 1
-      INSTALL_PY_38_PIP: 1
-      INSTALL_PY_39_PIP: 1
-      INSTALL_PY_310_PIP: 1
-      APPVEYOR_CONSOLE_DISABLE_PTY: true
 
     - PYTHON_HOME: "$HOME/venv3.8/bin"
       PYTHON_VERSION: '3.8'
-      PYTHON_ARCH: '64'
-      NOSE_PARAMETERIZED_NO_WARN: 1
-      INSTALL_PY_37_PIP: 1
-      INSTALL_PY_39_PIP: 1
-      INSTALL_PY_310_PIP: 1
-      APPVEYOR_CONSOLE_DISABLE_PTY: true
 
     - PYTHON_HOME: "$HOME/venv3.9/bin"
       PYTHON_VERSION: '3.9'
-      PYTHON_ARCH: '64'
-      NOSE_PARAMETERIZED_NO_WARN: 1
-      INSTALL_PY_37_PIP: 1
-      INSTALL_PY_38_PIP: 1
-      INSTALL_PY_310_PIP: 1
-      APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 install:
   # AppVeyor's apt-get cache might be outdated, and the package could potentially be 404.


### PR DESCRIPTION
Setting following environment variables as it was suggested by the AppVeyor team;
```
APPVEYOR_DETAILED_SHELL_LOGGING: true
APPVEYOR_CONSOLE_DISABLE_PTY: false
```

Moved following ones into general as it is been set for every configuration;
```
PYTHON_ARCH: '64'
NOSE_PARAMETERIZED_NO_WARN: 1
```

Removed following ones as they are not used anymore (they were used once we were managing python versions there, but we are now using the ones which are provided by AppVeyor);
```
INSTALL_PY_38_PIP: 1
INSTALL_PY_39_PIP: 1
INSTALL_PY_310_PIP: 1
```

Test runs can be found;
- https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux-dev/builds/46930470
- https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-windows-dev/builds/46930475


By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
