### PR TITLE
Add sanity check script and use it in pyinstaller GHA

### DIFF
--- a/.github/workflows/validate_pyinstaller.yml
+++ b/.github/workflows/validate_pyinstaller.yml
@@ -18,6 +18,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
       - name: Build PyInstaller
         run: |
           chmod +x ./installer/pyinstaller/build-linux.sh
@@ -45,6 +49,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
       - name: Build PyInstaller
         run: |
           chmod +x ./installer/pyinstaller/build-mac.sh

--- a/.github/workflows/validate_pyinstaller.yml
+++ b/.github/workflows/validate_pyinstaller.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+env:
+  CI_OVERRIDE: "1"
+
 jobs:
   build-for-linux:
     name: build-pyinstaller-linux
@@ -18,7 +21,7 @@ jobs:
       - name: Build PyInstaller
         run: |
           chmod +x ./installer/pyinstaller/build-linux.sh
-          CI_OVERRIDE=1 ./installer/pyinstaller/build-linux.sh aws-sam-cli-linux-x86_64.zip
+          ./installer/pyinstaller/build-linux.sh aws-sam-cli-linux-x86_64.zip
       - name: Basic tests for PyInstaller
         run: |
           unzip .build/output/aws-sam-cli-linux-x86_64.zip -d sam-installation
@@ -45,7 +48,7 @@ jobs:
       - name: Build PyInstaller
         run: |
           chmod +x ./installer/pyinstaller/build-mac.sh
-          CI_OVERRIDE=1 ./installer/pyinstaller/build-mac.sh aws-sam-cli-macos-x86_64.zip
+          ./installer/pyinstaller/build-mac.sh aws-sam-cli-macos-x86_64.zip
       - name: Basic tests for PyInstaller
         run: |
           unzip .build/output/aws-sam-cli-macos-x86_64.zip -d sam-installation

--- a/.github/workflows/validate_pyinstaller.yml
+++ b/.github/workflows/validate_pyinstaller.yml
@@ -24,6 +24,7 @@ jobs:
           unzip .build/output/aws-sam-cli-linux-x86_64.zip -d sam-installation
           ./sam-installation/install
           sam-beta --version
+          ./tests/sanity-check.sh
       - uses: actions/upload-artifact@v3
         with:
           name: pyinstaller-linux-zip
@@ -50,6 +51,7 @@ jobs:
           unzip .build/output/aws-sam-cli-macos-x86_64.zip -d sam-installation
           sudo ./sam-installation/install
           sam-beta --version
+          ./tests/sanity-check.sh
       - uses: actions/upload-artifact@v3
         with:
           name: pyinstaller-macos-zip

--- a/tests/sanity-check.sh
+++ b/tests/sanity-check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeo pipefail
 
-SAM_CLI_TELEMETRY="${SAM_CLI_TELEMETRY:-0}"
+export SAM_CLI_TELEMETRY="${SAM_CLI_TELEMETRY:-0}"
 
 if [ "$CI_OVERRIDE" = "1" ]; then
     sam_binary="sam-beta"

--- a/tests/sanity-check.sh
+++ b/tests/sanity-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xe
+set -xeo pipefail
 
 if [ "$CI_OVERRIDE" = "1" ]; then
     sam_binary="sam-beta"

--- a/tests/sanity-check.sh
+++ b/tests/sanity-check.sh
@@ -13,6 +13,11 @@ else
     sam_binary="sam"
 fi
 
+if ! command -v "$sam_binary" &> /dev/null; then
+    echo "$sam_binary not found. Please check if it is in PATH"
+    exit 1
+fi
+
 echo "Using ${sam_binary} as SAM CLI binary name" 
 
 if [ "$sam_binary" = "sam" ]; then
@@ -32,9 +37,9 @@ fi
 
 echo "Starting testing sam binary"
 rm -rf sam-app-testing
-$sam_binary init --no-interactive -n sam-app-testing --dependency-manager mod --runtime go1.x --app-template hello-world --package-type Zip --architecture x86_64
+"$sam_binary" init --no-interactive -n sam-app-testing --dependency-manager mod --runtime go1.x --app-template hello-world --package-type Zip --architecture x86_64
 cd sam-app-testing
-$sam_binary build
-$sam_binary validate
+GOFLAGS="-buildvcs=false" "$sam_binary" build
+"$sam_binary" validate
 
 echo "sam init, sam build, and sam validate commands Succeeded"

--- a/tests/sanity-check.sh
+++ b/tests/sanity-check.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -xeo pipefail
 
+SAM_CLI_TELEMETRY="${SAM_CLI_TELEMETRY:-0}"
+
 if [ "$CI_OVERRIDE" = "1" ]; then
     sam_binary="sam-beta"
 elif [ "$IS_NIGHTLY" = "1" ]; then

--- a/tests/sanity-check.sh
+++ b/tests/sanity-check.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -xe
+
+if [ "$CI_OVERRIDE" = "1" ]; then
+    sam_binary="sam-beta"
+elif [ "$IS_NIGHTLY" = "1" ]; then
+    sam_binary="sam-nightly"
+elif [ "$SAM_CLI_DEV" = "1" ]; then
+    sam_binary="samdev"
+else
+    sam_binary="sam"
+fi
+
+echo "Using ${sam_binary} as SAM CLI binary name" 
+
+if [ "$sam_binary" = "sam" ]; then
+    SAMCLI_INSTALLED_VERSION=$($sam_binary --version | cut -d " " -f 4)
+
+    # Get latest SAM CLI version from GH main branch
+    SAMCLI_LATEST_VERSION=$(curl -L https://raw.githubusercontent.com/aws/aws-sam-cli/master/samcli/__init__.py | tail -n 1 | cut -d '"' -f 2)
+
+    # Check version
+    if [[ "$SAMCLI_INSTALLED_VERSION" != "$SAMCLI_LATEST_VERSION" ]]; then
+        echo "expected: $SAMCLI_LATEST_VERSION; got: $SAMCLI_INSTALLED_VERSION"
+        exit 1
+    fi
+
+    echo "Version check succeeded"
+fi
+
+echo "Starting testing sam binary"
+rm -rf sam-app-testing
+$sam_binary init --no-interactive -n sam-app-testing --dependency-manager mod --runtime go1.x --app-template hello-world --package-type Zip --architecture x86_64
+cd sam-app-testing
+$sam_binary build
+$sam_binary validate
+
+echo "sam init, sam build, and sam validate commands Succeeded"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
The script is mainly used for sanity-checking artifacts during release. It's also beneficial to use the same script in the PyInstaller Validation GHA as part PR checks.

#### How does it address the issue?
- tests/sanity-check.sh does two things: 1/ version check against the version fetched from master branch, 2/ perform `sam init` -> `sam build` -> `sam validate` as a basic sanity check. Note that 1 is only needed during a release. It is skipped in the PyInstaller GHA, in nightly release, or in dev mode.

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
