### PR TITLE
feat: Parse parameters into JSON schema objects

### DIFF
--- a/schema/schema.py
+++ b/schema/schema.py
@@ -34,12 +34,12 @@ def format_param(param: click.core.Option) -> Dict[str, Any]:
 
     # NOTE: Params do not have explicit "string" type; either "text" or "path".
     #       All choice options are from a set of strings.
-    if param.type.name in ["text", "path", "choice", "filename", "directory"]:
+    if param.type.name.lower() in ["text", "path", "choice", "filename", "directory"]:
         formatted_param["type"] = "string"
-    elif param.type.name == "LIST":
+    elif param.type.name.lower() == "list":
         formatted_param["type"] = "array"
     else:
-        formatted_param["type"] = param.type.name or "string"
+        formatted_param["type"] = param.type.name.lower() or "string"
 
     if param.default:
         formatted_param["default"] = list(param.default) if isinstance(param.default, tuple) else param.default

--- a/schema/schema.py
+++ b/schema/schema.py
@@ -2,7 +2,9 @@
 
 
 import importlib
-from typing import Dict, List, Optional, Union
+import json
+from enum import Enum
+from typing import Any, Dict
 
 import click
 
@@ -10,7 +12,13 @@ from samcli.cli.command import _SAM_CLI_COMMAND_PACKAGES
 from samcli.lib.config.samconfig import SamConfig
 
 
-def format_param(param: click.core.Option) -> Dict[str, Union[Optional[str], List[str]]]:
+class SchemaKeys(Enum):
+    SCHEMA_FILE_NAME = "samcli.json"
+    SCHEMA_DRAFT = "http://json-schema.org/draft-04/schema"
+    TITLE = "AWS SAM CLI samconfig schema"
+
+
+def format_param(param: click.core.Option) -> Dict[str, Any]:
     """Format a click Option parameter to a dictionary object.
 
     A parameter object should contain the following information that will be
@@ -22,20 +30,22 @@ def format_param(param: click.core.Option) -> Dict[str, Union[Optional[str], Lis
                        a list of those allowed options
     * default - The default option for that parameter
     """
-    formatted_param: Dict[str, Union[Optional[str], List[str]]] = {"name": param.name, "help": param.help}
+    formatted_param: Dict[str, Any] = {"title": param.name, "description": param.help}
 
     # NOTE: Params do not have explicit "string" type; either "text" or "path".
     #       All choice options are from a set of strings.
-    if param.type.name in ["text", "path", "choice"]:
+    if param.type.name in ["text", "path", "choice", "filename", "directory"]:
         formatted_param["type"] = "string"
+    elif param.type.name == "LIST":
+        formatted_param["type"] = "array"
     else:
         formatted_param["type"] = param.type.name
 
     if param.default:
-        formatted_param["default"] = str(param.default)
+        formatted_param["default"] = list(param.default) if isinstance(param.default, tuple) else param.default
 
     if param.type.name == "choice" and isinstance(param.type, click.Choice):
-        formatted_param["choices"] = list(param.type.choices)
+        formatted_param["enum"] = list(param.type.choices)
 
     return formatted_param
 
@@ -91,14 +101,33 @@ def generate_schema() -> dict:
     schema: dict = {}
     commands = {}
     params = set()  # NOTE(leogama): Currently unused due to some params having different help values
-    # TODO: Populate schema with relevant attributes
+
+    # Populate schema with relevant attributes
+    schema["$schema"] = SchemaKeys.SCHEMA_DRAFT.value
+    schema["title"] = SchemaKeys.TITLE.value
+    schema["type"] = "object"
+    schema["properties"] = {
+        # Version number required for samconfig files to be valid
+        "version": {"type": "number"}
+    }
+    schema["required"] = ["version"]
+    schema["additionalProperties"] = False
+    # Iterate through packages for command and parameter information
     for package_name in _SAM_CLI_COMMAND_PACKAGES:
         new_command = retrieve_command_structure(package_name)
         commands.update(new_command)
         for param_list in new_command.values():
             command_params = [param for param in param_list]
         params.update(command_params)
+    # TODO: Generate schema for each of the commands
     return schema
+
+
+def write_schema():
+    """Generate the SAM CLI JSON schema and write it to file."""
+    schema = generate_schema()
+    with open(SchemaKeys.SCHEMA_FILE_NAME.value, "w+", encoding="utf-8") as outfile:
+        json.dump(schema, outfile)
 
 
 if __name__ == "__main__":

--- a/schema/schema.py
+++ b/schema/schema.py
@@ -39,7 +39,7 @@ def format_param(param: click.core.Option) -> Dict[str, Any]:
     elif param.type.name == "LIST":
         formatted_param["type"] = "array"
     else:
-        formatted_param["type"] = param.type.name
+        formatted_param["type"] = param.type.name or "string"
 
     if param.default:
         formatted_param["default"] = list(param.default) if isinstance(param.default, tuple) else param.default
@@ -127,7 +127,7 @@ def write_schema():
     """Generate the SAM CLI JSON schema and write it to file."""
     schema = generate_schema()
     with open(SchemaKeys.SCHEMA_FILE_NAME.value, "w+", encoding="utf-8") as outfile:
-        json.dump(schema, outfile)
+        json.dump(schema, outfile, indent=2)
 
 
 if __name__ == "__main__":

--- a/schema/schema.py
+++ b/schema/schema.py
@@ -34,12 +34,13 @@ def format_param(param: click.core.Option) -> Dict[str, Any]:
 
     # NOTE: Params do not have explicit "string" type; either "text" or "path".
     #       All choice options are from a set of strings.
-    if param.type.name.lower() in ["text", "path", "choice", "filename", "directory"]:
+    param_type = param.type.name.lower()
+    if param_type in ["text", "path", "choice", "filename", "directory"]:
         formatted_param["type"] = "string"
-    elif param.type.name.lower() == "list":
+    elif param_type == "list":
         formatted_param["type"] = "array"
     else:
-        formatted_param["type"] = param.type.name.lower() or "string"
+        formatted_param["type"] = param_type or "string"
 
     if param.default:
         formatted_param["default"] = list(param.default) if isinstance(param.default, tuple) else param.default


### PR DESCRIPTION
#### Why is this change necessary?
In order for SAM CLI parameters to be read correctly in the schema, they must be parsed in a certain format.

#### How does it address the issue?
Instead of formatting into an arbitrary dictionary, the parameters are parsed into JSON schema keywords. In addition, some other schema generation methods have been set up.

#### What side effects does this change have?
The parameters that are parsed use different keys.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
