### PR TITLE
fix: Add type checking on condition for mypy-boto3

### DIFF
--- a/samcli/lib/remote_invoke/lambda_invoke_executors.py
+++ b/samcli/lib/remote_invoke/lambda_invoke_executors.py
@@ -4,6 +4,7 @@ Remote invoke executor implementation for Lambda
 import base64
 import json
 import logging
+import typing
 from abc import ABC, abstractmethod
 from json import JSONDecodeError
 from typing import cast
@@ -11,7 +12,9 @@ from typing import cast
 from botocore.eventstream import EventStream
 from botocore.exceptions import ClientError, ParamValidationError
 from botocore.response import StreamingBody
-from mypy_boto3_lambda.client import LambdaClient
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from mypy_boto3_lambda.client import LambdaClient
 
 from samcli.lib.remote_invoke.exceptions import (
     ErrorBotoApiCallException,
@@ -47,11 +50,13 @@ class AbstractLambdaInvokeExecutor(BotoActionExecutor, ABC):
     For Payload parameter, if a file location provided, the file handle will be passed as Payload object
     """
 
-    _lambda_client: LambdaClient
+    _lambda_client: "LambdaClient"
     _function_name: str
     _remote_output_format: RemoteInvokeOutputFormat
 
-    def __init__(self, lambda_client: LambdaClient, function_name: str, remote_output_format: RemoteInvokeOutputFormat):
+    def __init__(
+        self, lambda_client: "LambdaClient", function_name: str, remote_output_format: RemoteInvokeOutputFormat
+    ):
         self._lambda_client = lambda_client
         self._function_name = function_name
         self._remote_output_format = remote_output_format
@@ -219,7 +224,7 @@ class LambdaStreamResponseConverter(RemoteInvokeRequestResponseMapper):
         return remote_invoke_input
 
 
-def _is_function_invoke_mode_response_stream(lambda_client: LambdaClient, function_name: str):
+def _is_function_invoke_mode_response_stream(lambda_client: "LambdaClient", function_name: str):
     """
     Returns True if given function has RESPONSE_STREAM as InvokeMode, False otherwise
     """

--- a/samcli/lib/remote_invoke/stepfunctions_invoke_executors.py
+++ b/samcli/lib/remote_invoke/stepfunctions_invoke_executors.py
@@ -3,11 +3,14 @@ Remote invoke executor implementation for Step Functions
 """
 import logging
 import time
+import typing
 from datetime import datetime
 from typing import cast
 
 from botocore.exceptions import ClientError, ParamValidationError
-from mypy_boto3_stepfunctions import SFNClient
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from mypy_boto3_stepfunctions import SFNClient
 
 from samcli.lib.remote_invoke.exceptions import (
     ErrorBotoApiCallException,
@@ -38,13 +41,13 @@ class StepFunctionsStartExecutionExecutor(BotoActionExecutor):
     execution details.
     """
 
-    _stepfunctions_client: SFNClient
+    _stepfunctions_client: "SFNClient"
     _state_machine_arn: str
     _remote_output_format: RemoteInvokeOutputFormat
     request_parameters: dict
 
     def __init__(
-        self, stepfunctions_client: SFNClient, physical_id: str, remote_output_format: RemoteInvokeOutputFormat
+        self, stepfunctions_client: "SFNClient", physical_id: str, remote_output_format: RemoteInvokeOutputFormat
     ):
         self._stepfunctions_client = stepfunctions_client
         self._remote_output_format = remote_output_format


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5566 

#### Why is this change necessary?
`mypy_boto3_lambda` which is used for type checking purposes breaks the command. `boto3-stubs` is a dev dependency and not included in the prod dependencies.

#### How does it address the issue?
Adds a condition to only import this for type checking.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
