### PR TITLE
fix: fix build SAR integration test cases

### DIFF
--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -2957,7 +2957,7 @@ class TestBuildWithZipFunctionsOrLayers(NestedBuildIntegBase):
 
 @skipIf(SKIP_SAR_TESTS, "Skip SAR tests")
 class TestBuildSAR(BuildIntegBase):
-    template = "aws-serverless-application-with-application-id-map.yaml"
+    template = "aws-serverless-application-with-application-id-map-build-only.yaml"
 
     @parameterized.expand(
         [

--- a/tests/integration/testdata/buildcmd/aws-serverless-application-with-application-id-map-build-only.yaml
+++ b/tests/integration/testdata/buildcmd/aws-serverless-application-with-application-id-map-build-only.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Mappings:
+  MappingExample:
+    us-east-2:
+      ApplicationId: arn:aws:serverlessrepo:us-east-1:077246666028:applications/hello-world
+
+Resources:
+  MyApplication:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: !FindInMap [ MappingExample, !Ref AWS::Region, ApplicationId ]
+        SemanticVersion: 1.0.4
+      Parameters:
+        IdentityNameParameter: AnyValue


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Have a separate Template to check building SAR App Templates, as SAM CLI does not support !Sub intrinsic function while processing the build functionality.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
