### PR TITLE
Fix generation logic

### DIFF
--- a/schema/make_schema.py
+++ b/schema/make_schema.py
@@ -20,6 +20,15 @@ PARAMS_TO_EXCLUDE = [
 PARAMS_TO_OMIT_DEFAULT_FIELD = [
     "layer_cache_basedir"  # sets default to root directory to that of machine the schema is generated on
 ]
+EXCEPTION_OPTION_CLASS_MAPPER = {  # for params without proper class names, map them uniquely
+    "parameter_overrides": ["array", "string"],
+    "image_repository": "string",
+    "image_repositories": "array",
+    "metadata": "string",
+    "signing_profiles": "string",
+    "tags": "array",
+    "parameter": "array",
+}
 CHARS_TO_CLEAN = [
     "\b",  # backspaces
     "\u001b[0m",  # ANSI start bold
@@ -147,14 +156,16 @@ def format_param(param: click.core.Option) -> SamCliParameterSchema:
     """
     if not param:
         raise SchemaGenerationException("Expected to format a parameter that doesn't exist")
-    if not param.type.name:
-        raise SchemaGenerationException(f"Parameter {param} passed without a type")
+    if not param.type.name and param.name not in EXCEPTION_OPTION_CLASS_MAPPER.keys():
+        raise SchemaGenerationException(f"Parameter {param} passed without a type:\n{param.type}")
 
     param_type = param.type.name.lower()
-    formatted_param_type = ""
+    formatted_param_type: Any = None
     # NOTE: Params do not have explicit "string" type; either "text" or "path".
     #       All choice options are from a set of strings.
-    if param_type in ["text", "path", "choice", "filename", "directory"]:
+    if param.name in EXCEPTION_OPTION_CLASS_MAPPER.keys():
+        formatted_param_type = EXCEPTION_OPTION_CLASS_MAPPER[param.name]
+    elif param_type in ["text", "path", "choice", "filename", "directory"]:
         formatted_param_type = "string"
     elif param_type == "list":
         formatted_param_type = "array"
@@ -165,7 +176,7 @@ def format_param(param: click.core.Option) -> SamCliParameterSchema:
         param.name or "",
         formatted_param_type,
         clean_text(param.help or ""),
-        items="string" if formatted_param_type == "array" else None,
+        items="string" if formatted_param_type == "array" or "array" in formatted_param_type else None,
     )
 
     if param.default and param.name not in PARAMS_TO_OMIT_DEFAULT_FIELD:

--- a/schema/samcli.json
+++ b/schema/samcli.json
@@ -313,7 +313,10 @@
                 },
                 "parameter_overrides": {
                   "title": "parameter_overrides",
-                  "type": "string",
+                  "type": [
+                    "array",
+                    "string"
+                  ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs."
                 },
                 "skip_pull_image": {
@@ -396,7 +399,10 @@
                 },
                 "parameter_overrides": {
                   "title": "parameter_overrides",
-                  "type": "string",
+                  "type": [
+                    "array",
+                    "string"
+                  ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs."
                 },
                 "debug_port": {
@@ -548,7 +554,10 @@
                 },
                 "parameter_overrides": {
                   "title": "parameter_overrides",
-                  "type": "string",
+                  "type": [
+                    "array",
+                    "string"
+                  ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs."
                 },
                 "debug_port": {
@@ -723,7 +732,10 @@
                 },
                 "parameter_overrides": {
                   "title": "parameter_overrides",
-                  "type": "string",
+                  "type": [
+                    "array",
+                    "string"
+                  ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs."
                 },
                 "debug_port": {
@@ -871,8 +883,11 @@
                 },
                 "image_repositories": {
                   "title": "image_repositories",
-                  "type": "string",
-                  "description": "Mapping of Function Logical ID to AWS ECR Repository URI.\n\nExample: Function_Logical_ID=ECR_Repo_Uri\nThis option can be specified multiple times."
+                  "type": "array",
+                  "description": "Mapping of Function Logical ID to AWS ECR Repository URI.\n\nExample: Function_Logical_ID=ECR_Repo_Uri\nThis option can be specified multiple times.",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "s3_prefix": {
                   "title": "s3_prefix",
@@ -1010,8 +1025,11 @@
                 },
                 "image_repositories": {
                   "title": "image_repositories",
-                  "type": "string",
-                  "description": "Mapping of Function Logical ID to AWS ECR Repository URI.\n\nExample: Function_Logical_ID=ECR_Repo_Uri\nThis option can be specified multiple times."
+                  "type": "array",
+                  "description": "Mapping of Function Logical ID to AWS ECR Repository URI.\n\nExample: Function_Logical_ID=ECR_Repo_Uri\nThis option can be specified multiple times.",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "force_upload": {
                   "title": "force_upload",
@@ -1063,12 +1081,18 @@
                 },
                 "tags": {
                   "title": "tags",
-                  "type": "string",
-                  "description": "List of tags to associate with the stack."
+                  "type": "array",
+                  "description": "List of tags to associate with the stack.",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "parameter_overrides": {
                   "title": "parameter_overrides",
-                  "type": "string",
+                  "type": [
+                    "array",
+                    "string"
+                  ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs."
                 },
                 "signing_profiles": {

--- a/tests/unit/schema/test_schema_logic.py
+++ b/tests/unit/schema/test_schema_logic.py
@@ -1,11 +1,10 @@
 from typing import List
-from unittest.mock import MagicMock, Mock, patch
-import click
+from unittest.mock import MagicMock, patch
 from parameterized import parameterized
 from unittest import TestCase
 from schema.exceptions import SchemaGenerationException
 
-from schema.schema import (
+from schema.make_schema import (
     SamCliCommandSchema,
     SamCliParameterSchema,
     SchemaKeys,
@@ -121,7 +120,7 @@ class TestSchemaLogic(TestCase):
             ("choice", SamCliParameterSchema("p_name", "string", default=["default", "value"], choices=["1", "2"])),
         ]
     )
-    @patch("schema.schema.isinstance")
+    @patch("schema.make_schema.isinstance")
     def test_param_formatted_given_type(self, param_type, expected_param, isinstance_mock):
         mock_param = MagicMock()
         mock_param.name = "p_name"
@@ -135,8 +134,8 @@ class TestSchemaLogic(TestCase):
 
         self.assertEqual(expected_param, formatted_param)
 
-    @patch("schema.schema.isinstance")
-    @patch("schema.schema.format_param")
+    @patch("schema.make_schema.isinstance")
+    @patch("schema.make_schema.format_param")
     def test_getting_params_from_cli_object(self, format_param_mock, isinstance_mock):
         mock_cli = MagicMock()
         mock_cli.params = []
@@ -154,8 +153,8 @@ class TestSchemaLogic(TestCase):
         self.assertNotIn("config_file", params)
         self.assertNotIn(None, params)
 
-    @patch("schema.schema.importlib.import_module")
-    @patch("schema.schema.get_params_from_command")
+    @patch("schema.make_schema.importlib.import_module")
+    @patch("schema.make_schema.get_params_from_command")
     def test_command_structure_is_retrieved(self, get_params_mock, import_mock):
         mock_module = self._setup_mock_module()
         import_mock.side_effect = lambda _: mock_module
@@ -165,9 +164,9 @@ class TestSchemaLogic(TestCase):
 
         self._validate_retrieved_command_structure(commands)
 
-    @patch("schema.schema.importlib.import_module")
-    @patch("schema.schema.get_params_from_command")
-    @patch("schema.schema.isinstance")
+    @patch("schema.make_schema.importlib.import_module")
+    @patch("schema.make_schema.get_params_from_command")
+    @patch("schema.make_schema.isinstance")
     def test_command_structure_is_retrieved_from_group_cli(self, isinstance_mock, get_params_mock, import_mock):
         mock_module = self._setup_mock_module()
         mock_module.cli.commands = {}
@@ -183,7 +182,7 @@ class TestSchemaLogic(TestCase):
 
         self._validate_retrieved_command_structure(commands)
 
-    @patch("schema.schema.retrieve_command_structure")
+    @patch("schema.make_schema.retrieve_command_structure")
     def test_schema_is_generated_properly(self, retrieve_commands_mock):
         def mock_retrieve_commands(package_name, counter=[0]):
             counter[0] += 1


### PR DESCRIPTION
#### Why is this change necessary?
Previously, generation logic was not working due to the file handling the generation being named identically to the folder, causing import errors. In addition, some custom parameter types were failing in the newly-implemented checks for type names.

#### How does it address the issue?
The file housing the generation logic has been renamed to `make_schema.py`. A new constant has been added to map the custom-typed parameters to their JSON schema representation type. This includes `parameter_overrides`, which can be provided as an array or a string.

#### What side effects does this change have?
Some of the types in the schema have been updated to better reflect their actual typing.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
