### PR TITLE
feat: Track config file extension

### DIFF
--- a/samcli/lib/config/file_manager.py
+++ b/samcli/lib/config/file_manager.py
@@ -7,7 +7,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Type
 
 import tomlkit
 from ruamel.yaml import YAML, YAMLError
@@ -332,3 +332,11 @@ class JsonFileManager(FileManager):
         """
         document.update({COMMENT_KEY: comment})
         return document
+
+
+FILE_MANAGER_MAPPER: Dict[str, Type[FileManager]] = {  # keys ordered by priority
+    ".toml": TomlFileManager,
+    ".yaml": YamlFileManager,
+    ".yml": YamlFileManager,
+    ".json": JsonFileManager,
+}

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -11,6 +11,7 @@ from uuid import UUID, uuid4
 
 from samcli.cli.context import Context
 from samcli.lib.build.workflows import ALL_CONFIGS
+from samcli.lib.config.file_manager import FILE_MANAGER_MAPPER
 from samcli.lib.telemetry.telemetry import Telemetry
 from samcli.local.common.runtime_template import INIT_RUNTIMES
 
@@ -26,6 +27,7 @@ class EventName(Enum):
     SYNC_FLOW_START = "SyncFlowStart"
     SYNC_FLOW_END = "SyncFlowEnd"
     BUILD_WORKFLOW_USED = "BuildWorkflowUsed"
+    CONFIG_FILE_EXTENSION = "SamConfigFileExtension"
 
 
 class UsedFeature(Enum):
@@ -69,6 +71,7 @@ class EventType:
         EventName.SYNC_FLOW_START: _SYNC_FLOWS,
         EventName.SYNC_FLOW_END: _SYNC_FLOWS,
         EventName.BUILD_WORKFLOW_USED: _WORKFLOWS,
+        EventName.CONFIG_FILE_EXTENSION: list(FILE_MANAGER_MAPPER.keys()),
     }
 
     @staticmethod

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -211,8 +211,10 @@ class TestExperimentalMetric(IntegBase):
 
             self.assertEqual(process.returncode, 2, "Command should fail")
             all_requests = server.get_all_requests()
-            self.assertEqual(1, len(all_requests), "Command run metric must be sent")
-            request = all_requests[0]
+            self.assertEqual(2, len(all_requests), "Command run metric must be sent")  # 2 = cmd_run + events
+            request = (
+                all_requests[0] if "commandRun" in all_requests[0]["data"]["metrics"][0].keys() else all_requests[1]
+            )  # ignore event request
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")
 

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -212,9 +212,8 @@ class TestExperimentalMetric(IntegBase):
             self.assertEqual(process.returncode, 2, "Command should fail")
             all_requests = server.get_all_requests()
             self.assertEqual(2, len(all_requests), "Command run metric must be sent")  # 2 = cmd_run + events
-            request = (
-                all_requests[0] if "commandRun" in all_requests[0]["data"]["metrics"][0].keys() else all_requests[1]
-            )  # ignore event request
+            all_requests.sort(key = lambda x: list(x["data"]["metrics"][0].keys())[0])
+            request = all_requests[0]  # "commandRun" comes before "events"
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")
 

--- a/tests/integration/telemetry/test_experimental_metric.py
+++ b/tests/integration/telemetry/test_experimental_metric.py
@@ -211,8 +211,10 @@ class TestExperimentalMetric(IntegBase):
 
             self.assertEqual(process.returncode, 2, "Command should fail")
             all_requests = server.get_all_requests()
-            self.assertEqual(2, len(all_requests), "Command run metric must be sent")  # 2 = cmd_run + events
-            all_requests.sort(key = lambda x: list(x["data"]["metrics"][0].keys())[0])
+            self.assertEqual(2, len(all_requests), "Command run and event metrics must be sent")
+            # NOTE: Since requests happen asynchronously, we cannot guarantee whether the
+            # commandRun metric will be first or second, so we sort for consistency.
+            all_requests.sort(key=lambda x: list(x["data"]["metrics"][0].keys())[0])
             request = all_requests[0]  # "commandRun" comes before "events"
             self.assertIn("Content-Type", request["headers"])
             self.assertEqual(request["headers"]["Content-Type"], "application/json")

--- a/tests/integration/telemetry/test_installed_metric.py
+++ b/tests/integration/telemetry/test_installed_metric.py
@@ -24,7 +24,9 @@ class TestSendInstalledMetric(IntegBase):
             self.assertIn(EXPECTED_TELEMETRY_PROMPT, stderrdata.decode())
 
             all_requests = server.get_all_requests()
-            self.assertEqual(2, len(all_requests), "There should be exactly two metrics request")
+            self.assertEqual(
+                3, len(all_requests), "There should be exactly two metrics request"
+            )  # 3 = 2 expected + events
 
             # First one is usually the installed metric
             requests = filter_installed_metric_requests(all_requests)

--- a/tests/integration/telemetry/test_installed_metric.py
+++ b/tests/integration/telemetry/test_installed_metric.py
@@ -25,7 +25,7 @@ class TestSendInstalledMetric(IntegBase):
 
             all_requests = server.get_all_requests()
             self.assertEqual(
-                3, len(all_requests), "There should be exactly two metrics request"
+                3, len(all_requests), "There should be exactly three metrics request"
             )  # 3 = 2 expected + events
 
             # First one is usually the installed metric

--- a/tests/integration/telemetry/test_telemetry_contract.py
+++ b/tests/integration/telemetry/test_telemetry_contract.py
@@ -28,7 +28,7 @@ class TestTelemetryContract(IntegBase):
 
             self.assertEqual(process.returncode, 0, "Command should successfully complete")
             all_requests = server.get_all_requests()
-            self.assertEqual(1, len(all_requests), "Command run metric should be sent")
+            self.assertEqual(2, len(all_requests), "Command run metric should be sent")  # 2 = cmd_run + events
 
     def test_must_send_metrics_if_enabled_via_envvar(self):
         """
@@ -52,7 +52,7 @@ class TestTelemetryContract(IntegBase):
 
             self.assertEqual(process.returncode, 0, "Command should successfully complete")
             all_requests = server.get_all_requests()
-            self.assertEqual(1, len(all_requests), "Command run metric must be sent")
+            self.assertEqual(2, len(all_requests), "Command run metric must be sent")  # cmd_run + events
 
     def test_must_not_crash_when_offline(self):
         """

--- a/tests/integration/telemetry/test_telemetry_contract.py
+++ b/tests/integration/telemetry/test_telemetry_contract.py
@@ -28,7 +28,9 @@ class TestTelemetryContract(IntegBase):
 
             self.assertEqual(process.returncode, 0, "Command should successfully complete")
             all_requests = server.get_all_requests()
-            self.assertEqual(2, len(all_requests), "Command run metric should be sent")  # 2 = cmd_run + events
+            self.assertEqual(
+                2, len(all_requests), "Command run and event metrics should be sent"
+            )  # 2 = cmd_run + events
 
     def test_must_send_metrics_if_enabled_via_envvar(self):
         """
@@ -52,7 +54,7 @@ class TestTelemetryContract(IntegBase):
 
             self.assertEqual(process.returncode, 0, "Command should successfully complete")
             all_requests = server.get_all_requests()
-            self.assertEqual(2, len(all_requests), "Command run metric must be sent")  # cmd_run + events
+            self.assertEqual(2, len(all_requests), "Command run and event metrics must be sent")  # cmd_run + events
 
     def test_must_not_crash_when_offline(self):
         """

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -9,8 +9,8 @@ import tomlkit
 
 from samcli.commands.exceptions import ConfigException
 from samcli.cli.cli_config_file import ConfigProvider, configuration_option, configuration_callback, get_ctx_defaults
-from samcli.lib.config.exceptions import FileParseException, SamConfigFileReadException, SamConfigVersionException
-from samcli.lib.config.samconfig import DEFAULT_ENV, TomlFileManager
+from samcli.lib.config.exceptions import SamConfigFileReadException, SamConfigVersionException
+from samcli.lib.config.samconfig import DEFAULT_ENV
 
 from tests.testing_utils import IS_WINDOWS
 

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -5,7 +5,7 @@ import tempfile
 from unittest import TestCase
 
 from samcli.lib.config.exceptions import SamConfigFileReadException, SamConfigVersionException
-from samcli.lib.config.file_manager import JsonFileManager, TomlFileManager, YamlFileManager
+from samcli.lib.config.file_manager import FILE_MANAGER_MAPPER, JsonFileManager, TomlFileManager, YamlFileManager
 from samcli.lib.config.samconfig import (
     DEFAULT_CONFIG_FILE,
     SamConfig,
@@ -256,7 +256,7 @@ class TestSamConfig(TestCase):
 
     def test_config_priority(self):
         config_files = []
-        extensions_in_priority = list(SamConfig.FILE_MANAGER_MAPPER.keys())  # priority by order in dict
+        extensions_in_priority = list(FILE_MANAGER_MAPPER.keys())  # priority by order in dict
         for extension in extensions_in_priority:
             filename = DEFAULT_CONFIG_FILE + extension
             config = SamConfig(self.config_dir, filename=filename)

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -306,6 +306,7 @@ class TestSamConfigFileManager(TestCase):
 
         def mock_tracker(name, value):  # when track_event is called, just append the Event to our list
             tracked_events.append(Event(name, value))
+
         track_mock.side_effect = mock_tracker
 
         samconfig = SamConfig(config_path, filename=filename)


### PR DESCRIPTION
#### Why is this change necessary?
These changes allow us to keep track of which config file extensions users are using. As such, it will provide us insights into how many people may prefer to use one file type over another, which could aid in the potential deprecation of less-used extensions, or the potential to support newer ones.

#### How does it address the issue?
A new `EventType` has been created for `EventName.CONFIG_FILE_EXTENSION`, which is called upon the creation of a `SamConfig` object. As such, whenever someone runs a command that reads in a config file, we will receive an Event.

#### What side effects does this change have?
In order to prevent a cyclic import, the `FILE_MANAGER_MAPPER` has been moved to `samconfig/file_manager.py` from `samconfig/samconfig.py`. This change makes sense, as the logic of pairing file extensions to `FileManager`s is encapsulated in this file anyway, and it reduces the number of imports made by `samconfig.py`.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
