### PR TITLE
fix: calculate hash of a file with given contents without writing to a  tmp location

### DIFF
--- a/samcli/lib/package/local_files_utils.py
+++ b/samcli/lib/package/local_files_utils.py
@@ -7,7 +7,7 @@ import uuid
 from contextlib import contextmanager
 from typing import Optional
 
-from samcli.lib.utils.hash import file_checksum
+from samcli.lib.utils.hash import file_checksum, str_checksum
 
 
 @contextmanager
@@ -51,10 +51,7 @@ def get_uploaded_s3_object_name(
     if precomputed_md5:
         filemd5 = precomputed_md5
     elif file_content:
-        with mktempfile() as temp_file:
-            temp_file.write(file_content)
-            temp_file.flush()
-            filemd5 = file_checksum(temp_file.name)
+        filemd5 = str_checksum(file_content)
     elif file_path:
         filemd5 = file_checksum(file_path)
     else:

--- a/tests/integration/delete/test_delete_command.py
+++ b/tests/integration/delete/test_delete_command.py
@@ -42,12 +42,7 @@ class TestDelete(DeleteIntegBase):
         time.sleep(CFN_SLEEP)
         super().setUp()
 
-    @parameterized.expand(
-        [
-            "aws-serverless-function.yaml",
-            "aws-s3-with-lang-ext.yaml"
-        ]
-    )
+    @parameterized.expand(["aws-serverless-function.yaml", "aws-s3-with-lang-ext.yaml"])
     def test_s3_options(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
@@ -134,9 +129,7 @@ class TestDelete(DeleteIntegBase):
         deploy_command_list = self.get_deploy_command_list(
             template_file=template_path, guided=True, config_file=config_file_name
         )
-        _ = run_command_with_input(
-            deploy_command_list, "{}\n\n\n\n\n\n\n\n\n".format(stack_name).encode()
-        )
+        _ = run_command_with_input(deploy_command_list, "{}\n\n\n\n\n\n\n\n\n".format(stack_name).encode())
 
         config_file_path = self.test_data_path.joinpath(config_file_name)
         delete_command_list = self.get_delete_command_list(
@@ -204,9 +197,7 @@ class TestDelete(DeleteIntegBase):
         deploy_command_list = self.get_deploy_command_list(
             template_file=template_path, guided=True, config_file=config_file_name
         )
-        _ = run_command_with_input(
-            deploy_command_list, "{}\n\n\n\n\n\n\n\n\n".format(stack_name).encode()
-        )
+        _ = run_command_with_input(deploy_command_list, "{}\n\n\n\n\n\n\n\n\n".format(stack_name).encode())
 
         config_file_path = self.test_data_path.joinpath(config_file_name)
         delete_command_list = self.get_delete_command_list(stack_name=stack_name, config_file=config_file_path)
@@ -234,9 +225,7 @@ class TestDelete(DeleteIntegBase):
         stack_name = self._method_to_stack_name(self.id())
 
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
-        _ = run_command_with_input(
-            deploy_command_list, "{}\n\n\n\n\nn\n\n\n".format(stack_name).encode()
-        )
+        _ = run_command_with_input(deploy_command_list, "{}\n\n\n\n\nn\n\n\n".format(stack_name).encode())
 
         delete_command_list = self.get_delete_command_list(
             stack_name=stack_name, region=self._session.region_name, no_prompts=True
@@ -522,7 +511,7 @@ class TestDelete(DeleteIntegBase):
             resp = self.cf_client.describe_stacks(StackName=stack_name)
         except ClientError as ex:
             self.assertIn(f"Stack with id {stack_name} does not exist", str(ex))
-    
+
     def validate_delete_process(self, command_result: CommandResult):
         self.assertEqual(command_result.process.returncode, 0)
         self.assertNotIn(b"Could not find and delete the S3 object with the key", command_result.stderr)

--- a/tests/integration/testdata/package/aws-s3-with-lang-ext.yaml
+++ b/tests/integration/testdata/package/aws-s3-with-lang-ext.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform:
+  - AWS::LanguageExtensions
+  - AWS::Serverless-2016-10-31
+
+Description: "Demonstration of AWS SAM CLI Issue #5254."
+
+Resources:
+
+  TestBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: "aws-sam-cli-issue-5254"

--- a/tests/unit/lib/package/test_local_files_utils.py
+++ b/tests/unit/lib/package/test_local_files_utils.py
@@ -12,23 +12,19 @@ class GetUploadedS3ObjectNameUtils(unittest.TestCase):
         self.file_content = MagicMock()
         self.file_path = MagicMock()
 
-    @patch("samcli.lib.package.local_files_utils.mktempfile")
-    @patch("samcli.lib.package.local_files_utils.file_checksum")
-    def test_get_uploaded_s3_object_name_with_only_file_content(self, mock_file_checksum, mock_mktempfile):
-        mock_file_checksum.return_value = self.file_hash_value
+    @patch("samcli.lib.package.local_files_utils.str_checksum")
+    def test_get_uploaded_s3_object_name_with_only_file_content(self, mock_str_checksum):
+        mock_str_checksum.return_value = self.file_hash_value
         res = get_uploaded_s3_object_name(file_content=self.file_content)
         self.assertEqual(res, self.file_hash_value)
-        mock_mktempfile.assert_called_once()
-        mock_file_checksum.assert_called_once()
+        mock_str_checksum.assert_called_once()
 
-    @patch("samcli.lib.package.local_files_utils.mktempfile")
-    @patch("samcli.lib.package.local_files_utils.file_checksum")
-    def test_get_uploaded_s3_object_name_with_file_content_and_extension(self, mock_file_checksum, mock_mktempfile):
-        mock_file_checksum.return_value = self.file_hash_value
+    @patch("samcli.lib.package.local_files_utils.str_checksum")
+    def test_get_uploaded_s3_object_name_with_file_content_and_extension(self, mock_str_checksum):
+        mock_str_checksum.return_value = self.file_hash_value
         res = get_uploaded_s3_object_name(file_content=self.file_content, extension=self.extension)
         self.assertEqual(res, f"{self.file_hash_value}.{self.extension}")
-        mock_mktempfile.assert_called_once()
-        mock_file_checksum.assert_called_once()
+        mock_str_checksum.assert_called_once()
 
     @patch("samcli.lib.package.local_files_utils.mktempfile")
     @patch("samcli.lib.package.local_files_utils.file_checksum")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#5254


#### Why is this change necessary?
`sam delete` command removes CFN stack, with its template which was used to deploy the stack itself. In order to find its location, `sam delete` command downloads the original template and gets its hash to calculate its S3 location (as it is done in `sam package`/`sam deploy` commands). However this creates some issues on Windows machines as writing to a temporary file and calculating its hash gets a different result, since python does some extra line ending conversion which ends up with extra lines comparing to original template.


#### How does it address the issue?
This PR changes the way we calculate the hash of the template. Instead of writing to a temporary file and calculating its hash, this gets the hash of the contents of the template, which eliminates the behaviour above.


#### What side effects does this change have?
N/A
This code branch is only used with `sam delete` command, and running the whole `sam delete` test suite succeeded,.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
