### PR TITLE
fix: Handler path mapping for layer-wrapped esbuild functions

### DIFF
--- a/samcli/lib/build/bundler.py
+++ b/samcli/lib/build/bundler.py
@@ -12,6 +12,7 @@ from samcli.lib.providers.sam_function_provider import SamFunctionProvider
 
 LOG = logging.getLogger(__name__)
 
+LAYER_PREFIX = "/opt"
 ESBUILD_PROPERTY = "esbuild"
 
 
@@ -156,6 +157,9 @@ class EsbuildBundlerManager:
         handler_filename = self._get_path_and_filename_from_handler(handler)
         if not handler_filename:
             LOG.debug("Unable to parse handler, continuing without post-processing template.")
+            return False
+        if handler_filename.startswith(LAYER_PREFIX):
+            LOG.debug("Skipping updating the handler path as it is pointing to a layer.")
             return False
         expected_artifact_path = Path(self._build_dir, name, handler_filename)
         return not expected_artifact_path.is_file()

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -4,8 +4,6 @@ from unittest import skipIf
 import json
 from pathlib import Path
 
-import shutil
-
 import os
 from parameterized import parameterized_class
 

--- a/tests/end_to_end/testdata/esbuild-datadog-integration/main.js
+++ b/tests/end_to_end/testdata/esbuild-datadog-integration/main.js
@@ -1,0 +1,8 @@
+exports.lambdaHandler = async (event, context) => {
+    return {
+        statusCode: 200,
+        body: JSON.stringify({
+            message: 'hello world!',
+        }),
+    };
+};

--- a/tests/end_to_end/testdata/esbuild-datadog-integration/template.yaml
+++ b/tests/end_to_end/testdata/esbuild-datadog-integration/template.yaml
@@ -1,18 +1,21 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
+# Latest extension version: https://github.com/DataDog/datadog-lambda-extension/releases
+# Latest Node.js layer version: https://github.com/DataDog/datadog-lambda-js/releases
+
 Parameters:
   DataDogLayers:
     Description: DataDog layers
     Type: CommaDelimitedList
-    Default: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node16-x:93, arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:44"
+    Default: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node18-x:93, arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:44"
 
 Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           DD_LAMBDA_HANDLER: main.lambdaHandler

--- a/tests/end_to_end/testdata/esbuild-datadog-integration/template.yaml
+++ b/tests/end_to_end/testdata/esbuild-datadog-integration/template.yaml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  DataDogLayers:
+    Description: DataDog layers
+    Type: CommaDelimitedList
+    Default: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node16-x:93, arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:44"
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
+      Runtime: nodejs16.x
+      Environment:
+        Variables:
+          DD_LAMBDA_HANDLER: main.lambdaHandler
+      Layers: !Ref DataDogLayers
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - main.js

--- a/tests/unit/lib/build_module/test_bundler.py
+++ b/tests/unit/lib/build_module/test_bundler.py
@@ -195,6 +195,13 @@ class PostProcessHandler(TestCase):
         return_val = bundler_manager._should_update_handler("", "")
         self.assertFalse(return_val)
 
+    def test_should_not_update_layer_path(self):
+        bundler_manager = EsbuildBundlerManager(Mock(), build_dir="/build/dir")
+        bundler_manager._get_path_and_filename_from_handler = Mock()
+        bundler_manager._get_path_and_filename_from_handler.return_value = "/opt/nodejs/node_modules/d/handler.handler"
+        return_val = bundler_manager._should_update_handler("", "")
+        self.assertFalse(return_val)
+
     def test_update_function_handler(self):
         resources = {
             "FunctionA": {


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5429

#### Why is this change necessary?
Fixes an issue where customers who wrap their Lambda function handlers with a layer using esbuild are not able to invoke their functions.

#### How does it address the issue?
Skips updating the esbuild function handler path if it is a layer path.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
