### PR TITLE
fix: Prevent stack trace when incorrect filetype is passed as config

### DIFF
--- a/samcli/lib/config/exceptions.py
+++ b/samcli/lib/config/exceptions.py
@@ -3,6 +3,9 @@ Exceptions to be used by samconfig.py
 """
 
 
+from samcli.commands.exceptions import UserException
+
+
 class SamConfigVersionException(Exception):
     """Exception for the `samconfig` file being not present or in unrecognized format"""
 
@@ -11,5 +14,5 @@ class FileParseException(Exception):
     """Exception when a file is incorrectly parsed by a FileManager object."""
 
 
-class SamConfigFileReadException(Exception):
+class SamConfigFileReadException(UserException):
     """Exception when a `samconfig` file is read incorrectly."""

--- a/tests/integration/buildcmd/test_build_samconfig.py
+++ b/tests/integration/buildcmd/test_build_samconfig.py
@@ -11,6 +11,7 @@ configs = {
     ".yaml": "samconfig/samconfig.yaml",
     ".yml": "samconfig/samconfig.yml",
     ".json": "samconfig/samconfig.json",
+    ".jpeg": "samconfig/samconfig.jpeg",  # unsupported format, but file that exists
 }
 
 
@@ -36,6 +37,16 @@ class TestSamConfigWithBuild(BuildIntegBase):
             f"Build template should use build_dir from samconfig{extension}",
         )
         self.assertIn("Starting Build use cache", stderr, f"'cache'=true should be set in samconfig{extension}")
+
+    def test_samconfig_fails_properly_with_incorrect_extension(self):
+        cmdlist = self.get_command_list(config_file=configs[".jpeg"])
+
+        command_result = run_command(cmdlist, cwd=self.working_dir)
+        stderr = str(command_result[2])
+
+        self.assertNotEqual(command_result.process.returncode, 0, "Build should not succeed")
+        self.assertEqual(command_result.process.returncode, 1, "Correct error code should be thrown")
+        self.assertNotIn("Traceback", stderr, "Traceback should not be in output")
 
     @parameterized.expand(
         [


### PR DESCRIPTION
#### Why is this change necessary?
Previously, if a config file is provided without a supporting extension, a stack trace is thrown rather than just an error. This prompts the user to open an issue, which they should not do, since it is not something we can immediately address.

#### How does it address the issue?
The `SamConfigFileReadException` class has been changed from inheriting from `Exception` to inheriting from `UserException`. That way, it is caught properly and is passed through the correct channels.

#### What side effects does this change have?
Any `SamConfigFileReadException` exceptions that are raised no longer prompt the user to open an issue about it

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
