### PR TITLE
fix: Convert paths to POSIX paths before checking in esbuild handling logic

### DIFF
--- a/samcli/lib/build/bundler.py
+++ b/samcli/lib/build/bundler.py
@@ -174,7 +174,8 @@ class EsbuildBundlerManager:
         :return: string path to built handler file
         """
         try:
-            path = str(Path(handler).parent / Path(handler).stem) + ".js"
+            path = (Path(handler).parent / Path(handler).stem).as_posix()
+            path = path + ".js"
         except (AttributeError, TypeError):
             return None
         return path


### PR DESCRIPTION
#### Why is this change necessary?
Windows paths contain an escape backslash (`\\`). This needs to be turned into a POSIX path before being parsed/saved into the template file.

#### How does it address the issue?
Makes sure that the string path from the helper method is a POSIX path (`/` instead of `\\`) before parsing.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
