### PR TITLE
Allow greater versions of typing_extensions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ pyopenssl~=23.2.0
 jsonschema<4.18
 
 # Needed for supporting Protocol in Python 3.7, Protocol class became public with python3.8
-typing_extensions>=4.4.0
+typing_extensions>=4.4.0,<5
 
 # NOTE: regex is not a direct dependency of SAM CLI, exclude version 2021.10.8 due to not working on M1 Mac - https://github.com/mrabarnett/mrab-regex/issues/399
 regex!=2021.10.8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ pyopenssl~=23.2.0
 jsonschema<4.18
 
 # Needed for supporting Protocol in Python 3.7, Protocol class became public with python3.8
-typing_extensions~=4.4.0
+typing_extensions>=4.4.0
 
 # NOTE: regex is not a direct dependency of SAM CLI, exclude version 2021.10.8 due to not working on M1 Mac - https://github.com/mrabarnett/mrab-regex/issues/399
 regex!=2021.10.8


### PR DESCRIPTION
#### Why is this change necessary?
`typing_extensions` is a dependency of many libraries and projects, notably including `aws-lambda-powertools`. The tilde syntax used as a dependency here hinders updating other packages, but limiting minor versions isn't necessary to fulfill the requirement mentioned in the pre-existing comment (about the need to support Protocol).

#### How does it address the issue?
This allows greater versions of `typing_extensions` to be installed by users of `aws-sam-cli`.

I recommend reconsidering all tilde requirements to see if they really need to be so limited. I haven't changed them myself to keep the scope of the PR limited and hopefully let it be merged faster, as my team constantly runs into issues updating dependencies due to `aws-sam-cli` and its `typing_extensions` limitation.

#### What side effects does this change have?
No breaking changes should be introduced in minor versions of `typing_extensions`, so no side effects are expected.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
