### PR TITLE
fix: remove resolve-image-repos error message from the commands it is not supported

### DIFF
--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -154,7 +154,7 @@ LOG = logging.getLogger(__name__)
 @capabilities_option
 @aws_creds_options
 @common_options
-@image_repository_validation
+@image_repository_validation()
 @pass_context
 @track_command
 @check_newer_version

--- a/samcli/commands/package/command.py
+++ b/samcli/commands/package/command.py
@@ -90,7 +90,7 @@ DESCRIPTION = """
 @no_progressbar_option
 @common_options
 @aws_creds_options
-@image_repository_validation
+@image_repository_validation(support_resolve_image_repos=False)
 @pass_context
 @track_command
 @check_newer_version

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -175,7 +175,7 @@ DEFAULT_CAPABILITIES = ("CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND")
 @pass_context
 @track_command
 @track_long_event("SyncUsed", "Start", "SyncUsed", "End")
-@image_repository_validation
+@image_repository_validation(support_resolve_image_repos=False)
 @track_template_warnings([CodeDeployWarning.__name__, CodeDeployConditionWarning.__name__])
 @check_newer_version
 @print_cmdline_args

--- a/tests/unit/lib/cli_validation/test_image_repository_validation.py
+++ b/tests/unit/lib/cli_validation/test_image_repository_validation.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 
 import click
 import posixpath
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 
 from samcli.lib.cli_validation.image_repository_validation import (
     image_repository_validation,
@@ -14,9 +14,18 @@ from samcli.lib.providers.sam_stack_provider import SamLocalStackProvider
 from samcli.lib.utils.packagetype import ZIP, IMAGE
 
 
+@parameterized_class(
+    ("support_resolve_image_repos"),
+    [
+        (True,),
+        (False,),
+    ],
+)
 class TestImageRepositoryValidation(TestCase):
+    support_resolve_image_repos = False
+
     def setUp(self):
-        @image_repository_validation
+        @image_repository_validation(self.support_resolve_image_repos)
         def foo():
             pass
 
@@ -102,10 +111,16 @@ class TestImageRepositoryValidation(TestCase):
 
         with self.assertRaises(click.BadOptionUsage) as ex:
             self.foobar()
-        self.assertIn(
-            "Only one of the following can be provided: '--image-repositories', '--image-repository', or '--resolve-image-repos'. ",
-            ex.exception.message,
-        )
+        if self.support_resolve_image_repos:
+            self.assertIn(
+                "Only one of the following can be provided: '--image-repositories', '--image-repository', '--resolve-image-repos'.",
+                ex.exception.message,
+            )
+        else:
+            self.assertIn(
+                "Only one of the following can be provided: '--image-repositories', '--image-repository'.",
+                ex.exception.message,
+            )
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
@@ -147,10 +162,17 @@ class TestImageRepositoryValidation(TestCase):
 
         with self.assertRaises(click.BadOptionUsage) as ex:
             self.foobar()
-        self.assertIn(
-            "Missing option '--image-repository', '--image-repositories', or '--resolve-image-repos'",
-            ex.exception.message,
-        )
+        if self.support_resolve_image_repos:
+            self.assertIn(
+                "Missing option '--image-repositories', '--image-repository', '--resolve-image-repos'",
+                ex.exception.message,
+            )
+        else:
+            self.assertIn(
+                "Missing option '--image-repositories', '--image-repository'",
+                ex.exception.message,
+            )
+
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")

--- a/tests/unit/lib/cli_validation/test_image_repository_validation.py
+++ b/tests/unit/lib/cli_validation/test_image_repository_validation.py
@@ -173,7 +173,6 @@ class TestImageRepositoryValidation(TestCase):
                 ex.exception.message,
             )
 
-
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
     @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#5424


#### Why is this change necessary?
Error messages for `sam package` and `sam sync` includes possible option `--resolve-image-repos` which is not supported for these commands.

#### How does it address the issue?
By removing it from error messages for these commands.

#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
