### PR TITLE
feat: Add and fix samconfig integration tests

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import click
+from click.core import ParameterSource
 
 from samcli.cli.context import get_cmd_names
 from samcli.commands.exceptions import ConfigException
@@ -169,7 +170,7 @@ def configuration_callback(
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
     config_file = (  # If given by default, check for other `samconfig` extensions first. Else use user-provided value
         SamConfig.get_default_file(config_dir=config_dir)
-        if getattr(ctx.get_parameter_source("config_file"), "name", "") == click.core.ParameterSource.DEFAULT
+        if getattr(ctx.get_parameter_source("config_file"), "name", "") == ParameterSource.DEFAULT.name
         else ctx.params.get("config_file") or SamConfig.get_default_file(config_dir=config_dir)
     )
     # If --config-file is an absolute path, use it, if not, start from config_dir

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -167,9 +167,9 @@ def configuration_callback(
     config_env_name = ctx.params.get("config_env") or DEFAULT_ENV
 
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
-    config_file = (
+    config_file = (  # If given by default, check for other `samconfig` extensions first. Else use user-provided value
         SamConfig.get_default_file(config_dir=config_dir)
-        if getattr(ctx.get_parameter_source("config_file"), "name", "") == "DEFAULT"
+        if getattr(ctx.get_parameter_source("config_file"), "name", "") == click.core.ParameterSource.DEFAULT
         else ctx.params.get("config_file") or SamConfig.get_default_file(config_dir=config_dir)
     )
     # If --config-file is an absolute path, use it, if not, start from config_dir

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -166,8 +166,12 @@ def configuration_callback(
     param.default = None
     config_env_name = ctx.params.get("config_env") or DEFAULT_ENV
 
-    config_file = ctx.params.get("config_file") or DEFAULT_CONFIG_FILE_NAME
     config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
+    config_file = (
+        SamConfig.get_default_file(config_dir=config_dir)
+        if getattr(ctx.get_parameter_source("config_file"), "name", "") == "DEFAULT"
+        else ctx.params.get("config_file") or SamConfig.get_default_file(config_dir=config_dir)
+    )
     # If --config-file is an absolute path, use it, if not, start from config_dir
     config_file_path = config_file if os.path.isabs(config_file) else os.path.join(config_dir, config_file)
     if (

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -83,6 +83,7 @@ class BuildIntegBase(TestCase):
         beta_features=None,
         build_in_source=None,
         mount_with=None,
+        config_file=None,
     ):
         command_list = [self.cmd, "build"]
 
@@ -145,6 +146,9 @@ class BuildIntegBase(TestCase):
 
         if build_in_source is not None:
             command_list += ["--build-in-source"] if build_in_source else ["--no-build-in-source"]
+
+        if config_file is not None:
+            command_list += ["--config-file", config_file]
 
         return command_list
 

--- a/tests/integration/buildcmd/test_build_samconfig.py
+++ b/tests/integration/buildcmd/test_build_samconfig.py
@@ -1,0 +1,133 @@
+import logging
+import os
+from pathlib import Path
+import shutil
+from parameterized import parameterized, parameterized_class
+
+from tests.integration.buildcmd.build_integ_base import BuildIntegBase
+from tests.testing_utils import run_command
+
+
+LOG = logging.getLogger(__name__)
+
+configs = {
+    ".toml": "samconfig/samconfig.toml",
+    ".yaml": "samconfig/samconfig.yaml",
+    ".json": "samconfig/samconfig.json",
+}
+
+
+class TestSamConfigWithBuild(BuildIntegBase):
+    @parameterized.expand(
+        [
+            (".toml"),
+            (".yaml"),
+            (".json"),
+        ]
+    )
+    def test_samconfig_works_with_extension(self, extension):
+        cmdlist = self.get_command_list(config_file=configs[extension])
+
+        LOG.info("Running Command: %s", cmdlist)
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+        stdout = str(command_result[1])
+        stderr = str(command_result[2])
+
+        self.assertEqual(command_result.process.returncode, 0, "Build should succeed")
+        self.assertIn(
+            str(Path(extension, self.template)),
+            stdout,
+            f"Build template should use build_dir from samconfig{extension}",
+        )
+        self.assertIn("Starting Build use cache", stderr, f"'cache'=true should be set in samconfig{extension}")
+
+    @parameterized.expand(
+        [
+            (".toml"),
+            (".yaml"),
+            (".json"),
+        ]
+    )
+    def test_samconfig_parameters_are_overridden(self, extension):
+        overrides = {"Runtime": "python3.8"}
+        overridden_build_dir = f"{extension}_override"
+
+        cmdlist = self.get_command_list(
+            config_file=configs[extension], parameter_overrides=overrides, build_dir=overridden_build_dir
+        )
+
+        LOG.info("Running Command: %s", cmdlist)
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+        stdout = str(command_result[1])
+        stderr = str(command_result[2])
+
+        self.assertEqual(command_result.process.returncode, 0, "Build should succeed")
+        self.assertNotIn(
+            str(Path(extension, self.template)),
+            stdout,
+            f"Build template should not use build_dir from samconfig{extension}",
+        )
+        self.assertIn(
+            str(Path(overridden_build_dir, self.template)), stdout, f"Build template should use overridden build_dir"
+        )
+        self.assertIn("Starting Build use cache", stderr, f"'cache'=true should be set in samconfig{extension}")
+        self.assertNotIn("python3.9", stderr, f"parameter_overrides runtime should not read from samconfig{extension}")
+        self.assertIn(overrides["Runtime"], stderr, "parameter_overrides should use overridden runtime")
+        self.assertNotIn("SomeURI", stderr, f"parameter_overrides should not read ANY values from samconfig{extension}")
+
+
+@parameterized_class(
+    [  # Ordered by expected priority
+        {"extensions": [".toml", ".yaml", ".json"]},
+        {"extensions": [".yaml", ".json"]},
+    ]
+)
+class TestSamConfigExtensionHierarchy(BuildIntegBase):
+    testing_wd = Path(os.getcwd(), "tests", "integration")
+
+    @classmethod
+    def setUpClass(cls):
+        # Bring config files to cwd
+        # for extension in path.exists(), f"File samconfig{extension} should have been created in cwd")
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+        new_template_location = Path(self.working_dir, "template.yaml")
+        new_template_location.write_text(Path(self.template_path).read_text())
+        for extension in self.extensions:
+            config_contents = Path(self.testing_wd, "testdata", "buildcmd", configs[extension]).read_text()
+            new_path = Path(self.working_dir, f"samconfig{extension}")
+            new_path.write_text(config_contents)
+            self.assertTrue(new_path.exists(), f"File samconfig{extension} should have been created in cwd")
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove brought config files from cwd
+        super().tearDownClass()
+
+    def tearDown(self):
+        for extension in self.extensions:
+            config_path = Path(self.working_dir, f"samconfig{extension}")
+            os.remove(config_path)
+        super().tearDown()
+
+    def test_samconfig_pulls_correct_file_if_multiple(self):
+        self.template_path = str(Path(self.working_dir, "template.yaml"))
+        cmdlist = self.get_command_list(debug=True)
+        LOG.info("Running Command: %s", cmdlist)
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+        stdout = str(command_result[1])
+
+        self.assertEqual(command_result.process.returncode, 0, "Build should succeed")
+        self.assertIn(
+            f" {self.extensions[0]}",
+            stdout,
+            f"samconfig{self.extensions[0]} should take priority in current test group",
+        )
+        for other_extension in self.extensions[1:]:
+            self.assertNotIn(
+                f" {other_extension}",
+                stdout,
+                f"samconfig{other_extension} should not be read over another, higher priority extension",
+            )

--- a/tests/integration/buildcmd/test_build_samconfig.py
+++ b/tests/integration/buildcmd/test_build_samconfig.py
@@ -1,14 +1,10 @@
-import logging
 import os
 from pathlib import Path
-import shutil
 from parameterized import parameterized, parameterized_class
 
 from tests.integration.buildcmd.build_integ_base import BuildIntegBase
 from tests.testing_utils import run_command
 
-
-LOG = logging.getLogger(__name__)
 
 configs = {
     ".toml": "samconfig/samconfig.toml",

--- a/tests/integration/buildcmd/test_build_samconfig.py
+++ b/tests/integration/buildcmd/test_build_samconfig.py
@@ -35,7 +35,7 @@ class TestSamConfigWithBuild(BuildIntegBase):
 
         self.assertEqual(command_result.process.returncode, 0, "Build should succeed")
         self.assertIn(
-            str(Path(extension, self.template)),
+            f"Built Artifacts  : {extension}\\n",
             stdout,
             f"Build template should use build_dir from samconfig{extension}",
         )
@@ -63,12 +63,12 @@ class TestSamConfigWithBuild(BuildIntegBase):
 
         self.assertEqual(command_result.process.returncode, 0, "Build should succeed")
         self.assertNotIn(
-            str(Path(extension, self.template)),
+            f"Built Artifacts  : {extension}\\n",
             stdout,
             f"Build template should not use build_dir from samconfig{extension}",
         )
         self.assertIn(
-            str(Path(overridden_build_dir, self.template)), stdout, f"Build template should use overridden build_dir"
+            f"Built Artifacts  : {overridden_build_dir}\\n", stdout, f"Build template should use overridden build_dir"
         )
         self.assertIn("Starting Build use cache", stderr, f"'cache'=true should be set in samconfig{extension}")
         self.assertNotIn("python3.9", stderr, f"parameter_overrides runtime should not read from samconfig{extension}")

--- a/tests/integration/buildcmd/test_build_samconfig.py
+++ b/tests/integration/buildcmd/test_build_samconfig.py
@@ -77,14 +77,12 @@ class TestSamConfigWithBuild(BuildIntegBase):
     ]
 )
 class TestSamConfigExtensionHierarchy(BuildIntegBase):
-    build_testdata_dir = Path(os.getcwd(), "tests", "integration", "testdata", "buildcmd")
-
     def setUp(self):
         super().setUp()
         new_template_location = Path(self.working_dir, "template.yaml")
         new_template_location.write_text(Path(self.template_path).read_text())
         for extension in self.extensions:
-            config_contents = Path(self.build_testdata_dir, configs[extension]).read_text()
+            config_contents = Path(self.test_data_path, configs[extension]).read_text()
             new_path = Path(self.working_dir, f"samconfig{extension}")
             new_path.write_text(config_contents)
             self.assertTrue(new_path.exists(), f"File samconfig{extension} should have been created in cwd")

--- a/tests/integration/buildcmd/test_build_samconfig.py
+++ b/tests/integration/buildcmd/test_build_samconfig.py
@@ -35,7 +35,7 @@ class TestSamConfigWithBuild(BuildIntegBase):
 
         self.assertEqual(command_result.process.returncode, 0, "Build should succeed")
         self.assertIn(
-            f"Built Artifacts  : {extension}\\n",
+            f"Built Artifacts  : {extension}",
             stdout,
             f"Build template should use build_dir from samconfig{extension}",
         )
@@ -50,7 +50,7 @@ class TestSamConfigWithBuild(BuildIntegBase):
     )
     def test_samconfig_parameters_are_overridden(self, extension):
         overrides = {"Runtime": "python3.8"}
-        overridden_build_dir = f"{extension}_override"
+        overridden_build_dir = f"override_{extension}"
 
         cmdlist = self.get_command_list(
             config_file=configs[extension], parameter_overrides=overrides, build_dir=overridden_build_dir
@@ -63,12 +63,12 @@ class TestSamConfigWithBuild(BuildIntegBase):
 
         self.assertEqual(command_result.process.returncode, 0, "Build should succeed")
         self.assertNotIn(
-            f"Built Artifacts  : {extension}\\n",
+            f"Built Artifacts  : {extension}",
             stdout,
             f"Build template should not use build_dir from samconfig{extension}",
         )
         self.assertIn(
-            f"Built Artifacts  : {overridden_build_dir}\\n", stdout, f"Build template should use overridden build_dir"
+            f"Built Artifacts  : {overridden_build_dir}", stdout, f"Build template should use overridden build_dir"
         )
         self.assertIn("Starting Build use cache", stderr, f"'cache'=true should be set in samconfig{extension}")
         self.assertNotIn("python3.9", stderr, f"parameter_overrides runtime should not read from samconfig{extension}")

--- a/tests/integration/buildcmd/test_build_samconfig.py
+++ b/tests/integration/buildcmd/test_build_samconfig.py
@@ -28,7 +28,6 @@ class TestSamConfigWithBuild(BuildIntegBase):
     def test_samconfig_works_with_extension(self, extension):
         cmdlist = self.get_command_list(config_file=configs[extension])
 
-        LOG.info("Running Command: %s", cmdlist)
         command_result = run_command(cmdlist, cwd=self.working_dir)
         stdout = str(command_result[1])
         stderr = str(command_result[2])
@@ -56,7 +55,6 @@ class TestSamConfigWithBuild(BuildIntegBase):
             config_file=configs[extension], parameter_overrides=overrides, build_dir=overridden_build_dir
         )
 
-        LOG.info("Running Command: %s", cmdlist)
         command_result = run_command(cmdlist, cwd=self.working_dir)
         stdout = str(command_result[1])
         stderr = str(command_result[2])
@@ -83,28 +81,17 @@ class TestSamConfigWithBuild(BuildIntegBase):
     ]
 )
 class TestSamConfigExtensionHierarchy(BuildIntegBase):
-    testing_wd = Path(os.getcwd(), "tests", "integration")
-
-    @classmethod
-    def setUpClass(cls):
-        # Bring config files to cwd
-        # for extension in path.exists(), f"File samconfig{extension} should have been created in cwd")
-        super().setUpClass()
+    build_testdata_dir = Path(os.getcwd(), "tests", "integration", "testdata", "buildcmd")
 
     def setUp(self):
         super().setUp()
         new_template_location = Path(self.working_dir, "template.yaml")
         new_template_location.write_text(Path(self.template_path).read_text())
         for extension in self.extensions:
-            config_contents = Path(self.testing_wd, "testdata", "buildcmd", configs[extension]).read_text()
+            config_contents = Path(self.build_testdata_dir, configs[extension]).read_text()
             new_path = Path(self.working_dir, f"samconfig{extension}")
             new_path.write_text(config_contents)
             self.assertTrue(new_path.exists(), f"File samconfig{extension} should have been created in cwd")
-
-    @classmethod
-    def tearDownClass(cls):
-        # Remove brought config files from cwd
-        super().tearDownClass()
 
     def tearDown(self):
         for extension in self.extensions:
@@ -115,7 +102,6 @@ class TestSamConfigExtensionHierarchy(BuildIntegBase):
     def test_samconfig_pulls_correct_file_if_multiple(self):
         self.template_path = str(Path(self.working_dir, "template.yaml"))
         cmdlist = self.get_command_list(debug=True)
-        LOG.info("Running Command: %s", cmdlist)
         command_result = run_command(cmdlist, cwd=self.working_dir)
         stdout = str(command_result[1])
 

--- a/tests/integration/deploy/deploy_integ_base.py
+++ b/tests/integration/deploy/deploy_integ_base.py
@@ -2,11 +2,13 @@ import shutil
 import tempfile
 from pathlib import Path
 from enum import Enum, auto
+from typing import List, Optional
 
 import boto3
 from botocore.config import Config
 
 from samcli.lib.bootstrap.bootstrap import SAM_CLI_STACK_NAME
+from samcli.lib.config.samconfig import SamConfig
 from tests.integration.package.package_integ_base import PackageIntegBase
 from tests.testing_utils import get_sam_command, run_command, run_command_with_input
 
@@ -212,3 +214,26 @@ class DeployIntegBase(PackageIntegBase):
             command_list = command_list + ["--build-dir", str(build_dir)]
 
         return command_list
+
+    def _assert_deploy_samconfig_parameters(
+        self,
+        config: SamConfig,
+        stack_name: str = SAM_CLI_STACK_NAME,
+        resolve_s3: bool = True,
+        region: str = "us-east-1",
+        capabilities: str = "CAPABILITY_IAM",
+        confirm_changeset: Optional[bool] = None,
+        parameter_overrides: Optional[str] = None,
+    ):
+        params = config.document["default"]["deploy"]["parameters"]
+
+        self.assertEqual(params["stack_name"], stack_name)
+        self.assertEqual(params["resolve_s3"], resolve_s3)
+        self.assertEqual(params["region"], region)
+        self.assertEqual(params["capabilities"], capabilities)
+
+        if confirm_changeset is not None:
+            self.assertEqual(params["confirm_changeset"], confirm_changeset)
+
+        if parameter_overrides is not None:
+            self.assertEqual(params["parameter_overrides"], parameter_overrides)

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -10,7 +10,7 @@ from botocore.exceptions import ClientError
 from parameterized import parameterized
 
 from samcli.lib.bootstrap.bootstrap import SAM_CLI_STACK_NAME
-from samcli.lib.config.samconfig import DEFAULT_CONFIG_FILE_NAME
+from samcli.lib.config.samconfig import DEFAULT_CONFIG_FILE_NAME, SamConfig
 from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
 
@@ -613,6 +613,13 @@ to create a managed default bucket, or run sam deploy --guided",
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stacks.append({"name": SAM_CLI_STACK_NAME})
+        # Verify the contents in samconfig
+        config = SamConfig(self.test_data_path)
+        deploy_config_params = config.document["default"]["deploy"]["parameters"]
+        self.assertEqual(deploy_config_params["stack_name"], stack_name)
+        self.assertTrue(deploy_config_params["resolve_s3"])
+        self.assertEqual(deploy_config_params["region"], "us-east-1")
+        self.assertEqual(deploy_config_params["capabilities"], "CAPABILITY_IAM")
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
 
@@ -627,7 +634,7 @@ to create a managed default bucket, or run sam deploy --guided",
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = self.run_command_with_input(
-            deploy_command_list, f"{stack_name}\n\n\n\n\ny\n\n\ny\n\n\n\n".encode()
+            deploy_command_list, f"{stack_name}\n\n\n\n\ny\n\n\n\n\n\n\n".encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -637,6 +644,10 @@ to create a managed default bucket, or run sam deploy --guided",
         companion_stack_name = self._stack_name_to_companion_stack(stack_name)
         self._assert_companion_stack(self.cfn_client, companion_stack_name)
         self._assert_companion_stack_content(self.ecr_client, companion_stack_name)
+
+        # Verify the contents in samconfig
+        config = SamConfig(self.test_data_path)
+        self._assert_deploy_samconfig_parameters(config, stack_name=stack_name)
 
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
@@ -669,6 +680,9 @@ to create a managed default bucket, or run sam deploy --guided",
             self.fail("Companion stack was created. This should not happen with specifying image repos.")
 
         self.stacks.append({"name": SAM_CLI_STACK_NAME})
+        # Verify the contents in samconfig
+        config = SamConfig(self.test_data_path)
+        self._assert_deploy_samconfig_parameters(config, stack_name=stack_name)
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
 
@@ -690,6 +704,11 @@ to create a managed default bucket, or run sam deploy --guided",
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stacks.append({"name": SAM_CLI_STACK_NAME})
+        # Verify the contents in samconfig
+        config = SamConfig(self.test_data_path)
+        self._assert_deploy_samconfig_parameters(
+            config, stack_name=stack_name, parameter_overrides='Parameter="SuppliedParameter"'
+        )
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
 
@@ -710,6 +729,14 @@ to create a managed default bucket, or run sam deploy --guided",
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stacks.append({"name": SAM_CLI_STACK_NAME})
+        # Verify the contents in samconfig
+        config = SamConfig(self.test_data_path)
+        self._assert_deploy_samconfig_parameters(
+            config,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM CAPABILITY_NAMED_IAM",
+            parameter_overrides='Parameter="SuppliedParameter"',
+        )
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
 
@@ -731,6 +758,11 @@ to create a managed default bucket, or run sam deploy --guided",
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stacks.append({"name": SAM_CLI_STACK_NAME})
+        # Verify the contents in samconfig
+        config = SamConfig(self.test_data_path)
+        self._assert_deploy_samconfig_parameters(
+            config, stack_name=stack_name, parameter_overrides='Parameter="SuppliedParameter"'
+        )
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
 
@@ -752,6 +784,11 @@ to create a managed default bucket, or run sam deploy --guided",
         # Deploy should succeed with a managed stack
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stacks.append({"name": SAM_CLI_STACK_NAME})
+        # Verify the contents in samconfig
+        config = SamConfig(self.test_data_path)
+        self._assert_deploy_samconfig_parameters(
+            config, stack_name=stack_name, confirm_changeset=True, parameter_overrides='Parameter="SuppliedParameter"'
+        )
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
 

--- a/tests/integration/testdata/buildcmd/samconfig/samconfig.json
+++ b/tests/integration/testdata/buildcmd/samconfig/samconfig.json
@@ -1,0 +1,12 @@
+{
+  "version": 0.1,
+  "default": {
+    "build": {
+      "parameters": {
+        "build_dir": ".json",
+        "cached": true,
+        "parameter_overrides": "Runtime=python3.9 CodeUri=SomeURI Handler=SomeHandler"
+      }
+    }
+  }
+}

--- a/tests/integration/testdata/buildcmd/samconfig/samconfig.toml
+++ b/tests/integration/testdata/buildcmd/samconfig/samconfig.toml
@@ -1,0 +1,5 @@
+version = 0.1
+[default.build.parameters]
+build_dir = ".toml"
+cached = true
+parameter_overrides = "Runtime=python3.9 CodeUri=SomeURI Handler=SomeHandler"

--- a/tests/integration/testdata/buildcmd/samconfig/samconfig.yaml
+++ b/tests/integration/testdata/buildcmd/samconfig/samconfig.yaml
@@ -1,0 +1,7 @@
+version: 0.1
+default:
+  build:
+    parameters:
+      build_dir: .yaml
+      cached: true
+      parameter_overrides: Runtime=python3.9 CodeUri=SomeURI Handler=SomeHandler

--- a/tests/integration/testdata/buildcmd/samconfig/template.yaml
+++ b/tests/integration/testdata/buildcmd/samconfig/template.yaml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  Runtime:
+    Type: String
+  CodeUri:
+    Type: String
+  Handler:
+    Type: String
+
+Resources:
+
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: !Ref Handler
+      Runtime: !Ref Runtime
+      CodeUri: !Ref CodeUri
+      Timeout: 600
+
+
+  OtherRelativePathResource:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      BodyS3Location: SomeRelativePath
+
+  GlueResource:
+    Type: AWS::Glue::Job
+    Properties:
+      Command:
+        ScriptLocation: SomeRelativePath
+
+  ExampleNestedStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3.amazonaws.com/examplebucket/exampletemplate.yml

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -125,6 +125,7 @@ class TestCliConfiguration(TestCase):
         self.ctx.parent = mock_context3
         self.ctx.info_name = "test_info"
         self.ctx.params = {"config_file": "invalid_config_file"}
+        self.ctx._parameter_source.__get__ = "COMMANDLINE"
         setattr(self.ctx, "samconfig_dir", None)
         with self.assertRaises(ConfigException):
             configuration_callback(


### PR DESCRIPTION
#### Why is this change necessary?
To ensure the functionality of `samconfig` remains accurate given its new changes, new integration tests have been added to `buildcmd` to confirm that the config file is written to and read accurately, regardless of its extension. In addition, guided deploy integration tests previously weren't verifying that the config file was being written, so they have been fixed.

#### How does it address the issue?
New integration tests have been added under `test_build_samconfig.py` to ensure that the config file is used regardless of extension, that parameters are overwritten correctly, and that the config files of the correct priority are selected. In addition, a new helper method has been added to `DeployIntegBase` to assert that the attributes of the `samconfig` file are set to be certain expected values.

#### What side effects does this change have?
This change adds new integration tests to the codebase, and includes minor fixes to the logic of selecting a default config file.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
