### PR TITLE
chore: Move boto3-stubs dependency from dev.txt to base.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,3 +32,6 @@ tzlocal==3.0
 
 #Adding cfn-lint dependency for SAM validate
 cfn-lint~=0.78.1
+
+# Type checking boto3 objects
+boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.28.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ Flask<2.3
 boto3>=1.26.109,==1.*
 jmespath~=1.0.1
 ruamel_yaml~=0.17.32
-PyYAML>=6.0.1
+PyYAML~=6.0,>=6.0.1
 cookiecutter~=2.1.1
 aws-sam-translator==1.71.0
 #docker minor version updates can include breaking changes. Auto update micro version only.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,6 @@ pytest-cov==4.1.0
 # mypy adds new rules in new minor versions, which could cause our PR check to fail
 # here we fix its version and upgrade it manually in the future
 mypy==1.3.0
-boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.28.2
 types-pywin32==306.0.0.2
 types-PyYAML==6.0.12
 types-chevron==0.14.2.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ types-Pygments==2.15.0.1
 types-colorama==0.4.15.11
 types-dateparser==1.1.4.9
 types-docutils==0.20.0.1
-types-jsonschema==4.17.0.8
+types-jsonschema==4.17.0.9
 types-pyOpenSSL==23.2.0.1
 types-requests==2.31.0.1
 types-urllib3==1.26.25.13

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -35,12 +35,20 @@ boto3==1.28.2 \
     # via
     #   aws-sam-cli (setup.py)
     #   aws-sam-translator
+boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.28.2 \
+    --hash=sha256:b140f56315cd99c659a2cbae32dc4ae1ee44073b4250e1ad391d03ecf4b5eb40 \
+    --hash=sha256:bcef1fcbd758de6078e75b036d3632dd95eaef00311e6688554b5b883a194563
+    # via aws-sam-cli (setup.py)
 botocore==1.31.2 \
     --hash=sha256:67a475bec9e52d495a358b34e219ef7f62907e83b87e5bc712528f998bd46dab \
     --hash=sha256:d368ac0b58e2b9025b9c397e4a4f86d71788913ee619263506885a866a4f6811
     # via
     #   boto3
     #   s3transfer
+botocore-stubs==1.31.7 \
+    --hash=sha256:0dd34b6c0c4825e69ff1e89ca1d783660f07573319886ec7bb19a81a16925f9f \
+    --hash=sha256:7edbba7db62e36777c0dd79896afba8ee61b10a7e32988bd42c91097dde0251a
+    # via boto3-stubs
 certifi==2023.5.7 \
     --hash=sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7 \
     --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
@@ -367,6 +375,54 @@ mpmath==1.3.0 \
     --hash=sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f \
     --hash=sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
     # via sympy
+mypy-boto3-apigateway==1.28.0 \
+    --hash=sha256:6a083efa3b9c303dc675711ab2efe8b3672d7335cd852477f1293e0bdb880e6b \
+    --hash=sha256:75d9445c0b57931046aa2ca1fe860265712cd8f8bb7776eff7720e5101ce00fe
+    # via boto3-stubs
+mypy-boto3-cloudformation==1.28.0 \
+    --hash=sha256:0d2ead02c352bc97ae59b65ae8b00d5ce186435b7cf5736213a52f58df192511 \
+    --hash=sha256:99d5db7d6b220ba016757670a917bdfdab1c475593153833ed6c5cdd9a9aa9ba
+    # via boto3-stubs
+mypy-boto3-ecr==1.28.0 \
+    --hash=sha256:46b493af9024e230f7b81c7dc1ca2b52d5cca168f867be60a55ce0b86a3999f7 \
+    --hash=sha256:d4cbad3f4d33abbfe0a7d7504b38f01d256c5200d754b5289d1f373bcd595bf4
+    # via boto3-stubs
+mypy-boto3-iam==1.28.3.post2 \
+    --hash=sha256:16d642b5507067bd2cfae5e3fd149b9ccf7070bc98e7214058cae40c478eaccf \
+    --hash=sha256:32ed5e5d961d628c0f5bad06e3b3342df6d3bec0d9a6dd5d746fce53a7d5f6dc
+    # via boto3-stubs
+mypy-boto3-lambda==1.28.0 \
+    --hash=sha256:5fd38df6418829b2f3a184918fc8ad1d49b6738509f1832cdc71f33588efbdfb \
+    --hash=sha256:a3abaf98e514f2cabed2cf0b1e77c94c81f0fbbba8a549b3c073577a9f9ac196
+    # via boto3-stubs
+mypy-boto3-s3==1.28.3.post2 \
+    --hash=sha256:02dc6b9edf799afa160be1e3a9b38a383af6fcd80a97abd75d09410b26621e70 \
+    --hash=sha256:c23b7802b80a0388a146d7e8025552f21d44e349026a18fb751d9c698ed714b1
+    # via boto3-stubs
+mypy-boto3-schemas==1.28.0 \
+    --hash=sha256:371972ab1301f03cb504ea16a0aa566e9c889a436b5b1a221c15d04f5710f47f \
+    --hash=sha256:d15c838e812a8e1b20c7a6ce7d794231e1d9cc73b65cbbf9385f3d2984f4e929
+    # via boto3-stubs
+mypy-boto3-secretsmanager==1.28.3.post2 \
+    --hash=sha256:3a5e5619ee945f244d2dfefcb382c85874171a18b46f75403465622095284d25 \
+    --hash=sha256:f359f6446ac856d0887e40cb0f5bc6e0a60873524be5dd4b68be1d0fc4ac513e
+    # via boto3-stubs
+mypy-boto3-signer==1.28.0 \
+    --hash=sha256:55288fed77e2ae3121c4ecb15b64d4cc3984f069ff4671d5dbd9b14fc9b6f5f1 \
+    --hash=sha256:c24d4fd291b194248c61f7696d1bb56c5e8db13f792dff1720126c208f922539
+    # via boto3-stubs
+mypy-boto3-stepfunctions==1.28.0 \
+    --hash=sha256:47ab107c76513a04d241357157ee6886c3e8b7965ccd7fcce66ec44efbd2b43a \
+    --hash=sha256:7a3f702287ae4d311ffa34643318257c9dbf25490131d244e1e085c222c33465
+    # via boto3-stubs
+mypy-boto3-sts==1.28.0 \
+    --hash=sha256:161acaf4ac14282f3a1accfe06e372b1ee902840d32c2bad4e4eebbf7dd66607 \
+    --hash=sha256:81daa1e27e1c07b70eccc8de8d95f2676593dd6f7fd217a22f269d94b9b81e36
+    # via boto3-stubs
+mypy-boto3-xray==1.28.0 \
+    --hash=sha256:64cd601a829c274665b977853f85b27464986e9eec1ebc03f5bc4530a400b2f6 \
+    --hash=sha256:8ce07598f7eeabe66e8dc8cb7e906efb96198b9102f58e9315e6daf166abf3e7
+    # via boto3-stubs
 networkx==2.6.3 \
     --hash=sha256:80b6b89c77d1dfb64a4c7854981b60aeea6360ac02c6d4e4913319e0a313abef \
     --hash=sha256:c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51
@@ -693,6 +749,16 @@ tomlkit==0.11.8 \
     --hash=sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171 \
     --hash=sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3
     # via aws-sam-cli (setup.py)
+types-awscrt==0.16.26 \
+    --hash=sha256:011b0efc054cddb542416f4a38452a3cab3f2d6cef7af0cd124c03a89634f101 \
+    --hash=sha256:47bcfd741465196e000e5a29ea98516765d2e93803d3fb67f9d6be79a632ee98
+    # via
+    #   botocore-stubs
+    #   types-s3transfer
+types-s3transfer==0.6.1 \
+    --hash=sha256:6d1ac1dedac750d570428362acdf60fdd4f277b0788855c3894d3226756b2bfb \
+    --hash=sha256:75ac1d7143d58c1e6af467cfd4a96c67ee058a3adf7c249d9309999e1f5f41e4
+    # via boto3-stubs
 typing-extensions==4.7.1 \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \
     --hash=sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -35,6 +35,10 @@ boto3==1.28.2 \
     # via
     #   aws-sam-cli (setup.py)
     #   aws-sam-translator
+boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.28.2 \
+    --hash=sha256:b140f56315cd99c659a2cbae32dc4ae1ee44073b4250e1ad391d03ecf4b5eb40 \
+    --hash=sha256:bcef1fcbd758de6078e75b036d3632dd95eaef00311e6688554b5b883a194563
+    # via aws-sam-cli (setup.py)
 botocore==1.31.7 \
     --hash=sha256:f211ef5714bec8ae24b3fe737b8689611ef4d0dbea0ab46ef8328e112dd10ada \
     --hash=sha256:f4473f66c153c262b8262404d737f4249366daf00fb068b495577a24b830ebcb

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -35,13 +35,9 @@ boto3==1.28.2 \
     # via
     #   aws-sam-cli (setup.py)
     #   aws-sam-translator
-boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.28.2 \
-    --hash=sha256:b140f56315cd99c659a2cbae32dc4ae1ee44073b4250e1ad391d03ecf4b5eb40 \
-    --hash=sha256:bcef1fcbd758de6078e75b036d3632dd95eaef00311e6688554b5b883a194563
-    # via aws-sam-cli (setup.py)
-botocore==1.31.2 \
-    --hash=sha256:67a475bec9e52d495a358b34e219ef7f62907e83b87e5bc712528f998bd46dab \
-    --hash=sha256:d368ac0b58e2b9025b9c397e4a4f86d71788913ee619263506885a866a4f6811
+botocore==1.31.7 \
+    --hash=sha256:f211ef5714bec8ae24b3fe737b8689611ef4d0dbea0ab46ef8328e112dd10ada \
+    --hash=sha256:f4473f66c153c262b8262404d737f4249366daf00fb068b495577a24b830ebcb
     # via
     #   boto3
     #   s3transfer

--- a/requirements/reproducible-mac.txt
+++ b/requirements/reproducible-mac.txt
@@ -53,13 +53,9 @@ boto3==1.28.2 \
     # via
     #   aws-sam-cli (setup.py)
     #   aws-sam-translator
-boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.28.2 \
-    --hash=sha256:b140f56315cd99c659a2cbae32dc4ae1ee44073b4250e1ad391d03ecf4b5eb40 \
-    --hash=sha256:bcef1fcbd758de6078e75b036d3632dd95eaef00311e6688554b5b883a194563
-    # via aws-sam-cli (setup.py)
-botocore==1.31.2 \
-    --hash=sha256:67a475bec9e52d495a358b34e219ef7f62907e83b87e5bc712528f998bd46dab \
-    --hash=sha256:d368ac0b58e2b9025b9c397e4a4f86d71788913ee619263506885a866a4f6811
+botocore==1.31.7 \
+    --hash=sha256:f211ef5714bec8ae24b3fe737b8689611ef4d0dbea0ab46ef8328e112dd10ada \
+    --hash=sha256:f4473f66c153c262b8262404d737f4249366daf00fb068b495577a24b830ebcb
     # via
     #   boto3
     #   s3transfer

--- a/requirements/reproducible-mac.txt
+++ b/requirements/reproducible-mac.txt
@@ -53,12 +53,20 @@ boto3==1.28.2 \
     # via
     #   aws-sam-cli (setup.py)
     #   aws-sam-translator
+boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.28.2 \
+    --hash=sha256:b140f56315cd99c659a2cbae32dc4ae1ee44073b4250e1ad391d03ecf4b5eb40 \
+    --hash=sha256:bcef1fcbd758de6078e75b036d3632dd95eaef00311e6688554b5b883a194563
+    # via aws-sam-cli (setup.py)
 botocore==1.31.2 \
     --hash=sha256:67a475bec9e52d495a358b34e219ef7f62907e83b87e5bc712528f998bd46dab \
     --hash=sha256:d368ac0b58e2b9025b9c397e4a4f86d71788913ee619263506885a866a4f6811
     # via
     #   boto3
     #   s3transfer
+botocore-stubs==1.31.7 \
+    --hash=sha256:0dd34b6c0c4825e69ff1e89ca1d783660f07573319886ec7bb19a81a16925f9f \
+    --hash=sha256:7edbba7db62e36777c0dd79896afba8ee61b10a7e32988bd42c91097dde0251a
+    # via boto3-stubs
 certifi==2023.5.7 \
     --hash=sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7 \
     --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
@@ -393,6 +401,54 @@ mpmath==1.3.0 \
     --hash=sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f \
     --hash=sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
     # via sympy
+mypy-boto3-apigateway==1.28.0 \
+    --hash=sha256:6a083efa3b9c303dc675711ab2efe8b3672d7335cd852477f1293e0bdb880e6b \
+    --hash=sha256:75d9445c0b57931046aa2ca1fe860265712cd8f8bb7776eff7720e5101ce00fe
+    # via boto3-stubs
+mypy-boto3-cloudformation==1.28.0 \
+    --hash=sha256:0d2ead02c352bc97ae59b65ae8b00d5ce186435b7cf5736213a52f58df192511 \
+    --hash=sha256:99d5db7d6b220ba016757670a917bdfdab1c475593153833ed6c5cdd9a9aa9ba
+    # via boto3-stubs
+mypy-boto3-ecr==1.28.0 \
+    --hash=sha256:46b493af9024e230f7b81c7dc1ca2b52d5cca168f867be60a55ce0b86a3999f7 \
+    --hash=sha256:d4cbad3f4d33abbfe0a7d7504b38f01d256c5200d754b5289d1f373bcd595bf4
+    # via boto3-stubs
+mypy-boto3-iam==1.28.3.post2 \
+    --hash=sha256:16d642b5507067bd2cfae5e3fd149b9ccf7070bc98e7214058cae40c478eaccf \
+    --hash=sha256:32ed5e5d961d628c0f5bad06e3b3342df6d3bec0d9a6dd5d746fce53a7d5f6dc
+    # via boto3-stubs
+mypy-boto3-lambda==1.28.0 \
+    --hash=sha256:5fd38df6418829b2f3a184918fc8ad1d49b6738509f1832cdc71f33588efbdfb \
+    --hash=sha256:a3abaf98e514f2cabed2cf0b1e77c94c81f0fbbba8a549b3c073577a9f9ac196
+    # via boto3-stubs
+mypy-boto3-s3==1.28.3.post2 \
+    --hash=sha256:02dc6b9edf799afa160be1e3a9b38a383af6fcd80a97abd75d09410b26621e70 \
+    --hash=sha256:c23b7802b80a0388a146d7e8025552f21d44e349026a18fb751d9c698ed714b1
+    # via boto3-stubs
+mypy-boto3-schemas==1.28.0 \
+    --hash=sha256:371972ab1301f03cb504ea16a0aa566e9c889a436b5b1a221c15d04f5710f47f \
+    --hash=sha256:d15c838e812a8e1b20c7a6ce7d794231e1d9cc73b65cbbf9385f3d2984f4e929
+    # via boto3-stubs
+mypy-boto3-secretsmanager==1.28.3.post2 \
+    --hash=sha256:3a5e5619ee945f244d2dfefcb382c85874171a18b46f75403465622095284d25 \
+    --hash=sha256:f359f6446ac856d0887e40cb0f5bc6e0a60873524be5dd4b68be1d0fc4ac513e
+    # via boto3-stubs
+mypy-boto3-signer==1.28.0 \
+    --hash=sha256:55288fed77e2ae3121c4ecb15b64d4cc3984f069ff4671d5dbd9b14fc9b6f5f1 \
+    --hash=sha256:c24d4fd291b194248c61f7696d1bb56c5e8db13f792dff1720126c208f922539
+    # via boto3-stubs
+mypy-boto3-stepfunctions==1.28.0 \
+    --hash=sha256:47ab107c76513a04d241357157ee6886c3e8b7965ccd7fcce66ec44efbd2b43a \
+    --hash=sha256:7a3f702287ae4d311ffa34643318257c9dbf25490131d244e1e085c222c33465
+    # via boto3-stubs
+mypy-boto3-sts==1.28.0 \
+    --hash=sha256:161acaf4ac14282f3a1accfe06e372b1ee902840d32c2bad4e4eebbf7dd66607 \
+    --hash=sha256:81daa1e27e1c07b70eccc8de8d95f2676593dd6f7fd217a22f269d94b9b81e36
+    # via boto3-stubs
+mypy-boto3-xray==1.28.0 \
+    --hash=sha256:64cd601a829c274665b977853f85b27464986e9eec1ebc03f5bc4530a400b2f6 \
+    --hash=sha256:8ce07598f7eeabe66e8dc8cb7e906efb96198b9102f58e9315e6daf166abf3e7
+    # via boto3-stubs
 networkx==2.6.3 \
     --hash=sha256:80b6b89c77d1dfb64a4c7854981b60aeea6360ac02c6d4e4913319e0a313abef \
     --hash=sha256:c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51
@@ -722,12 +778,36 @@ tomlkit==0.11.8 \
     --hash=sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171 \
     --hash=sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3
     # via aws-sam-cli (setup.py)
+types-awscrt==0.16.26 \
+    --hash=sha256:011b0efc054cddb542416f4a38452a3cab3f2d6cef7af0cd124c03a89634f101 \
+    --hash=sha256:47bcfd741465196e000e5a29ea98516765d2e93803d3fb67f9d6be79a632ee98
+    # via
+    #   botocore-stubs
+    #   types-s3transfer
+types-s3transfer==0.6.1 \
+    --hash=sha256:6d1ac1dedac750d570428362acdf60fdd4f277b0788855c3894d3226756b2bfb \
+    --hash=sha256:75ac1d7143d58c1e6af467cfd4a96c67ee058a3adf7c249d9309999e1f5f41e4
+    # via boto3-stubs
 typing-extensions==4.7.1 \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \
     --hash=sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
     # via
     #   aws-sam-cli (setup.py)
     #   aws-sam-translator
+    #   boto3-stubs
+    #   botocore-stubs
+    #   mypy-boto3-apigateway
+    #   mypy-boto3-cloudformation
+    #   mypy-boto3-ecr
+    #   mypy-boto3-iam
+    #   mypy-boto3-lambda
+    #   mypy-boto3-s3
+    #   mypy-boto3-schemas
+    #   mypy-boto3-secretsmanager
+    #   mypy-boto3-signer
+    #   mypy-boto3-stepfunctions
+    #   mypy-boto3-sts
+    #   mypy-boto3-xray
     #   pydantic
     #   rich
 tzlocal==3.0 \

--- a/requirements/reproducible-mac.txt
+++ b/requirements/reproducible-mac.txt
@@ -53,6 +53,10 @@ boto3==1.28.2 \
     # via
     #   aws-sam-cli (setup.py)
     #   aws-sam-translator
+boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray]==1.28.2 \
+    --hash=sha256:b140f56315cd99c659a2cbae32dc4ae1ee44073b4250e1ad391d03ecf4b5eb40 \
+    --hash=sha256:bcef1fcbd758de6078e75b036d3632dd95eaef00311e6688554b5b883a194563
+    # via aws-sam-cli (setup.py)
 botocore==1.31.7 \
     --hash=sha256:f211ef5714bec8ae24b3fe737b8689611ef4d0dbea0ab46ef8328e112dd10ada \
     --hash=sha256:f4473f66c153c262b8262404d737f4249366daf00fb068b495577a24b830ebcb

--- a/samcli/__init__.py
+++ b/samcli/__init__.py
@@ -2,4 +2,4 @@
 SAM CLI version
 """
 
-__version__ = "1.92.0"
+__version__ = "1.93.0"

--- a/samcli/lib/bootstrap/companion_stack/companion_stack_manager.py
+++ b/samcli/lib/bootstrap/companion_stack/companion_stack_manager.py
@@ -2,12 +2,14 @@
     Companion stack manager
 """
 import logging
-import typing
 from typing import Dict, List, Optional
 
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError, NoRegionError
+from mypy_boto3_cloudformation.client import CloudFormationClient
+from mypy_boto3_cloudformation.type_defs import WaiterConfigTypeDef
+from mypy_boto3_s3.client import S3Client
 
 from samcli.commands.exceptions import AWSServiceClientError, RegionError
 from samcli.lib.bootstrap.companion_stack.companion_stack_builder import CompanionStackBuilder
@@ -18,12 +20,6 @@ from samcli.lib.providers.sam_function_provider import SamFunctionProvider
 from samcli.lib.providers.sam_stack_provider import SamLocalStackProvider
 from samcli.lib.utils.packagetype import IMAGE
 from samcli.lib.utils.s3 import parse_s3_url
-
-# pylint: disable=E0401
-if typing.TYPE_CHECKING:  # pragma: no cover
-    from mypy_boto3_cloudformation.client import CloudFormationClient
-    from mypy_boto3_cloudformation.type_defs import WaiterConfigTypeDef
-    from mypy_boto3_s3.client import S3Client
 
 LOG = logging.getLogger(__name__)
 
@@ -37,12 +33,12 @@ class CompanionStackManager:
     _companion_stack: CompanionStack
     _builder: CompanionStackBuilder
     _boto_config: Config
-    _update_stack_waiter_config: "WaiterConfigTypeDef"
-    _delete_stack_waiter_config: "WaiterConfigTypeDef"
+    _update_stack_waiter_config: WaiterConfigTypeDef
+    _delete_stack_waiter_config: WaiterConfigTypeDef
     _s3_bucket: str
     _s3_prefix: str
-    _cfn_client: "CloudFormationClient"
-    _s3_client: "S3Client"
+    _cfn_client: CloudFormationClient
+    _s3_client: S3Client
 
     def __init__(self, stack_name, region, s3_bucket, s3_prefix):
         self._companion_stack = CompanionStack(stack_name)

--- a/samcli/lib/remote_invoke/lambda_invoke_executors.py
+++ b/samcli/lib/remote_invoke/lambda_invoke_executors.py
@@ -4,7 +4,6 @@ Remote invoke executor implementation for Lambda
 import base64
 import json
 import logging
-import typing
 from abc import ABC, abstractmethod
 from json import JSONDecodeError
 from typing import cast
@@ -12,9 +11,7 @@ from typing import cast
 from botocore.eventstream import EventStream
 from botocore.exceptions import ClientError, ParamValidationError
 from botocore.response import StreamingBody
-
-if typing.TYPE_CHECKING:  # pragma: no cover
-    from mypy_boto3_lambda.client import LambdaClient
+from mypy_boto3_lambda.client import LambdaClient
 
 from samcli.lib.remote_invoke.exceptions import (
     ErrorBotoApiCallException,
@@ -50,13 +47,11 @@ class AbstractLambdaInvokeExecutor(BotoActionExecutor, ABC):
     For Payload parameter, if a file location provided, the file handle will be passed as Payload object
     """
 
-    _lambda_client: "LambdaClient"
+    _lambda_client: LambdaClient
     _function_name: str
     _remote_output_format: RemoteInvokeOutputFormat
 
-    def __init__(
-        self, lambda_client: "LambdaClient", function_name: str, remote_output_format: RemoteInvokeOutputFormat
-    ):
+    def __init__(self, lambda_client: LambdaClient, function_name: str, remote_output_format: RemoteInvokeOutputFormat):
         self._lambda_client = lambda_client
         self._function_name = function_name
         self._remote_output_format = remote_output_format
@@ -224,7 +219,7 @@ class LambdaStreamResponseConverter(RemoteInvokeRequestResponseMapper):
         return remote_invoke_input
 
 
-def _is_function_invoke_mode_response_stream(lambda_client: "LambdaClient", function_name: str):
+def _is_function_invoke_mode_response_stream(lambda_client: LambdaClient, function_name: str):
     """
     Returns True if given function has RESPONSE_STREAM as InvokeMode, False otherwise
     """

--- a/samcli/lib/remote_invoke/stepfunctions_invoke_executors.py
+++ b/samcli/lib/remote_invoke/stepfunctions_invoke_executors.py
@@ -3,14 +3,11 @@ Remote invoke executor implementation for Step Functions
 """
 import logging
 import time
-import typing
 from datetime import datetime
 from typing import cast
 
 from botocore.exceptions import ClientError, ParamValidationError
-
-if typing.TYPE_CHECKING:  # pragma: no cover
-    from mypy_boto3_stepfunctions import SFNClient
+from mypy_boto3_stepfunctions import SFNClient
 
 from samcli.lib.remote_invoke.exceptions import (
     ErrorBotoApiCallException,
@@ -41,13 +38,13 @@ class StepFunctionsStartExecutionExecutor(BotoActionExecutor):
     execution details.
     """
 
-    _stepfunctions_client: "SFNClient"
+    _stepfunctions_client: SFNClient
     _state_machine_arn: str
     _remote_output_format: RemoteInvokeOutputFormat
     request_parameters: dict
 
     def __init__(
-        self, stepfunctions_client: "SFNClient", physical_id: str, remote_output_format: RemoteInvokeOutputFormat
+        self, stepfunctions_client: SFNClient, physical_id: str, remote_output_format: RemoteInvokeOutputFormat
     ):
         self._stepfunctions_client = stepfunctions_client
         self._remote_output_format = remote_output_format


### PR DESCRIPTION
#### Why is this change necessary?
`boto3-stubs` is a dev dependency and to use the boto3 objects for type checking, they need to be imported conditionally. If the import is not conditional, it can break production installers as the testing uses dev-dependencies and this can get missed.

#### How does it address the issue?
This PR moves `boto3-stubs` to base.txt for making the boto3 type checks more sustainable. I built a mac binary with the new changes and tested the functionality for `remote invoke` and `sam deploy` companion stack and it works as expected.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
