### PR TITLE
test: GHA to Execute Test without Docker Running

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,8 @@ jobs:
     name: Docker-disabled Tests / ${{ matrix.os }}
     if: github.repository_owner == 'aws'
     runs-on: ${{ matrix.os }}
+    env:
+      SAM_CLI_DEV: "1"
     strategy:
       matrix:
         os:
@@ -211,7 +213,6 @@ jobs:
             3.7
       - name: Init samdev
         run: make init
-
       - name: Stop Docker Linux
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo systemctl stop docker
@@ -219,7 +220,6 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         shell: pwsh
         run: stop-service docker
-
       - name: Check Docker not Running
         run: docker info
         id: run-docker-info
@@ -227,6 +227,5 @@ jobs:
       - name: Report failure
         if: steps.run-docker-info.outcome == 'success'
         run: exit 1
-
       - name: Run tests without Docker
-        run: SAM_CLI_DEV=1 pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_PythonFunctions_WithoutDocker
+        run: pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_PythonFunctions_WithoutDocker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,12 +205,13 @@ jobs:
         with:
           # These are the versions of Python that correspond to the supported Lambda runtimes
           python-version: |
-            3.7
-            3.8
-            3.9
             3.10
+            3.9
+            3.8
+            3.7
       - name: Init samdev
         run: make init
+
       - name: Stop Docker Linux
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo systemctl stop docker
@@ -218,6 +219,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         shell: pwsh
         run: stop-service docker
+
       - name: Check Docker not Running
         run: docker info
         id: run-docker-info
@@ -225,5 +227,6 @@ jobs:
       - name: Report failure
         if: steps.run-docker-info.outcome == 'success'
         run: exit 1
+
       - name: Run tests without Docker
         run: SAM_CLI_DEV=1 pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_PythonFunctions_WithoutDocker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,3 +187,15 @@ jobs:
         run: make init
       - name: Run functional & smoke tests
         run: pytest -vv -n 4 tests/functional tests/smoke
+        
+  docker-disabled:
+    name: docker-disabled-test
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: sudo systemctl stop docker
+      - run: docker info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
+          # These are the versions of Python that correspond to the supported Lambda runtimes
           python-version: |
             3.7
             3.8
@@ -215,4 +216,4 @@ jobs:
         if: steps.run-docker-info.outcome == 'success'
         run: exit 1
       - name: Run tests without Docker
-        run: pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_PythonFunctions_WithoutDocker
+        run: SAM_CLI_DEV=1 pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_PythonFunctions_WithoutDocker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,10 +194,11 @@ jobs:
     name: Docker-disabled Tests / ${{ matrix.os }}
     if: github.repository_owner == 'aws'
     runs-on: ${{ matrix.os }}
-    matrix:
-      os:
-        - ubuntu-latest
-        - windows-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,5 +201,6 @@ jobs:
         run: make init
       - run: sudo systemctl stop docker
       - run: docker info
+        continue-on-error: true
       - if: failure()
         run: pytest -vv tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_PythonFunctions_0_template_yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
         run: make init
       - name: Run functional & smoke tests
         run: pytest -vv -n 4 tests/functional tests/smoke
-        
+
   docker-disabled:
     name: docker-disabled-test
     if: github.repository_owner == 'aws'
@@ -196,6 +196,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.7" # The integration test below needs python3.7 be to configured on the PATH
       - run: sudo systemctl stop docker
       - run: docker info
+      - if: success()
+        run: exit 1
+      - if: failure()
+        run: pytest -vv tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_PythonFunctions_0_template_yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,5 @@ jobs:
         run: make init
       - run: sudo systemctl stop docker
       - run: docker info
-      - if: success()
-        run: exit 1
       - if: failure()
         run: pytest -vv tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_PythonFunctions_0_template_yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,14 @@ jobs:
       - make-pr
       - integration-tests
       - smoke-and-functional-tests
+      - docker-disabled
     steps:
       - name: report-failure
         if : |
           needs.make-pr.result != 'success' ||
           needs.integration-tests.result != 'success' ||
-          needs.smoke-and-functional-tests.result != 'success'
+          needs.smoke-and-functional-tests.result != 'success' ||
+          needs.docker-disabled.result != 'success'
         run: exit 1
       - name: report-success
         run: exit 0
@@ -206,7 +208,7 @@ jobs:
       - name: Stop Docker
         run: sudo systemctl stop docker
       - name: Check Docker not Running
-      - run: docker info
+        run: docker info
         id: run-docker-info
         continue-on-error: true
       - name: Report failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,13 +196,21 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7" # The integration test below needs python3.7 be to configured on the PATH
+          python-version: |
+            3.7
+            3.8
+            3.9
+            3.10
       - name: Init samdev
         run: make init
-      - run: sudo systemctl stop docker
+      - name: Stop Docker
+        run: sudo systemctl stop docker
+      - name: Check Docker not Running
       - run: docker info
         id: run-docker-info
         continue-on-error: true
-      - if: steps.run-docker-info.outcome == 'success'
+      - name: Report failure
+        if: steps.run-docker-info.outcome == 'success'
         run: exit 1
-      - run: pytest -vv tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_PythonFunctions_0_template_yaml
+      - name: Run tests without Docker
+        run: pytest -vv tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_PythonFunctions_without_docker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7" # The integration test below needs python3.7 be to configured on the PATH
+      - name: Init samdev
+        run: make init
       - run: sudo systemctl stop docker
       - run: docker info
       - if: success()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,9 +191,13 @@ jobs:
         run: pytest -vv -n 4 tests/functional tests/smoke
 
   docker-disabled:
-    name: docker-disabled-test
+    name: Docker-disabled Tests / ${{ matrix.os }}
     if: github.repository_owner == 'aws'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    matrix:
+      os:
+        - ubuntu-latest
+        - windows-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -206,8 +210,13 @@ jobs:
             3.10
       - name: Init samdev
         run: make init
-      - name: Stop Docker
+      - name: Stop Docker Linux
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo systemctl stop docker
+      - name: Stop Docker Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: stop-service docker
       - name: Check Docker not Running
         run: docker info
         id: run-docker-info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,6 +201,8 @@ jobs:
         run: make init
       - run: sudo systemctl stop docker
       - run: docker info
+        id: run-docker-info
         continue-on-error: true
-      - if: failure()
-        run: pytest -vv tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_PythonFunctions_0_template_yaml
+      - if: steps.run-docker-info.outcome == 'success'
+        run: exit 1
+      - run: pytest -vv tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_PythonFunctions_0_template_yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,4 +213,4 @@ jobs:
         if: steps.run-docker-info.outcome == 'success'
         run: exit 1
       - name: Run tests without Docker
-        run: pytest -vv tests/integration/buildcmd/test_build_cmd.py::TestBuildCommand_PythonFunctions_without_docker
+        run: pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_PythonFunctions_WithoutDocker

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -398,33 +398,64 @@ class TestSkipBuildingFlaggedFunctions(BuildIntegPythonBase):
         "overrides",
         "runtime",
         "codeuri",
-        "use_container",
         "check_function_only",
         "prop",
     ),
     [
-        ("template.yaml", "Function", True, "python3.7", "Python", False, False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.8", "Python", False, False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.9", "Python", False, False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.10", "Python", False, False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.7", "PythonPEP600", False, False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.8", "PythonPEP600", False, False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.7", "Python", "use_container", False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.8", "Python", "use_container", False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.9", "Python", "use_container", False, "CodeUri"),
-        ("template.yaml", "Function", True, "python3.10", "Python", "use_container", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.7", "Python", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.8", "Python", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.9", "Python", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.10", "Python", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.7", "PythonPEP600", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.8", "PythonPEP600", False, "CodeUri"),
     ],
 )
-class TestBuildCommand_PythonFunctions(BuildIntegPythonBase):
+class TestBuildCommand_PythonFunctions_WithoutDocker(BuildIntegPythonBase):
     overrides = True
     runtime = "python3.9"
     codeuri = "Python"
+    check_function_only = False
     use_container = False
+
+    @pytest.mark.flaky(reruns=3)
+    def test_with_default_requirements(self):
+        self._test_with_default_requirements(
+            self.runtime,
+            self.codeuri,
+            self.use_container,
+            self.test_data_path,
+            do_override=self.overrides,
+            check_function_only=self.check_function_only,
+        )
+
+
+@parameterized_class(
+    (
+        "template",
+        "FUNCTION_LOGICAL_ID",
+        "overrides",
+        "runtime",
+        "codeuri",
+        "check_function_only",
+        "prop",
+    ),
+    [
+        ("template.yaml", "Function", True, "python3.7", "Python", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.8", "Python", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.9", "Python", False, "CodeUri"),
+        ("template.yaml", "Function", True, "python3.10", "Python", False, "CodeUri"),
+    ],
+)
+class TestBuildCommand_PythonFunctions_WithDocker(BuildIntegPythonBase):
+    overrides = True
+    runtime = "python3.9"
+    codeuri = "Python"
+    use_container = "use_container"
     check_function_only = False
 
     @pytest.mark.flaky(reruns=3)
     def test_with_default_requirements(self):
-        if self.use_container and (SKIP_DOCKER_TESTS or SKIP_DOCKER_BUILD):
+        if SKIP_DOCKER_TESTS or SKIP_DOCKER_BUILD:
             self.skipTest(SKIP_DOCKER_MESSAGE)
         self._test_with_default_requirements(
             self.runtime,
@@ -465,7 +496,9 @@ class TestBuildCommand_PythonFunctions(BuildIntegPythonBase):
         ),
     ],
 )
-class TestBuildCommand_PythonFunctions_CDK(TestBuildCommand_PythonFunctions):
+class TestBuildCommand_PythonFunctions_CDK(TestBuildCommand_PythonFunctions_WithoutDocker):
+    use_container = False
+
     @pytest.mark.flaky(reruns=3)
     def test_cdk_app_with_default_requirements(self):
         self._test_with_default_requirements(

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -429,6 +429,7 @@ class TestBuildCommand_PythonFunctions_WithoutDocker(BuildIntegPythonBase):
         )
 
 
+@skipIf(SKIP_DOCKER_TESTS or SKIP_DOCKER_BUILD, SKIP_DOCKER_MESSAGE)
 @parameterized_class(
     (
         "template",
@@ -455,8 +456,6 @@ class TestBuildCommand_PythonFunctions_WithDocker(BuildIntegPythonBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_with_default_requirements(self):
-        if SKIP_DOCKER_TESTS or SKIP_DOCKER_BUILD:
-            self.skipTest(SKIP_DOCKER_MESSAGE)
         self._test_with_default_requirements(
             self.runtime,
             self.codeuri,


### PR DESCRIPTION
#### Why is this change necessary?
To ensure that executing AWS SAM CLI commands while Docker isn't running succeeds.
Guard against regressions.

#### How does it address the issue?
Creates a GitHub action that runs on PRs to ensure that a build test succeeds after the Docker daemon is stopped.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
