### PR TITLE
feat: update remote invoke context to actually invoke the executor

### DIFF
--- a/samcli/commands/remote_invoke/exceptions.py
+++ b/samcli/commands/remote_invoke/exceptions.py
@@ -18,3 +18,7 @@ class AmbiguousResourceForRemoteInvoke(UserException):
 
 class UnsupportedServiceForRemoteInvoke(UserException):
     pass
+
+
+class NoExecutorFoundForRemoteInvoke(UserException):
+    pass

--- a/samcli/commands/remote_invoke/remote_invoke_context.py
+++ b/samcli/commands/remote_invoke/remote_invoke_context.py
@@ -99,7 +99,9 @@ class RemoteInvokeContext:
             self._resource_summary = self._get_from_physical_resource_id()
             return
 
-        self._resource_summary = get_resource_summary(self._boto_resource_provider, self._stack_name, self._resource_id)
+        self._resource_summary = get_resource_summary(
+            self._boto_resource_provider, self._boto_client_provider, self._stack_name, self._resource_id
+        )
 
     def _get_single_resource_from_stack(self) -> CloudFormationResourceSummary:
         """

--- a/samcli/commands/remote_invoke/remote_invoke_context.py
+++ b/samcli/commands/remote_invoke/remote_invoke_context.py
@@ -7,14 +7,18 @@ from typing import Optional, cast
 from samcli.commands.remote_invoke.exceptions import (
     AmbiguousResourceForRemoteInvoke,
     InvalidRemoteInvokeParameters,
+    NoExecutorFoundForRemoteInvoke,
     NoResourceFoundForRemoteInvoke,
     UnsupportedServiceForRemoteInvoke,
 )
+from samcli.lib.remote_invoke.remote_invoke_executor_factory import RemoteInvokeExecutorFactory
+from samcli.lib.remote_invoke.remote_invoke_executors import RemoteInvokeExecutionInfo
 from samcli.lib.utils.arn_utils import ARNParts, InvalidArnValue
 from samcli.lib.utils.boto_utils import BotoProviderType
 from samcli.lib.utils.cloudformation import (
     CloudFormationResourceSummary,
     get_resource_summaries,
+    get_resource_summary,
     get_resource_summary_from_physical_id,
 )
 from samcli.lib.utils.resources import AWS_LAMBDA_FUNCTION
@@ -53,8 +57,21 @@ class RemoteInvokeContext:
     def __exit__(self, *args) -> None:
         pass
 
-    def run(self):
-        pass
+    def run(self, remote_invoke_input: RemoteInvokeExecutionInfo) -> RemoteInvokeExecutionInfo:
+        if not self._resource_summary:
+            raise AmbiguousResourceForRemoteInvoke(
+                f"Can't find resource information from stack name ({self._stack_name}) "
+                f"and resource id ({self._resource_id})"
+            )
+
+        remote_invoke_executor_factory = RemoteInvokeExecutorFactory(self._boto_client_provider)
+        remote_invoke_executor = remote_invoke_executor_factory.create_remote_invoke_executor(self._resource_summary)
+        if not remote_invoke_executor:
+            raise NoExecutorFoundForRemoteInvoke(
+                f"Resource type {self._resource_summary.resource_type} is not supported for remote invoke"
+            )
+
+        return remote_invoke_executor.execute(remote_invoke_input)
 
     def _populate_resource_summary(self) -> None:
         """
@@ -75,10 +92,19 @@ class RemoteInvokeContext:
             # no resource id provided, list all resources from stack and try to find one
             self._resource_summary = self._get_single_resource_from_stack()
             self._resource_id = self._resource_summary.logical_resource_id
+            return
 
         if not self._stack_name:
             # no stack name provided, resource id should be physical id so that we can use it
             self._resource_summary = self._get_from_physical_resource_id()
+            return
+
+        self._resource_summary = get_resource_summary(self._boto_resource_provider, self._stack_name, self._resource_id)
+        if not self._resource_summary:
+            raise AmbiguousResourceForRemoteInvoke(
+                f"Can't find resource information from stack name ({self._stack_name}) "
+                f"and resource id ({self._resource_id})"
+            )
 
     def _get_single_resource_from_stack(self) -> CloudFormationResourceSummary:
         """

--- a/samcli/commands/remote_invoke/remote_invoke_context.py
+++ b/samcli/commands/remote_invoke/remote_invoke_context.py
@@ -100,11 +100,6 @@ class RemoteInvokeContext:
             return
 
         self._resource_summary = get_resource_summary(self._boto_resource_provider, self._stack_name, self._resource_id)
-        if not self._resource_summary:
-            raise AmbiguousResourceForRemoteInvoke(
-                f"Can't find resource information from stack name ({self._stack_name}) "
-                f"and resource id ({self._resource_id})"
-            )
 
     def _get_single_resource_from_stack(self) -> CloudFormationResourceSummary:
         """

--- a/samcli/commands/remote_invoke/remote_invoke_context.py
+++ b/samcli/commands/remote_invoke/remote_invoke_context.py
@@ -58,6 +58,22 @@ class RemoteInvokeContext:
         pass
 
     def run(self, remote_invoke_input: RemoteInvokeExecutionInfo) -> RemoteInvokeExecutionInfo:
+        """
+        Instantiates remote invoke executor with populated resource summary information, executes it with the provided
+        input & returns its response back to the caller. If no executor can be instantiated it raises
+        NoExecutorFoundForRemoteInvoke exception.
+
+        Parameters
+        ----------
+        remote_invoke_input: RemoteInvokeExecutionInfo
+            RemoteInvokeExecutionInfo which contains the payload and other information that will be required during
+            the invocation
+
+        Returns
+        -------
+        RemoteInvokeExecutionInfo
+            Populates result and exception info (if any) and returns back to the caller
+        """
         if not self._resource_summary:
             raise AmbiguousResourceForRemoteInvoke(
                 f"Can't find resource information from stack name ({self._stack_name}) "

--- a/samcli/lib/utils/cloudformation.py
+++ b/samcli/lib/utils/cloudformation.py
@@ -127,7 +127,10 @@ def get_resource_summaries(
 
 
 def get_resource_summary(
-    boto_resource_provider: BotoProviderType, stack_name: str, resource_logical_id: str
+    boto_resource_provider: BotoProviderType,
+    boto_client_provider: BotoProviderType,
+    stack_name: str,
+    resource_logical_id: str,
 ) -> Optional[CloudFormationResourceSummary]:
     """
     Returns resource summary of given single resource with its logical id
@@ -136,6 +139,8 @@ def get_resource_summary(
     ----------
     boto_resource_provider : BotoProviderType
         A callable which will return boto3 resource
+    boto_client_provider : BotoProviderType
+        A callable which will return boto3 client
     stack_name : str
         Name of the stack which is deployed to CFN
     resource_logical_id : str
@@ -145,19 +150,12 @@ def get_resource_summary(
     -------
         CloudFormationResourceSummary of the resource which is identified by given logical id
     """
-    try:
-        cfn_resource_summary = boto_resource_provider("cloudformation").StackResource(stack_name, resource_logical_id)
+    cfn_resource_summaries = get_resource_summaries(boto_resource_provider, boto_client_provider, stack_name)
+    for logical_id, cfn_resource_summary in cfn_resource_summaries.items():
+        if logical_id == resource_logical_id:
+            return cfn_resource_summary
 
-        return CloudFormationResourceSummary(
-            cfn_resource_summary.resource_type,
-            cfn_resource_summary.logical_resource_id,
-            cfn_resource_summary.physical_resource_id,
-        )
-    except ClientError as e:
-        LOG.error(
-            "Failed to pull resource (%s) information from stack (%s)", resource_logical_id, stack_name, exc_info=e
-        )
-        return None
+    return None
 
 
 def get_resource_summary_from_physical_id(

--- a/tests/unit/commands/remote_invoke/test_remote_invoke_context.py
+++ b/tests/unit/commands/remote_invoke/test_remote_invoke_context.py
@@ -7,6 +7,7 @@ from samcli.commands.remote_invoke.exceptions import (
     AmbiguousResourceForRemoteInvoke,
     NoResourceFoundForRemoteInvoke,
     UnsupportedServiceForRemoteInvoke,
+    NoExecutorFoundForRemoteInvoke,
 )
 from samcli.commands.remote_invoke.remote_invoke_context import RemoteInvokeContext, SUPPORTED_SERVICES
 from samcli.lib.utils.cloudformation import CloudFormationResourceSummary
@@ -82,6 +83,13 @@ class TestRemoteInvokeContext(TestCase):
             with self._get_remote_invoke_context():
                 pass
 
+    @patch("samcli.commands.remote_invoke.remote_invoke_context.get_resource_summary")
+    def test_if_no_resource_found_with_given_stack_and_resource_id_should_fail(self, patched_get_resource_summary):
+        patched_get_resource_summary.return_value = None
+        with self.assertRaises(AmbiguousResourceForRemoteInvoke):
+            with self._get_remote_invoke_context():
+                pass
+
     @patch("samcli.commands.remote_invoke.remote_invoke_context.get_resource_summary_from_physical_id")
     def test_only_resource_id_as_valid_physical_id_should_be_valid(self, patched_resource_summary_from_physical_id):
         self.stack_name = None
@@ -89,3 +97,35 @@ class TestRemoteInvokeContext(TestCase):
         patched_resource_summary_from_physical_id.return_value = resource_summary
         with self._get_remote_invoke_context() as remote_invoke_context:
             self.assertEqual(remote_invoke_context._resource_summary, resource_summary)
+
+    def test_running_without_resource_summary_should_raise_exception(self):
+        with self._get_remote_invoke_context() as remote_invoke_context:
+            remote_invoke_context._resource_summary = None
+            with self.assertRaises(AmbiguousResourceForRemoteInvoke):
+                remote_invoke_context.run(Mock())
+
+    def test_running_with_unsupported_resource_should_raise_exception(self):
+        with self._get_remote_invoke_context() as remote_invoke_context:
+            remote_invoke_context._resource_summary = Mock(resource_type="UnSupportedResource")
+            with self.assertRaises(NoExecutorFoundForRemoteInvoke):
+                remote_invoke_context.run(Mock())
+
+    @patch("samcli.commands.remote_invoke.remote_invoke_context.RemoteInvokeExecutorFactory")
+    @patch("samcli.commands.remote_invoke.remote_invoke_context.get_resource_summary")
+    def test_running_should_execute_remote_invoke_executor_instance(
+        self, patched_get_resource_summary, patched_remote_invoke_executor_factory
+    ):
+        mocked_remote_invoke_executor_factory = Mock()
+        patched_remote_invoke_executor_factory.return_value = mocked_remote_invoke_executor_factory
+        mocked_remote_invoke_executor = Mock()
+        mocked_output = Mock()
+        mocked_remote_invoke_executor.execute.return_value = mocked_output
+        mocked_remote_invoke_executor_factory.create_remote_invoke_executor.return_value = mocked_remote_invoke_executor
+
+        given_input = Mock()
+        with self._get_remote_invoke_context() as remote_invoke_context:
+            remote_invoke_result = remote_invoke_context.run(given_input)
+
+            mocked_remote_invoke_executor_factory.create_remote_invoke_executor.assert_called_once()
+            mocked_remote_invoke_executor.execute.assert_called_with(given_input)
+            self.assertEqual(remote_invoke_result, mocked_output)

--- a/tests/unit/commands/remote_invoke/test_remote_invoke_context.py
+++ b/tests/unit/commands/remote_invoke/test_remote_invoke_context.py
@@ -87,8 +87,8 @@ class TestRemoteInvokeContext(TestCase):
     def test_if_no_resource_found_with_given_stack_and_resource_id_should_fail(self, patched_get_resource_summary):
         patched_get_resource_summary.return_value = None
         with self.assertRaises(AmbiguousResourceForRemoteInvoke):
-            with self._get_remote_invoke_context():
-                pass
+            with self._get_remote_invoke_context() as remote_invoke_context:
+                remote_invoke_context.run(Mock())
 
     @patch("samcli.commands.remote_invoke.remote_invoke_context.get_resource_summary_from_physical_id")
     def test_only_resource_id_as_valid_physical_id_should_be_valid(self, patched_resource_summary_from_physical_id):

--- a/tests/unit/commands/remote_invoke/test_remote_invoke_context.py
+++ b/tests/unit/commands/remote_invoke/test_remote_invoke_context.py
@@ -98,15 +98,17 @@ class TestRemoteInvokeContext(TestCase):
         with self._get_remote_invoke_context() as remote_invoke_context:
             self.assertEqual(remote_invoke_context._resource_summary, resource_summary)
 
-    def test_running_without_resource_summary_should_raise_exception(self):
+    @patch("samcli.commands.remote_invoke.remote_invoke_context.get_resource_summary")
+    def test_running_without_resource_summary_should_raise_exception(self, patched_get_resource_summary):
+        patched_get_resource_summary.return_value = None
         with self._get_remote_invoke_context() as remote_invoke_context:
-            remote_invoke_context._resource_summary = None
             with self.assertRaises(AmbiguousResourceForRemoteInvoke):
                 remote_invoke_context.run(Mock())
 
-    def test_running_with_unsupported_resource_should_raise_exception(self):
+    @patch("samcli.commands.remote_invoke.remote_invoke_context.get_resource_summary")
+    def test_running_with_unsupported_resource_should_raise_exception(self, patched_get_resource_summary):
+        patched_get_resource_summary.return_value = Mock(resource_type="UnSupportedResource")
         with self._get_remote_invoke_context() as remote_invoke_context:
-            remote_invoke_context._resource_summary = Mock(resource_type="UnSupportedResource")
             with self.assertRaises(NoExecutorFoundForRemoteInvoke):
                 remote_invoke_context.run(Mock())
 


### PR DESCRIPTION
Updates `RemoteInvokeContext` object to invoke the remote invoke executor;
- Updated `__enter__` method to find resource summary for given stack name and resource logical id
- Implemented `run` method, to instantiate remote invoke executor through its factory and run execute method on it
- Updated `get_resource_summary` in CFN utilities to return resources from nested stacks.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
