### PR TITLE
fix: Install both Py3.7 and Py3.11 in GHA to upgrade SAM-T

### DIFF
--- a/.github/workflows/automated-updates-to-sam-cli.yml
+++ b/.github/workflows/automated-updates-to-sam-cli.yml
@@ -74,7 +74,9 @@ jobs:
       
       - uses: actions/setup-python@v4 # used for make update-reproducible-reqs below
         with:
-          python-version: "3.7"
+          python-version: |
+            3.7
+            3.11
 
       - name: Update aws-sam-translator & commit
         run: |


### PR DESCRIPTION
Due to recent changes of upgrading linux installer from 3.7 to 3.11, we need to have both available in the GHA or the job will fail.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Get the `updateSAMTranslator` GHA to run properly

#### How does it address the issue?
Installs both Python3.7 and Python3.11 in the GHA

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
