### PR TITLE
feat: map gateway integration response resources to integration method resources

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
@@ -153,6 +153,36 @@ class LambdaFunctionToApiGatewayIntegrationLocalVariablesLinkingLimitationExcept
     """
 
 
+class OneRestApiToApiGatewayIntegrationResponseLinkingLimitationException(OneResourceLinkingLimitationException):
+    """
+    Exception specific for Gateway Integration Response linking to more than one Rest API
+    """
+
+
+class RestApiToApiGatewayIntegrationResponseLocalVariablesLinkingLimitationException(
+    LocalVariablesLinkingLimitationException
+):
+    """
+    Exception specific for Gateway Integration Response linking to Rest API using locals.
+    """
+
+
+class OneGatewayResourceToApiGatewayIntegrationResponseLinkingLimitationException(
+    OneResourceLinkingLimitationException
+):
+    """
+    Exception specific for Gateway Integration Response linking to more than one Gateway resource
+    """
+
+
+class GatewayResourceToApiGatewayIntegrationResponseLocalVariablesLinkingLimitationException(
+    LocalVariablesLinkingLimitationException
+):
+    """
+    Exception specific for Gateway Integration Response linking to Gateway Resource using locals.
+    """
+
+
 class InvalidSamMetadataPropertiesException(UserException):
     pass
 

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -10,21 +10,25 @@ from typing import Callable, Dict, List, Optional, Type, Union
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     FunctionLayerLocalVariablesLinkingLimitationException,
     GatewayResourceToApiGatewayIntegrationLocalVariablesLinkingLimitationException,
+    GatewayResourceToApiGatewayIntegrationResponseLocalVariablesLinkingLimitationException,
     GatewayResourceToApiGatewayMethodLocalVariablesLinkingLimitationException,
     GatewayResourceToGatewayRestApiLocalVariablesLinkingLimitationException,
     InvalidResourceLinkingException,
     LambdaFunctionToApiGatewayIntegrationLocalVariablesLinkingLimitationException,
     LocalVariablesLinkingLimitationException,
     OneGatewayResourceToApiGatewayIntegrationLinkingLimitationException,
+    OneGatewayResourceToApiGatewayIntegrationResponseLinkingLimitationException,
     OneGatewayResourceToApiGatewayMethodLinkingLimitationException,
     OneGatewayResourceToRestApiLinkingLimitationException,
     OneLambdaFunctionResourceToApiGatewayIntegrationLinkingLimitationException,
     OneLambdaLayerLinkingLimitationException,
     OneResourceLinkingLimitationException,
     OneRestApiToApiGatewayIntegrationLinkingLimitationException,
+    OneRestApiToApiGatewayIntegrationResponseLinkingLimitationException,
     OneRestApiToApiGatewayMethodLinkingLimitationException,
     OneRestApiToApiGatewayStageLinkingLimitationException,
     RestApiToApiGatewayIntegrationLocalVariablesLinkingLimitationException,
+    RestApiToApiGatewayIntegrationResponseLocalVariablesLinkingLimitationException,
     RestApiToApiGatewayMethodLocalVariablesLinkingLimitationException,
     RestApiToApiGatewayStageLocalVariablesLinkingLimitationException,
 )
@@ -1066,13 +1070,13 @@ def _link_gateway_resource_to_gateway_rest_apis_rest_api_id_call_back(
     gateway_cfn_resource: Dict, referenced_rest_apis_values: List[ReferenceType]
 ) -> None:
     """
-    Callback function that used by the linking algorithm to update an Api Gateway Method CFN Resource with
-    a reference to the Rest Api resource.
+    Callback function that used by the linking algorithm to update an Api Gateway resource
+    (Method, Integration, or Integration Response) CFN Resource with a reference to the Rest Api resource.
 
     Parameters
     ----------
     gateway_cfn_resource: Dict
-        API Gateway Method CFN resource
+        API Gateway CFN resource
     referenced_rest_apis_values: List[ReferenceType]
         List of referenced REST API either as the logical id of REST API resource defined in the customer project, or
         ARN values for actual REST API resource defined in customer's account. This list should always contain one
@@ -1080,7 +1084,7 @@ def _link_gateway_resource_to_gateway_rest_apis_rest_api_id_call_back(
     """
     # if the destination rest api list contains more than one element, so we have an issue in our linking logic
     if len(referenced_rest_apis_values) > 1:
-        raise InvalidResourceLinkingException("Could not link multiple Rest APIs to one Gateway method resource")
+        raise InvalidResourceLinkingException("Could not link multiple Rest APIs to one Gateway resource")
 
     logical_id = referenced_rest_apis_values[0]
     gateway_cfn_resource["Properties"]["RestApiId"] = (
@@ -1089,15 +1093,15 @@ def _link_gateway_resource_to_gateway_rest_apis_rest_api_id_call_back(
 
 
 def _link_gateway_resource_to_gateway_resource_call_back(
-    gateway_method_cfn_resource: Dict, referenced_gateway_resource_values: List[ReferenceType]
+    gateway_resource_cfn_resource: Dict, referenced_gateway_resource_values: List[ReferenceType]
 ) -> None:
     """
-    Callback function that is used by the linking algorithm to update an Api Gateway resource CFN Resource with
-    a reference to the Gateway Resource resource.
+    Callback function that is used by the linking algorithm to update an Api Gateway resource
+    (Method, Integration, or Integration Response) CFN with a reference to the Gateway Resource resource.
 
     Parameters
     ----------
-    gateway_method_cfn_resource: Dict
+    gateway_resource_cfn_resource: Dict
         API Gateway resource CFN resource
     referenced_gateway_resource_values: List[ReferenceType]
         List of referenced Gateway Resources either as the logical id of Gateway Resource resource
@@ -1105,12 +1109,10 @@ def _link_gateway_resource_to_gateway_resource_call_back(
         in customer's account. This list should always contain one element only.
     """
     if len(referenced_gateway_resource_values) > 1:
-        raise InvalidResourceLinkingException(
-            "Could not link multiple Gateway Resources to one Gateway method resource"
-        )
+        raise InvalidResourceLinkingException("Could not link multiple Gateway Resources to one Gateway resource")
 
     logical_id = referenced_gateway_resource_values[0]
-    gateway_method_cfn_resource["Properties"]["ResourceId"] = (
+    gateway_resource_cfn_resource["Properties"]["ResourceId"] = (
         {"Ref": logical_id.value} if isinstance(logical_id, LogicalIdReference) else logical_id.value
     )
 
@@ -1395,6 +1397,83 @@ def _link_gateway_integrations_to_function_resource(
         cfn_link_field_name="Uri",
         terraform_resource_type_prefix=LAMBDA_FUNCTION_RESOURCE_ADDRESS_PREFIX,
         cfn_resource_update_call_back_function=_link_gateway_integration_to_function_call_back,
+        linking_exceptions=exceptions,
+    )
+    ResourceLinker(resource_linking_pair).link_resources()
+
+
+def _link_gateway_integration_responses_to_gateway_rest_apis(
+    gateway_integration_responses_config_resources: Dict[str, TFResource],
+    gateway_integration_responses_config_address_cfn_resources_map: Dict[str, List],
+    rest_apis_terraform_resources: Dict[str, Dict],
+):
+    """
+    Iterate through all the resources and link the corresponding Rest API resource to each Gateway Integration Response
+    resource.
+
+    Parameters
+    ----------
+    gateway_integration_responses_config_resources: Dict[str, TFResource]
+        Dictionary of Terraform configuration Gateway Integration Response resources.
+    gateway_integration_responses_config_address_cfn_resources_map: Dict[str, List]
+        Dictionary containing resolved configuration addresses matched up to the internal mapped cfn Gateway
+        Integration Response.
+    rest_apis_terraform_resources: Dict[str, Dict]
+        Dictionary of all actual terraform Rest API resources (not configuration resources). The dictionary's key is the
+        calculated logical id for each resource.
+    """
+
+    exceptions = ResourcePairExceptions(
+        OneRestApiToApiGatewayIntegrationResponseLinkingLimitationException,
+        RestApiToApiGatewayIntegrationResponseLocalVariablesLinkingLimitationException,
+    )
+    resource_linking_pair = ResourceLinkingPair(
+        source_resource_cfn_resource=gateway_integration_responses_config_address_cfn_resources_map,
+        source_resource_tf_config=gateway_integration_responses_config_resources,
+        destination_resource_tf=rest_apis_terraform_resources,
+        tf_destination_attribute_name="id",
+        terraform_link_field_name="rest_api_id",
+        cfn_link_field_name="RestApiId",
+        terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+        cfn_resource_update_call_back_function=_link_gateway_resource_to_gateway_rest_apis_rest_api_id_call_back,
+        linking_exceptions=exceptions,
+    )
+    ResourceLinker(resource_linking_pair).link_resources()
+
+
+def _link_gateway_integration_responses_to_gateway_resource(
+    gateway_integration_responses_config_resources: Dict[str, TFResource],
+    gateway_integration_responses_config_address_cfn_resources_map: Dict[str, List],
+    gateway_resources_terraform_resources: Dict[str, Dict],
+):
+    """
+    Iterate through all the resources and link the corresponding Gateway Resource resource to each Gateway Integration
+    Response resource.
+    Parameters
+    ----------
+    gateway_integration_responses_config_resources: Dict[str, TFResource]
+        Dictionary of configuration Gateway Integration Response resources.
+    gateway_integration_responses_config_address_cfn_resources_map: Dict[str, List]
+        Dictionary containing resolved configuration addresses matched up to the internal mapped cfn Gateway
+        Integration Response.
+    gateway_resources_terraform_resources: Dict[str, Dict]
+        Dictionary of all actual terraform Rest API resources (not configuration resources). The dictionary's key is the
+        calculated logical id for each resource.
+    """
+
+    exceptions = ResourcePairExceptions(
+        OneGatewayResourceToApiGatewayIntegrationResponseLinkingLimitationException,
+        GatewayResourceToApiGatewayIntegrationResponseLocalVariablesLinkingLimitationException,
+    )
+    resource_linking_pair = ResourceLinkingPair(
+        source_resource_cfn_resource=gateway_integration_responses_config_address_cfn_resources_map,
+        source_resource_tf_config=gateway_integration_responses_config_resources,
+        destination_resource_tf=gateway_resources_terraform_resources,
+        tf_destination_attribute_name="id",
+        terraform_link_field_name="resource_id",
+        cfn_link_field_name="ResourceId",
+        terraform_resource_type_prefix=API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
+        cfn_resource_update_call_back_function=_link_gateway_resource_to_gateway_resource_call_back,
         linking_exceptions=exceptions,
     )
     ResourceLinker(resource_linking_pair).link_resources()

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/resource_links.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/resource_links.py
@@ -2,6 +2,7 @@ from typing import List
 
 from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     TF_AWS_API_GATEWAY_INTEGRATION,
+    TF_AWS_API_GATEWAY_INTEGRATION_RESPONSE,
     TF_AWS_API_GATEWAY_METHOD,
     TF_AWS_API_GATEWAY_RESOURCE,
     TF_AWS_API_GATEWAY_REST_API,
@@ -10,6 +11,8 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     TF_AWS_LAMBDA_LAYER_VERSION,
 )
 from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
+    _link_gateway_integration_responses_to_gateway_resource,
+    _link_gateway_integration_responses_to_gateway_rest_apis,
     _link_gateway_integrations_to_function_resource,
     _link_gateway_integrations_to_gateway_resource,
     _link_gateway_integrations_to_gateway_rest_apis,
@@ -57,5 +60,15 @@ RESOURCE_LINKS: List[LinkingPairCaller] = [
         source=TF_AWS_API_GATEWAY_INTEGRATION,
         dest=TF_AWS_LAMBDA_FUNCTION,
         linking_func=_link_gateway_integrations_to_function_resource,
+    ),
+    LinkingPairCaller(
+        source=TF_AWS_API_GATEWAY_INTEGRATION_RESPONSE,
+        dest=TF_AWS_API_GATEWAY_REST_API,
+        linking_func=_link_gateway_integration_responses_to_gateway_rest_apis,
+    ),
+    LinkingPairCaller(
+        source=TF_AWS_API_GATEWAY_INTEGRATION_RESPONSE,
+        dest=TF_AWS_API_GATEWAY_RESOURCE,
+        linking_func=_link_gateway_integration_responses_to_gateway_resource,
     ),
 ]

--- a/samcli/hook_packages/terraform/hooks/prepare/translate.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/translate.py
@@ -16,6 +16,7 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
     REMOTE_DUMMY_VALUE,
     RESOURCE_TRANSLATOR_MAPPING,
     TF_AWS_API_GATEWAY_INTEGRATION,
+    TF_AWS_API_GATEWAY_INTEGRATION_RESPONSE,
     TF_AWS_API_GATEWAY_METHOD,
     TF_AWS_API_GATEWAY_REST_API,
     PropertyBuilderMapping,
@@ -26,6 +27,7 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
 )
 from samcli.hook_packages.terraform.hooks.prepare.resources.apigw import (
     RESTAPITranslationValidator,
+    add_integration_responses_to_methods,
     add_integrations_to_methods,
 )
 from samcli.hook_packages.terraform.hooks.prepare.resources.internal import INTERNAL_PREFIX
@@ -236,6 +238,11 @@ def translate_to_cfn(tf_json: dict, output_directory_path: str, terraform_applic
     add_integrations_to_methods(
         resource_property_mapping.get(TF_AWS_API_GATEWAY_METHOD, ResourceProperties()).cfn_resources,
         resource_property_mapping.get(TF_AWS_API_GATEWAY_INTEGRATION, ResourceProperties()).cfn_resources,
+    )
+
+    add_integration_responses_to_methods(
+        resource_property_mapping.get(TF_AWS_API_GATEWAY_METHOD, ResourceProperties()).cfn_resources,
+        resource_property_mapping.get(TF_AWS_API_GATEWAY_INTEGRATION_RESPONSE, ResourceProperties()).cfn_resources,
     )
 
     if sam_metadata_resources:

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -76,6 +76,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
             self.assertEqual(translated_cfn_dict, expected_empty_cfn_dict)
             mock_enrich_resources_and_generate_makefile.assert_not_called()
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.translate.add_integration_responses_to_methods")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.add_integrations_to_methods")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._handle_linking")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._check_dummy_remote_values")
@@ -92,6 +93,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         mock_check_dummy_remote_values,
         mock_handle_linking,
         mock_add_integrations_to_methods,
+        mock_add_integration_responses_to_methods,
     ):
         root_module = MagicMock()
         root_module.get.return_value = "module.m1"
@@ -123,6 +125,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         )
         mock_validator.return_value.validate.assert_called_once()
         mock_add_integrations_to_methods.assert_called_once()
+        mock_add_integration_responses_to_methods.assert_called_once()
 
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._resolve_resource_attribute")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._check_dummy_remote_values")
@@ -206,6 +209,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         mock_handle_linking.assert_called_once()
         mock_check_dummy_remote_values.assert_called_once_with(translated_cfn_dict.get("Resources"))
 
+    @patch("samcli.hook_packages.terraform.hooks.prepare.translate.add_integration_responses_to_methods")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.add_integrations_to_methods")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate._handle_linking")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.get_resource_property_mapping")
@@ -230,6 +234,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         mock_resource_property_mapping,
         mock_handle_linking,
         mock_add_integrations_to_methods,
+        mock_add_integration_responses_to_methods,
     ):
         root_module = MagicMock()
         root_module.get.return_value = "module.m1"


### PR DESCRIPTION
#### Why is this change necessary?
Link the internal CFN mapped integration response resources to the RestAPIs, and Gateway Resource resources, then update the Integration Method CFN resources that match these integration response resources.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
