### PR TITLE
fix: remove circular dependency by moving parse_s3 method to its own util file

### DIFF
--- a/samcli/lib/bootstrap/companion_stack/companion_stack_manager.py
+++ b/samcli/lib/bootstrap/companion_stack/companion_stack_manager.py
@@ -17,6 +17,7 @@ from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.providers.sam_function_provider import SamFunctionProvider
 from samcli.lib.providers.sam_stack_provider import SamLocalStackProvider
 from samcli.lib.utils.packagetype import IMAGE
+from samcli.lib.utils.s3 import parse_s3_url
 
 # pylint: disable=E0401
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -112,7 +113,7 @@ class CompanionStackManager:
                 self._s3_client, bucket_name=self._s3_bucket, prefix=self._s3_prefix, no_progressbar=True
             )
             # TemplateUrl property requires S3 URL to be in path-style format
-            parts = S3Uploader.parse_s3_url(
+            parts = parse_s3_url(
                 s3_uploader.upload_with_dedup(temporary_file.name, "template"), version_property="Version"
             )
 

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -38,6 +38,7 @@ from samcli.lib.deploy.utils import DeployColor, FailureMode
 from samcli.lib.package.local_files_utils import get_uploaded_s3_object_name, mktempfile
 from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.utils.colors import Colored, Colors
+from samcli.lib.utils.s3 import parse_s3_url
 from samcli.lib.utils.time import utc_to_timestamp
 
 LOG = logging.getLogger(__name__)
@@ -203,9 +204,7 @@ class Deployer:
                 temporary_file.flush()
                 remote_path = get_uploaded_s3_object_name(file_path=temporary_file.name, extension="template")
                 # TemplateUrl property requires S3 URL to be in path-style format
-                parts = S3Uploader.parse_s3_url(
-                    s3_uploader.upload(temporary_file.name, remote_path), version_property="Version"
-                )
+                parts = parse_s3_url(s3_uploader.upload(temporary_file.name, remote_path), version_property="Version")
                 kwargs["TemplateURL"] = s3_uploader.to_path_style_s3_url(parts["Key"], parts.get("Version", None))
 
         # don't set these arguments if not specified to use existing values

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -29,7 +29,6 @@ from samcli.lib.package.packageable_resources import (
     ECRResource,
     ResourceZip,
 )
-from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.package.uploaders import Destination, Uploaders
 from samcli.lib.package.utils import (
     is_local_file,
@@ -47,6 +46,7 @@ from samcli.lib.utils.resources import (
     AWS_SERVERLESS_FUNCTION,
     RESOURCES_WITH_LOCAL_PATHS,
 )
+from samcli.lib.utils.s3 import parse_s3_url
 from samcli.yamlhelper import yaml_dump, yaml_parse
 
 # NOTE: sriram-mv, A cyclic dependency on `Template` needs to be broken.
@@ -99,7 +99,7 @@ class CloudFormationStackResource(ResourceZip):
             url = self.uploader.upload(temporary_file.name, remote_path)
 
             # TemplateUrl property requires S3 URL to be in path-style format
-            parts = S3Uploader.parse_s3_url(url, version_property="Version")
+            parts = parse_s3_url(url, version_property="Version")
             s3_path_url = self.uploader.to_path_style_s3_url(parts["Key"], parts.get("Version", None))
             set_value_from_jmespath(resource_dict, self.PROPERTY_NAME, s3_path_url)
 
@@ -146,7 +146,7 @@ class CloudFormationStackSetResource(ResourceZip):
         url = self.uploader.upload(abs_template_path, remote_path)
 
         # TemplateUrl property requires S3 URL to be in path-style format
-        parts = S3Uploader.parse_s3_url(url, version_property="Version")
+        parts = parse_s3_url(url, version_property="Version")
         s3_path_url = self.uploader.to_path_style_s3_url(parts["Key"], parts.get("Version", None))
         set_value_from_jmespath(resource_dict, self.PROPERTY_NAME, s3_path_url)
 

--- a/samcli/lib/package/code_signer.py
+++ b/samcli/lib/package/code_signer.py
@@ -5,7 +5,7 @@ Client for initiate and monitor code signing jobs
 import logging
 
 from samcli.commands.exceptions import UserException
-from samcli.lib.package.s3_uploader import S3Uploader
+from samcli.lib.utils.s3 import parse_s3_url
 
 LOG = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class CodeSigner:
         profile_owner = signing_profile_for_resource["profile_owner"]
 
         # parse given s3 url, and extract bucket and object key
-        parsed_s3_url = S3Uploader.parse_s3_url(s3_url)
+        parsed_s3_url = parse_s3_url(s3_url)
         s3_bucket = parsed_s3_url["Bucket"]
         s3_key = parsed_s3_url["Key"]
         s3_target_prefix = s3_key.rsplit("/", 1)[0] + "/signed_"

--- a/samcli/lib/package/packageable_resources.py
+++ b/samcli/lib/package/packageable_resources.py
@@ -51,6 +51,7 @@ from samcli.lib.utils.resources import (
     RESOURCES_WITH_IMAGE_COMPONENT,
     RESOURCES_WITH_LOCAL_PATHS,
 )
+from samcli.lib.utils.s3 import parse_s3_url
 
 LOG = logging.getLogger(__name__)
 
@@ -196,7 +197,7 @@ class ResourceZip(Resource):
         # artifact, as deletion of intrinsic ref function artifacts is not supported yet.
         # TODO: Allow deletion of S3 artifacts with intrinsic ref functions.
         if resource_path and isinstance(resource_path, str):
-            return self.uploader.parse_s3_url(resource_path)
+            return parse_s3_url(resource_path)
         return {"Bucket": None, "Key": None}
 
 
@@ -340,7 +341,7 @@ class ResourceWithS3UrlDict(ResourceZip):
             self.RESOURCE_TYPE, resource_id, resource_dict, self.PROPERTY_NAME, parent_dir, self.uploader
         )
 
-        parsed_url = S3Uploader.parse_s3_url(
+        parsed_url = parse_s3_url(
             artifact_s3_url,
             bucket_name_property=self.BUCKET_NAME_PROPERTY,
             object_key_property=self.OBJECT_KEY_PROPERTY,

--- a/samcli/lib/package/utils.py
+++ b/samcli/lib/package/utils.py
@@ -26,6 +26,7 @@ from samcli.lib.package.permissions import (
 from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.utils.hash import dir_checksum
 from samcli.lib.utils.resources import LAMBDA_LOCAL_RESOURCES
+from samcli.lib.utils.s3 import parse_s3_url
 
 LOG = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ def is_s3_protocol_url(url):
     Check whether url is a valid path in the form of "s3://..."
     """
     try:
-        S3Uploader.parse_s3_url(url)
+        parse_s3_url(url)
         return True
     except ValueError:
         return False

--- a/samcli/lib/utils/s3.py
+++ b/samcli/lib/utils/s3.py
@@ -1,0 +1,74 @@
+"""Contains utility functions related to AWS S3 service"""
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qs, urlparse
+
+
+def parse_s3_url(
+    url: Any,
+    bucket_name_property: str = "Bucket",
+    object_key_property: str = "Key",
+    version_property: Optional[str] = None,
+) -> Dict:
+    if isinstance(url, str) and url.startswith("s3://"):
+        return _parse_s3_format_url(
+            url=url,
+            bucket_name_property=bucket_name_property,
+            object_key_property=object_key_property,
+            version_property=version_property,
+        )
+
+    if isinstance(url, str) and url.startswith("https://s3"):
+        return _parse_path_style_s3_url(
+            url=url, bucket_name_property=bucket_name_property, object_key_property=object_key_property
+        )
+
+    raise ValueError("URL given to the parse method is not a valid S3 url {0}".format(url))
+
+
+def _parse_s3_format_url(
+    url: Any,
+    bucket_name_property: str = "Bucket",
+    object_key_property: str = "Key",
+    version_property: Optional[str] = None,
+) -> Dict:
+    """
+    Method for parsing s3 urls that begin with s3://
+    e.g. s3://bucket/key
+    """
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+    if parsed.netloc and parsed.path:
+        result = dict()
+        result[bucket_name_property] = parsed.netloc
+        result[object_key_property] = parsed.path.lstrip("/")
+
+        # If there is a query string that has a single versionId field,
+        # set the object version and return
+        if version_property is not None and "versionId" in query and len(query["versionId"]) == 1:
+            result[version_property] = query["versionId"][0]
+
+        return result
+
+    raise ValueError("URL given to the parse method is not a valid S3 url {0}".format(url))
+
+
+def _parse_path_style_s3_url(
+    url: Any,
+    bucket_name_property: str = "Bucket",
+    object_key_property: str = "Key",
+) -> Dict:
+    """
+    Static method for parsing path style s3 urls.
+    e.g. https://s3.us-east-1.amazonaws.com/bucket/key
+    """
+    parsed = urlparse(url)
+    result = dict()
+    # parsed.path would point to /bucket/key
+    if parsed.path:
+        s3_bucket_key = parsed.path.split("/", 2)[1:]
+
+        result[bucket_name_property] = s3_bucket_key[0]
+        result[object_key_property] = s3_bucket_key[1]
+
+        return result
+    raise ValueError("URL given to the parse method is not a valid S3 url {0}".format(url))

--- a/tests/end_to_end/test_stages.py
+++ b/tests/end_to_end/test_stages.py
@@ -12,6 +12,7 @@ import os
 
 from samcli.cli.global_config import GlobalConfig
 from filelock import FileLock
+from samcli.lib.utils.s3 import parse_s3_url
 from tests.end_to_end.end_to_end_context import EndToEndTestContext
 from tests.testing_utils import CommandResult, run_command, run_command_with_input
 
@@ -102,7 +103,7 @@ class PackageDownloadZipFunctionStage(EndToEndBaseStage):
         )
 
         if zipped_fn_s3_loc:
-            s3_info = S3Uploader.parse_s3_url(zipped_fn_s3_loc)
+            s3_info = parse_s3_url(zipped_fn_s3_loc)
             self.s3_client.download_file(s3_info["Bucket"], s3_info["Key"], str(zip_file_path))
 
             with zipfile.ZipFile(zip_file_path, "r") as zip_refzip:

--- a/tests/unit/lib/bootstrap/companion_stack/test_companion_stack_manager.py
+++ b/tests/unit/lib/bootstrap/companion_stack/test_companion_stack_manager.py
@@ -48,8 +48,10 @@ class TestCompanionStackManager(TestCase):
 
     @patch("samcli.lib.bootstrap.companion_stack.companion_stack_manager.mktempfile")
     @patch("samcli.lib.bootstrap.companion_stack.companion_stack_manager.S3Uploader")
+    @patch("samcli.lib.bootstrap.companion_stack.companion_stack_manager.parse_s3_url")
     def test_create_companion_stack(
         self,
+        parse_s3_url_mock,
         s3_uploader_mock,
         mktempfile_mock,
     ):
@@ -70,8 +72,10 @@ class TestCompanionStackManager(TestCase):
 
     @patch("samcli.lib.bootstrap.companion_stack.companion_stack_manager.mktempfile")
     @patch("samcli.lib.bootstrap.companion_stack.companion_stack_manager.S3Uploader")
+    @patch("samcli.lib.bootstrap.companion_stack.companion_stack_manager.parse_s3_url")
     def test_update_companion_stack(
         self,
+        parse_s3_url_mock,
         s3_uploader_mock,
         mktempfile_mock,
     ):

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -19,7 +19,6 @@ from samcli.lib.package.permissions import (
     AdditiveFilePermissionPermissionMapper,
     AdditiveDirPermissionPermissionMapper,
 )
-from samcli.lib.package.s3_uploader import S3Uploader
 from samcli.lib.package.uploaders import Destination
 from samcli.lib.package.utils import zip_folder, make_zip, make_zip_with_lambda_permissions, make_zip_with_permissions
 from samcli.lib.utils.packagetype import ZIP, IMAGE
@@ -292,51 +291,6 @@ class TestArtifactExporter(unittest.TestCase):
 
     def _assert_is_invalid_s3_url(self, url):
         self.assertFalse(is_s3_protocol_url(url), "{0} should be valid".format(url))
-
-    def test_parse_s3_url(self):
-        valid = [
-            {"url": "s3://foo/bar", "result": {"Bucket": "foo", "Key": "bar"}},
-            {"url": "s3://foo/bar/cat/dog", "result": {"Bucket": "foo", "Key": "bar/cat/dog"}},
-            {
-                "url": "s3://foo/bar/baz?versionId=abc&param1=val1&param2=val2",
-                "result": {"Bucket": "foo", "Key": "bar/baz", "VersionId": "abc"},
-            },
-            {
-                # VersionId is not returned if there are more than one versionId
-                # keys in query parameter
-                "url": "s3://foo/bar/baz?versionId=abc&versionId=123",
-                "result": {"Bucket": "foo", "Key": "bar/baz"},
-            },
-            {
-                # Path style url
-                "url": "https://s3-eu-west-1.amazonaws.com/bucket/key",
-                "result": {"Bucket": "bucket", "Key": "key"},
-            },
-            {
-                # Path style url
-                "url": "https://s3.us-east-1.amazonaws.com/bucket/key",
-                "result": {"Bucket": "bucket", "Key": "key"},
-            },
-        ]
-
-        invalid = [
-            # For purposes of exporter, we need S3 URLs to point to an object
-            # and not a bucket
-            "s3://foo",
-            "https://www.amazon.com",
-            "https://s3.us-east-1.amazonaws.com",
-        ]
-
-        for config in valid:
-            result = S3Uploader.parse_s3_url(
-                config["url"], bucket_name_property="Bucket", object_key_property="Key", version_property="VersionId"
-            )
-
-            self.assertEqual(result, config["result"])
-
-        for url in invalid:
-            with self.assertRaises(ValueError):
-                S3Uploader.parse_s3_url(url)
 
     def test_is_local_file(self):
         with tempfile.NamedTemporaryFile() as handle:

--- a/tests/unit/lib/utils/test_s3.py
+++ b/tests/unit/lib/utils/test_s3.py
@@ -1,0 +1,49 @@
+from unittest import TestCase
+from samcli.lib.utils.s3 import parse_s3_url
+
+
+class TestS3Utils(TestCase):
+    def test_parse_s3_url(self):
+        valid = [
+            {"url": "s3://foo/bar", "result": {"Bucket": "foo", "Key": "bar"}},
+            {"url": "s3://foo/bar/cat/dog", "result": {"Bucket": "foo", "Key": "bar/cat/dog"}},
+            {
+                "url": "s3://foo/bar/baz?versionId=abc&param1=val1&param2=val2",
+                "result": {"Bucket": "foo", "Key": "bar/baz", "VersionId": "abc"},
+            },
+            {
+                # VersionId is not returned if there are more than one versionId
+                # keys in query parameter
+                "url": "s3://foo/bar/baz?versionId=abc&versionId=123",
+                "result": {"Bucket": "foo", "Key": "bar/baz"},
+            },
+            {
+                # Path style url
+                "url": "https://s3-eu-west-1.amazonaws.com/bucket/key",
+                "result": {"Bucket": "bucket", "Key": "key"},
+            },
+            {
+                # Path style url
+                "url": "https://s3.us-east-1.amazonaws.com/bucket/key",
+                "result": {"Bucket": "bucket", "Key": "key"},
+            },
+        ]
+
+        invalid = [
+            # For purposes of exporter, we need S3 URLs to point to an object
+            # and not a bucket
+            "s3://foo",
+            "https://www.amazon.com",
+            "https://s3.us-east-1.amazonaws.com",
+        ]
+
+        for config in valid:
+            result = parse_s3_url(
+                config["url"], bucket_name_property="Bucket", object_key_property="Key", version_property="VersionId"
+            )
+
+            self.assertEqual(result, config["result"])
+
+        for url in invalid:
+            with self.assertRaises(ValueError):
+                parse_s3_url(url)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Fixing circular dependency which happens during E2E tests;
```
E   ImportError: cannot import name 'S3Uploader' from partially initialized module 'samcli.lib.package.s3_uploader' (most likely due to a circular import) 
```


#### How does it address the issue?
By moving `parse_s3_url` to a new module under `utils`.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
