### PR TITLE
feat: Add support for translating and linking gateway integrations

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
@@ -4,6 +4,7 @@ Terraform prepare property builder
 from typing import Any, Dict, Optional
 
 from samcli.hook_packages.terraform.hooks.prepare.resource_linking import _resolve_resource_attribute
+from samcli.hook_packages.terraform.hooks.prepare.resources.internal import INTERNAL_API_GATEWAY_INTEGRATION
 from samcli.hook_packages.terraform.hooks.prepare.types import (
     PropertyBuilder,
     PropertyBuilderMapping,
@@ -27,6 +28,7 @@ TF_AWS_API_GATEWAY_RESOURCE = "aws_api_gateway_resource"
 TF_AWS_API_GATEWAY_REST_API = "aws_api_gateway_rest_api"
 TF_AWS_API_GATEWAY_STAGE = "aws_api_gateway_stage"
 TF_AWS_API_GATEWAY_METHOD = "aws_api_gateway_method"
+TF_AWS_API_GATEWAY_INTEGRATION = "aws_api_gateway_integration"
 
 
 def _build_code_property(tf_properties: dict, resource: TFResource) -> Any:
@@ -250,6 +252,16 @@ AWS_API_GATEWAY_METHOD_PROPERTY_BUILDER_MAPPING: PropertyBuilderMapping = {
     "OperationName": _get_property_extractor("operation_name"),
 }
 
+AWS_API_GATEWAY_INTEGRATION_PROPERTY_BUILDER_MAPPING: PropertyBuilderMapping = {
+    "RestApiId": _get_property_extractor("rest_api_id"),
+    "ResourceId": _get_property_extractor("resource_id"),
+    "HttpMethod": _get_property_extractor("http_method"),
+    "Uri": _get_property_extractor("uri"),
+    "Type": _get_property_extractor("type"),
+    "ContentHandling": _get_property_extractor("content_handling"),
+    "ConnectionType": _get_property_extractor("connection_type"),
+}
+
 RESOURCE_TRANSLATOR_MAPPING: Dict[str, ResourceTranslator] = {
     TF_AWS_LAMBDA_FUNCTION: ResourceTranslator(CFN_AWS_LAMBDA_FUNCTION, AWS_LAMBDA_FUNCTION_PROPERTY_BUILDER_MAPPING),
     TF_AWS_LAMBDA_LAYER_VERSION: ResourceTranslator(
@@ -266,5 +278,8 @@ RESOURCE_TRANSLATOR_MAPPING: Dict[str, ResourceTranslator] = {
     ),
     TF_AWS_API_GATEWAY_METHOD: ResourceTranslator(
         CFN_AWS_APIGATEWAY_METHOD, AWS_API_GATEWAY_METHOD_PROPERTY_BUILDER_MAPPING
+    ),
+    TF_AWS_API_GATEWAY_INTEGRATION: ResourceTranslator(
+        INTERNAL_API_GATEWAY_INTEGRATION, AWS_API_GATEWAY_INTEGRATION_PROPERTY_BUILDER_MAPPING
     ),
 }

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/internal.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/internal.py
@@ -10,5 +10,6 @@ class InternalApiGatewayIntegrationProperties(ResourceProperties):
     Collect resource properties for translating and linking an aws_api_gateway_integration
     to the AWS::ApiGateway::Method resource
     """
+
     def __init__(self):
         super(InternalApiGatewayIntegrationProperties, self).__init__()

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/internal.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/internal.py
@@ -5,6 +5,7 @@ INTERNAL_PREFIX = "Internal::"
 INTERNAL_API_GATEWAY_INTEGRATION = f"{INTERNAL_PREFIX}ApiGateway::Method::Integration"
 
 
+# TODO(mladan): Add a mechanism for gating internal resources from being added to the metadata file
 class InternalApiGatewayIntegrationProperties(ResourceProperties):
     """
     Collect resource properties for translating and linking an aws_api_gateway_integration

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/internal.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/internal.py
@@ -1,0 +1,14 @@
+"""Module containing logic specific to internal resources handling during the prepare hook execution"""
+from samcli.hook_packages.terraform.hooks.prepare.types import ResourceProperties
+
+INTERNAL_PREFIX = "Internal::"
+INTERNAL_API_GATEWAY_INTEGRATION = f"{INTERNAL_PREFIX}ApiGateway::Method::Integration"
+
+
+class InternalApiGatewayIntegrationProperties(ResourceProperties):
+    """
+    Collect resource properties for translating and linking an aws_api_gateway_integration
+    to the AWS::ApiGateway::Method resource
+    """
+    def __init__(self):
+        super(InternalApiGatewayIntegrationProperties, self).__init__()

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/resource_properties.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/resource_properties.py
@@ -2,6 +2,7 @@
 from typing import Dict
 
 from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
+    TF_AWS_API_GATEWAY_INTEGRATION,
     TF_AWS_API_GATEWAY_METHOD,
     TF_AWS_API_GATEWAY_RESOURCE,
     TF_AWS_API_GATEWAY_REST_API,
@@ -15,6 +16,7 @@ from samcli.hook_packages.terraform.hooks.prepare.resources.apigw import (
     ApiGatewayRestApiProperties,
     ApiGatewayStageProperties,
 )
+from samcli.hook_packages.terraform.hooks.prepare.resources.internal import InternalApiGatewayIntegrationProperties
 from samcli.hook_packages.terraform.hooks.prepare.resources.lambda_function import LambdaFunctionProperties
 from samcli.hook_packages.terraform.hooks.prepare.resources.lambda_layers import LambdaLayerVersionProperties
 from samcli.hook_packages.terraform.hooks.prepare.types import ResourceProperties
@@ -38,4 +40,5 @@ def get_resource_property_mapping() -> Dict[str, ResourceProperties]:
         TF_AWS_API_GATEWAY_REST_API: ApiGatewayRestApiProperties(),
         TF_AWS_API_GATEWAY_METHOD: ApiGatewayMethodProperties(),
         TF_AWS_API_GATEWAY_STAGE: ApiGatewayStageProperties(),
+        TF_AWS_API_GATEWAY_INTEGRATION: InternalApiGatewayIntegrationProperties(),
     }

--- a/samcli/hook_packages/terraform/hooks/prepare/translate.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/translate.py
@@ -49,6 +49,7 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     _resolve_resource_attribute,
 )
 from samcli.hook_packages.terraform.hooks.prepare.resources.apigw import RESTAPITranslationValidator
+from samcli.hook_packages.terraform.hooks.prepare.resources.internal import INTERNAL_PREFIX
 from samcli.hook_packages.terraform.hooks.prepare.resources.resource_properties import get_resource_property_mapping
 from samcli.hook_packages.terraform.hooks.prepare.types import (
     CodeResourceProperties,
@@ -221,7 +222,11 @@ def translate_to_cfn(tf_json: dict, output_directory_path: str, terraform_applic
             logical_id = build_cfn_logical_id(resource_full_address)
 
             # Add resource to cfn dict
-            cfn_dict["Resources"][logical_id] = translated_resource
+            if not translated_resource.get("Type", "").startswith(INTERNAL_PREFIX):
+                # Internal resources are ones used for the purpose of translation, they are not real CFN resources.
+                # These are usually resources that exist in other IaCs that don't map 1:1 with CFN resources, but their
+                # properties need to be mapped to other, existing CFN resources.
+                cfn_dict["Resources"][logical_id] = translated_resource
 
             resource_translation_properties = ResourceTranslationProperties(
                 resource=resource,

--- a/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
@@ -12,6 +12,7 @@ from samcli.lib.utils.resources import (
     AWS_APIGATEWAY_STAGE,
     AWS_APIGATEWAY_METHOD,
 )
+from samcli.hook_packages.terraform.hooks.prepare.resources.internal import INTERNAL_API_GATEWAY_INTEGRATION
 
 
 class PrepareHookUnitBase(TestCase):
@@ -42,6 +43,7 @@ class PrepareHookUnitBase(TestCase):
         self.apigw_stage_name = "my_stage"
         self.apigw_rest_api_name = "my_rest_api"
         self.apigw_method_name = "my_method"
+        self.apigw_integration_name = "my_integration"
 
         self.tf_function_common_properties: dict = {
             "function_name": self.zip_function_name,
@@ -322,6 +324,11 @@ class PrepareHookUnitBase(TestCase):
             "provider_name": AWS_PROVIDER_NAME,
         }
 
+        self.tf_apigw_integration_common_attributes: dict = {
+            "type": "aws_api_gateway_integration",
+            "provider_name": AWS_PROVIDER_NAME,
+        }
+
         self.tf_apigw_method_common_attributes: dict = {
             "type": "aws_api_gateway_method",
             "provider_name": AWS_PROVIDER_NAME,
@@ -521,6 +528,39 @@ class PrepareHookUnitBase(TestCase):
             "Metadata": {"SamResourceId": f"aws_api_gateway_resource.{self.apigw_resource_name}"},
         }
 
+        self.tf_apigw_integration_properties: dict = {
+            "rest_api_id": "aws_api_gateway_rest_api.MyDemoAPI.id",
+            "resource_id": "aws_api_gateway_resource.MyResource.id",
+            "http_method": "POST",
+            "type": "AWS_PROXY",
+            "uri": "https://www.google.com",
+            "content_handling": "CONVERT_TO_TEXT",
+            "connection_type": "INTERNET",
+        }
+
+        self.expected_internal_apigw_integration_properties: dict = {
+            "RestApiId": "aws_api_gateway_rest_api.MyDemoAPI.id",
+            "ResourceId": "aws_api_gateway_resource.MyResource.id",
+            "HttpMethod": "POST",
+            "Type": "AWS_PROXY",
+            "Uri": "https://www.google.com",
+            "ContentHandling": "CONVERT_TO_TEXT",
+            "ConnectionType": "INTERNET",
+        }
+
+        self.tf_apigw_integration_resource: dict = {
+            **self.tf_apigw_integration_common_attributes,
+            "values": self.tf_apigw_integration_properties,
+            "address": f"aws_api_gateway_integration.{self.apigw_integration_name}",
+            "name": self.apigw_integration_name,
+        }
+
+        self.expected_internal_apigw_integration: dict = {
+            "Type": INTERNAL_API_GATEWAY_INTEGRATION,
+            "Properties": self.expected_internal_apigw_integration_properties,
+            "Metadata": {"SamResourceId": f"aws_api_gateway_integration.{self.apigw_integration_name}"},
+        }
+
         self.tf_apigw_method_properties: dict = {
             "rest_api_id": "aws_api_gateway_rest_api.MyDemoAPI.id",
             "resource_id": "aws_api_gateway_resource.MyDemoResource.id",
@@ -623,6 +663,7 @@ class PrepareHookUnitBase(TestCase):
                         self.tf_apigw_rest_api_resource,
                         self.tf_apigw_stage_resource,
                         self.tf_apigw_method_resource,
+                        self.tf_apigw_integration_resource,
                     ]
                 }
             }

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -38,6 +38,7 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     TF_AWS_API_GATEWAY_METHOD,
     TF_AWS_API_GATEWAY_RESOURCE,
     TF_AWS_API_GATEWAY_STAGE,
+    TF_AWS_API_GATEWAY_INTEGRATION,
 )
 from samcli.hook_packages.terraform.hooks.prepare.types import (
     SamMetadataResource,
@@ -488,6 +489,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         gateway_method_properties_mock = Mock()
         gateway_resource_properties_mock = Mock()
         gateway_stage_properties_mock = Mock()
+        internal_gateway_integration_properties_mock = Mock()
         mock_resource_property_mapping.return_value = {
             TF_AWS_LAMBDA_FUNCTION: lambda_properties_mock,
             TF_AWS_LAMBDA_LAYER_VERSION: lambda_layer_properties_mock,
@@ -495,6 +497,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
             TF_AWS_API_GATEWAY_METHOD: gateway_method_properties_mock,
             TF_AWS_API_GATEWAY_RESOURCE: gateway_resource_properties_mock,
             TF_AWS_API_GATEWAY_STAGE: gateway_stage_properties_mock,
+            TF_AWS_API_GATEWAY_INTEGRATION: internal_gateway_integration_properties_mock,
         }
 
         translated_cfn_dict = translate_to_cfn(

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -24,6 +24,7 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
     API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
 )
+from samcli.hook_packages.terraform.hooks.prepare.resources.internal import INTERNAL_PREFIX
 from tests.unit.hook_packages.terraform.hooks.prepare.prepare_base import PrepareHookUnitBase
 from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     AWS_LAMBDA_FUNCTION_PROPERTY_BUILDER_MAPPING,
@@ -39,6 +40,7 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     TF_AWS_API_GATEWAY_RESOURCE,
     TF_AWS_API_GATEWAY_STAGE,
     TF_AWS_API_GATEWAY_INTEGRATION,
+    AWS_API_GATEWAY_INTEGRATION_PROPERTY_BUILDER_MAPPING,
 )
 from samcli.hook_packages.terraform.hooks.prepare.types import (
     SamMetadataResource,
@@ -1634,3 +1636,9 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
             self.tf_apigw_method_properties, AWS_API_GATEWAY_METHOD_PROPERTY_BUILDER_MAPPING, Mock()
         )
         self.assertEqual(translated_cfn_properties, self.expected_cfn_apigw_method_properties)
+
+    def test_translating_apigw_integration_method(self):
+        translated_cfn_properties = _translate_properties(
+            self.tf_apigw_integration_properties, AWS_API_GATEWAY_INTEGRATION_PROPERTY_BUILDER_MAPPING, Mock()
+        )
+        self.assertEqual(translated_cfn_properties, self.expected_internal_apigw_integration_properties)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
To support sam local start-api for Terraform resources, we need to read in the APIGW methods and convert them to the corresponding CFN resources.

#### How does it address the issue?
Adds a new "Internal" resource type for translating resources that exist in Terraform but not in CFN. These resources are stored temporarily to handle necessary linking and translation logic, but are not written to the metadata file.

Creates the first internal resource `Internal::ApiGateway::Method::Integration`

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
