### PR TITLE
fix: Graceful error handling for port already in use

### DIFF
--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -21,6 +21,7 @@ from samcli.lib.utils import osutils
 from samcli.lib.utils.async_utils import AsyncContext
 from samcli.lib.utils.packagetype import ZIP
 from samcli.lib.utils.stream_writer import StreamWriter
+from samcli.local.docker.exceptions import PortAlreadyInUse
 from samcli.local.docker.lambda_image import LambdaImage
 from samcli.local.docker.manager import ContainerManager
 from samcli.local.lambdafn.runtime import LambdaRuntime, WarmLambdaRuntime
@@ -317,6 +318,8 @@ class InvokeContext:
             LOG.debug("Ctrl+C was pressed. Aborting containers initialization")
             self._clean_running_containers_and_related_resources()
             raise
+        except PortAlreadyInUse as port_inuse_ex:
+            raise port_inuse_ex
         except Exception as ex:
             LOG.error("Lambda functions containers initialization failed because of %s", ex)
             self._clean_running_containers_and_related_resources()

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -17,7 +17,7 @@ from samcli.commands.local.invoke.core.command import InvokeCommand
 from samcli.commands.local.lib.exceptions import InvalidIntermediateImageError
 from samcli.lib.telemetry.metric import track_command
 from samcli.lib.utils.version_checker import check_newer_version
-from samcli.local.docker.exceptions import ContainerNotStartableException
+from samcli.local.docker.exceptions import ContainerNotStartableException, PortAlreadyInUse
 
 LOG = logging.getLogger(__name__)
 
@@ -218,6 +218,7 @@ def do_cli(  # pylint: disable=R0914
         InvalidIntermediateImageError,
         DebuggingNotSupported,
         NoPrivilegeException,
+        PortAlreadyInUse,
     ) as ex:
         raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex
     except DockerImagePullFailedException as ex:

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -26,7 +26,7 @@ from samcli.commands.local.lib.exceptions import InvalidIntermediateImageError
 from samcli.commands.local.start_api.core.command import InvokeAPICommand
 from samcli.lib.telemetry.metric import track_command
 from samcli.lib.utils.version_checker import check_newer_version
-from samcli.local.docker.exceptions import ContainerNotStartableException
+from samcli.local.docker.exceptions import ContainerNotStartableException, PortAlreadyInUse
 
 LOG = logging.getLogger(__name__)
 
@@ -243,6 +243,7 @@ def do_cli(  # pylint: disable=R0914
         InvalidLayerReference,
         InvalidIntermediateImageError,
         DebuggingNotSupported,
+        PortAlreadyInUse,
     ) as ex:
         raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex
     except ContainerNotStartableException as ex:

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -26,7 +26,7 @@ from samcli.commands.local.lib.exceptions import InvalidIntermediateImageError
 from samcli.commands.local.start_lambda.core.command import InvokeLambdaCommand
 from samcli.lib.telemetry.metric import track_command
 from samcli.lib.utils.version_checker import check_newer_version
-from samcli.local.docker.exceptions import ContainerNotStartableException
+from samcli.local.docker.exceptions import ContainerNotStartableException, PortAlreadyInUse
 
 LOG = logging.getLogger(__name__)
 
@@ -223,6 +223,7 @@ def do_cli(  # pylint: disable=R0914
         InvalidLayerReference,
         InvalidIntermediateImageError,
         DebuggingNotSupported,
+        PortAlreadyInUse,
     ) as ex:
         raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex
     except ContainerNotStartableException as ex:

--- a/samcli/local/docker/exceptions.py
+++ b/samcli/local/docker/exceptions.py
@@ -11,3 +11,9 @@ class NoFreePortsError(Exception):
     """
     Exception to raise when there are no free ports found in a specified range.
     """
+
+
+class PortAlreadyInUse(Exception):
+    """
+    Exception to raise when the provided port is not available for use.
+    """

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from unittest.mock import patch, Mock
 from parameterized import parameterized, param
 
-from samcli.local.docker.exceptions import ContainerNotStartableException
+from samcli.local.docker.exceptions import ContainerNotStartableException, PortAlreadyInUse
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.lib.providers.exceptions import InvalidLayerReference
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
@@ -164,7 +164,7 @@ class TestCli(TestCase):
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_must_raise_user_exception_on_function_not_found(
-        self, side_effect_exception, expected_exectpion_message, get_event_mock, InvokeContextMock
+        self, side_effect_exception, expected_exception_message, get_event_mock, InvokeContextMock
     ):
         event_data = "data"
         get_event_mock.return_value = event_data
@@ -179,7 +179,7 @@ class TestCli(TestCase):
             self.call_cli()
 
         msg = str(ex_ctx.exception)
-        self.assertEqual(msg, expected_exectpion_message)
+        self.assertEqual(msg, expected_exception_message)
 
     @parameterized.expand(
         [
@@ -192,7 +192,7 @@ class TestCli(TestCase):
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_must_raise_user_exception_on_function_local_invoke_image_not_found_for_IMAGE_packagetype(
-        self, side_effect_exception, expected_exectpion_message, get_event_mock, InvokeContextMock
+        self, side_effect_exception, expected_exception_message, get_event_mock, InvokeContextMock
     ):
         event_data = "data"
         get_event_mock.return_value = event_data
@@ -207,7 +207,7 @@ class TestCli(TestCase):
             self.call_cli()
 
         msg = str(ex_ctx.exception)
-        self.assertEqual(msg, expected_exectpion_message)
+        self.assertEqual(msg, expected_exception_message)
 
     @parameterized.expand(
         [
@@ -222,18 +222,18 @@ class TestCli(TestCase):
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_must_raise_user_exception_on_invalid_sam_template(
-        self, exeception_to_raise, execption_message, get_event_mock, InvokeContextMock
+        self, exception_to_raise, exception_message, get_event_mock, InvokeContextMock
     ):
         event_data = "data"
         get_event_mock.return_value = event_data
 
-        InvokeContextMock.side_effect = exeception_to_raise
+        InvokeContextMock.side_effect = exception_to_raise
 
         with self.assertRaises(UserException) as ex_ctx:
             self.call_cli()
 
         msg = str(ex_ctx.exception)
-        self.assertEqual(msg, execption_message)
+        self.assertEqual(msg, exception_message)
 
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
@@ -255,12 +255,16 @@ class TestCli(TestCase):
                 ContainerNotStartableException("Container cannot be started, no free ports on host"),
                 "Container cannot be started, no free ports on host",
             ),
+            param(
+                PortAlreadyInUse("Container cannot be started, provided port already in use"),
+                "Container cannot be started, provided port already in use",
+            ),
         ]
     )
     @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_must_raise_user_exception_on_function_no_free_ports(
-        self, side_effect_exception, expected_exectpion_message, get_event_mock, InvokeContextMock
+        self, side_effect_exception, expected_exception_message, get_event_mock, InvokeContextMock
     ):
         event_data = "data"
         get_event_mock.return_value = event_data
@@ -275,7 +279,7 @@ class TestCli(TestCase):
             self.call_cli()
 
         msg = str(ex_ctx.exception)
-        self.assertEqual(msg, expected_exectpion_message)
+        self.assertEqual(msg, expected_exception_message)
 
 
 class TestGetEvent(TestCase):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5346 

#### Why is this change necessary?
When debugging port is provided as `-d` option and the port is already in use, `sam cli` throws a trace error.

#### How does it address the issue?
This PR handles the above exception gracefully with the following message `Ports are not available: exposing port TCP 127.0.0.1:<port_num> -> 0.0.0.0:0: listen tcp 127.0.0.1:<port_num>: bind: address already in use.`

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
