### PR TITLE
fix: Bug Bash UX Issues

### DIFF
--- a/samcli/commands/_utils/experimental.py
+++ b/samcli/commands/_utils/experimental.py
@@ -10,7 +10,7 @@ import click
 from samcli.cli.context import Context
 from samcli.cli.global_config import ConfigEntry, GlobalConfig
 from samcli.commands._utils.parameterized_option import parameterized_option
-from samcli.lib.utils.colors import Colored
+from samcli.lib.utils.colors import Colored, Colors
 
 LOG = logging.getLogger(__name__)
 
@@ -162,7 +162,7 @@ def update_experimental_context(show_warning=True):
     if not Context.get_current_context().experimental:
         Context.get_current_context().experimental = True
         if show_warning:
-            LOG.warning(Colored().yellow(EXPERIMENTAL_WARNING))
+            LOG.warning(Colored().color_log(EXPERIMENTAL_WARNING, color=Colors.WARNING), extra=dict(markup=True))
 
 
 def _experimental_option_callback(ctx, param, enabled: Optional[bool]):

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -223,14 +223,15 @@ def do_cli(  # pylint: disable=R0914
         ) as invoke_context:
             service = LocalApiService(lambda_invoke_context=invoke_context, port=port, host=host, static_dir=static_dir)
             service.start()
-            command_suggestions = generate_next_command_recommendation(
-                [
-                    ("Validate SAM template", "sam validate"),
-                    ("Test Function in the Cloud", "sam sync --stack-name {{stack-name}} --watch"),
-                    ("Deploy", "sam deploy --guided"),
-                ]
-            )
-            click.secho(command_suggestions, fg="yellow")
+            if not hook_name:
+                command_suggestions = generate_next_command_recommendation(
+                    [
+                        ("Validate SAM template", "sam validate"),
+                        ("Test Function in the Cloud", "sam sync --stack-name {{stack-name}} --watch"),
+                        ("Deploy", "sam deploy --guided"),
+                    ]
+                )
+                click.secho(command_suggestions, fg="yellow")
 
     except NoApisDefined as ex:
         raise UserException(

--- a/samcli/hook_packages/terraform/hooks/prepare/translate.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/translate.py
@@ -52,7 +52,7 @@ from samcli.hook_packages.terraform.lib.utils import (
     get_sam_metadata_planned_resource_value_attribute,
 )
 from samcli.lib.hook.exceptions import PrepareHookException
-from samcli.lib.utils.colors import Colored
+from samcli.lib.utils.colors import Colored, Colors
 from samcli.lib.utils.resources import AWS_LAMBDA_FUNCTION as CFN_AWS_LAMBDA_FUNCTION
 
 SAM_METADATA_RESOURCE_TYPE = "null_resource"
@@ -134,9 +134,12 @@ def _check_unresolvable_values(root_module: dict, root_tf_module: TFModule) -> N
 
                 if config_values and not planned_values:
                     LOG.warning(
-                        Colored().yellow(
-                            "\nUnresolvable attributes discovered in project, run terraform apply to resolve them.\n"
-                        )
+                        Colored().color_log(
+                            msg="\nUnresolvable attributes discovered in project, "
+                            "run terraform apply to resolve them.\n",
+                            color=Colors.WARNING,
+                        ),
+                        extra=dict(markup=True),
                     )
 
                     return

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from samcli.lib.providers.provider import Api, Cors
-from samcli.lib.utils.colors import Colored
+from samcli.lib.utils.colors import Colored, Colors
 from samcli.local.apigw.authorizers.authorizer import Authorizer
 from samcli.local.apigw.route import Route
 
@@ -197,7 +197,7 @@ and authorizers deployed on AWS. Any application critical behavior should
 be validated thoroughly before deploying to production.
 
 Testing application behaviour against authorizers deployed on AWS can be done using the sam sync command.{os.linesep}"""
-                LOG.warning(Colored().yellow(message))
+                LOG.warning(Colored().color_log(message, color=Colors.WARNING), extra=dict(markup=True))
 
                 break
 

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -1,7 +1,8 @@
 """Test Terraform prepare translate"""
 import copy
+from unittest import TestCase
 from unittest.mock import Mock, call, patch, MagicMock, ANY
-from samcli.lib.utils.colors import Colored
+from samcli.lib.utils.colors import Colored, Colors
 
 from tests.unit.hook_packages.terraform.hooks.prepare.prepare_base import PrepareHookUnitBase
 from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
@@ -1112,7 +1113,7 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
         self.assertEqual(translated_cfn_properties, self.expected_internal_apigw_integration_response_properties)
 
 
-class TestUnresolvableAttributeCheck:
+class TestUnresolvableAttributeCheck(TestCase):
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.RESOURCE_TRANSLATOR_MAPPING")
     @patch("samcli.hook_packages.terraform.hooks.prepare.translate.LOG")
     def test_module_contains_unresolvables(self, log_mock, mapping_mock):
@@ -1136,5 +1137,9 @@ class TestUnresolvableAttributeCheck:
         _check_unresolvable_values(module, tf_module)
 
         log_mock.warning.assert_called_with(
-            Colored().yellow("\nUnresolvable attributes discovered in project, run terraform apply to resolve them.\n")
+            Colored().color_log(
+                msg="\nUnresolvable attributes discovered in project, " "run terraform apply to resolve them.\n",
+                color=Colors.WARNING,
+            ),
+            extra=dict(markup=True),
         )

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -1138,7 +1138,7 @@ class TestUnresolvableAttributeCheck(TestCase):
 
         log_mock.warning.assert_called_with(
             Colored().color_log(
-                msg="\nUnresolvable attributes discovered in project, " "run terraform apply to resolve them.\n",
+                msg="\nUnresolvable attributes discovered in project, run terraform apply to resolve them.\n",
                 color=Colors.WARNING,
             ),
             extra=dict(markup=True),


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Fix the issues that came up during the Terraform `sam local start-api` bug bash.

#### How does it address the issue?
- Fixes bug where apply warning message was not printed in the correct colour.
- Change `start-api` command to not print next command suggestions if `--hook-name` is provided.
- Fixes the random characters printed during the beta features warning.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
