### PR TITLE
pin pytest-metadata to avoid its breaking change

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,6 +30,8 @@ pytest-xdist==3.2.0
 pytest-forked==1.6.0
 pytest-timeout==2.1.0
 pytest-rerunfailures==11.1.2
+# NOTE (hawflau): DO NOT upgrade pytest-metadata and pytest-json-report unless pytest-json-report addresses https://github.com/numirias/pytest-json-report/issues/89
+pytest-metadata==2.0.4
 pytest-json-report==1.5.0
 filelock==3.12.0
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
A breaking change was introduced in `pytest-metadata` 3.0.0, resulting in empty `Environment` section in the test reports generated with `pytest-json-report`. This breaks our internal tools for test failure investigations.

#### How does it address the issue?
Pin `pytest-metadata` to 2.0.4, which is the last version before 3.0.0.

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
