### PR TITLE
chore: temporary pin python version to 3.7.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,11 +61,11 @@ jobs:
     # TODO: Revert back to use 3.7 to all operating systems after the regression issue in Python
     # https://github.com/actions/setup-python/issues/682 in github action got resolved
     - uses: actions/setup-python@v4
-      if: matrix.os != 'macos-latest' || ( matrix.os == 'macos-latest' && matrix.python != "3.7" )
+      if: matrix.os != 'macos-latest' || ( matrix.os == 'macos-latest' && matrix.python != '3.7' )
       with:
         python-version: ${{ matrix.python }}
     - uses: actions/setup-python@v4
-      if: matrix.os == 'macos-latest' && matrix.python == "3.7"
+      if: matrix.os == 'macos-latest' && matrix.python == '3.7'
       with:
         python-version: "3.7.16"
     - run: test -f "./.github/ISSUE_TEMPLATE/Bug_report.md"  # prevent Bug_report.md from being renamed or deleted

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,17 @@ jobs:
           - "3.11"
     steps:
     - uses: actions/checkout@v3
+    # @melasmar
+    # TODO: Revert back to use 3.7 to all operating systems after the regression issue in Python
+    # https://github.com/actions/setup-python/issues/682 in github action got resolved
     - uses: actions/setup-python@v4
+      if: matrix.os != 'macos-latest' || ( matrix.os == 'macos-latest' && matrix.python != "3.7" )
       with:
         python-version: ${{ matrix.python }}
+    - uses: actions/setup-python@v4
+      if: matrix.os == 'macos-latest' && matrix.python == "3.7"
+      with:
+        python-version: "3.7.16"
     - run: test -f "./.github/ISSUE_TEMPLATE/Bug_report.md"  # prevent Bug_report.md from being renamed or deleted
     - run: make init
     - run: make pr


### PR DESCRIPTION
Python Setup github action has some regression issue related to the new python version 3.7.17 (https://github.com/actions/setup-python/issues/682). This Pr is a temporary fix till the github action issue got fixed.

In this PR, we pin the python version to 3.7.16 for macos.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
