### PR TITLE
fix: remove ruby3.2 from preview runtimes

### DIFF
--- a/samcli/lib/utils/preview_runtimes.py
+++ b/samcli/lib/utils/preview_runtimes.py
@@ -4,4 +4,4 @@ But deployment of them would probably fail until their GA date
 """
 from typing import Set
 
-PREVIEW_RUNTIMES: Set[str] = {}
+PREVIEW_RUNTIMES: Set[str] = set()

--- a/samcli/lib/utils/preview_runtimes.py
+++ b/samcli/lib/utils/preview_runtimes.py
@@ -4,4 +4,4 @@ But deployment of them would probably fail until their GA date
 """
 from typing import Set
 
-PREVIEW_RUNTIMES: Set[str] = {"ruby3.2"}
+PREVIEW_RUNTIMES: Set[str] = {}


### PR DESCRIPTION
Remove `ruby3.2` from preview runtimes.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
