### PR TITLE
chore: GHA for Auto Closing issues that were released

### DIFF
--- a/.github/workflows/close-issue-on-release.yml
+++ b/.github/workflows/close-issue-on-release.yml
@@ -1,0 +1,21 @@
+name: Close issues on release cut
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  run-workflow:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Close issues marked
+      env:
+        REPO : ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        release_url=$(gh release view ${{ github.ref_name }} --repo $REPO --json url --jq ".url")
+        for issue_number in $(gh issue list -l "stage/waiting-for-release" --repo $REPO --json number --jq ".[].number"); do
+          gh issue close $issue_number -c "Patch is released in [${{ github.ref_name }}]($release_url). Closing" -r completed --repo $REPO
+        done


### PR DESCRIPTION
This GHA closes any issue that is marked "stage/waiting-for-release". This may close issues that are linked to PRs that were merged into develop but not yet released. There was no easy way to get all issues that are linked to a PR closed between two commits. Instead of doing long queries to get the exact issues, we will rely on the labels being updated and handle false positives as/if they happen.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None

#### Why is this change necessary?
Make releases less manual

#### How does it address the issue?
See above commit comments

#### What side effects does this change have?
none

Example: https://github.com/jfuss/aws-sam-cli/issues/10

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
