### PR TITLE
fix: Relax document version check for authorizers

### DIFF
--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -81,7 +81,7 @@ class SwaggerParser:
         authorizers: Dict[str, Authorizer] = {}
 
         authorizer_dict = {}
-        document_version = self.swagger.get(SwaggerParser._SWAGGER) or self.swagger.get(SwaggerParser._OPENAPI) or ""
+        document_version = self._get_document_version()
 
         if document_version.startswith(SwaggerParser._2_X_VERSION):
             LOG.debug("Parsing Swagger document using 2.0 specification")
@@ -240,6 +240,19 @@ class SwaggerParser:
 
         return identity_sources
 
+    def _get_document_version(self) -> str:
+        """
+        Helper method to fetch the Swagger document version
+
+        Returns
+        -------
+        str
+            A string representing a version, blank if not found
+        """
+        document_version = self.swagger.get(SwaggerParser._SWAGGER) or self.swagger.get(SwaggerParser._OPENAPI) or ""
+
+        return str(document_version)
+
     def get_default_authorizer(self, event_type: str) -> Union[str, None]:
         """
         Parses the body definition to find root level Authorizer definitions
@@ -254,7 +267,7 @@ class SwaggerParser:
         Union[str, None]
             Returns the name of the authorizer, if there is one defined, otherwise None
         """
-        document_version = self.swagger.get(SwaggerParser._SWAGGER) or self.swagger.get(SwaggerParser._OPENAPI) or ""
+        document_version = self._get_document_version()
         authorizers = self.swagger.get(SwaggerParser._SWAGGER_SECURITY, [])
 
         if not authorizers:

--- a/tests/unit/commands/local/lib/swagger/test_parser.py
+++ b/tests/unit/commands/local/lib/swagger/test_parser.py
@@ -1022,3 +1022,21 @@ class TestSwaggerParser_get_lambda_identity_sources(TestCase):
 
         with self.assertRaises(InvalidSecurityDefinition):
             parser._get_lambda_identity_sources(Mock(), "request", Route.API, properties, auth_properties)
+
+
+class TestGetDocumentVersion(TestCase):
+    @parameterized.expand(
+        [
+            ({"swagger": "2.0"}, "2.0"),
+            ({"swagger": 2.0}, "2.0"),
+            ({"openapi": "3.0"}, "3.0"),
+            ({"openapi": 3.0}, "3.0"),
+            ({"not valid": 3.0}, ""),
+            ({}, ""),
+        ]
+    )
+    def test_get_document_version(self, swagger_doc, expected_output):
+        parser = SwaggerParser(Mock(), swagger_doc)
+        output = parser._get_document_version()
+
+        self.assertEqual(output, expected_output)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None

#### Why is this change necessary?
Using a float as a version for the document body (eg. `swagger: 2.0`) is a valid format. Currently, the parser expects versions to be a string.

#### How does it address the issue?
Casts the float (or any value for that matter), into a string.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
