### PR TITLE
chore: fix issues with appveyor ubuntu setup

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -43,7 +43,7 @@ environment:
 
 install:
   # AppVeyor's apt-get cache might be outdated, and the package could potentially be 404.
-  - sh: "sudo apt-get update"
+  - sh: "sudo apt-get update --allow-releaseinfo-change"
 
   - sh: "gvm use go1.19"
   - sh: "echo $PATH"
@@ -87,7 +87,7 @@ install:
   - sh: "sudo apt install -y jq"
 
   # install Terraform
-  - sh: "sudo apt update"
+  - sh: "sudo apt update --allow-releaseinfo-change"
   - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
   - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
   - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"


### PR DESCRIPTION
Added `--allow-releaseinfo-change` for `apt-get update` and `apt update` commands to fix recent issues.

Tested with dev canaries as it is passing these commands successfully
https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux-dev/builds/47363646

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
