### PR TITLE
feat: Add hierarchy for samconfig filetypes

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -67,7 +67,9 @@ class ConfigProvider:
 
         # Use default sam config file name if config_path only contain the directory
         config_file_path = (
-            Path(os.path.abspath(config_path)) if config_path else Path(os.getcwd(), DEFAULT_CONFIG_FILE_NAME)
+            Path(os.path.abspath(config_path))
+            if config_path
+            else Path(os.getcwd(), SamConfig.get_default_file(os.getcwd()))
         )
         config_file_name = config_file_path.name
         config_file_dir = config_file_path.parents[0]

--- a/samcli/commands/deploy/guided_config.py
+++ b/samcli/commands/deploy/guided_config.py
@@ -8,7 +8,7 @@ import click
 from samcli.cli.context import get_cmd_names
 from samcli.commands.deploy.exceptions import GuidedDeployFailedError
 from samcli.lib.config.exceptions import SamConfigFileReadException
-from samcli.lib.config.samconfig import DEFAULT_CONFIG_FILE_NAME, DEFAULT_ENV, SamConfig
+from samcli.lib.config.samconfig import DEFAULT_ENV, SamConfig
 
 
 class GuidedConfig:
@@ -20,9 +20,10 @@ class GuidedConfig:
         ctx = click.get_current_context()
 
         samconfig_dir = getattr(ctx, "samconfig_dir", None)
+        config_dir = samconfig_dir if samconfig_dir else SamConfig.config_dir(template_file_path=self.template_file)
         samconfig = SamConfig(
-            config_dir=samconfig_dir if samconfig_dir else SamConfig.config_dir(template_file_path=self.template_file),
-            filename=config_file or DEFAULT_CONFIG_FILE_NAME,
+            config_dir=config_dir,
+            filename=config_file or SamConfig.get_default_file(config_dir=config_dir),
         )
         return ctx, samconfig
 

--- a/samcli/lib/config/file_manager.py
+++ b/samcli/lib/config/file_manager.py
@@ -187,7 +187,7 @@ class YamlFileManager(FileManager):
             A dictionary-like yaml object, which represents the contents of the YAML file at the
             provided location.
         """
-        yaml_doc = YamlFileManager.yaml.load("")
+        yaml_doc = {}
         try:
             yaml_doc = YamlFileManager.yaml.load(filepath.read_text())
         except OSError as e:

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -45,7 +45,7 @@ class SamConfig:
             could automatically support auto-resolving multiple config files within same directory.
         """
         self.document = {}
-        self.filepath = Path(config_dir, filename or self._get_default_file(config_dir=config_dir))
+        self.filepath = Path(config_dir, filename or self.get_default_file(config_dir=config_dir))
         self.file_manager = self.FILE_MANAGER_MAPPER.get(self.filepath.suffix, None)
         if not self.file_manager:
             LOG.warning(
@@ -248,7 +248,8 @@ class SamConfig:
             # Only keep the global parameter
             del self.document[env][cmd_name_key][section][key]
 
-    def _get_default_file(self, config_dir: str) -> str:
+    @staticmethod
+    def get_default_file(config_dir: str) -> str:
         """Return a defaultly-named config file, if it exists, otherwise the current default.
 
         Parameters
@@ -265,7 +266,7 @@ class SamConfig:
         config_files_found = 0
         config_file = DEFAULT_CONFIG_FILE_NAME
 
-        for extension in reversed(self.FILE_MANAGER_MAPPER.keys()):
+        for extension in reversed(SamConfig.FILE_MANAGER_MAPPER.keys()):
             filename = DEFAULT_CONFIG_FILE + extension
             if Path(config_dir, filename).exists():
                 config_files_found += 1

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -249,7 +249,19 @@ class SamConfig:
             del self.document[env][cmd_name_key][section][key]
 
     def _get_default_file(self, config_dir: str) -> str:
-        """Return a defaultly-named config file, if it exists, otherwise the current default."""
+        """Return a defaultly-named config file, if it exists, otherwise the current default.
+
+        Parameters
+        ----------
+        config_dir: str
+            The name of the directory where the config file is/will be stored.
+
+        Returns
+        -------
+        str
+            The name of the config file found, if it exists. In the case that it does not exist, the default config
+            file name is returned instead.
+        """
         config_files_found = 0
         config_file = DEFAULT_CONFIG_FILE_NAME
 
@@ -260,9 +272,12 @@ class SamConfig:
                 config_file = filename
 
         if config_files_found == 0:  # Config file doesn't exist (yet!)
-            LOG.debug(f"No config file exists yet. Creating one as {config_file}.")
+            LOG.info(f"No config file found. Creating one as {config_file}.")
         elif config_files_found > 1:  # Multiple config files; let user know which is used
-            LOG.debug(f"More than one samconfig file found. Using {config_file}.")
+            LOG.info(
+                f"More than one samconfig file found; using {config_file}."
+                f" To use another config file, please specify it using the '--config-file' flag."
+            )
 
         return config_file
 

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -266,7 +266,7 @@ class SamConfig:
         config_files_found = 0
         config_file = DEFAULT_CONFIG_FILE_NAME
 
-        for extension in reversed(SamConfig.FILE_MANAGER_MAPPER.keys()):
+        for extension in reversed(list(SamConfig.FILE_MANAGER_MAPPER.keys())):
             filename = DEFAULT_CONFIG_FILE + extension
             if Path(config_dir, filename).exists():
                 config_files_found += 1

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -14,7 +14,8 @@ from samcli.lib.config.version import SAM_CONFIG_VERSION, VERSION_KEY
 LOG = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_FILE_EXTENSION = ".toml"
-DEFAULT_CONFIG_FILE_NAME = f"samconfig{DEFAULT_CONFIG_FILE_EXTENSION}"
+DEFAULT_CONFIG_FILE = "samconfig"
+DEFAULT_CONFIG_FILE_NAME = DEFAULT_CONFIG_FILE + DEFAULT_CONFIG_FILE_EXTENSION
 DEFAULT_ENV = "default"
 DEFAULT_GLOBAL_CMDNAME = "global"
 
@@ -24,7 +25,7 @@ class SamConfig:
     Class to represent `samconfig` config options.
     """
 
-    FILE_MANAGER_MAPPER: Dict[str, Type[FileManager]] = {
+    FILE_MANAGER_MAPPER: Dict[str, Type[FileManager]] = {  # keys ordered by priority
         ".toml": TomlFileManager,
         ".yaml": YamlFileManager,
         ".yml": YamlFileManager,
@@ -44,7 +45,7 @@ class SamConfig:
             could automatically support auto-resolving multiple config files within same directory.
         """
         self.document = {}
-        self.filepath = Path(config_dir, filename or DEFAULT_CONFIG_FILE_NAME)
+        self.filepath = Path(config_dir, filename or self._get_default_file(config_dir=config_dir))
         self.file_manager = self.FILE_MANAGER_MAPPER.get(self.filepath.suffix, None)
         if not self.file_manager:
             LOG.warning(
@@ -246,6 +247,24 @@ class SamConfig:
             LOG.info(save_global_message)
             # Only keep the global parameter
             del self.document[env][cmd_name_key][section][key]
+
+    def _get_default_file(self, config_dir: str) -> str:
+        """Return a defaultly-named config file, if it exists, otherwise the current default."""
+        config_files_found = 0
+        config_file = DEFAULT_CONFIG_FILE_NAME
+
+        for extension in reversed(self.FILE_MANAGER_MAPPER.keys()):
+            filename = DEFAULT_CONFIG_FILE + extension
+            if Path(config_dir, filename).exists():
+                config_files_found += 1
+                config_file = filename
+
+        if config_files_found == 0:  # Config file doesn't exist (yet!)
+            LOG.debug(f"No config file exists yet. Creating one as {config_file}.")
+        elif config_files_found > 1:  # Multiple config files; let user know which is used
+            LOG.debug(f"More than one samconfig file found. Using {config_file}.")
+
+        return config_file
 
     @staticmethod
     def _version_sanity_check(version: Any) -> None:

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -14,9 +14,6 @@ from click.testing import CliRunner
 from unittest import TestCase
 from unittest.mock import patch, ANY
 import logging
-from parameterized import parameterized
-from samcli.lib.config.exceptions import SamConfigFileReadException
-from samcli.lib.config.file_manager import JsonFileManager, TomlFileManager, YamlFileManager
 
 from samcli.lib.config.samconfig import SamConfig, DEFAULT_ENV
 from samcli.lib.utils.packagetype import ZIP, IMAGE
@@ -1246,38 +1243,6 @@ class TestSamConfigWithOverrides(TestCase):
             self.assertIsNone(result.exception)
 
             do_cli_mock.assert_called_with(ANY, str(Path(os.getcwd(), "mytemplate.yaml")), False)
-
-
-class TestSamConfigFileManager(TestCase):
-    def test_file_manager_not_declared(self):
-        config_dir = tempfile.gettempdir()
-        config_path = Path(config_dir, "samconfig")
-
-        with self.assertRaises(SamConfigFileReadException):
-            SamConfig(config_path, filename="samconfig")
-
-    def test_file_manager_unsupported(self):
-        config_dir = tempfile.gettempdir()
-        config_path = Path(config_dir, "samconfig.jpeg")
-
-        with self.assertRaises(SamConfigFileReadException):
-            SamConfig(config_path, filename="samconfig.jpeg")
-
-    @parameterized.expand(
-        [
-            ("samconfig.toml", TomlFileManager),
-            ("samconfig.yaml", YamlFileManager),
-            ("samconfig.yml", YamlFileManager),
-            ("samconfig.json", JsonFileManager),
-        ]
-    )
-    def test_file_manager(self, filename, expected_file_manager):
-        config_dir = tempfile.gettempdir()
-        config_path = Path(config_dir, filename)
-
-        samconfig = SamConfig(config_path, filename=filename)
-
-        self.assertIs(samconfig.file_manager, expected_file_manager)
 
 
 @contextmanager

--- a/tests/unit/lib/samconfig/test_file_manager.py
+++ b/tests/unit/lib/samconfig/test_file_manager.py
@@ -134,7 +134,7 @@ class TestYamlFileManager(TestCase):
 
         config_doc = YamlFileManager.read(config_path)
 
-        self.assertEqual(config_doc, self.yaml.load(""))
+        self.assertEqual(config_doc, {})
 
     def test_write_yaml(self):
         config_dir = tempfile.gettempdir()

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -269,7 +269,7 @@ class TestSamConfig(TestCase):
         while extensions_in_priority:
             config = SamConfig(self.config_dir)
             next_priority = extensions_in_priority.pop(0)
-            self.assertEqual(config.path(), self.config_dir + "/" + DEFAULT_CONFIG_FILE + next_priority)
+            self.assertEqual(config.filepath, Path(self.config_dir, DEFAULT_CONFIG_FILE + next_priority))
             os.remove(config.path())
 
 

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -6,7 +6,13 @@ from unittest import TestCase
 
 from samcli.lib.config.exceptions import SamConfigFileReadException, SamConfigVersionException
 from samcli.lib.config.file_manager import JsonFileManager, TomlFileManager, YamlFileManager
-from samcli.lib.config.samconfig import DEFAULT_CONFIG_FILE, SamConfig, DEFAULT_CONFIG_FILE_NAME, DEFAULT_GLOBAL_CMDNAME, DEFAULT_ENV
+from samcli.lib.config.samconfig import (
+    DEFAULT_CONFIG_FILE,
+    SamConfig,
+    DEFAULT_CONFIG_FILE_NAME,
+    DEFAULT_GLOBAL_CMDNAME,
+    DEFAULT_ENV,
+)
 from samcli.lib.config.version import VERSION_KEY, SAM_CONFIG_VERSION
 from samcli.lib.utils import osutils
 


### PR DESCRIPTION
#### Why is this change necessary?
If users have multiple `samconfig` files of varying extensions, we want to prioritize them in a certain way. Currently that priority is set to be TOML > YAML > (YML) > JSON, according to the order of the dictionary keys in `SamConfig.FILE_MANAGER_MAPPER`, making this ordering flexible in the future.

#### How does it address the issue?
A new method, `SamConfig._get_default_file()` has been added, which searches for whether different samconfig files exist in the project. If no files exist, it uses the default file `DEFAULT_CONFIG_FILE_NAME`. If one file exists, it is returned. If multiple files exist, the one with the higher priority is returned, and the user is given a message about which of those config files were used.

#### What side effects does this change have?
* The previous `FileManager` tests have been moved to `../lib/samconfig/test_samconfig.py` instead of `../commands/samconfig/test_samconfig.py`, since they should have been there in the first place.
* `YamlFileManager` now returns an empty dictionary if its file doesn't exist (previously was returning `NoneType`) for consistency.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
