### PR TITLE
feat: Refactor TomlProvider

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -10,6 +10,7 @@ import functools
 import logging
 import os
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
 
 import click
 
@@ -17,38 +18,52 @@ from samcli.cli.context import get_cmd_names
 from samcli.commands.exceptions import ConfigException
 from samcli.lib.config.samconfig import DEFAULT_CONFIG_FILE_NAME, DEFAULT_ENV, SamConfig
 
-__all__ = ("TomlProvider", "configuration_option", "get_ctx_defaults")
+__all__ = ("ConfigProvider", "configuration_option", "get_ctx_defaults")
 
 LOG = logging.getLogger(__name__)
 
 
-class TomlProvider:
+class ConfigProvider:
     """
-    A parser for toml configuration files
+    A parser for sam configuration files
     """
 
     def __init__(self, section=None, cmd_names=None):
         """
-        The constructor for TomlProvider class
-        :param section: section defined in the configuration file nested within `cmd`
-        :param cmd_names: cmd_name defined in the configuration file
+        The constructor for ConfigProvider class
+
+        Parameters
+        ----------
+        section
+            The section defined in the configuration file nested within `cmd`
+        cmd_names
+            The cmd_name defined in the configuration file
         """
         self.section = section
         self.cmd_names = cmd_names
 
-    def __call__(self, config_path, config_env, cmd_names):
+    def __call__(self, config_path: Path, config_env: str, cmd_names: List[str]) -> dict:
         """
         Get resolved config based on the `file_path` for the configuration file,
         `config_env` targeted inside the config file and corresponding `cmd_name`
         as denoted by `click`.
 
-        :param config_path: The path of configuration file.
-        :param config_env: The name of the sectional config_env within configuration file.
-        :param list cmd_names: sam command name as defined by click
-        :returns dictionary containing the configuration parameters under specified config_env
+        Parameters
+        ----------
+        config_path: Path
+            The path of configuration file.
+        config_env: str
+            The name of the sectional config_env within configuration file.
+        cmd_names: List[str]
+            The sam command name as defined by click.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the configuration parameters under specified config_env.
         """
 
-        resolved_config = {}
+        resolved_config: dict = {}
 
         # Use default sam config file name if config_path only contain the directory
         config_file_path = (
@@ -105,27 +120,47 @@ class TomlProvider:
         return resolved_config
 
 
-def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx, param, value):
+def configuration_callback(
+    cmd_name: str,
+    option_name: str,
+    saved_callback: Optional[Callable],
+    provider: Callable,
+    ctx: click.Context,
+    param: click.Parameter,
+    value,
+):
     """
     Callback for reading the config file.
 
     Also takes care of calling user specified custom callback afterwards.
 
-    :param cmd_name: `sam` command name derived from click.
-    :param option_name: The name of the option. This is used for error messages.
-    :param saved_callback: User-specified callback to be called later.
-    :param provider:  A callable that parses the configuration file and returns a dictionary
+    Parameters
+    ----------
+    cmd_name: str
+        The `sam` command name derived from click.
+    option_name: str
+        The name of the option. This is used for error messages.
+    saved_callback: Optional[Callable]
+        User-specified callback to be called later.
+    provider: Callable
+        A callable that parses the configuration file and returns a dictionary
         of the configuration parameters. Will be called as
         `provider(file_path, config_env, cmd_name)`.
-    :param ctx: Click context
-    :param param: Click parameter
-    :param value: Specified value for config_env
-    :returns specified callback or the specified value for config_env.
+    ctx: click.Context
+        Click context
+    param: click.Parameter
+        Click parameter
+    value
+        Specified value for config_env
+
+    Returns
+    -------
+    The specified callback or the specified value for config_env.
     """
 
     # ctx, param and value are default arguments for click specified callbacks.
     ctx.default_map = ctx.default_map or {}
-    cmd_name = cmd_name or ctx.info_name
+    cmd_name = cmd_name or str(ctx.info_name)
     param.default = None
     config_env_name = ctx.params.get("config_env") or DEFAULT_ENV
 
@@ -154,21 +189,35 @@ def configuration_callback(cmd_name, option_name, saved_callback, provider, ctx,
     return saved_callback(ctx, param, config_env_name) if saved_callback else config_env_name
 
 
-def get_ctx_defaults(cmd_name, provider, ctx, config_env_name, config_file=None):
+def get_ctx_defaults(
+    cmd_name: str, provider: Callable, ctx: click.Context, config_env_name: str, config_file: Optional[str] = None
+) -> Any:
     """
     Get the set of the parameters that are needed to be set into the click command.
+
     This function also figures out the command name by looking up current click context's parent
     and constructing the parsed command name that is used in default configuration file.
     If a given cmd_name is start-api, the parsed name is "local_start_api".
     provider is called with `config_file`, `config_env_name` and `parsed_cmd_name`.
 
-    :param cmd_name: `sam` command name
-    :param provider: provider to be called for reading configuration file
-    :param ctx: Click context
-    :param config_env_name: config-env within configuration file, sam configuration file will be relative to the
-                            supplied original template if its path is not specified
-    :param config_file: configuration file name
-    :return: dictionary of defaults for parameters
+    Parameters
+    ----------
+    cmd_name: str
+        The `sam` command name.
+    provider: Callable
+        The provider to be called for reading configuration file.
+    ctx: click.Context
+        Click context
+    config_env_name: str
+        The config-env within configuration file, sam configuration file will be relative to the
+        supplied original template if its path is not specified.
+    config_file: Optional[str]
+        The configuration file name.
+
+    Returns
+    -------
+    Any
+        A dictionary of defaults for parameters.
     """
 
     return provider(config_file, config_env_name, get_cmd_names(cmd_name, ctx))
@@ -180,30 +229,38 @@ def configuration_option(*param_decls, **attrs):
     """
     Adds configuration file support to a click application.
 
-    NOTE: This decorator should be added to the top of parameter chain, right below click.command, before
-          any options are declared.
-
-    Example:
-        >>> @click.command("hello")
-            @configuration_option(provider=TomlProvider(section="parameters"))
-            @click.option('--name', type=click.String)
-            def hello(name):
-                print("Hello " + name)
-
     This will create a hidden click option whose callback function loads configuration parameters from default
     configuration environment [default] in default configuration file [samconfig.toml] in the template file
     directory.
-    :param preconfig_decorator_list: A list of click option decorator which need to place before this function. For
-        exmple, if we want to add option "--config-file" and "--config-env" to allow customized configuration file
+
+    Note
+    ----
+    This decorator should be added to the top of parameter chain, right below click.command, before
+    any options are declared.
+
+    Example
+    -------
+    >>> @click.command("hello")
+        @configuration_option(provider=ConfigProvider(section="parameters"))
+        @click.option('--name', type=click.String)
+        def hello(name):
+            print("Hello " + name)
+
+    Parameters
+    ----------
+    preconfig_decorator_list: list
+        A list of click option decorator which need to place before this function. For
+        example, if we want to add option "--config-file" and "--config-env" to allow customized configuration file
         and configuration environment, we will use configuration_option as below:
         @configuration_option(
             preconfig_decorator_list=[decorator_customize_config_file, decorator_customize_config_env],
-            provider=TomlProvider(section=CONFIG_SECTION),
+            provider=ConfigProvider(section=CONFIG_SECTION),
         )
         By default, we enable these two options.
-    :param provider: A callable that parses the configuration file and returns a dictionary
+    provider: Callable
+        A callable that parses the configuration file and returns a dictionary
         of the configuration parameters. Will be called as
-        `provider(file_path, config_env, cmd_name)
+        `provider(file_path, config_env, cmd_name)`
     """
 
     def decorator_configuration_setup(f):
@@ -240,14 +297,22 @@ def configuration_option(*param_decls, **attrs):
     return composed_decorator(decorator_list)
 
 
-def decorator_customize_config_file(f):
+def decorator_customize_config_file(f: Callable) -> Callable:
     """
     CLI option to customize configuration file name. By default it is 'samconfig.toml' in project directory.
     Ex: --config-file samconfig.toml
-    :param f: Callback function passed by Click
-    :return: Callback function
+
+    Parameters
+    ----------
+    f: Callable
+        Callback function passed by Click
+
+    Returns
+    -------
+    Callable
+        A Callback function
     """
-    config_file_attrs = {}
+    config_file_attrs: Dict[str, Any] = {}
     config_file_param_decls = ("--config-file",)
     config_file_attrs["help"] = "Configuration file containing default parameter values."
     config_file_attrs["default"] = "samconfig.toml"
@@ -258,14 +323,22 @@ def decorator_customize_config_file(f):
     return click.option(*config_file_param_decls, **config_file_attrs)(f)
 
 
-def decorator_customize_config_env(f):
+def decorator_customize_config_env(f: Callable) -> Callable:
     """
     CLI option to customize configuration environment name. By default it is 'default'.
     Ex: --config-env default
-    :param f: Callback function passed by Click
-    :return: Callback function
+
+    Parameters
+    ----------
+    f: Callable
+        Callback function passed by Click
+
+    Returns
+    -------
+    Callable
+        A Callback function
     """
-    config_env_attrs = {}
+    config_env_attrs: Dict[str, Any] = {}
     config_env_param_decls = ("--config-env",)
     config_env_attrs["help"] = "Environment name specifying default parameter values in the configuration file."
     config_env_attrs["default"] = "default"

--- a/samcli/commands/_utils/custom_options/hook_name_option.py
+++ b/samcli/commands/_utils/custom_options/hook_name_option.py
@@ -141,7 +141,7 @@ def _get_customer_input_beta_features_option(default_map, experimental_entry, op
     if beta_features is not None:
         return beta_features
 
-    # Get the beta-features flag value from the SamConfig toml file if provided.
+    # Get the beta-features flag value from the SamConfig file if provided.
     beta_features = default_map.get("beta_features")
     if beta_features is not None:
         return beta_features

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -26,7 +26,7 @@ from samcli.commands._utils.option_value_processor import process_env_var, proce
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options, print_cmdline_args
 from samcli.commands.build.core.command import BuildCommand
 from samcli.lib.telemetry.metric import track_command
-from samcli.cli.cli_config_file import configuration_option, TomlProvider
+from samcli.cli.cli_config_file import configuration_option, ConfigProvider
 from samcli.lib.utils.version_checker import check_newer_version
 from samcli.commands.build.click_container import ContainerOptions
 from samcli.commands.build.utils import MountMode
@@ -68,7 +68,7 @@ DESCRIPTION = """
     short_help=HELP_TEXT,
     context_settings={"max_content_width": 120},
 )
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @hook_name_click_option(
     force_prepare=True,
     invalid_coexist_options=["t", "template-file", "template", "parameter-overrides"],

--- a/samcli/commands/delete/delete_context.py
+++ b/samcli/commands/delete/delete_context.py
@@ -9,7 +9,7 @@ import boto3
 import click
 from click import confirm, prompt
 
-from samcli.cli.cli_config_file import TomlProvider
+from samcli.cli.cli_config_file import ConfigProvider
 from samcli.cli.context import Context
 from samcli.commands.delete.exceptions import CfDeleteFailedStatusError
 from samcli.lib.bootstrap.companion_stack.companion_stack_builder import CompanionStack
@@ -82,8 +82,8 @@ class DeleteContext:
         """
         Read the provided config file if it exists and assign the options values.
         """
-        toml_provider = TomlProvider(CONFIG_SECTION, [CONFIG_COMMAND])
-        config_options = toml_provider(
+        config_provider = ConfigProvider(CONFIG_SECTION, [CONFIG_COMMAND])
+        config_options = config_provider(
             config_path=self.config_file, config_env=self.config_env, cmd_names=[CONFIG_COMMAND]
         )
         if not config_options:

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -6,7 +6,7 @@ import os
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.cdk_support_decorators import unsupported_command_cdk
 from samcli.commands._utils.click_mutex import ClickMutex
@@ -75,7 +75,7 @@ LOG = logging.getLogger(__name__)
     description=DESCRIPTION,
     requires_credentials=True,
 )
-@configuration_option(provider=TomlProvider(section=CONFIG_SECTION))
+@configuration_option(provider=ConfigProvider(section=CONFIG_SECTION))
 @click.option(
     "--guided",
     "-g",

--- a/samcli/commands/init/command.py
+++ b/samcli/commands/init/command.py
@@ -7,7 +7,7 @@ from json import JSONDecodeError
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.click_mutex import ClickMutex
 from samcli.commands.init.core.command import InitCommand
@@ -112,7 +112,7 @@ def non_interactive_validation(func):
     description=DESCRIPTION,
     requires_credentials=False,
 )
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @click.option(
     "--no-interactive",
     is_flag=True,

--- a/samcli/commands/list/endpoints/command.py
+++ b/samcli/commands/list/endpoints/command.py
@@ -4,7 +4,7 @@ Sets up the cli for resources
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands._utils.options import parameter_override_option, template_option_without_build
@@ -21,7 +21,7 @@ are Lambda functions and API Gateway API resources.
 
 
 @click.command(name="endpoints", help=HELP_TEXT)
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @parameter_override_option
 @stack_name_option
 @output_option

--- a/samcli/commands/list/resources/command.py
+++ b/samcli/commands/list/resources/command.py
@@ -4,7 +4,7 @@ Sets up the cli for resources
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands._utils.options import parameter_override_option, template_option_without_build
@@ -20,7 +20,7 @@ resource will be mapped to the logical ID of each resource.
 
 
 @click.command(name="resources", help=HELP_TEXT)
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @parameter_override_option
 @stack_name_option
 @output_option

--- a/samcli/commands/list/stack_outputs/command.py
+++ b/samcli/commands/list/stack_outputs/command.py
@@ -4,7 +4,7 @@ Sets up the cli for stack-outputs
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.command_exception_handler import command_exception_handler
 from samcli.commands.list.cli_common.options import output_option
@@ -23,7 +23,7 @@ Get the stack outputs as defined in the SAM/CloudFormation template.
     required=True,
     type=click.STRING,
 )
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @output_option
 @aws_creds_options
 @common_options

--- a/samcli/commands/local/generate_event/event_generation.py
+++ b/samcli/commands/local/generate_event/event_generation.py
@@ -6,7 +6,7 @@ import functools
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.options import debug_option
 from samcli.lib.generated_sample_events import events
 from samcli.lib.telemetry.metric import track_command
@@ -160,7 +160,7 @@ class EventTypeSubCommand(click.MultiCommand):
             callback=command_callback,
         )
 
-        cmd = configuration_option(provider=TomlProvider(section="parameters"))(debug_option(cmd))
+        cmd = configuration_option(provider=ConfigProvider(section="parameters"))(debug_option(cmd))
         return cmd
 
     def list_commands(self, ctx):

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -6,7 +6,7 @@ import logging
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.commands._utils.experimental import ExperimentalFlag, is_experimental_enabled
@@ -43,7 +43,7 @@ STDIN_FILE_NAME = "-"
     short_help=HELP_TEXT,
     context_settings={"max_content_width": 120},
 )
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @hook_name_click_option(
     force_prepare=False, invalid_coexist_options=["t", "template-file", "template", "parameter-overrides"]
 )

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -6,7 +6,7 @@ import logging
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.commands._utils.option_value_processor import process_image_options
@@ -53,7 +53,7 @@ DESCRIPTION = """
     requires_credentials=False,
     context_settings={"max_content_width": 120},
 )
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @service_common_options(3000)
 @click.option(
     "--static-dir",

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -6,7 +6,7 @@ import logging
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.commands._utils.experimental import ExperimentalFlag, is_experimental_enabled
@@ -52,7 +52,7 @@ DESCRIPTION = """
     requires_credentials=False,
     context_settings={"max_content_width": 120},
 )
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @hook_name_click_option(
     force_prepare=False, invalid_coexist_options=["t", "template-file", "template", "parameter-overrides"]
 )

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -6,7 +6,7 @@ import logging
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.commands._utils.command_exception_handler import command_exception_handler
@@ -51,7 +51,7 @@ $ sam logs --stack-name mystack -n MyNestedStack/HelloWorldFunction
 
 
 @click.command("logs", help=HELP_TEXT, short_help="Fetch logs for a function")
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @click.option(
     "--name",
     "-n",

--- a/samcli/commands/package/command.py
+++ b/samcli/commands/package/command.py
@@ -3,7 +3,7 @@ CLI command for "package" command
 """
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.cdk_support_decorators import unsupported_command_cdk
 from samcli.commands._utils.command_exception_handler import command_exception_handler
@@ -56,7 +56,7 @@ The following resources and their property locations are supported.
 
 
 @click.command("package", short_help=SHORT_HELP, help=HELP_TEXT, context_settings=dict(max_content_width=120))
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @template_click_option(include_build=True)
 @click.option(
     "--output-template-file",

--- a/samcli/commands/pipeline/bootstrap/cli.py
+++ b/samcli/commands/pipeline/bootstrap/cli.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, common_options, pass_context, print_cmdline_args
 from samcli.commands._utils.click_mutex import ClickMutex
 from samcli.commands._utils.command_exception_handler import command_exception_handler
@@ -38,7 +38,7 @@ OPENID_CONNECT = "OpenID Connect (OIDC)"
 
 
 @click.command("bootstrap", short_help=SHORT_HELP, help=HELP_TEXT, context_settings=dict(max_content_width=120))
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @click.option(
     "--interactive/--no-interactive",
     is_flag=True,

--- a/samcli/commands/pipeline/init/cli.py
+++ b/samcli/commands/pipeline/init/cli.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.cli.main import pass_context
 from samcli.commands._utils.command_exception_handler import command_exception_handler
@@ -24,7 +24,7 @@ file generation process, or refer to resources you have previously created with 
 
 
 @click.command("init", help=HELP_TEXT, short_help=SHORT_HELP)
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @click.option(
     "--bootstrap",
     is_flag=True,

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -7,7 +7,7 @@ import boto3
 import click
 from serverlessrepo.publish import CREATE_APPLICATION
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.commands._utils.command_exception_handler import command_exception_handler
@@ -44,7 +44,7 @@ SEMANTIC_VERSION = "SemanticVersion"
 
 
 @click.command("publish", help=HELP_TEXT, short_help=SHORT_HELP)
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @template_common_option
 @click.option("--semantic-version", help=SEMANTIC_VERSION_HELP)
 @aws_creds_options

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, List, Optional, Set
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.context import Context
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
@@ -111,7 +111,7 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
     requires_credentials=True,
     context_settings={"max_content_width": 120},
 )
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @template_option_without_build
 @click.option(
     "--code",

--- a/samcli/commands/traces/command.py
+++ b/samcli/commands/traces/command.py
@@ -5,7 +5,7 @@ import logging
 
 import click
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
 from samcli.commands._utils.command_exception_handler import command_exception_handler
@@ -28,7 +28,7 @@ $ sam traces --tail
 
 
 @click.command("traces", help=HELP_TEXT, short_help="Fetch AWS X-Ray traces")
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @click.option(
     "--trace-id",
     "-ti",

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -8,7 +8,7 @@ import click
 from botocore.exceptions import NoCredentialsError
 from samtranslator.translator.arn_generator import NoRegionFound
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option
+from samcli.cli.cli_config_file import ConfigProvider, configuration_option
 from samcli.cli.context import Context
 from samcli.cli.main import aws_creds_options, pass_context, print_cmdline_args
 from samcli.cli.main import common_options as cli_framework_options
@@ -35,7 +35,7 @@ DESCRIPTION = """
     requires_credentials=False,
     context_settings={"max_content_width": 120},
 )
-@configuration_option(provider=TomlProvider(section="parameters"))
+@configuration_option(provider=ConfigProvider(section="parameters"))
 @template_option_without_build
 @aws_creds_options
 @cli_framework_options

--- a/tests/unit/commands/delete/test_delete_context.py
+++ b/tests/unit/commands/delete/test_delete_context.py
@@ -6,7 +6,7 @@ import click
 
 from samcli.commands.delete.delete_context import DeleteContext
 from samcli.lib.package.artifact_exporter import Template
-from samcli.cli.cli_config_file import TomlProvider
+from samcli.cli.cli_config_file import ConfigProvider
 from samcli.lib.delete.cfn_utils import CfnUtils
 from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.package.ecr_uploader import ECRUploader
@@ -56,7 +56,7 @@ class TestDeleteContext(TestCase):
             self.assertEqual(delete_context.init_clients.call_count, 1)
 
     @patch.object(
-        TomlProvider,
+        ConfigProvider,
         "__call__",
         MagicMock(
             return_value=(
@@ -121,7 +121,7 @@ class TestDeleteContext(TestCase):
         self.assertEqual(expected_prompt_calls, patched_prompt.call_args_list)
 
     @patch.object(
-        TomlProvider,
+        ConfigProvider,
         "__call__",
         MagicMock(
             return_value=(
@@ -488,7 +488,7 @@ class TestDeleteContext(TestCase):
             self.assertEqual(delete_context.s3_prefix, "s3_prefix")
 
     @patch.object(
-        TomlProvider,
+        ConfigProvider,
         "__call__",
         MagicMock(
             return_value=(


### PR DESCRIPTION
#### Why is this change necessary?
Since `SamConfig` no longer deals solely with TOML files, the `TomlProvider` class that makes use of it has been refactored to decouple it from any mention of TOML.

#### How does it address the issue?
The `TomlProvider` class was renamed to `ConfigProvider` in the code, and mentions of it in the codebase have been updated accordingly. In addition, since the docstrings were using an outdated format, they have been updated to the NumPy/SciPy style, and type hints have been added.

#### What side effects does this change have?
`TomlProvider` is now renamed to `ConfigProvider` in this codebase, which could impact future changes or implementations of the class.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
