### PR TITLE
fix: fix failing Terraform integration test cases

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/translate.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/translate.py
@@ -111,15 +111,21 @@ def _check_unresolvable_values(root_module: dict, root_tf_module: TFModule) -> N
         # iterate over resources for current module
         for resource in curr_module.get("resources", []):
             resource_type = resource.get("type")
+            resource_name = resource.get("name")
+            resource_mode = resource.get("mode")
 
             resource_mapper = RESOURCE_TRANSLATOR_MAPPING.get(resource_type)
             if not resource_mapper:
                 continue
 
             resource_values = resource.get("values")
-            resource_full_address = resource.get("address")
+            resource_address = (
+                f"data.{resource_type}.{resource_name}"
+                if resource_mode == "data"
+                else f"{resource_type}.{resource_name}"
+            )
 
-            config_resource_address = get_configuration_address(resource_full_address)
+            config_resource_address = get_configuration_address(resource_address)
             config_resource = curr_tf_module.resources[config_resource_address]
 
             for prop_builder in resource_mapper.property_builder_mapping.values():

--- a/tests/integration/local/invoke/test_invoke_terraform_applications.py
+++ b/tests/integration/local/invoke/test_invoke_terraform_applications.py
@@ -159,7 +159,7 @@ class TestInvokeTerraformApplicationWithoutBuild(InvokeTerraformApplicationInteg
             "You can also enable this beta feature with 'sam local invoke --beta-features'."
         )
         self.assertRegex(stdout.decode("utf-8"), terraform_beta_feature_prompted_text)
-        self.assertTrue(stderr.decode("utf-8").startswith(Colored().yellow(EXPERIMENTAL_WARNING)))
+        self.assertRegex(stderr.decode("utf-8"), EXPERIMENTAL_WARNING)
 
         response = json.loads(stdout.decode("utf-8").split("\n")[2][85:].strip())
         expected_response = json.loads('{"statusCode":200,"body":"{\\"message\\": \\"hello world\\"}"}')

--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
     # Make it faster by skipping something
-    skip_get_ec2_platforms      = true
     skip_metadata_api_check     = true
     skip_region_validation      = true
     skip_credentials_validation = true

--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/main.tf
@@ -4,7 +4,6 @@ terraform {
 
 provider "aws" {
     # Make it faster by skipping something
-    skip_get_ec2_platforms      = true
     skip_metadata_api_check     = true
     skip_region_validation      = true
     skip_credentials_validation = true

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -1116,8 +1116,12 @@ class TestUnresolvableAttributeCheck:
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.RESOURCE_TRANSLATOR_MAPPING")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.LOG")
     def test_module_contains_unresolvables(self, log_mock, mapping_mock):
-        config_addr = "addr"
-        module = {"resources": [{"address": config_addr, "values": Mock()}]}
+        config_addr = "function.func1"
+        module = {
+            "resources": [
+                {"address": config_addr, "values": Mock(), "type": "function", "mode": "resource", "name": "func1"}
+            ]
+        }
 
         tf_module = Mock()
         tf_module_attr = Mock()


### PR DESCRIPTION
#### Changes:
 - Removed the `skip_get_ec2_platforms` flag from the sample Terraform testing project, AS Hashicorp pushed a new AWS Provider and removed this flag.
 - Fix the resource address while accessing the module config resources
 - Fix checking the experimental log integration test cases


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
