### PR TITLE
chore: run all sam init tests in the same group

### DIFF
--- a/tests/integration/init/schemas/schemas_test_data_setup.py
+++ b/tests/integration/init/schemas/schemas_test_data_setup.py
@@ -2,6 +2,7 @@ import os
 import time
 import shutil
 import tempfile
+import pytest
 from unittest import TestCase
 from typing import Optional
 
@@ -18,6 +19,7 @@ AWS_PROFILE = "AWS_PROFILE"
 SLEEP_TIME = 1
 
 
+@pytest.mark.xdist_group(name="sam_init")
 class SchemaTestDataSetup(TestCase):
     original_cred_file: Optional[str]
     original_config_file: Optional[str]

--- a/tests/integration/init/schemas/test_init_with_schemas_command.py
+++ b/tests/integration/init/schemas/test_init_with_schemas_command.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import pytest
 from pathlib import Path
 from unittest import skipIf
 
@@ -14,6 +15,7 @@ SKIP_SCHEMA_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_
 
 
 @skipIf(SKIP_SCHEMA_TESTS, "Skip schema test")
+@pytest.mark.xdist_group(name="sam_init")
 class TestBasicInitWithEventBridgeCommand(SchemaTestDataSetup):
     def test_init_interactive_with_event_bridge_app_aws_registry(self):
         # WHEN the user follows interactive init prompts

--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -1,6 +1,7 @@
 import platform
 import time
 import signal
+import pytest
 
 from click.testing import CliRunner
 
@@ -28,6 +29,7 @@ TIMEOUT = 300
 COMMIT_ERROR = "WARN: Commit not exist:"
 
 
+@pytest.mark.xdist_group(name="sam_init")
 class TestBasicInitCommand(TestCase):
     def test_init_command_passes_and_dir_created(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -501,6 +503,7 @@ You can run 'sam init' without any options for an interactive initialization flo
 """
 
 
+@pytest.mark.xdist_group(name="sam_init")
 class TestInitForParametersCompatibility(TestCase):
     def test_init_command_no_interactive_missing_name(self):
         stderr = None
@@ -751,6 +754,7 @@ Error: Invalid value for '-p' / '--package-type': 'WrongPT' is not one of 'Zip',
             self.assertIn(errmsg.strip(), "\n".join(stderr.strip().splitlines()))
 
 
+@pytest.mark.xdist_group(name="sam_init")
 class TestInitWithArbitraryProject(TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
@@ -833,6 +837,7 @@ class TestInitWithArbitraryProject(TestCase):
             self._validate_expected_files_exist(Path(tmp, project_name))
 
 
+@pytest.mark.xdist_group(name="sam_init")
 class TestInteractiveInit(TestCase):
     def test_interactive_init(self):
         # 1: AWS Quick Start Templates
@@ -886,6 +891,7 @@ sam-interactive-init-app-default-runtime
             self.assertTrue(Path(expected_output_folder, "hello_world", "app.py").is_file())
 
 
+@pytest.mark.xdist_group(name="sam_init")
 class TestSubsequentInitCaching(TestCase):
     def test_subsequent_init_skips_cloning(self):
         from platform import system
@@ -947,6 +953,7 @@ class TestSubsequentInitCaching(TestCase):
         return os.path.getmtime(file)
 
 
+@pytest.mark.xdist_group(name="sam_init")
 class TestInitProducesSamconfigFile(TestCase):
     def test_zip_template_config(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -1060,6 +1067,7 @@ class TestInitProducesSamconfigFile(TestCase):
     IS_WINDOWS and RUNNING_ON_APPVEYOR,
     "Killing process in Windows in Appveyor gets stuck, skipping this test since it is already run in GHA",
 )
+@pytest.mark.xdist_group(name="sam_init")
 class TestInitCommand(InitIntegBase):
     def test_graceful_exit(self):
         # Run the Base Command


### PR DESCRIPTION
Mark all `sam init` tests with `xdist_group` so that they will run in the same group during integration tests.

If we don't do this, different `sam init` tests might start at the same time, which causes issues during cloning step of the application templates.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
