### PR TITLE
chore: Upgrade Docker-py/ Support Py3.11 for running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 	# Linter performs static analysis to catch latent bugs
 	ruff samcli
 	# mypy performs type check
-	mypy --no-incremental setup.py samcli tests
+	mypy --exclude /testdata/ --exclude /init/templates/ --no-incremental setup.py samcli tests
 
 # Command to run everytime you make changes to verify everything works
 dev: lint test

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,7 @@ warn_return_any=True
 warn_unused_configs=True
 no_implicit_optional=True
 warn_redundant_casts=True
-warn_unused_ignores=True
+warn_unused_ignores=False # @jfuss Done as a stop gap since different py versions have different errors
 warn_unreachable=True
 
 #

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,21 +3,21 @@ click~=8.0
 Flask<2.3
 #Need to add Schemas latest SDK.
 boto3>=1.19.5,==1.*
-jmespath~=0.10.0
-ruamel_yaml==0.17.21
+jmespath~=1.0.1
+ruamel_yaml~=0.17.21
 PyYAML>=5.4.1,==5.*
 cookiecutter~=2.1.1
 aws-sam-translator==1.68.0
 #docker minor version updates can include breaking changes. Auto update micro version only.
-docker~=4.2.0
+docker~=6.1.0
 dateparser~=1.1
-requests==2.31.0
+requests~=2.31.0
 serverlessrepo==0.1.10
 aws_lambda_builders==1.33.0
 tomlkit==0.11.8
 watchdog==2.1.2
 rich~=13.3.3
-pyopenssl==23.0.0
+pyopenssl~=23.0.0
 
 # Needed for supporting Protocol in Python 3.7, Protocol class became public with python3.8
 typing_extensions~=4.4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,22 +1,30 @@
 -r pre-dev.txt
 
-coverage==5.3
+coverage==7.2.7
 pytest-cov==4.0.0
 
 
 # type checking and related stubs
 # mypy adds new rules in new minor versions, which could cause our PR check to fail
 # here we fix its version and upgrade it manually in the future
-mypy==0.790
+mypy==1.3.0
 boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.26.131
 types-pywin32==306.0.0.0
 types-PyYAML==6.0.12
 types-chevron==0.14.2.4
 types-psutil==5.9.5.12
 types-setuptools==65.4.0.0
+types-Pygments==2.15.0.1 
+types-colorama==0.4.15.11
+types-dateparser==1.1.4.9
+types-docutils==0.20.0.1
+types-jsonschema==4.17.0.8
+types-pyOpenSSL==23.2.0.0
+types-requests==2.31.0.1
+types-urllib3==1.26.25.13
 
 # Test requirements
-pytest==7.2.2
+pytest~=7.2.2
 parameterized==0.9.0
 pytest-xdist==3.2.0
 pytest-forked==1.6.0

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -241,9 +241,9 @@ dateparser==1.1.8 \
     --hash=sha256:070b29b5bbf4b1ec2cd51c96ea040dc68a614de703910a91ad1abba18f9f379f \
     --hash=sha256:86b8b7517efcc558f085a142cdb7620f0921543fcabdb538c8a4c4001d8178e3
     # via aws-sam-cli (setup.py)
-docker==4.2.2 \
-    --hash=sha256:03a46400c4080cb6f7aa997f881ddd84fef855499ece219d75fbdb53289c17ab \
-    --hash=sha256:26eebadce7e298f55b76a88c4f8802476c5eaddbdbe38dbc6cce8781c47c9b54
+docker==6.1.3 \
+    --hash=sha256:aa6d17830045ba5ef0168d5eaa34d37beeb113948c413affe1d5991fc11f9a20 \
+    --hash=sha256:aecd2277b8bf8e506e484f6ab7aec39abe0038e29fa4a6d3ba86c3fe01844ed9
     # via aws-sam-cli (setup.py)
 flask==2.2.5 \
     --hash=sha256:58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf \
@@ -268,9 +268,9 @@ jinja2-time==0.2.0 \
     --hash=sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40 \
     --hash=sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa
     # via cookiecutter
-jmespath==0.10.0 \
-    --hash=sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9 \
-    --hash=sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f
+jmespath==1.0.1 \
+    --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
+    --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
     # via
     #   aws-sam-cli (setup.py)
     #   boto3
@@ -371,6 +371,10 @@ networkx==2.6.3 \
     --hash=sha256:80b6b89c77d1dfb64a4c7854981b60aeea6360ac02c6d4e4913319e0a313abef \
     --hash=sha256:c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51
     # via cfn-lint
+packaging==23.1 \
+    --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
+    --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
+    # via docker
 pbr==5.11.1 \
     --hash=sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b \
     --hash=sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3
@@ -630,7 +634,6 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
-    #   docker
     #   junit-xml
     #   python-dateutil
     #   serverlessrepo
@@ -664,6 +667,7 @@ urllib3==1.26.15 \
     --hash=sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42
     # via
     #   botocore
+    #   docker
     #   requests
 watchdog==2.1.2 \
     --hash=sha256:0237db4d9024859bea27d0efb59fe75eef290833fd988b8ead7a879b0308c2db \

--- a/requirements/reproducible-mac.txt
+++ b/requirements/reproducible-mac.txt
@@ -259,9 +259,9 @@ dateparser==1.1.8 \
     --hash=sha256:070b29b5bbf4b1ec2cd51c96ea040dc68a614de703910a91ad1abba18f9f379f \
     --hash=sha256:86b8b7517efcc558f085a142cdb7620f0921543fcabdb538c8a4c4001d8178e3
     # via aws-sam-cli (setup.py)
-docker==4.2.2 \
-    --hash=sha256:03a46400c4080cb6f7aa997f881ddd84fef855499ece219d75fbdb53289c17ab \
-    --hash=sha256:26eebadce7e298f55b76a88c4f8802476c5eaddbdbe38dbc6cce8781c47c9b54
+docker==6.1.3 \
+    --hash=sha256:aa6d17830045ba5ef0168d5eaa34d37beeb113948c413affe1d5991fc11f9a20 \
+    --hash=sha256:aecd2277b8bf8e506e484f6ab7aec39abe0038e29fa4a6d3ba86c3fe01844ed9
     # via aws-sam-cli (setup.py)
 flask==2.2.5 \
     --hash=sha256:58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf \
@@ -299,9 +299,9 @@ jinja2-time==0.2.0 \
     --hash=sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40 \
     --hash=sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa
     # via cookiecutter
-jmespath==0.10.0 \
-    --hash=sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9 \
-    --hash=sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f
+jmespath==1.0.1 \
+    --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
+    --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
     # via
     #   aws-sam-cli (setup.py)
     #   boto3
@@ -402,6 +402,10 @@ networkx==2.6.3 \
     --hash=sha256:80b6b89c77d1dfb64a4c7854981b60aeea6360ac02c6d4e4913319e0a313abef \
     --hash=sha256:c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51
     # via cfn-lint
+packaging==23.1 \
+    --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
+    --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
+    # via docker
 pbr==5.11.1 \
     --hash=sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b \
     --hash=sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3
@@ -703,7 +707,6 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
-    #   docker
     #   junit-xml
     #   python-dateutil
     #   serverlessrepo
@@ -742,6 +745,7 @@ urllib3==1.26.15 \
     --hash=sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42
     # via
     #   botocore
+    #   docker
     #   requests
 watchdog==2.1.2 \
     --hash=sha256:0237db4d9024859bea27d0efb59fe75eef290833fd988b8ead7a879b0308c2db \

--- a/samcli/cli/global_config.py
+++ b/samcli/cli/global_config.py
@@ -163,7 +163,7 @@ class GlobalConfig(metaclass=Singleton):
         self,
         config_entry: ConfigEntry,
         default: Optional[T] = None,
-        value_type: Type[T] = T,
+        value_type: Type[T] = T,  # type: ignore
         is_flag: bool = False,
         reload_config: bool = False,
     ) -> Optional[T]:

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -2,17 +2,10 @@
 Keeps list of hidden/dynamic imports that is being used in SAM CLI, so that pyinstaller can include these packages
 """
 import pkgutil
-from typing import cast
-
-from typing_extensions import Protocol
+from types import ModuleType
 
 
-class HasPathAndName(Protocol):
-    __path__: str
-    __name__: str
-
-
-def walk_modules(module: HasPathAndName, visited: set) -> None:
+def walk_modules(module: ModuleType, visited: set) -> None:
     """Recursively find all modules from a parent module"""
     for pkg in pkgutil.walk_packages(module.__path__, module.__name__ + "."):
         if pkg.name in visited:
@@ -20,13 +13,11 @@ def walk_modules(module: HasPathAndName, visited: set) -> None:
         visited.add(pkg.name)
         if pkg.ispkg:
             submodule = __import__(pkg.name)
-            submodule = cast(HasPathAndName, submodule)
             walk_modules(submodule, visited)
 
 
 samcli_modules = set(["samcli"])
 samcli = __import__("samcli")
-samcli = cast(HasPathAndName, samcli)
 walk_modules(samcli, samcli_modules)
 
 SAM_CLI_HIDDEN_IMPORTS = list(samcli_modules) + [

--- a/samcli/commands/package/package_context.py
+++ b/samcli/commands/package/package_context.py
@@ -22,6 +22,7 @@ from typing import List, Optional
 import boto3
 import click
 import docker
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 
 from samcli.commands.package.exceptions import PackageFailedError
 from samcli.lib.intrinsic_resolver.intrinsics_symbol_table import IntrinsicsSymbolTable
@@ -120,7 +121,7 @@ class PackageContext:
         )
         ecr_client = boto3.client("ecr", config=get_boto_config_with_user_agent(region_name=region_name))
 
-        docker_client = docker.from_env()
+        docker_client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
 
         s3_uploader = S3Uploader(
             s3_client, self.s3_bucket, self.s3_prefix, self.kms_key_id, self.force_upload, self.no_progressbar

--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -243,7 +243,7 @@ class ResourceLinker:
             return
 
         for cfn_resource in cfn_resources:
-            self._resource_pair.cfn_resource_update_call_back_function(cfn_resource, dest_resources)  # type: ignore
+            self._resource_pair.cfn_resource_update_call_back_function(cfn_resource, dest_resources)
 
     def _link_using_linking_fields(self, cfn_resource: Dict) -> None:
         """
@@ -298,7 +298,7 @@ class ResourceLinker:
             return
 
         LOG.debug("The value of the source resource linking field after mapping %s", dest_resources)
-        self._resource_pair.cfn_resource_update_call_back_function(cfn_resource, dest_resources)  # type: ignore
+        self._resource_pair.cfn_resource_update_call_back_function(cfn_resource, dest_resources)
 
     def _process_resolved_resources(
         self,

--- a/samcli/hook_packages/terraform/lib/utils.py
+++ b/samcli/hook_packages/terraform/lib/utils.py
@@ -74,7 +74,7 @@ def _calculate_configuration_attribute_value_hash(
     else:
         sorted_references_list = sorted(
             configuration_attribute_value,
-            key=lambda x: x.value if isinstance(x, ConstantValue) else f"{x.module_address}.{x.value}",  # type: ignore
+            key=lambda x: x.value if isinstance(x, ConstantValue) else f"{x.module_address}.{x.value}",
         )
         for ref in sorted_references_list:
             md5.update(

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -8,6 +8,7 @@ import logging
 import pathlib
 from typing import List, Optional, Dict, cast, NamedTuple
 import docker
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 import docker.errors
 from aws_lambda_builders import (
     RPC_PROTOCOL_VERSION as lambda_builders_protocol_version,
@@ -156,7 +157,7 @@ class ApplicationBuilder:
         self._parallel = parallel
         self._mode = mode
         self._stream_writer = stream_writer if stream_writer else StreamWriter(stream=osutils.stderr(), auto_flush=True)
-        self._docker_client = docker_client if docker_client else docker.from_env()
+        self._docker_client = docker_client if docker_client else docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
 
         self._deprecated_runtimes = DEPRECATED_RUNTIMES
         self._colored = Colored()

--- a/samcli/lib/build/workflows.py
+++ b/samcli/lib/build/workflows.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from typing import List
 
 CONFIG = namedtuple(
-    "Capability",
+    "CONFIG",
     [
         "language",
         "dependency_manager",

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -624,7 +624,7 @@ class Deployer:
             msg = ""
 
             if exists:
-                kwargs["DisableRollback"] = disable_rollback
+                kwargs["DisableRollback"] = disable_rollback  # type: ignore
 
                 result = self.update_stack(**kwargs)
                 self.wait_for_execute(stack_name, "UPDATE", disable_rollback, on_failure=on_failure)

--- a/samcli/lib/hook/hook_config.py
+++ b/samcli/lib/hook/hook_config.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from typing import Dict, NamedTuple, Optional, cast
 
-import jsonschema  # type: ignore
+import jsonschema
 
 from .exceptions import InvalidHookPackageConfigException
 

--- a/samcli/lib/iac/cdk/cdk_iac.py
+++ b/samcli/lib/iac/cdk/cdk_iac.py
@@ -19,13 +19,13 @@ class CdkIacImplementation(IaCPluginInterface):
         the CDK project type
     """
 
-    def read_project(self, lookup_paths: List[LookupPath]) -> SamCliProject:
+    def read_project(self, lookup_paths: List[LookupPath]) -> SamCliProject:  # type: ignore
         pass
 
-    def write_project(self, project: SamCliProject, build_dir: str) -> bool:
+    def write_project(self, project: SamCliProject, build_dir: str) -> bool:  # type: ignore
         pass
 
-    def update_packaged_locations(self, stack: Stack) -> bool:
+    def update_packaged_locations(self, stack: Stack) -> bool:  # type: ignore
         pass
 
     @staticmethod

--- a/samcli/lib/iac/cfn/cfn_iac.py
+++ b/samcli/lib/iac/cfn/cfn_iac.py
@@ -1,7 +1,6 @@
 """
 Provide a CFN implementation of IaCPluginInterface
 """
-
 import logging
 import os
 from typing import List, Optional
@@ -72,11 +71,11 @@ class CfnIacImplementation(IaCPluginInterface):
         stack = self._build_stack(self._template_file)
         return SamCliProject([stack])
 
-    def write_project(self, project: SamCliProject, build_dir: str) -> bool:
+    def write_project(self, project: SamCliProject, build_dir: str) -> bool:  # type: ignore
         # TODO
         pass
 
-    def update_packaged_locations(self, stack: Stack) -> bool:
+    def update_packaged_locations(self, stack: Stack) -> bool:  # type: ignore
         # TODO
         pass
 

--- a/samcli/lib/package/ecr_uploader.py
+++ b/samcli/lib/package/ecr_uploader.py
@@ -9,6 +9,7 @@ from typing import Dict
 import botocore
 import click
 import docker
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 from docker.errors import APIError, BuildError
 
 from samcli.commands.package.exceptions import (
@@ -35,7 +36,7 @@ class ECRUploader:
     def __init__(
         self, docker_client, ecr_client, ecr_repo, ecr_repo_multi, no_progressbar=False, tag="latest", stream=stderr()
     ):
-        self.docker_client = docker_client if docker_client else docker.from_env()
+        self.docker_client = docker_client if docker_client else docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         self.ecr_client = ecr_client
         self.ecr_repo = ecr_repo
         self.ecr_repo_multi = ecr_repo_multi

--- a/samcli/lib/package/image_utils.py
+++ b/samcli/lib/package/image_utils.py
@@ -2,6 +2,7 @@
 Image artifacts based utilities
 """
 import docker
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 from docker.errors import APIError, NullResource
 
 from samcli.commands.package.exceptions import DockerGetLocalImageFailedError
@@ -35,7 +36,7 @@ def tag_translation(image, docker_image_id=None, gen_tag="latest"):
 
     if not docker_image_id:
         try:
-            docker_client = docker.from_env()
+            docker_client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
             docker_image_id = docker_client.images.get(image).id
         except APIError as ex:
             raise DockerGetLocalImageFailedError(str(ex)) from ex

--- a/samcli/lib/pipeline/bootstrap/stage.py
+++ b/samcli/lib/pipeline/bootstrap/stage.py
@@ -13,7 +13,7 @@ import boto3
 import click
 import requests
 from botocore.exceptions import ClientError
-from OpenSSL import SSL, crypto  # type: ignore
+from OpenSSL import SSL, crypto
 
 from samcli.commands.pipeline.bootstrap.guided_context import BITBUCKET, GITHUB_ACTIONS, GITLAB, OPEN_ID_CONNECT
 from samcli.commands.pipeline.bootstrap.pipeline_oidc_provider import PipelineOidcProvider
@@ -222,7 +222,7 @@ class Stage:
         # If we attempt to get the cert chain without exchanging some traffic it will be empty
         c.sendall(str.encode("HEAD / HTTP/1.0\n\n"))
         peerCertChain = c.get_peer_cert_chain()
-        cert = peerCertChain[-1]
+        cert = peerCertChain[-1]  # type: ignore
 
         # Dump the certificate in DER/ASN1 format so that its SHA1 hash can be computed
         dumped_cert = crypto.dump_certificate(crypto.FILETYPE_ASN1, cert)

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -466,9 +466,11 @@ class Api:
         return list(self.binary_media_types_set)
 
 
-_CorsTuple = namedtuple("Cors", ["allow_origin", "allow_methods", "allow_headers", "allow_credentials", "max_age"])
+_CorsTuple = namedtuple(
+    "_CorsTuple", ["allow_origin", "allow_methods", "allow_headers", "allow_credentials", "max_age"]
+)
 
-_CorsTuple.__new__.__defaults__ = (  # type: ignore
+_CorsTuple.__new__.__defaults__ = (
     None,  # Allow Origin defaults to None
     None,  # Allow Methods is optional and defaults to empty
     None,  # Allow Headers is optional and defaults to empty

--- a/samcli/lib/sync/flows/image_function_sync_flow.py
+++ b/samcli/lib/sync/flows/image_function_sync_flow.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import docker
 from docker.client import DockerClient
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 
 from samcli.lib.build.app_builder import ApplicationBuilder, ApplicationBuildResult
 from samcli.lib.package.ecr_uploader import ECRUploader
@@ -69,7 +70,7 @@ class ImageFunctionSyncFlow(FunctionSyncFlow):
     def _get_docker_client(self) -> DockerClient:
         """Lazy instantiates and returns the docker client"""
         if not self._docker_client:
-            self._docker_client = docker.from_env()
+            self._docker_client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         return self._docker_client
 
     def _get_ecr_client(self) -> Any:

--- a/samcli/lib/utils/file_observer.py
+++ b/samcli/lib/utils/file_observer.py
@@ -11,6 +11,7 @@ from typing import Callable, Dict, List, Optional
 
 import docker
 from docker import DockerClient
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 from docker.errors import ImageNotFound
 from docker.types import CancellableStream
 from watchdog.events import FileSystemEvent, FileSystemEventHandler, PatternMatchingEventHandler
@@ -257,7 +258,7 @@ class ImageObserver(ResourceObserver):
         """
         self._observed_images: Dict[str, str] = {}
         self._input_on_change: Callable = on_change
-        self.docker_client: DockerClient = docker.from_env()
+        self.docker_client: DockerClient = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         self.events: CancellableStream = self.docker_client.events(filters={"type": "image"}, decode=True)
         self._images_observer_thread: Optional[Thread] = None
         self._lock: Lock = threading.Lock()

--- a/samcli/lib/utils/lock_distributor.py
+++ b/samcli/lib/utils/lock_distributor.py
@@ -72,7 +72,7 @@ class LockDistributor:
         self._manager = manager
         self._dict_lock = self._create_new_lock()
         self._locks = (
-            self._manager.dict()
+            self._manager.dict()  # type: ignore
             if self._lock_type == LockDistributorType.PROCESS and self._manager is not None
             else dict()
         )

--- a/samcli/lib/utils/system_info.py
+++ b/samcli/lib/utils/system_info.py
@@ -53,10 +53,11 @@ def _gather_docker_info() -> str:
     import contextlib
 
     import docker
+    from docker.constants import DEFAULT_DOCKER_API_VERSION
 
     from samcli.local.docker.utils import is_docker_reachable
 
-    with contextlib.closing(docker.from_env()) as client:
+    with contextlib.closing(docker.from_env(version=DEFAULT_DOCKER_API_VERSION)) as client:
         if is_docker_reachable(client):
             return cast(str, client.version().get("Version", "Not available"))
         return "Not available"

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -206,9 +206,6 @@ class Container:
             # Ex: 128m => 128MB
             kwargs["mem_limit"] = "{}m".format(self._memory_limit_mb)
 
-        if self.network_id == "host":
-            kwargs["network_mode"] = self.network_id
-
         real_container = self.docker_client.containers.create(self._image, **kwargs)
         self.id = real_container.id
 

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import docker
 import requests
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 from docker.errors import NotFound as DockerNetworkNotFound
 
 from samcli.lib.utils.retry import retry
@@ -111,7 +112,7 @@ class Container:
         self._logs_thread = None
 
         # Use the given Docker client or create new one
-        self.docker_client = docker_client or docker.from_env()
+        self.docker_client = docker_client or docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
 
         # Runtime properties of the container. They won't have value until container is created or started
         self.id = None

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Optional
 
 import docker
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 
 from samcli.commands.local.cli_common.user_exceptions import (
     DockerDistributionAPIError,
@@ -123,7 +124,7 @@ class LambdaImage:
         self.layer_downloader = layer_downloader
         self.skip_pull_image = skip_pull_image
         self.force_image_build = force_image_build
-        self.docker_client = docker_client or docker.from_env()
+        self.docker_client = docker_client or docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         self.invoke_images = invoke_images
 
     def build(self, runtime, packagetype, image, layers, architecture, stream=None, function_name=None):

--- a/samcli/local/docker/manager.py
+++ b/samcli/local/docker/manager.py
@@ -7,6 +7,7 @@ import sys
 import threading
 
 import docker
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.docker import utils
@@ -35,7 +36,7 @@ class ContainerManager:
 
         self.skip_pull_image = skip_pull_image
         self.docker_network_id = docker_network_id
-        self.docker_client = docker_client or docker.from_env()
+        self.docker_client = docker_client or docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         self.do_shutdown_event = do_shutdown_event
 
         self._lock = threading.Lock()

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -331,7 +331,7 @@ class WarmLambdaRuntime(LambdaRuntime):
     warm containers life cycle.
     """
 
-    def __init__(self, container_manager, image_builder):
+    def __init__(self, container_manager, image_builder, observer=None):
         """
         Initialize the Local Lambda runtime
 
@@ -347,7 +347,7 @@ class WarmLambdaRuntime(LambdaRuntime):
         self._function_configs = {}
         self._containers = {}
 
-        self._observer = LambdaFunctionObserver(self._on_code_change)
+        self._observer = observer if observer else LambdaFunctionObserver(self._on_code_change)
 
         super().__init__(container_manager, image_builder)
 

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Internet",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Utilities",

--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 import time
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import boto3
 import pytest
@@ -30,7 +30,7 @@ class LogsIntegTestCases(LogsIntegBase):
     test_template_folder = ""
 
     stack_name = ""
-    stack_resources = {}
+    stack_resources: Dict[Any, Any] = {}
     stack_info = None
 
     def setUp(self):
@@ -76,7 +76,7 @@ class LogsIntegTestCases(LogsIntegBase):
         return self.stack_resources[resource_path]
 
     def _get_output_value(self, key: str):
-        for output in self.stack_info.outputs:
+        for output in self.stack_info.outputs:  # type: ignore
             if output.get("OutputKey", "") == key:
                 return output.get("OutputValue", "")
 

--- a/tests/integration/traces/test_traces_command.py
+++ b/tests/integration/traces/test_traces_command.py
@@ -1,7 +1,7 @@
 import itertools
 import time
 from pathlib import Path
-from typing import List
+from typing import Any, List
 from unittest import skipIf
 
 import boto3
@@ -32,7 +32,7 @@ SKIP_TRACES_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_
 @skipIf(SKIP_TRACES_TESTS, "Skip traces tests in CI/CD only")
 @pytest.mark.xdist_group(name="sam_traces")
 class TestTracesCommand(TracesIntegBase):
-    stack_resources = []
+    stack_resources: List[Any] = []
     stack_name = ""
 
     def setUp(self):

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -64,7 +64,7 @@ class TestDeployCliCommand(TestCase):
     def tearDown(self):
         self.companion_stack_manager_patch.stop()
 
-    @patch("os.environ", {**os.environ, "SAM_CLI_POLL_DELAY": 10})
+    @patch("os.environ", {**os.environ, "SAM_CLI_POLL_DELAY": 10})  # type: ignore
     @patch("samcli.commands.package.command.click")
     @patch("samcli.commands.package.package_context.PackageContext")
     @patch("samcli.commands.deploy.command.click")

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -555,13 +555,20 @@ class TestInvokeContext_function_name_property(TestCase):
 
 
 class TestInvokeContext_local_lambda_runner(TestCase):
+    @patch("samcli.local.lambdafn.runtime.LambdaFunctionObserver")
     @patch("samcli.commands.local.cli_common.invoke_context.LambdaImage")
     @patch("samcli.commands.local.cli_common.invoke_context.LayerDownloader")
     @patch("samcli.commands.local.cli_common.invoke_context.LambdaRuntime")
     @patch("samcli.commands.local.cli_common.invoke_context.LocalLambdaRunner")
     @patch("samcli.commands.local.cli_common.invoke_context.SamFunctionProvider")
     def test_must_create_runner(
-        self, SamFunctionProviderMock, LocalLambdaMock, LambdaRuntimeMock, download_layers_mock, lambda_image_patch
+        self,
+        SamFunctionProviderMock,
+        LocalLambdaMock,
+        LambdaRuntimeMock,
+        download_layers_mock,
+        lambda_image_patch,
+        LambdaFunctionObserver_patch,
     ):
         runtime_mock = Mock()
         LambdaRuntimeMock.return_value = runtime_mock
@@ -574,6 +581,9 @@ class TestInvokeContext_local_lambda_runner(TestCase):
 
         image_mock = Mock()
         lambda_image_patch.return_value = image_mock
+
+        LambdaFunctionObserver_mock = Mock()
+        LambdaFunctionObserver_patch.return_value = LambdaFunctionObserver_mock
 
         cwd = "cwd"
         self.context = InvokeContext(
@@ -705,13 +715,20 @@ class TestInvokeContext_local_lambda_runner(TestCase):
             # assert that lambda runner is created only one time, and the cached version used in the second call
             self.assertEqual(LocalLambdaMock.call_count, 1)
 
+    @patch("samcli.local.lambdafn.runtime.LambdaFunctionObserver")
     @patch("samcli.commands.local.cli_common.invoke_context.LambdaImage")
     @patch("samcli.commands.local.cli_common.invoke_context.LayerDownloader")
     @patch("samcli.commands.local.cli_common.invoke_context.LambdaRuntime")
     @patch("samcli.commands.local.cli_common.invoke_context.LocalLambdaRunner")
     @patch("samcli.commands.local.cli_common.invoke_context.SamFunctionProvider")
     def test_must_create_runner_with_container_host_option(
-        self, SamFunctionProviderMock, LocalLambdaMock, LambdaRuntimeMock, download_layers_mock, lambda_image_patch
+        self,
+        SamFunctionProviderMock,
+        LocalLambdaMock,
+        LambdaRuntimeMock,
+        download_layers_mock,
+        lambda_image_patch,
+        LambdaFunctionObserver_patch,
     ):
         runtime_mock = Mock()
         LambdaRuntimeMock.return_value = runtime_mock
@@ -724,6 +741,9 @@ class TestInvokeContext_local_lambda_runner(TestCase):
 
         image_mock = Mock()
         lambda_image_patch.return_value = image_mock
+
+        LambdaFunctionObserver_mock = Mock()
+        LambdaFunctionObserver_patch.return_value = LambdaFunctionObserver_mock
 
         cwd = "cwd"
         self.context = InvokeContext(
@@ -779,13 +799,20 @@ class TestInvokeContext_local_lambda_runner(TestCase):
             # assert that lambda runner is created only one time, and the cached version used in the second call
             self.assertEqual(LocalLambdaMock.call_count, 1)
 
+    @patch("samcli.local.lambdafn.runtime.LambdaFunctionObserver")
     @patch("samcli.commands.local.cli_common.invoke_context.LambdaImage")
     @patch("samcli.commands.local.cli_common.invoke_context.LayerDownloader")
     @patch("samcli.commands.local.cli_common.invoke_context.LambdaRuntime")
     @patch("samcli.commands.local.cli_common.invoke_context.LocalLambdaRunner")
     @patch("samcli.commands.local.cli_common.invoke_context.SamFunctionProvider")
     def test_must_create_runner_with_invoke_image_option(
-        self, SamFunctionProviderMock, LocalLambdaMock, LambdaRuntimeMock, download_layers_mock, lambda_image_patch
+        self,
+        SamFunctionProviderMock,
+        LocalLambdaMock,
+        LambdaRuntimeMock,
+        download_layers_mock,
+        lambda_image_patch,
+        LambdaFunctionObserver_patch,
     ):
         runtime_mock = Mock()
         LambdaRuntimeMock.return_value = runtime_mock
@@ -798,6 +825,9 @@ class TestInvokeContext_local_lambda_runner(TestCase):
 
         image_mock = Mock()
         lambda_image_patch.return_value = image_mock
+
+        LambdaFunctionObserver_mock = Mock()
+        LambdaFunctionObserver_patch.return_value = LambdaFunctionObserver_mock
 
         cwd = "cwd"
         self.context = InvokeContext(

--- a/tests/unit/commands/sync/test_command.py
+++ b/tests/unit/commands/sync/test_command.py
@@ -68,7 +68,7 @@ class TestDoCli(TestCase):
             (False, False, False, False, True, InfraSyncResult(True)),
         ]
     )
-    @patch("os.environ", {**os.environ, "SAM_CLI_POLL_DELAY": 10})
+    @patch("os.environ", {**os.environ, "SAM_CLI_POLL_DELAY": 10})  # type: ignore
     @patch("samcli.commands.sync.command.click")
     @patch("samcli.commands.sync.command.execute_code_sync")
     @patch("samcli.commands.build.command.click")

--- a/tests/unit/commands/validate/test_cli.py
+++ b/tests/unit/commands/validate/test_cli.py
@@ -11,8 +11,8 @@ from samcli.commands.local.cli_common.user_exceptions import SamTemplateNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.validate.validate import do_cli, _read_sam_file, _lint
 
-ctx_mock = namedtuple("ctx", ["profile", "region"])
-ctx_lint_mock = namedtuple("ctx", ["debug", "region"])
+ctx_mock = namedtuple("ctx_mock", ["profile", "region"])
+ctx_lint_mock = namedtuple("ctx_lint_mock", ["debug", "region"])
 
 
 class TestValidateCli(TestCase):

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -1418,8 +1418,7 @@ class TestApplicationBuilder_update_template_windows(TestCase):
     def test_must_write_absolute_path_for_different_drives(self):
         def mock_new(cls, *args, **kwargs):
             cls = WindowsPath
-            self = cls._from_parts(args, init=False)
-            self._init()
+            self = cls._from_parts(args)
             return self
 
         def mock_resolve(self):

--- a/tests/unit/lib/deploy/test_deployer.py
+++ b/tests/unit/lib/deploy/test_deployer.py
@@ -343,7 +343,7 @@ class TestDeployer(CustomTestCase):
         self.deployer._client.get_waiter = MagicMock(return_value=MockChangesetWaiter())
         self.deployer.wait_for_changeset("test-id", "test-stack")
 
-    @patch("os.environ", {**os.environ, "SAM_CLI_POLL_DELAY": 10})
+    @patch("os.environ", {**os.environ, "SAM_CLI_POLL_DELAY": 10})  # type: ignore
     def test_wait_for_changeset_client_sleep(self):
         deployer = Deployer(MagicMock().client("cloudformation"), client_sleep=os.getenv("SAM_CLI_POLL_DELAY", 0.5))
         deployer._client.get_waiter = MagicMock(return_value=MockChangesetWaiter())
@@ -358,7 +358,7 @@ class TestDeployer(CustomTestCase):
             ChangeSetName="test-id", StackName="test-stack", WaiterConfig={"Delay": 0.5}
         )
 
-    @patch("os.environ", {**os.environ, "SAM_CLI_POLL_DELAY": 10})
+    @patch("os.environ", {**os.environ, "SAM_CLI_POLL_DELAY": 10})  # type: ignore
     def test_wait_for_changeset_custom_delay(self):
         deployer = Deployer(MagicMock().client("cloudformation"), client_sleep=os.getenv("SAM_CLI_POLL_DELAY"))
         deployer.wait_for_changeset("test-id", "test-stack")

--- a/tests/unit/lib/pipeline/bootstrap/test_environment.py
+++ b/tests/unit/lib/pipeline/bootstrap/test_environment.py
@@ -2,7 +2,7 @@ import hashlib
 from unittest import TestCase
 from unittest.mock import Mock, patch, call, MagicMock
 
-import OpenSSL.SSL  # type: ignore
+import OpenSSL.SSL
 import requests
 
 from samcli.commands.pipeline.bootstrap.guided_context import GITHUB_ACTIONS

--- a/tests/unit/local/apigw/test_lambda_authorizer.py
+++ b/tests/unit/local/apigw/test_lambda_authorizer.py
@@ -25,7 +25,7 @@ class TestHeaderIdentitySource(TestCase):
         [
             ({"headers": Headers({})},),  # test empty headers
             ({},),  # test no headers
-            ({"headers": Headers({"not here": 123})},),  # test missing headers
+            ({"headers": Headers({"not here": 123})},),  # type: ignore  # test missing headers
             ({"validation_expression": "^123$"},),  # test no headers, but provided validation
         ]
     )

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -296,7 +296,6 @@ class TestContainer_create(TestCase):
             tty=False,
             use_config_proxy=True,
             volumes=expected_volumes,
-            network_mode="host",
         )
 
         self.mock_docker_client.networks.get.assert_not_called()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#5243

#### Why is this change necessary?
Re-adds:
1. docker upgrade
2. getting SAM CLI dev dependencies installable in py3.11

This also fixes issues we found that `docker.from_env()` fails when docker is not running.

#### How does it address the issue?
In order for the docker.from_env() not to fail when docker is not installed/running,
we force the min version on client creation. This was the default behavior in 4.X of
docker-py but not longer in the latest version.

#### What side effects does this change have?
None that I know of

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
