### PR TITLE
fix: catch all ClientError from Boto

### DIFF
--- a/samcli/cli/context.py
+++ b/samcli/cli/context.py
@@ -9,7 +9,7 @@ from typing import List, Optional, cast
 import click
 
 from samcli.cli.formatters import RootCommandHelpTextFormatter
-from samcli.commands.exceptions import CredentialsError
+from samcli.commands.exceptions import AWSServiceClientError
 from samcli.lib.utils.sam_logging import (
     LAMBDA_BULDERS_LOGGER_NAME,
     SAM_CLI_FORMATTER_WITH_TIMESTAMP,
@@ -213,7 +213,7 @@ class Context:
             ).cache = credentials.JSONFileCache()
 
         except exceptions.ProfileNotFound as ex:
-            raise CredentialsError(str(ex)) from ex
+            raise AWSServiceClientError(str(ex)) from ex
 
 
 def get_cmd_names(cmd_name, ctx) -> List[str]:

--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -68,9 +68,9 @@ class UnhandledException(click.ClickException):
         click.secho(msg, file=file, err=True, fg="yellow")
 
 
-class CredentialsError(UserException):
+class AWSServiceClientError(UserException):
     """
-    Exception class when credentials that have been passed are invalid.
+    Exception class when there are errors calling any AWS services via Boto.
     """
 
 

--- a/samcli/commands/pipeline/bootstrap/guided_context.py
+++ b/samcli/commands/pipeline/bootstrap/guided_context.py
@@ -11,7 +11,7 @@ from xmlrpc.client import boolean
 import click
 from botocore.credentials import EnvProvider
 
-from samcli.commands.exceptions import CredentialsError
+from samcli.commands.exceptions import AWSServiceClientError
 from samcli.commands.pipeline.bootstrap.oidc_config import (
     BitbucketOidcConfig,
     GitHubOidcConfig,
@@ -115,7 +115,7 @@ class GuidedContext:
             click.echo(
                 self.color.green(f"Associated account {account_id} with configuration {self.stage_configuration_name}.")
             )
-        except CredentialsError as ex:
+        except AWSServiceClientError as ex:
             click.echo(f"{self.color.red(ex.message)}\n")
             self._prompt_account_id()
 

--- a/samcli/lib/bootstrap/bootstrap.py
+++ b/samcli/lib/bootstrap/bootstrap.py
@@ -11,7 +11,7 @@ from botocore.exceptions import ClientError
 
 from samcli import __version__
 from samcli.cli.global_config import GlobalConfig
-from samcli.commands.exceptions import CredentialsError, UserException
+from samcli.commands.exceptions import AWSServiceClientError, UserException
 from samcli.lib.utils.managed_cloudformation_stack import StackOutput
 from samcli.lib.utils.managed_cloudformation_stack import manage_stack as manage_cloudformation_stack
 
@@ -43,10 +43,10 @@ def get_current_account_id(profile: Optional[str] = None):
         caller_identity = sts_client.get_caller_identity()
     except ClientError as ex:
         if ex.response["Error"]["Code"] == "InvalidClientTokenId":
-            raise CredentialsError("Cannot identify account due to invalid configured credentials.") from ex
-        raise CredentialsError("Cannot identify account based on configured credentials.") from ex
+            raise AWSServiceClientError("Cannot identify account due to invalid configured credentials.") from ex
+        raise AWSServiceClientError("Cannot identify account based on configured credentials.") from ex
     if "Account" not in caller_identity:
-        raise CredentialsError("Cannot identify account based on configured credentials.")
+        raise AWSServiceClientError("Cannot identify account based on configured credentials.")
     return caller_identity["Account"]
 
 

--- a/samcli/lib/bootstrap/companion_stack/companion_stack_manager.py
+++ b/samcli/lib/bootstrap/companion_stack/companion_stack_manager.py
@@ -9,7 +9,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError, NoRegionError
 
-from samcli.commands.exceptions import CredentialsError, RegionError
+from samcli.commands.exceptions import AWSServiceClientError, RegionError
 from samcli.lib.bootstrap.companion_stack.companion_stack_builder import CompanionStackBuilder
 from samcli.lib.bootstrap.companion_stack.data_types import CompanionStack, ECRRepo
 from samcli.lib.package.artifact_exporter import mktempfile
@@ -58,7 +58,7 @@ class CompanionStackManager:
             self._account_id = boto3.client("sts").get_caller_identity().get("Account")
             self._region_name = self._cfn_client.meta.region_name
         except NoCredentialsError as ex:
-            raise CredentialsError(
+            raise AWSServiceClientError(
                 "Error Setting Up Managed Stack Client: Unable to resolve "
                 "credentials for the AWS SDK for Python client. "
                 "Please see their documentation for options to pass in credentials: "

--- a/samcli/lib/utils/managed_cloudformation_stack.py
+++ b/samcli/lib/utils/managed_cloudformation_stack.py
@@ -10,7 +10,7 @@ import click
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError, NoRegionError, ProfileNotFound
 
-from samcli.commands.exceptions import CredentialsError, RegionError, UserException
+from samcli.commands.exceptions import AWSServiceClientError, RegionError, UserException
 
 LOG = logging.getLogger(__name__)
 
@@ -70,13 +70,13 @@ def update_stack(
                 "cloudformation", config=Config(region_name=region if region else None)
             )
     except ProfileNotFound as ex:
-        raise CredentialsError(
+        raise AWSServiceClientError(
             f"Error Setting Up Managed Stack Client: the provided AWS name profile '{profile}' is not found. "
             "please check the documentation for setting up a named profile: "
             "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html"
         ) from ex
     except NoCredentialsError as ex:
-        raise CredentialsError(
+        raise AWSServiceClientError(
             "Error Setting Up Managed Stack Client: Unable to resolve credentials for the AWS SDK for Python client. "
             "Please see their documentation for options to pass in credentials: "
             "https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html"
@@ -126,13 +126,13 @@ def manage_stack(
                 "cloudformation", config=Config(region_name=region if region else None)
             )
     except ProfileNotFound as ex:
-        raise CredentialsError(
+        raise AWSServiceClientError(
             f"Error Setting Up Managed Stack Client: the provided AWS name profile '{profile}' is not found. "
             "please check the documentation for setting up a named profile: "
             "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html"
         ) from ex
     except NoCredentialsError as ex:
-        raise CredentialsError(
+        raise AWSServiceClientError(
             "Error Setting Up Managed Stack Client: Unable to resolve credentials for the AWS SDK for Python client. "
             "Please see their documentation for options to pass in credentials: "
             "https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html"

--- a/tests/unit/lib/bootstrap/test_bootstrap.py
+++ b/tests/unit/lib/bootstrap/test_bootstrap.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from samcli.commands.exceptions import UserException, CredentialsError
+from samcli.commands.exceptions import UserException, AWSServiceClientError
 from samcli.lib.bootstrap.bootstrap import manage_stack, StackOutput, get_current_account_id
 
 
@@ -41,5 +41,5 @@ class TestBootstrapManagedStack(TestCase):
         sts_mock = MagicMock()
         sts_mock.get_caller_identity.return_value = {}
         session_mock.client.return_value = sts_mock
-        with self.assertRaises(CredentialsError):
+        with self.assertRaises(AWSServiceClientError):
             get_current_account_id()

--- a/tests/unit/lib/utils/test_managed_cloudformation_stack.py
+++ b/tests/unit/lib/utils/test_managed_cloudformation_stack.py
@@ -7,7 +7,7 @@ from botocore.exceptions import NoCredentialsError, NoRegionError, ProfileNotFou
 from botocore.stub import Stubber
 from parameterized import parameterized
 
-from samcli.commands.exceptions import UserException, CredentialsError, RegionError
+from samcli.commands.exceptions import UserException, AWSServiceClientError, RegionError
 from samcli.lib.bootstrap.bootstrap import _get_stack_template, SAM_CLI_STACK_NAME
 from samcli.lib.utils.managed_cloudformation_stack import (
     manage_stack,
@@ -35,7 +35,7 @@ class TestManagedCloudFormationStack(TestCase):
     @patch("boto3.Session")
     def test_session_missing_profile(self, boto_mock):
         boto_mock.side_effect = ProfileNotFound(profile="test-profile")
-        with self.assertRaises(CredentialsError):
+        with self.assertRaises(AWSServiceClientError):
             manage_stack(
                 profile="test-profile",
                 region="fake-region",
@@ -46,7 +46,7 @@ class TestManagedCloudFormationStack(TestCase):
     @patch("boto3.Session")
     def test_session_missing_profile_update(self, boto_mock):
         boto_mock.side_effect = ProfileNotFound(profile="test-profile")
-        with self.assertRaises(CredentialsError):
+        with self.assertRaises(AWSServiceClientError):
             update_stack(
                 profile="test-profile",
                 region="fake-region",
@@ -57,7 +57,7 @@ class TestManagedCloudFormationStack(TestCase):
     @patch("boto3.client")
     def test_client_missing_credentials(self, boto_mock):
         boto_mock.side_effect = NoCredentialsError()
-        with self.assertRaises(CredentialsError):
+        with self.assertRaises(AWSServiceClientError):
             manage_stack(
                 profile=None, region="fake-region", stack_name=SAM_CLI_STACK_NAME, template_body=_get_stack_template()
             )
@@ -65,7 +65,7 @@ class TestManagedCloudFormationStack(TestCase):
     @patch("boto3.client")
     def test_client_missing_credentials_update(self, boto_mock):
         boto_mock.side_effect = NoCredentialsError()
-        with self.assertRaises(CredentialsError):
+        with self.assertRaises(AWSServiceClientError):
             update_stack(
                 profile=None, region="fake-region", stack_name=SAM_CLI_STACK_NAME, template_body=_get_stack_template()
             )


### PR DESCRIPTION
- regardless of error code in exception message - DO NOT Crash.

#### Which issue(s) does this change fix?

Per https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html we should be catching all `ClientError`


#### Why is this change necessary?
![Screen Shot 2023-05-10 at 12 22 27 PM](https://github.com/aws/aws-sam-cli/assets/3770774/55e1e55d-2e08-4024-bdad-fb8c2d8c9d7b)


#### How does it address the issue?
* Catch all ClientError and transform them to click exceptions.
![Screen Shot 2023-05-10 at 2 05 41 PM](https://github.com/aws/aws-sam-cli/assets/3770774/f36947eb-3232-463b-a3ff-3aaf3453d079)


#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
