### PR TITLE
chore: cleanup appveyor definitions for not running jobs which is already run with GHA & add docker info/version commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,13 +47,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # TODO: Add macos-latest; fails currently, see e.g. https://github.com/aws/aws-sam-cli/actions/runs/3596883449/jobs/6058055981
+          - macos-latest
           - ubuntu-latest
           - windows-latest
         python:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.11"
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -114,6 +115,7 @@ jobs:
             3.8
             3.9
             3.10
+            3.11
             ${{ matrix.python }}
       - uses: actions/setup-go@v4
         with:
@@ -180,6 +182,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -61,7 +61,8 @@ install:
 
   - sh: "source ${HOME}/venv${PYTHON_VERSION}/bin/activate"
   - sh: "rvm use 2.7.2"
-  - sh: "docker --version"
+  - sh: "docker info"
+  - sh: "docker version"
   - sh: "nvm install ${NODE_VERSION}"
   - sh: "npm install npm@7.24.2 -g"
   - sh: "npm -v"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -149,7 +149,8 @@ install:
 
 
 build_script:
-      - "python -c \"import sys; print(sys.executable)\""
+    - "python -c \"import sys; print(sys.executable)\""
+    - "make init"
 
 # Final clean up no matter success or failure
 on_finish:
@@ -176,10 +177,6 @@ for:
         - configuration: BuildIntegTesting
 
     test_script:
-      # Pre-dev Tests
-      - "pip install -e \".[pre-dev]\""
-
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv tests/integration/buildcmd --ignore=tests/integration/buildcmd/test_build_terraform_applications.py --ignore=tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
       # Set JAVA_HOME to java11
@@ -193,10 +190,6 @@ for:
         - configuration: LocalZipTerraformBuildIntegTesting
 
     test_script:
-      # Pre-dev Tests
-      - "pip install -e \".[pre-dev]\""
-
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Local ZIP  Terraform Build In Container  integ testing
@@ -206,10 +199,6 @@ for:
         - configuration: LocalZipTerraformBuildInContainerIntegTesting
 
     test_script:
-      # Pre-dev Tests
-      - "pip install -e \".[pre-dev]\""
-
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build integ testing
@@ -219,10 +208,6 @@ for:
         - configuration: S3ZipTerraformBuildIntegTesting
 
     test_script:
-      # Pre-dev Tests
-      - "pip install -e \".[pre-dev]\""
-
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build In Container integ testing
@@ -232,10 +217,6 @@ for:
         - configuration: S3ZipTerraformBuildInContainerIntegTesting
 
     test_script:
-      # Pre-dev Tests
-      - "pip install -e \".[pre-dev]\""
-
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Other Terraform Build In Container integ testing
@@ -245,10 +226,6 @@ for:
         - configuration: OtherTerraformBuildIntegTesting
 
     test_script:
-      # Pre-dev Tests
-      - "pip install -e \".[pre-dev]\""
-
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Integ testing deploy
@@ -258,7 +235,6 @@ for:
         - configuration: DeployIntegTesting
 
     test_script:
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --dist=loadgroup --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
 
   # Integ testing package
@@ -268,7 +244,6 @@ for:
         - configuration: PackageIntegTesting
 
     test_script:
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv tests/integration/package -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package.json"
 
   # Integ testing delete
@@ -278,7 +253,6 @@ for:
         - configuration: DeleteIntegTesting
 
     test_script:
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv tests/integration/delete -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-delete.json"
 
   # Integ testing sync
@@ -288,7 +262,6 @@ for:
         - configuration: SyncIntegTesting
 
     test_script:
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv tests/integration/sync -n 3 --reruns 3 --dist loadscope --json-report --json-report-file=TEST_REPORT-integration-sync.json"
 
   # Integ testing local
@@ -298,11 +271,6 @@ for:
         - configuration: LocalIntegTesting
 
     test_script:
-      # Pre-dev Tests
-      - "pip install -e \".[pre-dev]\""
-      - "ruff samcli"
-
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
   # End-to-end testing
@@ -312,7 +280,6 @@ for:
         - configuration: EndToEndTesting
 
     test_script:
-      - "pip install -e \".[dev]\""
       - sh: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
 
   # Other testing
@@ -322,18 +289,5 @@ for:
         - configuration: OtherTesting
 
     test_script:
-      # Pre-dev Tests
-      - "pip install -e \".[pre-dev]\""
-      - "ruff samcli"
-
-      # Dev Tests
-      - "pip install -e \".[dev]\""
-      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit --json-report --json-report-file=TEST_REPORT-unit.json"
-      - "ruff samcli"
-      - "mypy setup.py samcli tests"
-      - "pytest -n 4 tests/functional --json-report --json-report-file=TEST_REPORT-functional.json"
-      
       - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
       - sh: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"
-      - sh: "black --check setup.py tests samcli"
-      - sh: "pytest -n 4 -vv tests/smoke --json-report --json-report-file=TEST_REPORT-smoke.json"

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -136,9 +136,12 @@ install:
 
   - "IF DEFINED BY_CANARY ECHO Logging in Public ECR && aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws"
 
-build_script:
+  # claim some disk space before starting the tests
   - "docker system prune -a -f"
+  # activate virtual environment
   - "venv\\Scripts\\activate"
+
+
 
 # Final clean up no matter success or failure
 on_finish:

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -74,6 +74,7 @@ install:
   - "echo %PATH%"
   - "python --version"
   - "docker info"
+  - "docker version"
 
   # install Terraform CLI
   - "choco install terraform"

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -135,6 +135,10 @@ install:
 
   - "IF DEFINED BY_CANARY ECHO Logging in Public ECR && aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws"
 
+build_script:
+  - "docker system prune -a -f"
+  - "venv\\Scripts\\activate"
+
 # Final clean up no matter success or failure
 on_finish:
   # Upload test reports as artifacts
@@ -181,10 +185,6 @@ for:
       - cargo lambda -V
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv tests/integration/buildcmd --ignore tests/integration/buildcmd/test_build_terraform_applications.py --ignore=tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Local ZIP  Terraform Build integ testing
@@ -193,10 +193,6 @@ for:
         - configuration: LocalZipTerraformBuildIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Local ZIP  Terraform Build In Container  integ testing
@@ -205,10 +201,6 @@ for:
         - configuration: LocalZipTerraformBuildInContainerIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build integ testing
@@ -217,10 +209,6 @@ for:
         - configuration: S3ZipTerraformBuildIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build In Container integ testing
@@ -229,10 +217,6 @@ for:
         - configuration: S3ZipTerraformBuildInContainerIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Other Terraform Build integ testing
@@ -241,10 +225,6 @@ for:
         - configuration: OtherTerraformBuildIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   #Integ testing deploy
@@ -253,10 +233,6 @@ for:
         - configuration: DeployIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --dist=loadgroup --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
 
   # Integ testing package
@@ -265,10 +241,6 @@ for:
         - configuration: PackageIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv tests/integration/package -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package.json"
 
   # Integ testing delete
@@ -277,10 +249,6 @@ for:
         - configuration: DeleteIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv tests/integration/delete -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-delete.json"
 
   # Integ testing sync
@@ -289,10 +257,6 @@ for:
         - configuration: SyncIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv tests/integration/sync -n 3 --reruns 3 --dist loadscope --json-report --json-report-file=TEST_REPORT-integration-sync.json"
 
   #Integ testing local
@@ -301,10 +265,6 @@ for:
         - configuration: LocalIntegTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
   # End-to-end testing
@@ -313,10 +273,6 @@ for:
         - configuration: EndToEndTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
       - ps: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
 
   #Other testing
@@ -325,13 +281,6 @@ for:
         - configuration: OtherTesting
 
     test_script:
-      # Reactivate virtualenv before running tests
-      - "git --version"
-      - "venv\\Scripts\\activate"
-      - "docker system prune -a -f"
-      - ps: "pytest --cov samcli --cov-report term-missing --cov-fail-under 94 tests/unit --json-report --json-report-file=TEST_REPORT-unit.json"
-      - "mypy setup.py samcli tests"
-      - ps: "pytest -n 4 tests/functional --json-report --json-report-file=TEST_REPORT-functional.json"
       - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
       - ps: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"
 # Uncomment for RDP


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Some of the checks that we do in GHA is also run with Appveyor jobs and they have custom configuration rather than using the ones from `Makefile`. 

#### How does it address the issue?
- Removing the tests/checks from Appveyor that we already run with GHA
- Cleaning up some Appveyor setup where it was repeated couple of times


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
