### PR TITLE
add sleep between close and reopen

### DIFF
--- a/.github/workflows/automated-updates-to-sam-cli.yml
+++ b/.github/workflows/automated-updates-to-sam-cli.yml
@@ -50,6 +50,7 @@ jobs:
           git push --force origin update_app_templates_hash
           gh pr list --repo aws/aws-sam-cli --head update_app_templates_hash --json id --jq length | grep 1 && \
               gh pr close update_app_templates_hash --repo aws/aws-sam-cli && \
+              sleep 2 && \
               gh pr reopen update_app_templates_hash --repo aws/aws-sam-cli && \
               exit 0 # if there is exisitng pr, close/reopen to re-run checks, then exit
           gh pr create --base develop --head update_app_templates_hash --title "feat: update SAM CLI with latest App Templates commit hash" --body "This PR & commit is automatically created from App Templates repo to update the SAM CLI with latest hash of the App Templates." --label "pr/internal"
@@ -110,6 +111,7 @@ jobs:
           git push --force origin update_sam_transform_version
           gh pr list --repo aws/aws-sam-cli --head update_sam_transform_version --json id --jq length | grep 1 && \
               gh pr close update_sam_transform_version --repo aws/aws-sam-cli && \
+              sleep 2 && \
               gh pr reopen update_sam_transform_version --repo aws/aws-sam-cli && \
               exit 0 # if there is exisitng pr, close/reopen to re-run checks, then exit
           gh pr create --base develop --head update_sam_transform_version --fill --label "pr/internal"
@@ -169,6 +171,7 @@ jobs:
           git push --force origin update_lambda_builders_version
           gh pr list --repo aws/aws-sam-cli --head update_lambda_builders_version --json id --jq length | grep 1 && \
               gh pr close update_lambda_builders_version --repo aws/aws-sam-cli && \
+              sleep 2 && \
               gh pr reopen update_lambda_builders_version --repo aws/aws-sam-cli && \
               exit 0 # if there is exisitng pr, close/reopen to re-run checks, then exit
           gh pr create --base develop --head update_lambda_builders_version --fill --label "pr/internal"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
NA


#### Why is this change necessary?
In GHA for updating app template commit hash, GH API sometimes returns error when trying to reopen a PR after closing it. e.g. https://github.com/aws/aws-sam-cli/actions/runs/5224495677/jobs/9432756673
```
To https://github.com/aws/aws-sam-cli
 + 22c26c1...33b0fe0 update_app_templates_hash -> update_app_templates_hash (forced update)
1
✓ Closed pull request #5314 (feat: update SAM CLI with latest App Templates commit hash)
API call failed: GraphQL: Could not open the pull request. (reopenPullRequest)
```

Successful example - https://github.com/aws/aws-sam-cli/actions/runs/5225642402/jobs/9435377828
```
To https://github.com/aws/aws-sam-cli
 + 33b0fe0...682295d update_app_templates_hash -> update_app_templates_hash (forced update)
1
✓ Closed pull request #5316 (feat: update SAM CLI with latest App Templates commit hash)
✓ Reopened pull request #5316 (feat: update SAM CLI with latest App Templates commit hash)
```

It is not clear why this error occurs sometimes but not always.

#### How does it address the issue?
Adding a 2s sleep between close and reopen.

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
