### PR TITLE
chore: run other test group in parallel

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -333,7 +333,7 @@ for:
       - "mypy setup.py samcli tests"
       - "pytest -n 4 tests/functional --json-report --json-report-file=TEST_REPORT-functional.json"
       
-      - sh: "pytest tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
+      - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
       - sh: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"
       - sh: "black --check setup.py tests samcli"
       - sh: "pytest -n 4 -vv tests/smoke --json-report --json-report-file=TEST_REPORT-smoke.json"

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -332,7 +332,7 @@ for:
       - ps: "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit --json-report --json-report-file=TEST_REPORT-unit.json"
       - "mypy setup.py samcli tests"
       - ps: "pytest -n 4 tests/functional --json-report --json-report-file=TEST_REPORT-functional.json"
-      - ps: "pytest -vv tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
+      - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
       - ps: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"
 # Uncomment for RDP
 # on_finish:

--- a/tests/integration/init/test_init_base.py
+++ b/tests/integration/init/test_init_base.py
@@ -1,8 +1,10 @@
+import pytest
 from unittest import TestCase
 
 from tests.testing_utils import get_sam_command
 
 
+@pytest.mark.xdist_group(name="sam_init")
 class InitIntegBase(TestCase):
     BINARY_READY_WAIT_TIME = 5
 

--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -239,6 +239,7 @@ REGULAR_STACK_SFN_LIST = [
 ]
 
 
+@pytest.mark.xdist_group(name="sam_logs_regular")
 class TestLogsCommandWithRegularStack(LogsIntegTestCases):
     test_template_folder = "python-apigw-sfn"
 
@@ -313,6 +314,7 @@ NESTED_STACK_SFN_LIST = [
 ]
 
 
+@pytest.mark.xdist_group(name="sam_logs_nested")
 class TestLogsCommandWithNestedStack(LogsIntegTestCases):
     test_template_folder = "nested-python-apigw-sfn"
 

--- a/tests/integration/pipeline/base.py
+++ b/tests/integration/pipeline/base.py
@@ -9,12 +9,14 @@ from unittest.mock import Mock
 
 import boto3
 import botocore.exceptions
+import pytest
 from botocore.exceptions import ClientError
 
 from samcli.lib.pipeline.bootstrap.stage import Stage
 from tests.testing_utils import get_sam_command
 
 
+@pytest.mark.xdist_group(name="sam_pipeline")
 class PipelineBase(TestCase):
     pass
 

--- a/tests/integration/telemetry/integ_base.py
+++ b/tests/integration/telemetry/integ_base.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 import time
 import re
+import pytest
 
 from flask import Flask, request, Response
 from threading import Thread
@@ -26,6 +27,7 @@ TELEMETRY_ENDPOINT_URL = "http://{}:{}".format(TELEMETRY_ENDPOINT_HOST, TELEMETR
 EXPECTED_TELEMETRY_PROMPT = re.sub(r"\n", os.linesep, TELEMETRY_PROMPT)
 
 
+@pytest.mark.xdist_group(name="sam_telemetry")
 class IntegBase(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/integration/traces/test_traces_command.py
+++ b/tests/integration/traces/test_traces_command.py
@@ -30,6 +30,7 @@ SKIP_TRACES_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_
 
 
 @skipIf(SKIP_TRACES_TESTS, "Skip traces tests in CI/CD only")
+@pytest.mark.xdist_group(name="sam_traces")
 class TestTracesCommand(TracesIntegBase):
     stack_resources = []
     stack_name = ""


### PR DESCRIPTION
Updates tests in `OtherTesting` group for running them in parallel with 4 threads and 4 reruns.
- Adds `xdist_group` pytest mark for following test classes so that each test in that class can run in the same thread. Otherwise they cause failures.
  - `InitIntegBase` is marked as `sam_init`
  - `TestLogsCommandWithRegularStack` marked as `sam_logs_regular`
  - `TestLogsCommandWithNestedStack` marked as `sam_logs_nested`
  - All tests that extends from `PipelineBase` marked as `sam_pipeline`
  - All telemetry integration tests that extends from `IntegBase` in `tests/integration/telemetry/integ_base.py` module is marked as `sam_telemetry`
  - All `sam traces` tests that extends from `TestTracesCommand` marked as `sam_traces`
- Updated AppVeyor configurations to run them in 4 threads  with 4 reruns, distributed by `loadgroup` (which will make sure that each tests in the same group will be executed in the same thread).
 
Have been testing more than 3 times, found no failures so far. Last night's canary completed this job group around 90mins, with this change it is now completed around 25mins (~70% improvement).


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
