### PR TITLE
fix: Pin click to be < 8.1.4 temporarily

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 chevron~=0.12
 # 8.1.4 of Click has an issue with the typing breaking the linter - https://github.com/pallets/click/issues/2558
-click~=8.0,!=8.1.4
+# Allow click to be greater than 8.1.4 when https://github.com/pallets/click/pull/2565 is released.
+click~=8.0,<8.1.4
 Flask<2.3
 #Need to add latest lambda changes which will return invoke mode details
 boto3>=1.26.109,==1.*


### PR DESCRIPTION
Pin click until the linting issues are addressed on their end.

Tracking https://github.com/pallets/click/pull/2565

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
