### PR TITLE
Revert "chore(deps): bump sympy from 1.10.1 to 1.12 in /requirements"

### DIFF
--- a/requirements/reproducible-mac.txt
+++ b/requirements/reproducible-mac.txt
@@ -706,9 +706,9 @@ six==1.16.0 \
     #   junit-xml
     #   python-dateutil
     #   serverlessrepo
-sympy==1.12 \
-    --hash=sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5 \
-    --hash=sha256:ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8
+sympy==1.10.1 \
+    --hash=sha256:5939eeffdf9e152172601463626c022a2c27e75cf6278de8d401d50c9d58787b \
+    --hash=sha256:df75d738930f6fe9ebe7034e59d56698f29e85f443f743e51e47df0caccc2130
     # via cfn-lint
 text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \


### PR DESCRIPTION
We need to revert this PR until we use py3.11 for creating re-producable linux files since this is breaking the GHA for updating our dependencies. See: https://github.com/aws/aws-sam-cli/actions/workflows/automated-updates-to-sam-cli.yml