### PR TITLE
fix: Allow SAM-T version update GHA to get latest tag

### DIFF
--- a/.github/workflows/automated-updates-to-sam-cli.yml
+++ b/.github/workflows/automated-updates-to-sam-cli.yml
@@ -64,6 +64,7 @@ jobs:
           repository: aws/serverless-application-model
           path: serverless-application-model
           ref: main
+          fetch-depth: 0
       
       - name: Checkout SAM CLI
         uses: actions/checkout@v3
@@ -81,11 +82,13 @@ jobs:
           git config --global user.name "GitHub Action"
           cd serverless-application-model
           SAM_T_CUR_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+          echo "SAM-T cur version is $SAM_T_CUR_VERSION"
           cd ../aws-sam-cli
           git checkout -b update_sam_transform_version
           SAM_T_PRE_VERSION=$(grep "aws-sam-translator=" requirements/base.txt)
+          echo "SAM-T pre version is $SAM_T_PRE_VERSION"
           git reset --hard develop
-          sed -i "s/aws-sam-translator=$SAM_T_CUR_VERSION/$SAM_T_PRE_VERSION/g" requirements/base.txt; make update-reproducible-reqs
+          sed -i "s/$SAM_T_PRE_VERSION/aws-sam-translator==$SAM_T_CUR_VERSION/g" requirements/base.txt; make update-reproducible-reqs
           cp -r ../serverless-application-model/tests/translator/input ./tests/functional/commands/validate/lib/models
           git status
           git diff --quiet && exit 0 # exit if there is no change


### PR DESCRIPTION
There are two issues this patch fixes:
1) the sed for updating the SAM-T version was flipped causing an invalid base.txt
2) The default fetch depth is 1 causing only the latest commit to be pulled. For some reason, this causes the tag "git describe" returns nothing. With a fetch depth of 0, we get the right value.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
none

#### Why is this change necessary?
See above commit message

#### How does it address the issue?
See above commit message

#### What side effects does this change have?
None

Proof it works this time :) https://github.com/jfuss/aws-sam-cli/actions/runs/4943420245/jobs/8837895491

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
