### PR TITLE
feat: Disable samconfig.json support

### DIFF
--- a/samcli/lib/config/file_manager.py
+++ b/samcli/lib/config/file_manager.py
@@ -338,5 +338,5 @@ FILE_MANAGER_MAPPER: Dict[str, Type[FileManager]] = {  # keys ordered by priorit
     ".toml": TomlFileManager,
     ".yaml": YamlFileManager,
     ".yml": YamlFileManager,
-    ".json": JsonFileManager,
+    # ".json": JsonFileManager,  # JSON support disabled
 }

--- a/tests/integration/buildcmd/test_build_samconfig.py
+++ b/tests/integration/buildcmd/test_build_samconfig.py
@@ -9,6 +9,7 @@ from tests.testing_utils import run_command
 configs = {
     ".toml": "samconfig/samconfig.toml",
     ".yaml": "samconfig/samconfig.yaml",
+    ".yml": "samconfig/samconfig.yml",
     ".json": "samconfig/samconfig.json",
 }
 
@@ -18,7 +19,7 @@ class TestSamConfigWithBuild(BuildIntegBase):
         [
             (".toml"),
             (".yaml"),
-            (".json"),
+            # (".json"),
         ]
     )
     def test_samconfig_works_with_extension(self, extension):
@@ -40,7 +41,7 @@ class TestSamConfigWithBuild(BuildIntegBase):
         [
             (".toml"),
             (".yaml"),
-            (".json"),
+            # (".json"),
         ]
     )
     def test_samconfig_parameters_are_overridden(self, extension):
@@ -72,8 +73,8 @@ class TestSamConfigWithBuild(BuildIntegBase):
 
 @parameterized_class(
     [  # Ordered by expected priority
-        {"extensions": [".toml", ".yaml", ".json"]},
-        {"extensions": [".yaml", ".json"]},
+        {"extensions": [".toml", ".yaml", ".yml"]},
+        {"extensions": [".yaml", ".yml"]},
     ]
 )
 class TestSamConfigExtensionHierarchy(BuildIntegBase):

--- a/tests/integration/testdata/buildcmd/samconfig/samconfig.yml
+++ b/tests/integration/testdata/buildcmd/samconfig/samconfig.yml
@@ -1,0 +1,7 @@
+version: 0.1
+default:
+  build:
+    parameters:
+      build_dir: .yml
+      cached: true
+      parameter_overrides: Runtime=python3.9 CodeUri=SomeURI Handler=SomeHandler

--- a/tests/unit/lib/samconfig/test_file_manager.py
+++ b/tests/unit/lib/samconfig/test_file_manager.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 import tempfile
-from unittest import TestCase
+from unittest import TestCase, skip
 
 import tomlkit
 from ruamel.yaml import YAML
@@ -182,6 +182,7 @@ class TestYamlFileManager(TestCase):
         self.assertIn("# This is a comment", txt)
 
 
+@skip("JSON config support disabled")
 class TestJsonFileManager(TestCase):
     def test_read_json(self):
         config_dir = tempfile.gettempdir()

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -295,7 +295,7 @@ class TestSamConfigFileManager(TestCase):
             ("samconfig.toml", TomlFileManager, ".toml"),
             ("samconfig.yaml", YamlFileManager, ".yaml"),
             ("samconfig.yml", YamlFileManager, ".yml"),
-            ("samconfig.json", JsonFileManager, ".json"),
+            # ("samconfig.json", JsonFileManager, ".json"),
         ]
     )
     @patch("samcli.lib.telemetry.event.EventTracker.track_event")


### PR DESCRIPTION
#### Why is this change necessary?
As of now, the `SamConfig` class has already been overhauled to decouple it from TOML logic. In addition, we have already implemented YAML support. Thus, there is no reason to immediately add on several additional filetypes with these changes until we can be assured they work correctly.

#### How does it address the issue?
Any JSON samconfig references, including the mapping and unit tests, have been either commented out or skipped. In addition, integration tests that referenced a `samconfig.json` file have been updated accordingly.

#### What side effects does this change have?
JSON config files will no longer be supported.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
