### PR TITLE
fix: fix the python installation in CDK integration Appveyor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 # to automatically cancel the running workflow for same PR.
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ on:
       - "feat/*"
       - "feat-*"
 
+# to automatically cancel the running workflow for same PR.
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   run-workflow:
     name: PR Workflow

--- a/appveyor-iac-integration-ubuntu.yml
+++ b/appveyor-iac-integration-ubuntu.yml
@@ -5,33 +5,21 @@ image:
 environment:
   AWS_DEFAULT_REGION: us-east-1
   SAM_CLI_DEV: 1
- 
+  NOSE_PARAMETERIZED_NO_WARN: 1
+  APPVEYOR_CONSOLE_DISABLE_PTY: false
+  APPVEYOR_DETAILED_SHELL_LOGGING: true
+
   matrix:
+    - PYTHON_HOME: "$HOME/venv3.7/bin"
+      PYTHON_VERSION: '3.7'
 
-    - PYTHON_VERSION: '3.7'
-      PYTHON_ARCH: '64'
-      NOSE_PARAMETERIZED_NO_WARN: 1
-      INSTALL_PY_38_PIP: 1
-      INSTALL_PY_39_PIP: 1
-      APPVEYOR_CONSOLE_DISABLE_PTY: true
+    - PYTHON_HOME: "$HOME/venv3.8/bin"
+      PYTHON_VERSION: '3.8'
 
-    - PYTHON_VERSION: '3.8'
-      PYTHON_ARCH: '64'
-      NOSE_PARAMETERIZED_NO_WARN: 1
-      INSTALL_PY_37_PIP: 1
-      INSTALL_PY_39_PIP: 1
-      APPVEYOR_CONSOLE_DISABLE_PTY: true
-
-    - PYTHON_VERSION: '3.9'
-      PYTHON_ARCH: '64'
-      NOSE_PARAMETERIZED_NO_WARN: 1
-      INSTALL_PY_37_PIP: 1
-      INSTALL_PY_38_PIP: 1
-      APPVEYOR_CONSOLE_DISABLE_PTY: true
+    - PYTHON_HOME: "$HOME/venv3.9/bin"
+      PYTHON_VERSION: '3.9'
 
 install:
-  # apt repo for python3.9 installation
-  - sh: "sudo add-apt-repository ppa:deadsnakes/ppa"
   # AppVeyor's apt-get cache might be outdated, and the package could potentially be 404.
   - sh: "sudo apt-get update"
 
@@ -58,22 +46,7 @@ install:
   - sh: "sudo apt install maven"
   - sh: "mvn --version"
 
-  - sh: "sudo apt-get -y install python3.7"
-  - sh: "sudo apt-get -y install python3.8"
-  - sh: "sudo apt-get -y install python3.9 python3.9-venv"
-
-  - sh: "which python3.8"
-  - sh: "which python3.7"
-  - sh: "which python3.9"
-
-  - sh: "PATH=$PATH:/usr/bin/python3.9:/usr/bin/python3.8:/usr/bin/python3.7"
-  - sh: "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
-
-  - sh: "sudo apt-get -y install python3-distutils"
-  - sh: "sudo apt-get -y install python3.9-distutils"
-  - ps: "If ($env:INSTALL_PY_39_PIP) {python3.9 get-pip.py --user}"
-  - ps: "If ($env:INSTALL_PY_38_PIP) {python3.8 get-pip.py --user}"
-  - ps: "If ($env:INSTALL_PY_37_PIP) {python3.7 get-pip.py --user}"
+  - sh: "PATH=$PATH:$HOME/venv3.7/bin:$HOME/venv3.8/bin:$HOME/venv3.9/bin:$HOME/venv3.10/bin"
 
   # get testing env vars
   - sh: "sudo apt install -y jq"

--- a/tests/iac_integration/cdk/testdata/cdk_v1/java/src/main/java/com/myorg/JavaStack.java
+++ b/tests/iac_integration/cdk/testdata/cdk_v1/java/src/main/java/com/myorg/JavaStack.java
@@ -128,6 +128,7 @@ public class JavaStack extends Stack {
         cfnLayerVersionNodeJsRuntime.addMetadata("BuildMethod", "nodejs14.x");
 
         NodejsFunction nodejsFunction = NodejsFunction.Builder.create(this, "NodejsFunction")
+                .runtime(Runtime.NODEJS_14_X)
                 .entry("../../src/nodejs/NodeJsFunctionConstruct/app.ts")
                 .depsLockFilePath("../../src/nodejs/NodeJsFunctionConstruct/package-lock.json")
                 .handler("lambdaHandler")

--- a/tests/iac_integration/cdk/testdata/cdk_v1/python/python/python_stack.py
+++ b/tests/iac_integration/cdk/testdata/cdk_v1/python/python/python_stack.py
@@ -150,6 +150,7 @@ class PythonStack(cdk.Stack):
         nodejs_function = NodejsFunction(
             self,
             "NodejsFunction",
+            runtime=lambda1.Runtime.NODEJS_14_X,
             entry=os.path.join(
                 Path(__file__).resolve().parents[0], "../../../src/nodejs/NodeJsFunctionConstruct/app.ts"
             ),

--- a/tests/iac_integration/cdk/testdata/cdk_v1/typescript/lib/test-stack.ts
+++ b/tests/iac_integration/cdk/testdata/cdk_v1/typescript/lib/test-stack.ts
@@ -124,6 +124,7 @@ export class CDKSupportDemoRootStack extends cdk.Stack {
     cfnLayerVersionNodeJsRuntime.addMetadata('BuildMethod', 'nodejs14.x');
 
     const nodejsFunction = new NodejsFunction(this, 'NodejsFunction', {
+      runtime: lambda.Runtime.NODEJS_14_X,
       entry: path.join(__dirname, '../../../src/nodejs/NodeJsFunctionConstruct/app.ts'),
       depsLockFilePath: path.join(__dirname, '../../../src/nodejs/NodeJsFunctionConstruct/package-lock.json'),
       bundling: {

--- a/tests/iac_integration/cdk/testdata/cdk_v2/java/src/main/java/com/myorg/JavaStack.java
+++ b/tests/iac_integration/cdk/testdata/cdk_v2/java/src/main/java/com/myorg/JavaStack.java
@@ -129,6 +129,7 @@ public class JavaStack extends Stack {
         cfnLayerVersionNodeJsRuntime.addMetadata("BuildMethod", "nodejs14.x");
 
         NodejsFunction nodejsFunction = NodejsFunction.Builder.create(this, "NodejsFunction")
+                .runtime(Runtime.NODEJS_14_X)
                 .entry("../../src/nodejs/NodeJsFunctionConstruct/app.ts")
                 .depsLockFilePath("../../src/nodejs/NodeJsFunctionConstruct/package-lock.json")
                 .handler("lambdaHandler")

--- a/tests/iac_integration/cdk/testdata/cdk_v2/python/python/python_stack.py
+++ b/tests/iac_integration/cdk/testdata/cdk_v2/python/python/python_stack.py
@@ -150,6 +150,7 @@ class PythonStack(Stack):
         nodejs_function = NodejsFunction(
             self,
             "NodejsFunction",
+            runtime=lambda1.Runtime.NODEJS_14_X,
             entry=os.path.join(
                 Path(__file__).resolve().parents[0], "../../../src/nodejs/NodeJsFunctionConstruct/app.ts"
             ),

--- a/tests/iac_integration/cdk/testdata/cdk_v2/typescript/lib/test-stack.ts
+++ b/tests/iac_integration/cdk/testdata/cdk_v2/typescript/lib/test-stack.ts
@@ -123,6 +123,7 @@ export class CDKSupportDemoRootStack extends cdk.Stack {
     cfnLayerVersionNodeJsRuntime.addMetadata('BuildMethod', 'nodejs14.x');
 
     const nodejsFunction = new NodejsFunction(this, 'NodejsFunction', {
+      runtime: lambda.Runtime.NODEJS_14_X,
       entry: path.join(__dirname, '../../../src/nodejs/NodeJsFunctionConstruct/app.ts'),
       depsLockFilePath: path.join(__dirname, '../../../src/nodejs/NodeJsFunctionConstruct/package-lock.json'),
       bundling: {


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Fix the failing CDK testing Appveyor jobs
https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-cdk-integration

#### How does it address the issue?
 - I fixed the Python installation to fix the failing jobs for py3.8, and py3.9.
 - I added the missed runtime for some NodeJS function to fix this error
 ```
ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.0:java (default-cli) on project java: An exception occured while executing the Java class. This lambda function uses a runtime that is incompatible with this layer (${Token[TOKEN.824]} is not in [nodejs14.x])
[ERROR] Error: This lambda function uses a runtime that is incompatible with this layer (${Token[TOKEN.824]} is not in [nodejs14.x])
[ERROR]     at NodejsFunction.addLayers (/tmp/jsii-kernel-yd4q3g/node_modules/aws-cdk-lib/aws-lambda/lib/function.js:1:14690)
[ERROR]     at new Function (/tmp/jsii-kernel-yd4q3g/node_modules/aws-cdk-lib/aws-lambda/lib/function.js:1:11605)
[ERROR]     at new NodejsFunction (/tmp/jsii-kernel-yd4q3g/node_modules/aws-cdk-lib/aws-lambda-nodejs/lib/function.js:1:1174)
[ERROR]     at Kernel._create (/tmp/jsii-java-runtime6771401402491732019/lib/program.js:9964:29)
[ERROR]     at Kernel.create (/tmp/jsii-java-runtime6771401402491732019/lib/program.js:9693:29)
[ERROR]     at KernelHost.processRequest (/tmp/jsii-java-runtime6771401402491732019/lib/program.js:11544:36)
[ERROR]     at KernelHost.run (/tmp/jsii-java-runtime6771401402491732019/lib/program.js:11504:22)
[ERROR]     at Immediate._onImmediate (/tmp/jsii-java-runtime6771401402491732019/lib/program.js:11505:46)
[ERROR]     at processImmediate (internal/timers.js:464:21)
[ERROR] -> [Help 1]

```


By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
