### PR TITLE
fix: Clean up lingering test file

### DIFF
--- a/tests/unit/local/lambdafn/test_remote_files.py
+++ b/tests/unit/local/lambdafn/test_remote_files.py
@@ -1,10 +1,21 @@
 from unittest.case import TestCase
 from unittest.mock import patch, Mock
 
+from pathlib import Path
+
 from samcli.local.lambdafn.remote_files import unzip_from_uri
 
 
 class TestUnzipFromUri(TestCase):
+    def setUp(self):
+        self.layer_path = "layer_zip_path"
+
+    def tearDown(self):
+        layer_path = Path(self.layer_path)
+
+        if layer_path.exists():
+            layer_path.unlink()
+
     @patch("samcli.local.lambdafn.remote_files.unzip")
     @patch("samcli.local.lambdafn.remote_files.Path")
     @patch("samcli.local.lambdafn.remote_files.progressbar")
@@ -25,14 +36,14 @@ class TestUnzipFromUri(TestCase):
 
         os_patch.environ.get.return_value = True
 
-        unzip_from_uri("uri", "layer_zip_path", "output_zip_dir", "layer_arn")
+        unzip_from_uri("uri", self.layer_path, "output_zip_dir", "layer_arn")
 
         requests_patch.get.assert_called_with("uri", stream=True, verify=True)
         get_request_mock.iter_content.assert_called_with(chunk_size=None)
         progressbar_mock.update.assert_called_with(5)
-        path_patch.assert_called_with("layer_zip_path")
+        path_patch.assert_called_with(self.layer_path)
         path_mock.unlink.assert_called()
-        unzip_patch.assert_called_with("layer_zip_path", "output_zip_dir", permission=0o700)
+        unzip_patch.assert_called_with(self.layer_path, "output_zip_dir", permission=0o700)
         os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", True)
 
     @patch("samcli.local.lambdafn.remote_files.unzip")
@@ -57,14 +68,14 @@ class TestUnzipFromUri(TestCase):
 
         os_patch.environ.get.return_value = True
 
-        unzip_from_uri("uri", "layer_zip_path", "output_zip_dir", "layer_arn")
+        unzip_from_uri("uri", self.layer_path, "output_zip_dir", "layer_arn")
 
         requests_patch.get.assert_called_with("uri", stream=True, verify=True)
         get_request_mock.iter_content.assert_called_with(chunk_size=None)
         progressbar_mock.update.assert_called_with(5)
-        path_patch.assert_called_with("layer_zip_path")
+        path_patch.assert_called_with(self.layer_path)
         path_mock.unlink.assert_not_called()
-        unzip_patch.assert_called_with("layer_zip_path", "output_zip_dir", permission=0o700)
+        unzip_patch.assert_called_with(self.layer_path, "output_zip_dir", permission=0o700)
         os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", True)
 
     @patch("samcli.local.lambdafn.remote_files.unzip")
@@ -89,12 +100,12 @@ class TestUnzipFromUri(TestCase):
 
         os_patch.environ.get.return_value = "/some/path/on/the/system"
 
-        unzip_from_uri("uri", "layer_zip_path", "output_zip_dir", "layer_arn")
+        unzip_from_uri("uri", self.layer_path, "output_zip_dir", "layer_arn")
 
         requests_patch.get.assert_called_with("uri", stream=True, verify="/some/path/on/the/system")
         get_request_mock.iter_content.assert_called_with(chunk_size=None)
         progressbar_mock.update.assert_called_with(5)
-        path_patch.assert_called_with("layer_zip_path")
+        path_patch.assert_called_with(self.layer_path)
         path_mock.unlink.assert_called()
-        unzip_patch.assert_called_with("layer_zip_path", "output_zip_dir", permission=0o700)
+        unzip_patch.assert_called_with(self.layer_path, "output_zip_dir", permission=0o700)
         os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", True)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
When running some of the tests, a lingering `layer_zip_path` file remained after all the tests have been run.

#### How does it address the issue?
The test mock out the `Path` object, causing the actual call to unlink the file to not do anything. This adds a `tearDown` method to actually remove the file after each test run.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
