### PR TITLE
update gha to force restart of status checks

### DIFF
--- a/.github/workflows/automated-updates-to-sam-cli.yml
+++ b/.github/workflows/automated-updates-to-sam-cli.yml
@@ -48,7 +48,10 @@ jobs:
         run: |
           cd aws-sam-cli
           git push --force origin update_app_templates_hash
-          gh pr list --repo aws/aws-sam-cli --head update_app_templates_hash --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
+          gh pr list --repo aws/aws-sam-cli --head update_app_templates_hash --json id --jq length | grep 1 && \
+              gh pr close update_app_templates_hash --repo aws/aws-sam-cli && \
+              gh pr reopen update_app_templates_hash --repo aws/aws-sam-cli && \
+              exit 0 # if there is exisitng pr, close/reopen to re-run checks, then exit
           gh pr create --base develop --head update_app_templates_hash --title "feat: update SAM CLI with latest App Templates commit hash" --body "This PR & commit is automatically created from App Templates repo to update the SAM CLI with latest hash of the App Templates." --label "pr/internal"
 
   updateSAMTranslator:
@@ -65,13 +68,13 @@ jobs:
           path: serverless-application-model
           ref: main
           fetch-depth: 0
-      
+
       - name: Checkout SAM CLI
         uses: actions/checkout@v3
         with:
           repository: aws/aws-sam-cli
           path: aws-sam-cli
-      
+
       - uses: actions/setup-python@v4 # used for make update-reproducible-reqs below
         with:
           python-version: |
@@ -105,7 +108,10 @@ jobs:
         run: |
           cd aws-sam-cli
           git push --force origin update_sam_transform_version
-          gh pr list --repo aws/aws-sam-cli --head update_sam_transform_version --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
+          gh pr list --repo aws/aws-sam-cli --head update_sam_transform_version --json id --jq length | grep 1 && \
+              gh pr close update_sam_transform_version --repo aws/aws-sam-cli && \
+              gh pr reopen update_sam_transform_version --repo aws/aws-sam-cli && \
+              exit 0 # if there is exisitng pr, close/reopen to re-run checks, then exit
           gh pr create --base develop --head update_sam_transform_version --fill --label "pr/internal"
 
   updateAWSLambdaBuilders:
@@ -161,5 +167,8 @@ jobs:
         run: |
           cd aws-sam-cli
           git push --force origin update_lambda_builders_version
-          gh pr list --repo aws/aws-sam-cli --head update_lambda_builders_version --json id --jq length | grep 1 && exit 0 # exit if there is existing pr
+          gh pr list --repo aws/aws-sam-cli --head update_lambda_builders_version --json id --jq length | grep 1 && \
+              gh pr close update_lambda_builders_version --repo aws/aws-sam-cli && \
+              gh pr reopen update_lambda_builders_version --repo aws/aws-sam-cli && \
+              exit 0 # if there is exisitng pr, close/reopen to re-run checks, then exit
           gh pr create --base develop --head update_lambda_builders_version --fill --label "pr/internal"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
When the GHA runs and force pushes a commit, the status checks in the PR do not restart. This requires manual closing & reopening the PR to kick off new status checks.

#### How does it address the issue?
automate closing & reopening PR if there's an existing PR

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
