### PR TITLE
fix: E2E test can't find test data directory

### DIFF
--- a/tests/end_to_end/end_to_end_base.py
+++ b/tests/end_to_end/end_to_end_base.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import os
 
 from typing import List
@@ -25,9 +27,11 @@ class EndToEndBase(InitIntegBase, StackOutputsIntegBase, DeleteIntegBase, SyncIn
 
     def setUp(self):
         super().setUp()
+        e2e_dir = Path(__file__).resolve().parent
         self.stacks = []
         self.config_file_dir = GlobalConfig().config_dir
         self._create_config_dir()
+        self.e2e_test_data_path = Path(e2e_dir, "testdata")
 
     def _create_config_dir(self):
         # Init tests will lock the config dir, ensure it exists before obtaining a lock

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -175,7 +175,7 @@ class TestEsbuildDatadogLayerIntegration(EndToEndBase):
         event = '{"hello": "world"}'
         stack_name = self._method_to_stack_name(self.id())
         with EndToEndTestContext(self.app_name) as e2e_context:
-            project_path = str(Path("testdata") / "esbuild-datadog-integration")
+            project_path = str(self.e2e_test_data_path / "esbuild-datadog-integration")
             os.mkdir(e2e_context.project_directory)
             copy_tree(project_path, e2e_context.project_directory)
             self.template_path = e2e_context.template_path


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Canaries are breaking because a new E2E test uses a test data directory that isn't found.

#### How does it address the issue?
The test currently uses a relative path that doesn't work when the test is run from the root directory. This change makes the `testdata` directory relative to the test file instead of the execution directory.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
