### PR TITLE
feat: Link stages to REST APIs, methods to resources

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
@@ -87,6 +87,32 @@ class RestApiToApiGatewayMethodLocalVariablesLinkingLimitationException(LocalVar
     """
 
 
+class OneGatewayResourceToApiGatewayMethodLinkingLimitationException(OneResourceLinkingLimitationException):
+    """
+    Exception specific for Gateway Method linking to more than API Gateway Resource
+    """
+
+
+class GatewayResourceToApiGatewayMethodLocalVariablesLinkingLimitationException(
+    LocalVariablesLinkingLimitationException
+):
+    """
+    Exception specific for Gateway Method linking to Gateway Resource using locals.
+    """
+
+
+class OneRestApiToApiGatewayStageLinkingLimitationException(OneResourceLinkingLimitationException):
+    """
+    Exception specific for Gateway Stage linking to more than Rest API
+    """
+
+
+class RestApiToApiGatewayStageLocalVariablesLinkingLimitationException(LocalVariablesLinkingLimitationException):
+    """
+    Exception specific for Gateway Stage linking to Rest API using locals.
+    """
+
+
 class InvalidSamMetadataPropertiesException(UserException):
     pass
 

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -25,6 +25,7 @@ from samcli.hook_packages.terraform.lib.utils import build_cfn_logical_id
 
 LAMBDA_LAYER_RESOURCE_ADDRESS_PREFIX = "aws_lambda_layer_version."
 API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX = "aws_api_gateway_rest_api."
+API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX = "aws_api_gateway_resource."
 TERRAFORM_LOCAL_VARIABLES_ADDRESS_PREFIX = "local."
 DATA_RESOURCE_ADDRESS_PREFIX = "data."
 

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/apigw.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/apigw.py
@@ -28,24 +28,6 @@ class RESTAPITranslationValidator(ResourceTranslationValidator):
             raise OpenAPIBodyNotSupportedException(self.config_resource.full_address)
 
 
-class ApiGatewayMethodProperties(ResourceProperties):
-    """
-    contains the collection logic of the required properties for linking the aws_api_gateway_method resources.
-    """
-
-    def __init__(self):
-        super(ApiGatewayMethodProperties, self).__init__()
-
-
-class ApiGatewayRestApiProperties(ResourceProperties):
-    """
-    contains the collection logic of the required properties for linking the aws_api_gateway_rest_api resources.
-    """
-
-    def __init__(self):
-        super(ApiGatewayRestApiProperties, self).__init__()
-
-
 def _unsupported_reference_field(field: str, resource: Dict, config_resource: TFResource) -> bool:
     """
     Check if a field in a resource is a reference to a computed value that is unknown until
@@ -82,3 +64,30 @@ class ApiGatewayResourceProperties(ResourceProperties):
 
     def __init__(self):
         super(ApiGatewayResourceProperties, self).__init__()
+
+
+class ApiGatewayMethodProperties(ResourceProperties):
+    """
+    contains the collection logic of the required properties for linking the aws_api_gateway_method resources.
+    """
+
+    def __init__(self):
+        super(ApiGatewayMethodProperties, self).__init__()
+
+
+class ApiGatewayRestApiProperties(ResourceProperties):
+    """
+    contains the collection logic of the required properties for linking the aws_api_gateway_rest_api resources.
+    """
+
+    def __init__(self):
+        super(ApiGatewayRestApiProperties, self).__init__()
+
+
+class ApiGatewayStageProperties(ResourceProperties):
+    """
+    Contains the collection logic of the required properties for linking the aws_api_gateway_stage resources.
+    """
+
+    def __init__(self):
+        super(ApiGatewayStageProperties, self).__init__()

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/resource_properties.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/resource_properties.py
@@ -5,6 +5,7 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     TF_AWS_API_GATEWAY_METHOD,
     TF_AWS_API_GATEWAY_RESOURCE,
     TF_AWS_API_GATEWAY_REST_API,
+    TF_AWS_API_GATEWAY_STAGE,
     TF_AWS_LAMBDA_FUNCTION,
     TF_AWS_LAMBDA_LAYER_VERSION,
 )
@@ -12,6 +13,7 @@ from samcli.hook_packages.terraform.hooks.prepare.resources.apigw import (
     ApiGatewayMethodProperties,
     ApiGatewayResourceProperties,
     ApiGatewayRestApiProperties,
+    ApiGatewayStageProperties,
 )
 from samcli.hook_packages.terraform.hooks.prepare.resources.lambda_function import LambdaFunctionProperties
 from samcli.hook_packages.terraform.hooks.prepare.resources.lambda_layers import LambdaLayerVersionProperties
@@ -35,4 +37,5 @@ def get_resource_property_mapping() -> Dict[str, ResourceProperties]:
         TF_AWS_API_GATEWAY_RESOURCE: ApiGatewayResourceProperties(),
         TF_AWS_API_GATEWAY_REST_API: ApiGatewayRestApiProperties(),
         TF_AWS_API_GATEWAY_METHOD: ApiGatewayMethodProperties(),
+        TF_AWS_API_GATEWAY_STAGE: ApiGatewayStageProperties(),
     }

--- a/samcli/hook_packages/terraform/hooks/prepare/translate.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/translate.py
@@ -5,7 +5,7 @@ This method contains the logic required to translate the `terraform show` JSON o
 """
 import hashlib
 import logging
-from typing import Any, Dict, List, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
 from samcli.hook_packages.terraform.hooks.prepare.constants import (
     CFN_CODE_PROPERTIES,
@@ -20,6 +20,10 @@ from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     OneLambdaLayerLinkingLimitationException,
     OneRestApiToApiGatewayMethodLinkingLimitationException,
     RestApiToApiGatewayMethodLocalVariablesLinkingLimitationException,
+    OneRestApiToApiGatewayStageLinkingLimitationException,
+    GatewayResourceToApiGatewayMethodLocalVariablesLinkingLimitationException,
+    OneGatewayResourceToApiGatewayMethodLinkingLimitationException,
+    RestApiToApiGatewayStageLocalVariablesLinkingLimitationException,
 )
 from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     REMOTE_DUMMY_VALUE,
@@ -27,6 +31,7 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     TF_AWS_API_GATEWAY_METHOD,
     TF_AWS_API_GATEWAY_RESOURCE,
     TF_AWS_API_GATEWAY_REST_API,
+    TF_AWS_API_GATEWAY_STAGE,
     TF_AWS_LAMBDA_FUNCTION,
     TF_AWS_LAMBDA_LAYER_VERSION,
     PropertyBuilderMapping,
@@ -40,7 +45,7 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     ResourceLinkingPair,
     ResourcePairExceptions,
     _build_module,
-    _resolve_resource_attribute,
+    _resolve_resource_attribute, API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
 )
 from samcli.hook_packages.terraform.hooks.prepare.resources.apigw import RESTAPITranslationValidator
 from samcli.hook_packages.terraform.hooks.prepare.resources.resource_properties import get_resource_property_mapping
@@ -76,6 +81,8 @@ LOG = logging.getLogger(__name__)
 TRANSLATION_VALIDATORS: Dict[str, Type[ResourceTranslationValidator]] = {
     TF_AWS_API_GATEWAY_REST_API: RESTAPITranslationValidator,
 }
+
+RESOURCE_LINKING_DEFINITIONS: List[Callable[[Dict[str, TFResource], Dict[str, List], Dict[str, Dict]], None]] = []
 
 
 def translate_to_cfn(tf_json: dict, output_directory_path: str, terraform_application_dir: str) -> dict:
@@ -258,6 +265,18 @@ def translate_to_cfn(tf_json: dict, output_directory_path: str, terraform_applic
         resource_property_mapping[TF_AWS_API_GATEWAY_REST_API].terraform_resources,
     )
 
+    _link_gateway_stage_to_rest_api(
+        resource_property_mapping[TF_AWS_API_GATEWAY_STAGE].terraform_config,
+        resource_property_mapping[TF_AWS_API_GATEWAY_STAGE].cfn_resources,
+        resource_property_mapping[TF_AWS_API_GATEWAY_REST_API].terraform_resources,
+    )
+
+    _link_gateway_method_to_gateway_resource(
+        resource_property_mapping[TF_AWS_API_GATEWAY_METHOD].terraform_config,
+        resource_property_mapping[TF_AWS_API_GATEWAY_METHOD].cfn_resources,
+        resource_property_mapping[TF_AWS_API_GATEWAY_RESOURCE].terraform_resources,
+    )
+
     if sam_metadata_resources:
         LOG.debug("Enrich the mapped resources with the sam metadata information and generate Makefile")
         enrich_resources_and_generate_makefile(
@@ -346,7 +365,7 @@ def _translate_properties(
     ----------
     tf_properties: dict
         The terraform properties to translate
-    property_builder_mappping: PropertyBuilderMapping
+    property_builder_mapping: PropertyBuilderMapping
         A mapping of the CloudFormation property name to a function for building that property
     resource: TFResource
         The terraform configuration resource that can be used to retrieve some attributes values if needed
@@ -485,6 +504,32 @@ def _link_gateway_resource_to_gateway_rest_apis_call_back(
     )
 
 
+def _link_gateway_method_to_gateway_resource_call_back(
+        gateway_method_cfn_resource: Dict, referenced_gateway_resource_values: List[ReferenceType]
+) -> None:
+    """
+    Callback function that is used by the linking algorithm to update an Api Gateway Method CFN Resource with
+    a reference to the Gateway Resource resource.
+
+    Parameters
+    ----------
+    gateway_method_cfn_resource: Dict
+        API Gateway Method CFN resource
+    referenced_gateway_resource_values: List[ReferenceType]
+        List of referenced Gateway Resources either as the logical id of Gateway Resource resource
+        defined in the customer project, or ARN values for actual Gateway Resources resource defined
+        in customer's account. This list should always contain one element only.
+    """
+    # if the destination rest api list contains more than one element, so we have an issue in our linking logic
+    if len(referenced_gateway_resource_values) > 1:
+        raise InvalidResourceLinkingException("Could not link multiple Rest APIs to one Gateway method resource")
+
+    logical_id = referenced_gateway_resource_values[0]
+    gateway_method_cfn_resource["Properties"]["ResourceId"] = (
+        {"Ref": logical_id.value} if isinstance(logical_id, LogicalIdReference) else logical_id.value
+    )
+
+
 def _link_gateway_methods_to_gateway_rest_apis(
     gateway_methods_config_resources: Dict[str, TFResource],
     gateway_methods_config_address_cfn_resources_map: Dict[str, List],
@@ -517,6 +562,79 @@ def _link_gateway_methods_to_gateway_rest_apis(
         cfn_link_field_name="RestApiId",
         terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
         cfn_resource_update_call_back_function=_link_gateway_resource_to_gateway_rest_apis_call_back,
+        linking_exceptions=exceptions,
+    )
+    ResourceLinker(resource_linking_pair).link_resources()
+
+
+def _link_gateway_stage_to_rest_api(
+    gateway_stages_config_resources: Dict[str, TFResource],
+    gateway_stages_config_address_cfn_resources_map: Dict[str, List],
+    rest_apis_terraform_resources: Dict[str, Dict],
+):
+    """
+    Iterate through all the resources and link the corresponding Gateway Stage to each Gateway Rest API resource.
+
+    Parameters
+    ----------
+    gateway_stages_config_resources: Dict[str, TFResource]
+        Dictionary of configuration Gateway Stages
+    gateway_stages_config_address_cfn_resources_map: Dict[str, List]
+        Dictionary containing resolved configuration addresses matched up to the cfn Gateway Stage
+    rest_apis_terraform_resources: Dict[str, Dict]
+        Dictionary of all actual terraform Rest API resources (not configuration resources).
+        The dictionary's key is the calculated logical id for each resource.
+    """
+    exceptions = ResourcePairExceptions(
+        multiple_resource_linking_exception=OneRestApiToApiGatewayStageLinkingLimitationException,
+        local_variable_linking_exception=RestApiToApiGatewayStageLocalVariablesLinkingLimitationException,
+    )
+    resource_linking_pair = ResourceLinkingPair(
+        source_resource_cfn_resource=gateway_stages_config_address_cfn_resources_map,
+        source_resource_tf_config=gateway_stages_config_resources,
+        destination_resource_tf=rest_apis_terraform_resources,
+        tf_destination_attribute_name="id",
+        terraform_link_field_name="rest_api_id",
+        cfn_link_field_name="RestApiId",
+        terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+        cfn_resource_update_call_back_function=_link_gateway_resource_to_gateway_rest_apis_call_back,
+        linking_exceptions=exceptions,
+    )
+    ResourceLinker(resource_linking_pair).link_resources()
+
+
+def _link_gateway_method_to_gateway_resource(
+    gateway_method_config_resources: Dict[str, TFResource],
+    gateway_method_config_address_cfn_resources_map: Dict[str, List],
+    gateway_resources_terraform_resources: Dict[str, Dict],
+):
+    """
+    Iterate through all the resources and link the corresponding
+    Gateway Method resources to each Gateway Resource resources.
+
+    Parameters
+    ----------
+    gateway_method_config_resources: Dict[str, TFResource]
+        Dictionary of configuration Gateway Methods
+    gateway_method_config_address_cfn_resources_map: Dict[str, List]
+        Dictionary containing resolved configuration addresses matched up to the cfn Gateway Stage
+    gateway_resources_terraform_resources: Dict[str, Dict]
+        Dictionary of all actual terraform Rest API resources (not configuration resources).
+        The dictionary's key is the calculated logical id for each resource.
+    """
+    exceptions = ResourcePairExceptions(
+        multiple_resource_linking_exception=OneGatewayResourceToApiGatewayMethodLinkingLimitationException,
+        local_variable_linking_exception=GatewayResourceToApiGatewayMethodLocalVariablesLinkingLimitationException,
+    )
+    resource_linking_pair = ResourceLinkingPair(
+        source_resource_cfn_resource=gateway_method_config_address_cfn_resources_map,
+        source_resource_tf_config=gateway_method_config_resources,
+        destination_resource_tf=gateway_resources_terraform_resources,
+        tf_destination_attribute_name="id",
+        terraform_link_field_name="resource_id",
+        cfn_link_field_name="ResourceId",
+        terraform_resource_type_prefix=API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
+        cfn_resource_update_call_back_function=_link_gateway_method_to_gateway_resource_call_back,
         linking_exceptions=exceptions,
     )
     ResourceLinker(resource_linking_pair).link_resources()

--- a/samcli/hook_packages/terraform/hooks/prepare/translate.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/translate.py
@@ -519,9 +519,10 @@ def _link_gateway_method_to_gateway_resource_call_back(
         defined in the customer project, or ARN values for actual Gateway Resources resource defined
         in customer's account. This list should always contain one element only.
     """
-    # if the destination rest api list contains more than one element, so we have an issue in our linking logic
     if len(referenced_gateway_resource_values) > 1:
-        raise InvalidResourceLinkingException("Could not link multiple Rest APIs to one Gateway method resource")
+        raise InvalidResourceLinkingException(
+            "Could not link multiple Gateway Resources to one Gateway method resource"
+        )
 
     logical_id = referenced_gateway_resource_values[0]
     gateway_method_cfn_resource["Properties"]["ResourceId"] = (


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
To support `sam local start-api` for Terraform projects, AWS SAM CLI needs to be able to read the APIGW Terraform resources and then link related resources together.

#### How does it address the issue?
This PR adds the logic for linking: 
- `AWS::ApiGateway::Method` resources to their corresponding `AWS::ApiGateway::Resource` resources linked on the ResourceId field.
- `AWS::ApiGateway::Stage` resources to their corresponding `AWS::ApiGateway::RestApi` resources linked on the RestApiId field.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
