### PR TITLE
fix: use StringIO instead of BytesIO with StreamWriter

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -7,7 +7,7 @@ import logging
 import os
 from enum import Enum
 from pathlib import Path
-from typing import IO, Any, Dict, List, Optional, Tuple, Type, cast
+from typing import Any, Dict, List, Optional, TextIO, Tuple, Type, cast
 
 from samcli.commands._utils.template import TemplateFailedParsingException, TemplateNotFoundException
 from samcli.commands.exceptions import ContainersInitializationException
@@ -195,7 +195,7 @@ class InvokeContext:
         self._stacks: List[Stack] = None  # type: ignore
         self._env_vars_value: Optional[Dict] = None
         self._container_env_vars_value: Optional[Dict] = None
-        self._log_file_handle: Optional[IO] = None
+        self._log_file_handle: Optional[TextIO] = None
         self._debug_context: Optional[DebugContext] = None
         self._layers_downloader: Optional[LayerDownloader] = None
         self._container_manager: Optional[ContainerManager] = None
@@ -487,7 +487,7 @@ class InvokeContext:
             ) from ex
 
     @staticmethod
-    def _setup_log_file(log_file: Optional[str]) -> Optional[IO]:
+    def _setup_log_file(log_file: Optional[str]) -> Optional[TextIO]:
         """
         Open a log file if necessary and return the file handle. This will create a file if it does not exist
 
@@ -497,7 +497,7 @@ class InvokeContext:
         if not log_file:
             return None
 
-        return open(log_file, "wb")
+        return open(log_file, "w")
 
     @staticmethod
     def _get_debug_context(

--- a/samcli/lib/package/ecr_uploader.py
+++ b/samcli/lib/package/ecr_uploader.py
@@ -2,8 +2,8 @@
 Client for uploading packaged artifacts to ecr
 """
 import base64
-import io
 import logging
+from io import StringIO
 from typing import Dict
 
 import botocore
@@ -94,7 +94,7 @@ class ECRUploader:
             else:
                 # we need to wait till the image got pushed to ecr, without this workaround sam sync for template
                 # contains image always fail, because the provided ecr uri is not exist.
-                _log_streamer = LogStreamer(stream=StreamWriter(stream=io.BytesIO(), auto_flush=True))
+                _log_streamer = LogStreamer(stream=StreamWriter(stream=StringIO(), auto_flush=True))
                 _log_streamer.stream_progress(push_logs)
 
         except (BuildError, APIError, LogStreamError) as ex:

--- a/samcli/lib/utils/stream_writer.py
+++ b/samcli/lib/utils/stream_writer.py
@@ -1,11 +1,11 @@
 """
 This class acts like a wrapper around output streams to provide any flexibility with output we need
 """
-from typing import Union
+from typing import TextIO, Union
 
 
 class StreamWriter:
-    def __init__(self, stream, auto_flush: bool = False):
+    def __init__(self, stream: TextIO, auto_flush: bool = False):
         """
         Instatiates new StreamWriter to the specified stream
 
@@ -20,7 +20,7 @@ class StreamWriter:
         self._auto_flush = auto_flush
 
     @property
-    def stream(self):
+    def stream(self) -> TextIO:
         return self._stream
 
     def write_bytes(self, output: Union[bytes, bytearray]):
@@ -30,7 +30,7 @@ class StreamWriter:
         Parameters
         ----------
         output bytes-like object
-            Bytes to write
+            Bytes to write into buffer
         """
         self._stream.buffer.write(output)
 
@@ -43,8 +43,8 @@ class StreamWriter:
 
         Parameters
         ----------
-        output bytes-like object
-            Bytes to write
+        output string object
+            String to write
         """
         self._stream.write(output)
 

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -4,7 +4,7 @@ import base64
 import json
 import logging
 from datetime import datetime
-from io import BytesIO
+from io import StringIO
 from time import time
 from typing import Any, Dict, List, Optional
 
@@ -605,7 +605,7 @@ class LocalApigwService(BaseLocalService):
         str
             A string containing the output from the Lambda function
         """
-        with BytesIO() as stdout:
+        with StringIO() as stdout:
             event_str = json.dumps(event, sort_keys=True)
             stdout_writer = StreamWriter(stdout, auto_flush=True)
 

--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -162,7 +162,7 @@ class LocalLambdaInvokeService(BaseLocalService):
 
         request_data = request_data.decode("utf-8")
 
-        stdout_stream = io.BytesIO()
+        stdout_stream = io.StringIO()
         stdout_stream_writer = StreamWriter(stdout_stream, auto_flush=True)
 
         try:

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -82,7 +82,7 @@ class BaseLocalService:
 
 class LambdaOutputParser:
     @staticmethod
-    def get_lambda_output(stdout_stream: io.BytesIO) -> Tuple[str, bool]:
+    def get_lambda_output(stdout_stream: io.StringIO) -> Tuple[str, bool]:
         """
         This method will extract read the given stream and return the response from Lambda function separated out
         from any log statements it might have outputted. Logs end up in the stdout stream if the Lambda function
@@ -100,7 +100,7 @@ class LambdaOutputParser:
         bool
             If the response is an error/exception from the container
         """
-        lambda_response = stdout_stream.getvalue().decode("utf-8")
+        lambda_response = stdout_stream.getvalue()
 
         # When the Lambda Function returns an Error/Exception, the output is added to the stdout of the container. From
         # our perspective, the container returned some value, which is not always true. Since the output is the only

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -1106,7 +1106,7 @@ class TestInvokeContext_setup_log_file(TestCase):
         with patch("samcli.commands.local.cli_common.invoke_context.open", m):
             InvokeContext._setup_log_file(filename)
 
-        m.assert_called_with(filename, "wb")
+        m.assert_called_with(filename, "w")
 
 
 class TestInvokeContext_get_debug_context(TestCase):

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -66,17 +66,17 @@ class TestLocalHostRunner(TestCase):
 class TestLambdaOutputParser(TestCase):
     @parameterized.expand(
         [
-            param("with mixed data and json response", b'data\n{"a": "b"}', 'data\n{"a": "b"}'),
-            param("with response as string", b"response", "response"),
-            param("with json response only", b'{"a": "b"}', '{"a": "b"}'),
-            param("with one new line and json", b'\n{"a": "b"}', '\n{"a": "b"}'),
-            param("with response only as string", b"this is the response line", "this is the response line"),
-            param("with whitespaces", b'data\n{"a": "b"}  \n\n\n', 'data\n{"a": "b"}  \n\n\n'),
-            param("with empty data", b"", ""),
-            param("with just new lines", b"\n\n", "\n\n"),
+            param("with mixed data and json response", 'data\n{"a": "b"}', 'data\n{"a": "b"}'),
+            param("with response as string", "response", "response"),
+            param("with json response only", '{"a": "b"}', '{"a": "b"}'),
+            param("with one new line and json", '\n{"a": "b"}', '\n{"a": "b"}'),
+            param("with response only as string", "this is the response line", "this is the response line"),
+            param("with whitespaces", 'data\n{"a": "b"}  \n\n\n', 'data\n{"a": "b"}  \n\n\n'),
+            param("with empty data", "", ""),
+            param("with just new lines", "\n\n", "\n\n"),
             param(
                 "with whitespaces",
-                b"\n   \n   \n",
+                "\n   \n   \n",
                 "\n   \n   \n",
             ),
         ]


### PR DESCRIPTION
Related to https://github.com/aws/aws-sam-cli/pull/5427
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
With recently changed the way to write into stream to fix some issues related to encoding (see PR above). That changed caused some issues with ECRUpload class, due to discrepancy of the `write` method between `BytesIO` vs `StringIO`. `BytesIO` instance accepts byte array where `StringIO` accepts string.

#### How does it address the issue?
This resolves issue by using `StringIO` stream instead of `BytesIO`. This PR also adds some typing for the inner `stream` instance of the `StreamWrapper` class to check for other usages in the code base.


#### What side effects does this change have?
Manually running `sam local` tests to validate the change.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
