### PR TITLE
feat: Link APIGW Resources to APIGW REST APIs

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
@@ -63,6 +63,20 @@ class FunctionLayerLocalVariablesLinkingLimitationException(LocalVariablesLinkin
     """
 
 
+class OneGatewayResourceToRestApiLinkingLimitationException(OneResourceLinkingLimitationException):
+    """
+    Exception specific for Gateway Resource linking to more than one Rest API
+    """
+
+
+class GatewayResourceToGatewayRestApiLocalVariablesLinkingLimitationException(
+    LocalVariablesLinkingLimitationException
+):
+    """
+    Exception specific for Gateway Resource linking to Rest API using locals.
+    """
+
+
 class InvalidSamMetadataPropertiesException(UserException):
     pass
 

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -23,6 +23,7 @@ from samcli.hook_packages.terraform.hooks.prepare.types import (
 from samcli.hook_packages.terraform.lib.utils import build_cfn_logical_id
 
 LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX = "aws_lambda_layer_version."
+API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX = "aws_api_gateway_rest_api."
 TERRAFORM_LOCAL_VARIABLES_ADDRESS_PREFIX = "local."
 DATA_RESOURCE_ADDRESS_PREFIX = "data."
 

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/apigw.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/apigw.py
@@ -5,7 +5,7 @@ Module for API Gateway-related Terraform translation logic
 from typing import Dict
 
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import OpenAPIBodyNotSupportedException
-from samcli.hook_packages.terraform.hooks.prepare.types import References, ResourceTranslationValidator, TFResource
+from samcli.hook_packages.terraform.hooks.prepare.types import References, ResourceTranslationValidator, TFResource, ResourceProperties
 
 
 class RESTAPITranslationValidator(ResourceTranslationValidator):
@@ -50,3 +50,12 @@ def _unsupported_reference_field(field: str, resource: Dict, config_resource: TF
         and config_resource.attributes.get(field)
         and isinstance(config_resource.attributes.get(field), References)
     )
+
+
+class ApiGatewayResourceProperties(ResourceProperties):
+    """
+    contains the collection logic of the required properties for linking the aws_api_gateway_resource resources.
+    """
+
+    def __init__(self):
+        super(ApiGatewayResourceProperties, self).__init__()

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/resource_properties.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/resource_properties.py
@@ -4,7 +4,9 @@ from typing import Dict
 from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     TF_AWS_LAMBDA_FUNCTION,
     TF_AWS_LAMBDA_LAYER_VERSION,
+    TF_AWS_API_GATEWAY_RESOURCE,
 )
+from samcli.hook_packages.terraform.hooks.prepare.resources.apigw import ApiGatewayResourceProperties
 from samcli.hook_packages.terraform.hooks.prepare.resources.lambda_function import LambdaFunctionProperties
 from samcli.hook_packages.terraform.hooks.prepare.resources.lambda_layers import LambdaLayerVersionProperties
 from samcli.hook_packages.terraform.hooks.prepare.types import ResourceProperties
@@ -24,4 +26,5 @@ def get_resource_property_mapping() -> Dict[str, ResourceProperties]:
     return {
         TF_AWS_LAMBDA_LAYER_VERSION: LambdaLayerVersionProperties(),
         TF_AWS_LAMBDA_FUNCTION: LambdaFunctionProperties(),
+        TF_AWS_API_GATEWAY_RESOURCE: ApiGatewayResourceProperties()
     }

--- a/samcli/hook_packages/terraform/hooks/prepare/translate.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/translate.py
@@ -392,6 +392,19 @@ def _link_gateway_resources_to_gateway_rest_apis(
     gateway_resources_cfn_resources: Dict[str, List],
     rest_apis_terraform_resources: Dict[str, Dict],
 ):
+    """
+    Iterate through all the resources and link the corresponding Rest API resource to each Gateway Resource resource.
+
+    Parameters
+    ----------
+    gateway_resources_tf_configs: Dict[str, TFResource]
+        Dictionary of configuration Gateway Resource resources
+    gateway_resources_cfn_resources: Dict[str, List]
+        Dictionary containing resolved configuration addresses matched up to the cfn Gateway Resource
+    rest_apis_terraform_resources: Dict[str, Dict]
+        Dictionary of all actual terraform Rest API resources (not configuration resources). The dictionary's key is the
+        calculated logical id for each resource.
+    """
     exceptions = ResourcePairExceptions(
         multiple_resource_linking_exception=OneGatewayResourceToRestApiLinkingLimitationException,
         local_variable_linking_exception=GatewayResourceToGatewayRestApiLocalVariablesLinkingLimitationException,

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -1100,7 +1100,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.ResourceLinker")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.ResourceLinkingPair")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.ResourcePairExceptions")
-    def test_link_gateway_methods_to_gateway_rest_apis(
+    def test_link_gateway_resources_to_gateway_rest_apis(
         self,
         mock_resource_linking_exceptions,
         mock_resource_linking_pair,

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -10,6 +10,8 @@ from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     OneRestApiToApiGatewayMethodLinkingLimitationException,
     RestApiToApiGatewayMethodLocalVariablesLinkingLimitationException,
     InvalidResourceLinkingException,
+    OneGatewayResourceToRestApiLinkingLimitationException,
+    GatewayResourceToGatewayRestApiLocalVariablesLinkingLimitationException,
 )
 from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX,
@@ -29,6 +31,7 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     TF_AWS_LAMBDA_FUNCTION,
     TF_AWS_LAMBDA_LAYER_VERSION,
     TF_AWS_API_GATEWAY_METHOD,
+    TF_AWS_API_GATEWAY_RESOURCE,
 )
 from samcli.hook_packages.terraform.hooks.prepare.types import (
     SamMetadataResource,
@@ -45,6 +48,7 @@ from samcli.hook_packages.terraform.hooks.prepare.translate import (
     _link_lambda_functions_to_layers_call_back,
     _link_gateway_methods_to_gateway_rest_apis,
     _link_gateway_resource_to_gateway_rest_apis_call_back,
+    _link_gateway_resources_to_gateway_rest_apis,
 )
 from samcli.hook_packages.terraform.hooks.prepare.translate import AWS_PROVIDER_NAME
 from samcli.hook_packages.terraform.hooks.prepare.types import TFModule, TFResource, ConstantValue, ResolvedReference
@@ -91,6 +95,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._check_dummy_remote_values")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._build_module")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.get_configuration_address")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.translate._link_gateway_resources_to_gateway_rest_apis")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._link_gateway_methods_to_gateway_rest_apis")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.enrich_resources_and_generate_makefile")
@@ -101,6 +106,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         mock_enrich_resources_and_generate_makefile,
         mock_link_lambda_functions_to_layers,
         mock_link_gateway_methods_to_gateway_rest_apis,
+        mock_link_gateway_resources_to_gateway_rest_apis,
         mock_get_configuration_address,
         mock_build_module,
         mock_check_dummy_remote_values,
@@ -201,6 +207,18 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
             },
         ]
         mock_link_gateway_methods_to_gateway_rest_apis.assert_called_once_with(*expected_arguments_in_call)
+
+        expected_arguments_in_call = [
+            ANY,
+            {
+                f"aws_api_gateway_resource.my_resource": [self.expected_cfn_apigw_resource],
+            },
+            {
+                f"AwsApiGatewayRestApiMyRestApi{self.mock_logical_id_hash}": self.tf_apigw_rest_api_resource,
+            },
+        ]
+        mock_link_gateway_resources_to_gateway_rest_apis.assert_called_once_with(*expected_arguments_in_call)
+
         mock_validator.assert_called_once_with(
             resource=self.tf_apigw_rest_api_resource, config_resource=config_resource
         )
@@ -390,12 +408,14 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.get_configuration_address")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._link_lambda_functions_to_layers")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._link_gateway_methods_to_gateway_rest_apis")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.translate._link_gateway_resources_to_gateway_rest_apis")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.enrich_resources_and_generate_makefile")
     @patch("samcli.hook_packages.terraform.lib.utils.str_checksum")
     def test_translate_to_cfn_with_root_module_with_sam_metadata_resource(
         self,
         checksum_mock,
         mock_enrich_resources_and_generate_makefile,
+        mock_link_gateway_resources_to_gateway_rest_apis,
         mock_link_gateway_methods_to_gateway_rest_apis,
         mock_link_lambda_functions_to_layers,
         mock_get_configuration_address,
@@ -427,11 +447,13 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         lambda_layer_properties_mock = Mock()
         rest_api_properties_mock = Mock()
         gateway_method_properties_mock = Mock()
+        gateway_resource_properties_mock = Mock()
         mock_resource_property_mapping.return_value = {
             TF_AWS_LAMBDA_FUNCTION: lambda_properties_mock,
             TF_AWS_LAMBDA_LAYER_VERSION: lambda_layer_properties_mock,
             TF_AWS_API_GATEWAY_REST_API: rest_api_properties_mock,
             TF_AWS_API_GATEWAY_METHOD: gateway_method_properties_mock,
+            TF_AWS_API_GATEWAY_RESOURCE: gateway_resource_properties_mock,
         }
 
         translated_cfn_dict = translate_to_cfn(
@@ -1061,6 +1083,42 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         )
         mock_resource_linking_pair.assert_called_once_with(
             source_resource_cfn_resource=gateway_method_config_resources,
+            source_resource_tf_config=resources,
+            destination_resource_tf=terraform_rest_apis_resources,
+            tf_destination_attribute_name="id",
+            terraform_link_field_name="rest_api_id",
+            cfn_link_field_name="RestApiId",
+            terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+            cfn_resource_update_call_back_function=mock_link_gateway_methods_to_gateway_rest_apis_call_back,
+            linking_exceptions=mock_resource_linking_exceptions(),
+        )
+        mock_resource_linker.assert_called_once_with(mock_resource_linking_pair())
+
+    @patch(
+        "samcli.hook_packages.terraform.hooks.prepare.translate._link_gateway_resource_to_gateway_rest_apis_call_back"
+    )
+    @patch("samcli.hook_packages.terraform.hooks.prepare.translate.ResourceLinker")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.translate.ResourceLinkingPair")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.translate.ResourcePairExceptions")
+    def test_link_gateway_methods_to_gateway_rest_apis(
+        self,
+        mock_resource_linking_exceptions,
+        mock_resource_linking_pair,
+        mock_resource_linker,
+        mock_link_gateway_methods_to_gateway_rest_apis_call_back,
+    ):
+        gateway_resource_config_resources = Mock()
+        terraform_rest_apis_resources = Mock()
+        resources = Mock()
+        _link_gateway_resources_to_gateway_rest_apis(
+            resources, gateway_resource_config_resources, terraform_rest_apis_resources
+        )
+        mock_resource_linking_exceptions.assert_called_once_with(
+            multiple_resource_linking_exception=OneGatewayResourceToRestApiLinkingLimitationException,
+            local_variable_linking_exception=GatewayResourceToGatewayRestApiLocalVariablesLinkingLimitationException,
+        )
+        mock_resource_linking_pair.assert_called_once_with(
+            source_resource_cfn_resource=gateway_resource_config_resources,
             source_resource_tf_config=resources,
             destination_resource_tf=terraform_rest_apis_resources,
             tf_destination_attribute_name="id",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
To support `sam local start-api` for Terraform projects, AWS SAM CLI needs to be able to read the APIGW Terraform resources and then link related resources together. 

#### How does it address the issue?
This PR adds the logic for linking all `AWS::ApiGateway::Resource` resources to their corresponding `AWS::ApiGateway::RestApi` resources linked on the `RestApiId` field.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
