### PR TITLE
feat: Remove exclusionary logic from schema generation

### DIFF
--- a/schema/make_schema.py
+++ b/schema/make_schema.py
@@ -78,31 +78,9 @@ class SamCliCommandSchema:
 
     def to_schema(self) -> dict:
         """Return the JSON schema representation of the SAM CLI command."""
-        COMMANDS_TO_EXCLUDE = [  # TEMPORARY: for use only while generating piece-by-piece
-            "deploy",
-            "build",
-            "local",
-            "validate",
-            "package",
-            "init",
-            "delete",
-            "bootstrap",
-            "list",
-            "traces",
-            "sync",
-            "publish",
-            "pipeline",
-            "logs",
-            "remote",
-        ]
         split_cmd_name = self.name.split("_")
         formatted_cmd_name = " ".join(split_cmd_name)
-        exclude_params = split_cmd_name[0] in COMMANDS_TO_EXCLUDE
-        formatted_params_list = (
-            "* " + "\n* ".join([f"{param.name}:\n{param.description}" for param in self.parameters])
-            if not exclude_params
-            else ""
-        )
+        formatted_params_list = "* " + "\n* ".join([f"{param.name}:\n{param.description}" for param in self.parameters])
         params_description = f"Available parameters for the {formatted_cmd_name} command:\n{formatted_params_list}"
 
         return {
@@ -114,9 +92,7 @@ class SamCliCommandSchema:
                         "title": f"Parameters for the {formatted_cmd_name} command",
                         "description": params_description,
                         "type": "object",
-                        "properties": {param.name: param.to_schema() for param in self.parameters}
-                        if not exclude_params
-                        else {},
+                        "properties": {param.name: param.to_schema() for param in self.parameters},
                     },
                 },
                 "required": ["parameters"],


### PR DESCRIPTION
#### Why is this change necessary?
While the schema was being created, it was generated in pieces to make reviewing it easier, and less prone to errors in generation. Now that the schema is fully generated and approved of, we no longer need this additional logic.

#### How does it address the issue?
Any logic the schema previously implemented to exclude certain commands from appearing has been removed.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
