### PR TITLE
feat: Fix message when no config file is found

### DIFF
--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -269,7 +269,7 @@ class SamConfig:
                 config_file = filename
 
         if config_files_found == 0:  # Config file doesn't exist (yet!)
-            LOG.info(f"No config file found. Creating one as {config_file}.")
+            LOG.debug(f"No config file found in this directory.")
         elif config_files_found > 1:  # Multiple config files; let user know which is used
             LOG.info(
                 f"More than one samconfig file found; using {config_file}."

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -269,7 +269,7 @@ class SamConfig:
                 config_file = filename
 
         if config_files_found == 0:  # Config file doesn't exist (yet!)
-            LOG.debug(f"No config file found in this directory.")
+            LOG.debug("No config file found in this directory.")
         elif config_files_found > 1:  # Multiple config files; let user know which is used
             LOG.info(
                 f"More than one samconfig file found; using {config_file}."


### PR DESCRIPTION
#### Why is this change necessary?
Previously, the info message displayed when there was no config file in the given repository had implications that one would be created. This is not always the case, making the message itself misleading.

#### How does it address the issue?
This change removes the additional sentence that a new `samconfig` file is being created, preventing confusion on the user's end.

#### What side effects does this change have?
The output message of the function is different, and less misleading.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
