### PR TITLE
feat: Link Lambda Authorizer to Rest API

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
@@ -206,15 +206,14 @@ class GatewayAuthorizerToLambdaFunctionLocalVariablesLinkingLimitationException(
     Exception specific for Gateway Authorizer linking to Lambda Function using locals.
     """
 
+
 class OneGatewayAuthorizerToRestApiLinkingLimitationException(OneResourceLinkingLimitationException):
     """
     Exception specific for Gateway Authorizer linking to more than one Rest API
     """
 
 
-class GatewayAuthorizerToRestApiLocalVariablesLinkingLimitationException(
-    LocalVariablesLinkingLimitationException
-):
+class GatewayAuthorizerToRestApiLocalVariablesLinkingLimitationException(LocalVariablesLinkingLimitationException):
     """
     Exception specific for Gateway Authorizer linking to Rest APIs using locals.
     """

--- a/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/exceptions.py
@@ -206,6 +206,19 @@ class GatewayAuthorizerToLambdaFunctionLocalVariablesLinkingLimitationException(
     Exception specific for Gateway Authorizer linking to Lambda Function using locals.
     """
 
+class OneGatewayAuthorizerToRestApiLinkingLimitationException(OneResourceLinkingLimitationException):
+    """
+    Exception specific for Gateway Authorizer linking to more than one Rest API
+    """
+
+
+class GatewayAuthorizerToRestApiLocalVariablesLinkingLimitationException(
+    LocalVariablesLinkingLimitationException
+):
+    """
+    Exception specific for Gateway Authorizer linking to Rest APIs using locals.
+    """
+
 
 class InvalidSamMetadataPropertiesException(UserException):
     pass

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -1576,7 +1576,7 @@ def _link_gateway_authorizer_to_rest_api(
     rest_api_resource: Dict[str, Dict],
 ) -> None:
     """
-    Iterate through all the resources and link the corresponding Authorizer to each Lambda Function
+    Iterate through all the resources and link the corresponding Authorizer to each Rest Api
 
     Parameters
     ----------

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict, List, Optional, Type, Union
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     FunctionLayerLocalVariablesLinkingLimitationException,
     GatewayAuthorizerToLambdaFunctionLocalVariablesLinkingLimitationException,
+    GatewayAuthorizerToRestApiLocalVariablesLinkingLimitationException,
     GatewayResourceToApiGatewayIntegrationLocalVariablesLinkingLimitationException,
     GatewayResourceToApiGatewayIntegrationResponseLocalVariablesLinkingLimitationException,
     GatewayResourceToApiGatewayMethodLocalVariablesLinkingLimitationException,
@@ -18,6 +19,7 @@ from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     LambdaFunctionToApiGatewayIntegrationLocalVariablesLinkingLimitationException,
     LocalVariablesLinkingLimitationException,
     OneGatewayAuthorizerToLambdaFunctionLinkingLimitationException,
+    OneGatewayAuthorizerToRestApiLinkingLimitationException,
     OneGatewayResourceToApiGatewayIntegrationLinkingLimitationException,
     OneGatewayResourceToApiGatewayIntegrationResponseLinkingLimitationException,
     OneGatewayResourceToApiGatewayMethodLinkingLimitationException,
@@ -1535,7 +1537,7 @@ def _link_gateway_authorizer_to_lambda_function_call_back(
 def _link_gateway_authorizer_to_lambda_function(
     authorizer_config_resources: Dict[str, TFResource],
     authorizer_cfn_resources: Dict[str, List],
-    authorizer_tf_resources: Dict[str, Dict],
+    lamda_function_resources: Dict[str, Dict],
 ) -> None:
     """
     Iterate through all the resources and link the corresponding Authorizer to each Lambda Function
@@ -1546,8 +1548,8 @@ def _link_gateway_authorizer_to_lambda_function(
         Dictionary of configuration Authorizer resources
     authorizer_cfn_resources: Dict[str, List]
         Dictionary containing resolved configuration address of CFN Authorizer resources
-    lambda_layers_terraform_resources: Dict[str, Dict]
-        Dictionary of all actual terraform layers resources (not configuration resources). The dictionary's key is the
+    lamda_function_resources: Dict[str, Dict]
+        Dictionary of Terraform Lambda Function resources (not configuration resources). The dictionary's key is the
         calculated logical id for each resource
     """
     exceptions = ResourcePairExceptions(
@@ -1557,12 +1559,48 @@ def _link_gateway_authorizer_to_lambda_function(
     resource_linking_pair = ResourceLinkingPair(
         source_resource_cfn_resource=authorizer_cfn_resources,
         source_resource_tf_config=authorizer_config_resources,
-        destination_resource_tf=authorizer_tf_resources,
+        destination_resource_tf=lamda_function_resources,
         tf_destination_attribute_name="invoke_arn",
         terraform_link_field_name="authorizer_uri",
         cfn_link_field_name="AuthorizerUri",
         terraform_resource_type_prefix=LAMBDA_FUNCTION_RESOURCE_ADDRESS_PREFIX,
         cfn_resource_update_call_back_function=_link_gateway_authorizer_to_lambda_function_call_back,
+        linking_exceptions=exceptions,
+    )
+    ResourceLinker(resource_linking_pair).link_resources()
+
+
+def _link_gateway_authorizer_to_rest_api(
+    authorizer_config_resources: Dict[str, TFResource],
+    authorizer_cfn_resources: Dict[str, List],
+    rest_api_resource: Dict[str, Dict],
+) -> None:
+    """
+    Iterate through all the resources and link the corresponding Authorizer to each Lambda Function
+
+    Parameters
+    ----------
+    authorizer_config_resources: Dict[str, TFResource]
+        Dictionary of configuration Authorizer resources
+    authorizer_cfn_resources: Dict[str, List]
+        Dictionary containing resolved configuration address of CFN Authorizer resources
+    rest_api_resource: Dict[str, Dict]
+        Dictionary of Terraform Rest Api resources (not configuration resources). The dictionary's key is the
+        calculated logical id for each resource
+    """
+    exceptions = ResourcePairExceptions(
+        multiple_resource_linking_exception=OneGatewayAuthorizerToRestApiLinkingLimitationException,
+        local_variable_linking_exception=GatewayAuthorizerToRestApiLocalVariablesLinkingLimitationException,
+    )
+    resource_linking_pair = ResourceLinkingPair(
+        source_resource_cfn_resource=authorizer_cfn_resources,
+        source_resource_tf_config=authorizer_config_resources,
+        destination_resource_tf=rest_api_resource,
+        tf_destination_attribute_name="id",
+        terraform_link_field_name="rest_api_id",
+        cfn_link_field_name="RestApiId",
+        terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+        cfn_resource_update_call_back_function=_link_gateway_resource_to_gateway_rest_apis_rest_api_id_call_back,
         linking_exceptions=exceptions,
     )
     ResourceLinker(resource_linking_pair).link_resources()

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/resource_links.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/resource_links.py
@@ -13,6 +13,7 @@ from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
 )
 from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     _link_gateway_authorizer_to_lambda_function,
+    _link_gateway_authorizer_to_rest_api,
     _link_gateway_integration_responses_to_gateway_resource,
     _link_gateway_integration_responses_to_gateway_rest_apis,
     _link_gateway_integrations_to_function_resource,
@@ -77,5 +78,10 @@ RESOURCE_LINKS: List[LinkingPairCaller] = [
         source=TF_AWS_API_GATEWAY_AUTHORIZER,
         dest=TF_AWS_LAMBDA_FUNCTION,
         linking_func=_link_gateway_authorizer_to_lambda_function,
+    ),
+    LinkingPairCaller(
+        source=TF_AWS_API_GATEWAY_AUTHORIZER,
+        dest=TF_AWS_API_GATEWAY_REST_API,
+        linking_func=_link_gateway_authorizer_to_rest_api,
     ),
 ]

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -7,12 +7,14 @@ from uuid import uuid4
 from parameterized import parameterized
 from samcli.hook_packages.terraform.hooks.prepare.exceptions import (
     GatewayAuthorizerToLambdaFunctionLocalVariablesLinkingLimitationException,
+    GatewayAuthorizerToRestApiLocalVariablesLinkingLimitationException,
     InvalidResourceLinkingException,
     LocalVariablesLinkingLimitationException,
     ONE_LAMBDA_LAYER_LINKING_ISSUE_LINK,
     LOCAL_VARIABLES_SUPPORT_ISSUE_LINK,
     APPLY_WORK_AROUND_MESSAGE,
     OneGatewayAuthorizerToLambdaFunctionLinkingLimitationException,
+    OneGatewayAuthorizerToRestApiLinkingLimitationException,
     OneLambdaLayerLinkingLimitationException,
     FunctionLayerLocalVariablesLinkingLimitationException,
     OneGatewayResourceToApiGatewayMethodLinkingLimitationException,
@@ -39,6 +41,7 @@ from samcli.hook_packages.terraform.hooks.prepare.resource_linking import (
     _clean_references_list,
     _link_gateway_authorizer_to_lambda_function,
     _link_gateway_authorizer_to_lambda_function_call_back,
+    _link_gateway_authorizer_to_rest_api,
     _resolve_module_output,
     _resolve_module_variable,
     _build_module,
@@ -2241,6 +2244,46 @@ class TestResourceLinker(TestCase):
             cfn_link_field_name="AuthorizerUri",
             terraform_resource_type_prefix=LAMBDA_FUNCTION_RESOURCE_ADDRESS_PREFIX,
             cfn_resource_update_call_back_function=mock_link_gateway_authorizer_to_lambda_function_call_back,
+            linking_exceptions=mock_resource_linking_exceptions(),
+        )
+
+        mock_resource_linker.assert_called_once_with(mock_resource_linking_pair())
+
+    @patch(
+        "samcli.hook_packages.terraform.hooks.prepare.resource_linking._link_gateway_resource_to_gateway_rest_apis_rest_api_id_call_back"
+    )
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking.ResourceLinker")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking.ResourceLinkingPair")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking.ResourcePairExceptions")
+    def test_link_gateway_authorizer_to_rest_api(
+        self,
+        mock_resource_linking_exceptions,
+        mock_resource_linking_pair,
+        mock_resource_linker,
+        mock_link_resource_to_rest_api_call_back,
+    ):
+        authorizer_cfn_resources = Mock()
+        authorizer_config_resources = Mock()
+        rest_api_resources = Mock()
+
+        _link_gateway_authorizer_to_rest_api(
+            authorizer_config_resources, authorizer_cfn_resources, rest_api_resources
+        )
+
+        mock_resource_linking_exceptions.assert_called_once_with(
+            multiple_resource_linking_exception=OneGatewayAuthorizerToRestApiLinkingLimitationException,
+            local_variable_linking_exception=GatewayAuthorizerToRestApiLocalVariablesLinkingLimitationException,
+        )
+
+        mock_resource_linking_pair.assert_called_once_with(
+            source_resource_cfn_resource=authorizer_cfn_resources,
+            source_resource_tf_config=authorizer_config_resources,
+            destination_resource_tf=rest_api_resources,
+            tf_destination_attribute_name="id",
+            terraform_link_field_name="rest_api_id",
+            cfn_link_field_name="RestApiId",
+            terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+            cfn_resource_update_call_back_function=mock_link_resource_to_rest_api_call_back,
             linking_exceptions=mock_resource_linking_exceptions(),
         )
 

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -2266,9 +2266,7 @@ class TestResourceLinker(TestCase):
         authorizer_config_resources = Mock()
         rest_api_resources = Mock()
 
-        _link_gateway_authorizer_to_rest_api(
-            authorizer_config_resources, authorizer_cfn_resources, rest_api_resources
-        )
+        _link_gateway_authorizer_to_rest_api(authorizer_config_resources, authorizer_cfn_resources, rest_api_resources)
 
         mock_resource_linking_exceptions.assert_called_once_with(
             multiple_resource_linking_exception=OneGatewayAuthorizerToRestApiLinkingLimitationException,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Links links the Lambda Authorizer to the Rest API using the Rest API's Id.

#### How does it address the issue?
Adds the method to call the generalized Rest API Id linking call back to link the Authorizer to the Rest API.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
