### PR TITLE
fix: `sam local invoke -e` crashes on non existent file

### DIFF
--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -171,7 +171,7 @@ def do_cli(  # pylint: disable=R0914
     LOG.debug("local invoke command is called")
 
     if event:
-        event_data = _get_event(event)
+        event_data = _get_event(event, exception_class=UserException)
     else:
         event_data = "{}"
 
@@ -226,7 +226,7 @@ def do_cli(  # pylint: disable=R0914
         raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex
 
 
-def _get_event(event_file_name):
+def _get_event(event_file_name, exception_class):
     """
     Read the event JSON data from the given file. If no file is provided, read the event from stdin.
 
@@ -240,5 +240,8 @@ def _get_event(event_file_name):
 
     # click.open_file knows to open stdin when filename is '-'. This is safer than manually opening streams, and
     # accidentally closing a standard stream
-    with click.open_file(event_file_name, "r", encoding="utf-8") as fp:
-        return fp.read()
+    try:
+        with click.open_file(event_file_name, "r", encoding="utf-8") as fp:
+            return fp.read()
+    except FileNotFoundError as ex:
+        raise exception_class(str(ex), wrapped_from=ex.__class__.__name__) from ex


### PR DESCRIPTION
#### Which issue(s) does this change fix?

Before
![Screen Shot 2023-05-11 at 1 22 56 PM](https://github.com/aws/aws-sam-cli/assets/3770774/d8b23009-c7e5-46cb-aac1-d0eccd9d2b5a)
After
![Screen Shot 2023-05-11 at 1 23 29 PM](https://github.com/aws/aws-sam-cli/assets/3770774/dd063bf2-cf26-4c15-bc7c-945a4eec1aef)



#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
