### PR TITLE
Add JsonFileManager

### DIFF
--- a/samcli/lib/config/file_manager.py
+++ b/samcli/lib/config/file_manager.py
@@ -3,6 +3,7 @@ Class to represent the parsing of different file types into Python objects.
 """
 
 
+import json
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -37,8 +38,7 @@ class FileManager(ABC):
         Returns
         -------
         Any
-            A dictionary-like representation of the contents at the filepath location, along with a specialized
-            representation of the file that was read, if there is a specialization of it.
+            A dictionary-like representation of the contents at the filepath location.
         """
         raise NotImplementedError("Read method not implemented.")
 
@@ -260,3 +260,74 @@ class YamlFileManager(FileManager):
         with StringIO() as stream:
             YamlFileManager.yaml.dump(document, stream)
             return YamlFileManager.yaml.load(stream.getvalue())
+
+
+class JsonFileManager(FileManager):
+    """
+    Static class to read and write json files.
+    """
+
+    file_format = "JSON"
+
+    @staticmethod
+    def read(filepath: Path) -> Any:
+        """
+        Read a JSON file at a given path.
+
+        Parameters
+        ----------
+        filepath: Path
+            The Path object that points to the file to be read.
+
+        Returns
+        -------
+        Any
+            A dictionary representation of the contents of the JSON document.
+        """
+        json_file = {}
+        try:
+            json_file = json.loads(filepath.read_text())
+        except OSError as e:
+            LOG.debug(f"OSError occurred while reading {JsonFileManager.file_format} file: {str(e)}")
+        except json.JSONDecodeError as e:
+            raise FileParseException(e) from e
+        return json_file
+
+    @staticmethod
+    def write(document: dict, filepath: Path):
+        """
+        Write a dictionary or dictionary-like object to a JSON file.
+
+        Parameters
+        ----------
+        document: dict
+            The JSON object to write.
+        filepath: Path
+            The final location for the document to be written.
+        """
+        if not document:
+            LOG.debug("No document given to JsonFileManager to write.")
+            return
+
+        with filepath.open("w") as file:
+            json.dump(document, file)
+
+    @staticmethod
+    def put_comment(document: Any, comment: str) -> Any:
+        """
+        Put a comment in a JSON object.
+
+        Parameters
+        ----------
+        document: Any
+            The JSON object to write
+        comment: str
+            The comment to include in the document.
+
+        Returns
+        -------
+        Any
+            The new JSON dictionary object, with the comment added to it.
+        """
+        document.update({COMMENT_KEY: comment})
+        return document

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Type
 
 from samcli.lib.config.exceptions import FileParseException, SamConfigFileReadException, SamConfigVersionException
-from samcli.lib.config.file_manager import FileManager, TomlFileManager, YamlFileManager
+from samcli.lib.config.file_manager import FileManager, JsonFileManager, TomlFileManager, YamlFileManager
 from samcli.lib.config.version import SAM_CONFIG_VERSION, VERSION_KEY
 
 LOG = logging.getLogger(__name__)
@@ -28,6 +28,7 @@ class SamConfig:
         ".toml": TomlFileManager,
         ".yaml": YamlFileManager,
         ".yml": YamlFileManager,
+        ".json": JsonFileManager,
     }
 
     def __init__(self, config_dir, filename=None):

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -16,7 +16,7 @@ from unittest.mock import patch, ANY
 import logging
 from parameterized import parameterized
 from samcli.lib.config.exceptions import SamConfigFileReadException
-from samcli.lib.config.file_manager import YamlFileManager
+from samcli.lib.config.file_manager import JsonFileManager, YamlFileManager
 
 from samcli.lib.config.samconfig import SamConfig, DEFAULT_ENV, TomlFileManager
 from samcli.lib.utils.packagetype import ZIP, IMAGE
@@ -1256,11 +1256,19 @@ class TestSamConfigFileManager(TestCase):
         with self.assertRaises(SamConfigFileReadException):
             SamConfig(config_path, filename="samconfig")
 
+    def test_file_manager_unsupported(self):
+        config_dir = tempfile.gettempdir()
+        config_path = Path(config_dir, "samconfig.jpeg")
+
+        with self.assertRaises(SamConfigFileReadException):
+            SamConfig(config_path, filename="samconfig.jpeg")
+
     @parameterized.expand(
         [
             ("samconfig.toml", TomlFileManager),
             ("samconfig.yaml", YamlFileManager),
             ("samconfig.yml", YamlFileManager),
+            ("samconfig.json", JsonFileManager),
         ]
     )
     def test_file_manager(self, filename, expected_file_manager):

--- a/tests/unit/lib/samconfig/test_file_manager.py
+++ b/tests/unit/lib/samconfig/test_file_manager.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 import tempfile
 from unittest import TestCase
@@ -6,7 +7,7 @@ import tomlkit
 from ruamel.yaml import YAML
 
 from samcli.lib.config.exceptions import FileParseException
-from samcli.lib.config.file_manager import COMMENT_KEY, TomlFileManager, YamlFileManager
+from samcli.lib.config.file_manager import COMMENT_KEY, JsonFileManager, TomlFileManager, YamlFileManager
 
 
 class TestTomlFileManager(TestCase):
@@ -179,3 +180,98 @@ class TestYamlFileManager(TestCase):
         self.yaml.dump(yaml_doc, config_path)
         txt = config_path.read_text()
         self.assertIn("# This is a comment", txt)
+
+
+class TestJsonFileManager(TestCase):
+    def test_read_json(self):
+        config_dir = tempfile.gettempdir()
+        config_path = Path(config_dir, "samconfig.json")
+        config_path.write_text(
+            "{\n"
+            + '    "version": 0.1,\n'
+            + '    "config_env": {\n'
+            + '        "topic1": {\n'
+            + '            "parameters": {\n'
+            + '                "word": "clarity"\n'
+            + "            }\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n"
+        )
+
+        config_doc = JsonFileManager.read(config_path)
+
+        self.assertEqual(
+            config_doc,
+            {"version": 0.1, "config_env": {"topic1": {"parameters": {"word": "clarity"}}}},
+        )
+
+    def test_read_json_invalid_json(self):
+        config_dir = tempfile.gettempdir()
+        config_path = Path(config_dir, "samconfig.json")
+        config_path.write_text("{\n" + '    "bad_file": "very bad"\n' + '    "improperly": "formatted"\n' + "}\n")
+
+        with self.assertRaises(FileParseException):
+            JsonFileManager.read(config_path)
+
+    def test_read_json_file_path_not_valid(self):
+        config_dir = "path/that/doesnt/exist"
+        config_path = Path(config_dir, "samconfig.json")
+
+        config_doc = JsonFileManager.read(config_path)
+
+        self.assertEqual(config_doc, {})
+
+    def test_write_json(self):
+        config_dir = tempfile.gettempdir()
+        config_path = Path(config_dir, "samconfig.json")
+        yaml = {
+            "version": 0.1,
+            "config_env": {"topic2": {"parameters": {"word": "clarity"}}},
+            COMMENT_KEY: "This is a comment",
+        }
+
+        JsonFileManager.write(yaml, config_path)
+
+        txt = config_path.read_text()
+        self.assertIn('"version": 0.1', txt)
+        self.assertIn('"config_env": {', txt)
+        self.assertIn('"topic2": {', txt)
+        self.assertIn('"parameters": {', txt)
+        self.assertIn('"word": "clarity"', txt)
+        self.assertIn(f'"{COMMENT_KEY}": "This is a comment"', txt)
+
+    def test_dont_write_json_if_empty(self):
+        config_dir = tempfile.gettempdir()
+        config_path = Path(config_dir, "samconfig.json")
+        config_path.write_text("nothing to see here\n")
+        json_doc = {}
+
+        JsonFileManager.write(json_doc, config_path)
+
+        self.assertEqual(config_path.read_text(), "nothing to see here\n")
+
+    def test_write_json_file_bad_path(self):
+        config_path = Path("path/to/some", "file_that_doesnt_exist.json")
+
+        with self.assertRaises(FileNotFoundError):
+            JsonFileManager.write({"key": "value"}, config_path)
+
+    def test_json_put_comment(self):
+        json_doc = json.loads(
+            "{\n"
+            + '    "version": 0.1,\n'
+            + '    "config_env": {\n'
+            + '        "topic1": {\n'
+            + '            "parameters": {\n'
+            + '                "word": "clarity"\n'
+            + "            }\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n"
+        )
+
+        json_doc = JsonFileManager.put_comment(json_doc, "This is a comment")
+
+        txt = json.dumps(json_doc)
+        self.assertIn(f'"{COMMENT_KEY}": "This is a comment"', txt)


### PR DESCRIPTION
#### Why is this change necessary?
With this addition, users will also be able to define their config files in JSON, adding additional support for those who may be unfamiliar with TOML.

#### How does it address the issue?
A JSON `FileManager` child class has been added, which handles reading and writing to and from JSON files. It is used by `SamConfig` to read and write in config options.

#### What side effects does this change have?
Config files in TOML will not be affected, but any JSON config files can be passed in and read as well.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
