### PR TITLE
chore: use amazon ecr credential helper in windows appveyor

### DIFF
--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -134,7 +134,14 @@ install:
   # Echo final Path
   - "echo %PATH%"
 
-  - "IF DEFINED BY_CANARY ECHO Logging in Public ECR && aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws"
+  # use amazon-ecr-credential-helper
+  - choco install amazon-ecr-credential-helper
+  - ps: "
+    $docker_config = Get-Content $env:HOME/.docker/config.json -raw | ConvertFrom-Json;
+    $docker_config.credsStore = 'ecr-login';
+    $docker_config | ConvertTo-Json | set-content $env:HOME/.docker/config.json;
+  "
+  - ps: "get-content $env:HOME/.docker/config.json"
 
   # claim some disk space before starting the tests
   - "docker system prune -a -f"


### PR DESCRIPTION
This PR to use the amazon ecr credential helper in windows appveyor to fix the following error we received in windows canaries:
```
Logging in Public ECR 
Error saving credentials: error storing credentials - err: exit status 1, out: `error storing credentials - err: exit status 1, out: `The stub received bad data.``
```

It got tested in Dev canaries https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-windows-dev

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
