### PR TITLE
feat: Added APIGW V2 Authorizer property mapping

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
@@ -28,6 +28,7 @@ from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_API as CFN_AWS_APIGATEW
 from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_INTEGRATION as CFN_AWS_APIGATEWAY_V2_INTEGRATION
 from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_ROUTE as CFN_AWS_APIGATEWAY_V2_ROUTE
 from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_STAGE as CFN_AWS_APIGATEWAY_V2_STAGE
+from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_AUTHORIZER as CFN_AWS_APIGATEWAY_V2_AUTHORIZER
 from samcli.lib.utils.resources import AWS_LAMBDA_FUNCTION as CFN_AWS_LAMBDA_FUNCTION
 from samcli.lib.utils.resources import AWS_LAMBDA_LAYERVERSION as CFN_AWS_LAMBDA_LAYER_VERSION
 
@@ -49,6 +50,7 @@ TF_AWS_API_GATEWAY_V2_API = "aws_apigatewayv2_api"
 TF_AWS_API_GATEWAY_V2_ROUTE = "aws_apigatewayv2_route"
 TF_AWS_API_GATEWAY_V2_STAGE = "aws_apigatewayv2_stage"
 TF_AWS_API_GATEWAY_V2_INTEGRATION = "aws_apigatewayv2_integration"
+TF_AWS_API_GATEWAY_V2_AUTHORIZER = "aws_apigatewayv2_authorizer"
 
 
 def _build_code_property(tf_properties: dict, resource: TFResource) -> Any:
@@ -412,6 +414,16 @@ AWS_API_GATEWAY_V2_INTEGRATION_PROPERTY_BUILDER_MAPPING: PropertyBuilderMapping 
     "PayloadFormatVersion": _get_property_extractor("payload_format_version"),
 }
 
+AWS_API_GATEWAY_V2_AUTHORIZER_PROPERTY_BUILDER_MAPPING: PropertyBuilderMapping = {
+    "ApiId": _get_property_extractor("api_id"),
+    "AuthorizerType": _get_property_extractor("authorizer_type"),
+    "AuthorizerUri": _get_property_extractor("authorizer_uri"),
+    "Name": _get_property_extractor("name"),
+    "AuthorizerPayloadFormatVersion": _get_property_extractor("authorizer_payload_format_version"),
+    "IdentitySource": _get_property_extractor("identity_sources"),
+    "EnableSimpleResponses": _get_property_extractor("enable_simple_responses"),
+}
+
 RESOURCE_TRANSLATOR_MAPPING: Dict[str, ResourceTranslator] = {
     TF_AWS_LAMBDA_FUNCTION: ResourceTranslator(CFN_AWS_LAMBDA_FUNCTION, AWS_LAMBDA_FUNCTION_PROPERTY_BUILDER_MAPPING),
     TF_AWS_LAMBDA_LAYER_VERSION: ResourceTranslator(
@@ -449,5 +461,8 @@ RESOURCE_TRANSLATOR_MAPPING: Dict[str, ResourceTranslator] = {
     ),
     TF_AWS_API_GATEWAY_V2_INTEGRATION: ResourceTranslator(
         CFN_AWS_APIGATEWAY_V2_INTEGRATION, AWS_API_GATEWAY_V2_INTEGRATION_PROPERTY_BUILDER_MAPPING
+    ),
+    TF_AWS_API_GATEWAY_V2_AUTHORIZER: ResourceTranslator(
+        CFN_AWS_APIGATEWAY_V2_AUTHORIZER, AWS_API_GATEWAY_V2_AUTHORIZER_PROPERTY_BUILDER_MAPPING
     ),
 }

--- a/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/property_builder.py
@@ -25,10 +25,10 @@ from samcli.lib.utils.resources import AWS_APIGATEWAY_RESOURCE as CFN_AWS_APIGAT
 from samcli.lib.utils.resources import AWS_APIGATEWAY_RESTAPI as CFN_AWS_APIGATEWAY_RESTAPI
 from samcli.lib.utils.resources import AWS_APIGATEWAY_STAGE as CFN_AWS_APIGATEWAY_STAGE
 from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_API as CFN_AWS_APIGATEWAY_V2_API
+from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_AUTHORIZER as CFN_AWS_APIGATEWAY_V2_AUTHORIZER
 from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_INTEGRATION as CFN_AWS_APIGATEWAY_V2_INTEGRATION
 from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_ROUTE as CFN_AWS_APIGATEWAY_V2_ROUTE
 from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_STAGE as CFN_AWS_APIGATEWAY_V2_STAGE
-from samcli.lib.utils.resources import AWS_APIGATEWAY_V2_AUTHORIZER as CFN_AWS_APIGATEWAY_V2_AUTHORIZER
 from samcli.lib.utils.resources import AWS_LAMBDA_FUNCTION as CFN_AWS_LAMBDA_FUNCTION
 from samcli.lib.utils.resources import AWS_LAMBDA_LAYERVERSION as CFN_AWS_LAMBDA_LAYER_VERSION
 

--- a/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
@@ -1026,7 +1026,6 @@ class PrepareHookUnitBase(TestCase):
                 f"AwsApigatewayv2AuthorizerMyAuthorizerV2{self.mock_logical_id_hash}": self.expected_cfn_apigwv2_authorizer,
             },
         }
-        self.maxDiff = None
         self.tf_json_with_root_module_with_sam_metadata_resources: dict = {
             "planned_values": {
                 "root_module": {

--- a/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
@@ -955,7 +955,7 @@ class PrepareHookUnitBase(TestCase):
             "name": self.apigwv2_authorizer_name,
             "authorizer_payload_format_version": "2.0",
             "identity_sources": ["$request.header.hello"],
-            "enable_simple_responses": False
+            "enable_simple_responses": False,
         }
 
         self.expected_cfn_apigwv2_authorizer_properties: dict = {
@@ -965,7 +965,7 @@ class PrepareHookUnitBase(TestCase):
             "Name": self.apigwv2_authorizer_name,
             "AuthorizerPayloadFormatVersion": "2.0",
             "IdentitySource": ["$request.header.hello"],
-            "EnableSimpleResponses": False
+            "EnableSimpleResponses": False,
         }
 
         self.tf_apigwv2_authorizer_resource: dict = {

--- a/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 from samcli.hook_packages.terraform.hooks.prepare.translate import AWS_PROVIDER_NAME, NULL_RESOURCE_PROVIDER_NAME
 from samcli.lib.utils.resources import (
+    AWS_APIGATEWAY_V2_AUTHORIZER,
     AWS_LAMBDA_FUNCTION as CFN_AWS_LAMBDA_FUNCTION,
     AWS_LAMBDA_LAYERVERSION,
     AWS_APIGATEWAY_RESOURCE,
@@ -61,6 +62,7 @@ class PrepareHookUnitBase(TestCase):
         self.apigwv2_route_name = "my_apigwv2_route"
         self.apigwv2_stage_name = "my_apigwv2_stage"
         self.apigwv2_integration_name = "my_apigwv2_integration"
+        self.apigwv2_authorizer_name = "my_authorizer_v2"
 
         self.tf_function_common_properties: dict = {
             "function_name": self.zip_function_name,
@@ -939,6 +941,44 @@ class PrepareHookUnitBase(TestCase):
             "Type": AWS_APIGATEWAY_V2_INTEGRATION,
             "Properties": self.expected_cfn_apigwv2_integration_properties,
             "Metadata": {"SamResourceId": f"aws_apigatewayv2_integration.{self.apigwv2_integration_name}"},
+        }
+
+        self.tf_apigwv2_authorizer_common_attributes: dict = {
+            "type": "aws_apigatewayv2_authorizer",
+            "provider_name": AWS_PROVIDER_NAME,
+        }
+
+        self.tf_apigwv2_authorizer_properties: dict = {
+            "api_id": "aws_apigatewayv2_api.my_api.id",
+            "authorizer_type": "REQUEST",
+            "authorizer_uri": "aws_lambda_function.authorizerv2.invoke_arn",
+            "name": self.apigwv2_authorizer_name,
+            "authorizer_payload_format_version": "2.0",
+            "identity_sources": ["$request.header.hello"],
+            "enable_simple_responses": False
+        }
+
+        self.expected_cfn_apigwv2_authorizer_properties: dict = {
+            "ApiId": "aws_apigatewayv2_api.my_api.id",
+            "AuthorizerType": "REQUEST",
+            "AuthorizerUri": "aws_lambda_function.authorizerv2.invoke_arn",
+            "Name": self.apigwv2_authorizer_name,
+            "AuthorizerPayloadFormatVersion": "2.0",
+            "IdentitySource": ["$request.header.hello"],
+            "EnableSimpleResponses": False
+        }
+
+        self.tf_apigwv2_authorizer_resource: dict = {
+            **self.tf_apigwv2_authorizer_common_attributes,
+            "values": self.tf_apigwv2_authorizer_properties,
+            "address": f"aws_api_gateway_authorizer.{self.apigwv2_authorizer_name}",
+            "name": self.apigwv2_authorizer_name,
+        }
+
+        self.expectedv2_cfn_apigw_authorizer: dict = {
+            "Type": AWS_APIGATEWAY_V2_AUTHORIZER,
+            "Properties": self.expected_cfn_apigwv2_authorizer_properties,
+            "Metadata": {"SamResourceId": f"aws_api_gateway_authorizer.{self.apigwv2_authorizer_name}"},
         }
 
         self.tf_json_with_root_module_only: dict = {

--- a/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/prepare_base.py
@@ -971,14 +971,14 @@ class PrepareHookUnitBase(TestCase):
         self.tf_apigwv2_authorizer_resource: dict = {
             **self.tf_apigwv2_authorizer_common_attributes,
             "values": self.tf_apigwv2_authorizer_properties,
-            "address": f"aws_api_gateway_authorizer.{self.apigwv2_authorizer_name}",
+            "address": f"aws_apigatewayv2_authorizer.{self.apigwv2_authorizer_name}",
             "name": self.apigwv2_authorizer_name,
         }
 
-        self.expectedv2_cfn_apigw_authorizer: dict = {
+        self.expected_cfn_apigwv2_authorizer: dict = {
             "Type": AWS_APIGATEWAY_V2_AUTHORIZER,
             "Properties": self.expected_cfn_apigwv2_authorizer_properties,
-            "Metadata": {"SamResourceId": f"aws_api_gateway_authorizer.{self.apigwv2_authorizer_name}"},
+            "Metadata": {"SamResourceId": f"aws_apigatewayv2_authorizer.{self.apigwv2_authorizer_name}"},
         }
 
         self.tf_json_with_root_module_only: dict = {
@@ -1001,6 +1001,7 @@ class PrepareHookUnitBase(TestCase):
                         self.tf_apigwv2_route_resource,
                         self.tf_apigwv2_stage_resource,
                         self.tf_apigwv2_integration_resource,
+                        self.tf_apigwv2_authorizer_resource,
                     ]
                 }
             }
@@ -1022,9 +1023,10 @@ class PrepareHookUnitBase(TestCase):
                 f"AwsApigatewayv2RouteMyApigwv2Route{self.mock_logical_id_hash}": self.expected_cfn_apigwv2_route,
                 f"AwsApigatewayv2StageMyApigwv2Stage{self.mock_logical_id_hash}": self.expected_cfn_apigwv2_stage,
                 f"AwsApigatewayv2IntegrationMyApigwv2Integration{self.mock_logical_id_hash}": self.expected_cfn_apigwv2_integration,
+                f"AwsApigatewayv2AuthorizerMyAuthorizerV2{self.mock_logical_id_hash}": self.expected_cfn_apigwv2_authorizer,
             },
         }
-
+        self.maxDiff = None
         self.tf_json_with_root_module_with_sam_metadata_resources: dict = {
             "planned_values": {
                 "root_module": {

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_translate.py
@@ -6,6 +6,7 @@ from samcli.lib.utils.colors import Colored, Colors
 
 from tests.unit.hook_packages.terraform.hooks.prepare.prepare_base import PrepareHookUnitBase
 from samcli.hook_packages.terraform.hooks.prepare.property_builder import (
+    AWS_API_GATEWAY_V2_AUTHORIZER_PROPERTY_BUILDER_MAPPING,
     AWS_LAMBDA_FUNCTION_PROPERTY_BUILDER_MAPPING,
     REMOTE_DUMMY_VALUE,
     AWS_API_GATEWAY_RESOURCE_PROPERTY_BUILDER_MAPPING,
@@ -1145,6 +1146,12 @@ class TestPrepareHookTranslate(PrepareHookUnitBase):
             self.tf_apigwv2_integration_properties, AWS_API_GATEWAY_V2_INTEGRATION_PROPERTY_BUILDER_MAPPING, Mock()
         )
         self.assertEqual(translated_cfn_properties, self.expected_cfn_apigwv2_integration_properties)
+
+    def test_translating_apigwv2_authorizer(self):
+        translated_cfn_properties = _translate_properties(
+            self.tf_apigwv2_authorizer_properties, AWS_API_GATEWAY_V2_AUTHORIZER_PROPERTY_BUILDER_MAPPING, Mock()
+        )
+        self.assertEqual(translated_cfn_properties, self.expected_cfn_apigwv2_authorizer_properties)
 
 
 class TestUnresolvableAttributeCheck(TestCase):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
Adds the property mappings between the Terraform and Cloudformation V2 Authorizer resources.

#### How does it address the issue?
Uses the existing mapping logic to match the Terraform properties to their equivalent Cloudformation counter parts.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
