### PR TITLE
fix: Add type names to custom parameter types

### DIFF
--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -85,7 +85,6 @@ class CfnParameterOverridesType(click.ParamType):
 
     ordered_pattern_match = [_pattern_1, _pattern_2]
 
-    # NOTE(TheSriram): name needs to be added to click.ParamType requires it.
     name = "string,list"
 
     def convert(self, value, param, ctx):
@@ -140,7 +139,6 @@ class CfnMetadataType(click.ParamType):
 
     _pattern = r"(?:{key}={value})".format(key=PARAM_AND_METADATA_KEY_REGEX, value=VALUE_REGEX_COMMA_DELIM)
 
-    # NOTE(TheSriram): name needs to be added to click.ParamType requires it.
     name = "string"
 
     def convert(self, value, param, ctx):
@@ -196,7 +194,6 @@ class CfnTags(click.ParamType):
 
     _pattern = r"{tag}={tag}".format(tag=_generate_match_regex(match_pattern=TAG_REGEX, delim=" "))
 
-    # NOTE(TheSriram): name needs to be added to click.ParamType requires it.
     name = "list"
 
     def convert(self, value, param, ctx):
@@ -301,7 +298,6 @@ class SigningProfilesOptionType(click.ParamType):
 
     pattern = r"(?:(?: )([A-Za-z0-9\"]+)=(\"(?:\\.|[^\"\\]+)*\"|(?:\\.|[^ \"\\]+)+))"
 
-    # Note: this is required, otherwise it is failing when running help
     name = "string"
 
     def convert(self, value, param, ctx):

--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -86,7 +86,7 @@ class CfnParameterOverridesType(click.ParamType):
     ordered_pattern_match = [_pattern_1, _pattern_2]
 
     # NOTE(TheSriram): name needs to be added to click.ParamType requires it.
-    name = ""
+    name = "string,list"
 
     def convert(self, value, param, ctx):
         result = {}
@@ -141,7 +141,7 @@ class CfnMetadataType(click.ParamType):
     _pattern = r"(?:{key}={value})".format(key=PARAM_AND_METADATA_KEY_REGEX, value=VALUE_REGEX_COMMA_DELIM)
 
     # NOTE(TheSriram): name needs to be added to click.ParamType requires it.
-    name = ""
+    name = "string"
 
     def convert(self, value, param, ctx):
         result = {}
@@ -197,7 +197,7 @@ class CfnTags(click.ParamType):
     _pattern = r"{tag}={tag}".format(tag=_generate_match_regex(match_pattern=TAG_REGEX, delim=" "))
 
     # NOTE(TheSriram): name needs to be added to click.ParamType requires it.
-    name = ""
+    name = "list"
 
     def convert(self, value, param, ctx):
         result = {}
@@ -302,7 +302,7 @@ class SigningProfilesOptionType(click.ParamType):
     pattern = r"(?:(?: )([A-Za-z0-9\"]+)=(\"(?:\\.|[^\"\\]+)*\"|(?:\\.|[^ \"\\]+)+))"
 
     # Note: this is required, otherwise it is failing when running help
-    name = ""
+    name = "string"
 
     def convert(self, value, param, ctx):
         """
@@ -393,7 +393,7 @@ class ImageRepositoryType(click.ParamType):
 
     # Transformation callback function checks if the received option value is a valid ECR url.
     transformer = Transformer(converter=click.STRING, transformation=is_ecr_url)
-    name = ""
+    name = "string"
 
     def convert(self, value, param, ctx):
         """
@@ -410,7 +410,7 @@ class ImageRepositoriesType(click.ParamType):
     Custom Parameter Type for Multi valued Image Repositories option.
     """
 
-    name = ""
+    name = "list"
     KEY_VALUE_PAIR_LENGTH = 2
 
     def convert(self, value, param, ctx):
@@ -431,7 +431,7 @@ class RemoteInvokeBotoApiParameterType(click.ParamType):
     Custom Parameter Type for Multi valued Boto API parameter option of remote invoke command.
     """
 
-    name = ""
+    name = "list"
     MIN_KEY_VALUE_PAIR_LENGTH = 2
 
     def convert(self, value, param, ctx):

--- a/schema/make_schema.py
+++ b/schema/make_schema.py
@@ -166,6 +166,9 @@ def format_param(param: click.core.Option) -> SamCliParameterSchema:
             formatted_param_types.append("array")
         else:
             formatted_param_types.append(param_name or "string")
+    formatted_param_types = [
+        x for i, x in enumerate(formatted_param_types) if x not in formatted_param_types[:i]
+    ]  # deduplicate
 
     formatted_param: SamCliParameterSchema = SamCliParameterSchema(
         param.name or "",

--- a/schema/make_schema.py
+++ b/schema/make_schema.py
@@ -20,15 +20,6 @@ PARAMS_TO_EXCLUDE = [
 PARAMS_TO_OMIT_DEFAULT_FIELD = [
     "layer_cache_basedir"  # sets default to root directory to that of machine the schema is generated on
 ]
-EXCEPTION_OPTION_CLASS_MAPPER = {  # for params without proper class names, map them uniquely
-    "parameter_overrides": ["array", "string"],
-    "image_repository": ["string"],
-    "image_repositories": ["array"],
-    "metadata": ["string"],
-    "signing_profiles": ["string"],
-    "tags": ["array"],
-    "parameter": ["array"],
-}
 CHARS_TO_CLEAN = [
     "\b",  # backspaces
     "\u001b[0m",  # ANSI start bold
@@ -156,21 +147,25 @@ def format_param(param: click.core.Option) -> SamCliParameterSchema:
     """
     if not param:
         raise SchemaGenerationException("Expected to format a parameter that doesn't exist")
-    if not param.type.name and param.name not in EXCEPTION_OPTION_CLASS_MAPPER.keys():
+    if not param.type.name:
         raise SchemaGenerationException(f"Parameter {param} passed without a type:\n{param.type}")
 
-    param_type = param.type.name.lower()
+    param_type = []
+    if "," in param.type.name:  # custom type with support for various input values
+        param_type = [x.lower() for x in param.type.name.split(",")]
+    else:
+        param_type.append(param.type.name.lower())
+
     formatted_param_types = []
     # NOTE: Params do not have explicit "string" type; either "text" or "path".
     #       All choice options are from a set of strings.
-    if param.name in EXCEPTION_OPTION_CLASS_MAPPER.keys():
-        formatted_param_types = EXCEPTION_OPTION_CLASS_MAPPER[param.name]
-    elif param_type in ["text", "path", "choice", "filename", "directory"]:
-        formatted_param_types = ["string"]
-    elif param_type == "list":
-        formatted_param_types = ["array"]
-    else:
-        formatted_param_types = [param_type] or ["string"]
+    for param_name in param_type:
+        if param_name in ["text", "path", "choice", "filename", "directory"]:
+            formatted_param_types.append("string")
+        elif param_name == "list":
+            formatted_param_types.append("array")
+        else:
+            formatted_param_types.append(param_name or "string")
 
     formatted_param: SamCliParameterSchema = SamCliParameterSchema(
         param.name or "",

--- a/schema/make_schema.py
+++ b/schema/make_schema.py
@@ -166,9 +166,7 @@ def format_param(param: click.core.Option) -> SamCliParameterSchema:
             formatted_param_types.append("array")
         else:
             formatted_param_types.append(param_name or "string")
-    formatted_param_types = [
-        x for i, x in enumerate(formatted_param_types) if x not in formatted_param_types[:i]
-    ]  # deduplicate
+    formatted_param_types = sorted(list(set(formatted_param_types)))  # deduplicate
 
     formatted_param: SamCliParameterSchema = SamCliParameterSchema(
         param.name or "",

--- a/schema/samcli.json
+++ b/schema/samcli.json
@@ -314,8 +314,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "array",
-                    "string"
+                    "string",
+                    "array"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -403,8 +403,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "array",
-                    "string"
+                    "string",
+                    "array"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -561,8 +561,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "array",
-                    "string"
+                    "string",
+                    "array"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -742,8 +742,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "array",
-                    "string"
+                    "string",
+                    "array"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -1102,8 +1102,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "array",
-                    "string"
+                    "string",
+                    "array"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -1422,8 +1422,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "array",
-                    "string"
+                    "string",
+                    "array"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -1532,8 +1532,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "array",
-                    "string"
+                    "string",
+                    "array"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -1651,8 +1651,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "array",
-                    "string"
+                    "string",
+                    "array"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {

--- a/schema/samcli.json
+++ b/schema/samcli.json
@@ -314,8 +314,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "string",
-                    "array"
+                    "array",
+                    "string"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -403,8 +403,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "string",
-                    "array"
+                    "array",
+                    "string"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -561,8 +561,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "string",
-                    "array"
+                    "array",
+                    "string"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -742,8 +742,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "string",
-                    "array"
+                    "array",
+                    "string"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -1102,8 +1102,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "string",
-                    "array"
+                    "array",
+                    "string"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -1422,8 +1422,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "string",
-                    "array"
+                    "array",
+                    "string"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -1532,8 +1532,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "string",
-                    "array"
+                    "array",
+                    "string"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {
@@ -1651,8 +1651,8 @@
                 "parameter_overrides": {
                   "title": "parameter_overrides",
                   "type": [
-                    "string",
-                    "array"
+                    "array",
+                    "string"
                   ],
                   "description": "String that contains AWS CloudFormation parameter overrides encoded as key=value pairs.",
                   "items": {

--- a/tests/unit/schema/test_schema_logic.py
+++ b/tests/unit/schema/test_schema_logic.py
@@ -34,6 +34,14 @@ class TestParameterSchema(TestCase):
         expected_schema.update(added_property_field)
         self.assertEqual(expected_schema, param_schema)
 
+    def test_parameter_to_schema_with_multiple_type(self):
+        param = SamCliParameterSchema("param name", ["type1", "type2"], "param description")
+
+        param_schema = param.to_schema()
+
+        expected_schema = {"title": "param name", "type": ["type1", "type2"], "description": "param description"}
+        self.assertEqual(expected_schema, param_schema)
+
 
 class TestCommandSchema(TestCase):
     def test_command_to_schema(self):
@@ -87,6 +95,9 @@ class TestSchemaLogic(TestCase):
             ("filename", "string"),
             ("directory", "string"),
             ("LIST", "array"),
+            ("type1,type2", ["type1", "type2"]),
+            ("type1,list", ["type1", "array"]),
+            ("string,path,choice,filename,directory", "string"),
         ]
     )
     def test_param_formatted_correctly(self, param_type, expected_type):

--- a/tests/unit/schema/test_schema_logic.py
+++ b/tests/unit/schema/test_schema_logic.py
@@ -96,7 +96,7 @@ class TestSchemaLogic(TestCase):
             ("directory", "string"),
             ("LIST", "array"),
             ("type1,type2", ["type1", "type2"]),
-            ("type1,list", ["type1", "array"]),
+            ("list,type1", ["array", "type1"]),
             ("string,path,choice,filename,directory", "string"),
         ]
     )


### PR DESCRIPTION
#### Why is this change necessary?
Since the SAM CLI uses custom types without names, we had to create a constant to map the name of the parameter to its set of possible values. This creates additional overhead when creating new custom parameter types.

#### How does it address the issue?
The `name` fields of each of these types have now been populated, and as such, they are able to be read by the schema parser. This means we can include the expected type (or types) of the parameter to be read.

#### What side effects does this change have?
The `name` field of each SAM CLI custom type has been populated instead of being an empty string (not that it was being used to begin with).

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
