### PR TITLE
feat: Return early during linking if no destination resources are found

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -231,9 +231,12 @@ class ResourceLinker:
             )
         if not dest_resources:
             LOG.debug(
-                "There are destination resources defined for for the source resource %s",
+                "There are destination resources defined for for the source resource %s, skipping linking.",
                 source_tf_resource.full_address,
             )
+
+            return
+
         for cfn_resource in cfn_resources:
             self._resource_pair.cfn_resource_update_call_back_function(cfn_resource, dest_resources)  # type: ignore
 
@@ -284,7 +287,12 @@ class ResourceLinker:
             else ExistingResourceReference(value)
             for value in values
         ]
-        LOG.debug("The value of the source resource linking field after mapping $s", dest_resources)
+
+        if not dest_resources:
+            LOG.debug("Skipping linking call back, no destination resources discovered.")
+            return
+
+        LOG.debug("The value of the source resource linking field after mapping %s", dest_resources)
         self._resource_pair.cfn_resource_update_call_back_function(cfn_resource, dest_resources)  # type: ignore
 
     def _process_resolved_resources(

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -1124,6 +1124,21 @@ class TestResourceLinker(TestCase):
             linking_exceptions=self.linker_exceptions,
         )
 
+    def test_applied_empty_destination_skip_call_back(self):
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        resource_linker._link_using_linking_fields({"Properties": {"Layers": []}})
+
+        self.sample_resource_linking_pair.cfn_resource_update_call_back_function.assert_not_called()
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking._resolve_resource_attribute")
+    @patch("samcli.hook_packages.terraform.hooks.prepare.resource_linking.ResourceLinker._process_resolved_resources")
+    def test_config_empty_destination_skip_call_back(self, proccess_resolved_res_mock, resolve_resource_attr_mock):
+        resource_linker = ResourceLinker(self.sample_resource_linking_pair)
+        proccess_resolved_res_mock.return_value = []
+        resource_linker._link_using_terraform_config(Mock(), Mock())
+
+        self.sample_resource_linking_pair.cfn_resource_update_call_back_function.assert_not_called()
+
     def test_handle_linking_mix_of_applied_and_non_applied_resources(self):
         cfn_resource_depend_on_applied_resources = {
             "Type": "AWS::Lambda::Function",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
If there are no destinations found during linking, the call back method to link the properties together still run.

#### How does it address the issue?
Adds a check to exit early in the linking handler, in addition to the existing checks in the call back methods. As a result, this will not call the call back methods.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
