### PR TITLE
fix: Pin cython to a version that is less than 3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SAM_CLI_TELEMETRY ?= 0
 init:
 	pip install wheel
 	pip install "cython<3.0.0" pyyaml==5.4.1 --no-build-isolation
-	pip uninstall wheel cython
+	pip uninstall wheel cython --yes
 	SAM_CLI_DEV=1 pip install -e '.[dev]'
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@
 SAM_CLI_TELEMETRY ?= 0
 
 init:
+	pip install wheel
+	pip install "cython<3.0.0" pyyaml==5.4.1 --no-build-isolation
 	SAM_CLI_DEV=1 pip install -e '.[dev]'
+	pip uninstall cython --yes
 
 test:
 	# Run unit tests

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ SAM_CLI_TELEMETRY ?= 0
 init:
 	pip install wheel
 	pip install "cython<3.0.0" pyyaml==5.4.1 --no-build-isolation
+	pip uninstall wheel cython
 	SAM_CLI_DEV=1 pip install -e '.[dev]'
-	pip uninstall cython --yes
 
 test:
 	# Run unit tests

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -82,11 +82,11 @@ echo "Force cython package version to be lower than 3.x.x"
 ./venv/bin/pip install wheel
 ./venv/bin/pip install --no-build-isolation "cython<3.0.0" pyyaml==5.4.1
 
-./venv/bin/pip install -r src/requirements/reproducible-linux.txt
-
-# https://github.com/yaml/pyyaml/issues/724
 echo "Uninstall local cython package"
-./venv/bin/pip uninstall cython --yes
+./venv/bin/pip uninstall wheel cython --yes
+# end cython work around
+
+./venv/bin/pip install -r src/requirements/reproducible-linux.txt
 
 echo "Copying All Python Libraries"
 cp -r ./venv/lib/python*/site-packages/* ./output/python-libraries

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -73,13 +73,14 @@ make install
 ldconfig
 cd ..
 
-# https://github.com/yaml/pyyaml/issues/724
-echo "Force cython package version to be lower than 3.x.x"
-pip install cython<3.0.0
-
 echo "Installing Python Libraries"
 python3 -m venv venv
 ./venv/bin/pip install --upgrade pip
+
+# https://github.com/yaml/pyyaml/issues/724
+echo "Force cython package version to be lower than 3.x.x"
+./venv/bin/pip install --no-build-isolation "cython<3.0.0"
+
 ./venv/bin/pip install -r src/requirements/reproducible-linux.txt
 
 # https://github.com/yaml/pyyaml/issues/724

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -73,10 +73,18 @@ make install
 ldconfig
 cd ..
 
+# https://github.com/yaml/pyyaml/issues/724
+echo "Force cython package version to be lower than 3.x.x"
+pip install cython<3.0.0
+
 echo "Installing Python Libraries"
 python3 -m venv venv
 ./venv/bin/pip install --upgrade pip
 ./venv/bin/pip install -r src/requirements/reproducible-linux.txt
+
+# https://github.com/yaml/pyyaml/issues/724
+echo "Uninstall local cython package"
+./venv/bin/pip uninstall cython --yes
 
 echo "Copying All Python Libraries"
 cp -r ./venv/lib/python*/site-packages/* ./output/python-libraries

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -79,7 +79,8 @@ python3 -m venv venv
 
 # https://github.com/yaml/pyyaml/issues/724
 echo "Force cython package version to be lower than 3.x.x"
-./venv/bin/pip install --no-build-isolation "cython<3.0.0"
+./venv/bin/pip install wheel
+./venv/bin/pip install --no-build-isolation "cython<3.0.0" pyyaml==5.4.1
 
 ./venv/bin/pip install -r src/requirements/reproducible-linux.txt
 

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -74,6 +74,10 @@ cp -r ./src/* ./output/aws-sam-cli-src
 echo "Removing CI Scripts"
 rm -vf ./output/aws-sam-cli-src/appveyor*.yml
 
+# https://github.com/yaml/pyyaml/issues/724
+echo "Force cython package version to be lower than 3.x.x"
+pip install cython<3.0.0
+
 echo "Installing Python"
 curl "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz" --output python.tgz
 tar -xzf python.tgz
@@ -87,6 +91,10 @@ echo "Installing Python Libraries"
 /usr/local/bin/python3.8 -m venv venv
 ./venv/bin/pip install --upgrade pip
 ./venv/bin/pip install -r src/requirements/reproducible-mac.txt
+
+# https://github.com/yaml/pyyaml/issues/724
+echo "Uninstall local cython package"
+./venv/bin/pip uninstall cython --yes
 
 echo "Copying All Python Libraries"
 cp -r ./venv/lib/python*/site-packages/* ./output/python-libraries

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -89,7 +89,8 @@ echo "Installing Python Libraries"
 
 # https://github.com/yaml/pyyaml/issues/724
 echo "Force cython package version to be lower than 3.x.x"
-./venv/bin/pip install --no-build-isolation "cython<3.0.0"
+./venv/bin/pip install wheel
+./venv/bin/pip install --no-build-isolation "cython<3.0.0" pyyaml==5.4.1
 
 ./venv/bin/pip install -r src/requirements/reproducible-mac.txt
 

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -74,10 +74,6 @@ cp -r ./src/* ./output/aws-sam-cli-src
 echo "Removing CI Scripts"
 rm -vf ./output/aws-sam-cli-src/appveyor*.yml
 
-# https://github.com/yaml/pyyaml/issues/724
-echo "Force cython package version to be lower than 3.x.x"
-pip install cython<3.0.0
-
 echo "Installing Python"
 curl "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz" --output python.tgz
 tar -xzf python.tgz
@@ -90,6 +86,11 @@ cd ..
 echo "Installing Python Libraries"
 /usr/local/bin/python3.8 -m venv venv
 ./venv/bin/pip install --upgrade pip
+
+# https://github.com/yaml/pyyaml/issues/724
+echo "Force cython package version to be lower than 3.x.x"
+./venv/bin/pip install --no-build-isolation "cython<3.0.0"
+
 ./venv/bin/pip install -r src/requirements/reproducible-mac.txt
 
 # https://github.com/yaml/pyyaml/issues/724

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -92,11 +92,11 @@ echo "Force cython package version to be lower than 3.x.x"
 ./venv/bin/pip install wheel
 ./venv/bin/pip install --no-build-isolation "cython<3.0.0" pyyaml==5.4.1
 
-./venv/bin/pip install -r src/requirements/reproducible-mac.txt
-
-# https://github.com/yaml/pyyaml/issues/724
 echo "Uninstall local cython package"
-./venv/bin/pip uninstall cython --yes
+./venv/bin/pip uninstall wheel cython --yes
+# end cython work around
+
+./venv/bin/pip install -r src/requirements/reproducible-mac.txt
 
 echo "Copying All Python Libraries"
 cp -r ./venv/lib/python*/site-packages/* ./output/python-libraries


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Related:
https://github.com/yaml/pyyaml/issues/724
https://github.com/aws/aws-sam-cli/pull/5494
https://github.com/aws/homebrew-tap/pull/491

#### Why is this change necessary?
`cython` is breaking the `PyYAML` building process when building from source.

#### How does it address the issue?
Enforces a lower `cython` version to specifically build `PyYAML` before uninstalling `cython` and processing with the rest of the step.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
