### PR TITLE
feat: Repair and refine tests

### DIFF
--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -826,7 +826,7 @@ to create a managed default bucket, or run sam deploy --guided",
 
         deploy_process_execute = self.run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 1)
-        self.assertIn("Error reading configuration: Unexpected character", str(deploy_process_execute.stderr))
+        self.assertIn("SamConfigFileReadException: Unexpected character", str(deploy_process_execute.stderr))
 
     @parameterized.expand([("aws-serverless-function.yaml", "samconfig-tags-list.toml")])
     def test_deploy_with_valid_config_tags_list(self, template_file, config_file):

--- a/tests/unit/lib/samconfig/test_file_manager.py
+++ b/tests/unit/lib/samconfig/test_file_manager.py
@@ -14,11 +14,16 @@ class TestTomlFileManager(TestCase):
     def test_read_toml(self):
         config_dir = tempfile.gettempdir()
         config_path = Path(config_dir, "samconfig.toml")
-        config_path.write_text("version=0.1\n[config_env.topic1.parameters]\nword='clarity'\n")
+        config_path.write_text(
+            "version=0.1\n[config_env.topic1.parameters]\nword='clarity'\nmultiword=['thing 1', 'thing 2']"
+        )
         config_doc = TomlFileManager.read(config_path)
         self.assertEqual(
             config_doc,
-            {"version": 0.1, "config_env": {"topic1": {"parameters": {"word": "clarity"}}}},
+            {
+                "version": 0.1,
+                "config_env": {"topic1": {"parameters": {"word": "clarity", "multiword": ["thing 1", "thing 2"]}}},
+            },
         )
 
     def test_read_toml_invalid_toml(self):
@@ -111,13 +116,18 @@ class TestYamlFileManager(TestCase):
     def test_read_yaml(self):
         config_dir = tempfile.gettempdir()
         config_path = Path(config_dir, "samconfig.yaml")
-        config_path.write_text("version: 0.1\nconfig_env:\n  topic1:\n    parameters:\n      word: clarity\n")
+        config_path.write_text(
+            "version: 0.1\nconfig_env:\n  topic1:\n    parameters:\n      word: clarity\n      multiword: [thing 1, thing 2]"
+        )
 
         config_doc = YamlFileManager.read(config_path)
 
         self.assertEqual(
             config_doc,
-            {"version": 0.1, "config_env": {"topic1": {"parameters": {"word": "clarity"}}}},
+            {
+                "version": 0.1,
+                "config_env": {"topic1": {"parameters": {"word": "clarity", "multiword": ["thing 1", "thing 2"]}}},
+            },
         )
 
     def test_read_yaml_invalid_yaml(self):
@@ -189,7 +199,10 @@ class TestJsonFileManager(TestCase):
         config_path = Path(config_dir, "samconfig.json")
         config_path.write_text(
             json.dumps(
-                {"version": 0.1, "config_env": {"topic1": {"parameters": {"word": "clarity"}}}},
+                {
+                    "version": 0.1,
+                    "config_env": {"topic1": {"parameters": {"word": "clarity", "multiword": ["thing 1", "thing 2"]}}},
+                },
                 indent=JsonFileManager.INDENT_SIZE,
             )
         )
@@ -198,7 +211,10 @@ class TestJsonFileManager(TestCase):
 
         self.assertEqual(
             config_doc,
-            {"version": 0.1, "config_env": {"topic1": {"parameters": {"word": "clarity"}}}},
+            {
+                "version": 0.1,
+                "config_env": {"topic1": {"parameters": {"word": "clarity", "multiword": ["thing 1", "thing 2"]}}},
+            },
         )
 
     def test_read_json_invalid_json(self):


### PR DESCRIPTION
#### Why is this change necessary?
Previously, some canary tests were failing due to samconfig changes. 

#### How does it address the issue?
The failing deploy integration test has been updated to better reflect the new nature of samconfig. In addition, the `FileManager` tests have been updated to include checks for array-parameter support for parameters like `image-repositories`.

#### What side effects does this change have?
One of the deploy integration tests, as well as each `FileManager`'s initial read test, have been updated to better reflect new changes.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
