### PR TITLE
Update InvalidSamDocumentException to a subclass of UserException

### DIFF
--- a/samcli/commands/validate/lib/exceptions.py
+++ b/samcli/commands/validate/lib/exceptions.py
@@ -2,8 +2,10 @@
 Custom Exceptions for 'sam validate' commands
 """
 
+from samcli.commands.exceptions import UserException
 
-class InvalidSamDocumentException(Exception):
+
+class InvalidSamDocumentException(UserException):
     """
     Exception for Invalid Sam Documents
     """

--- a/tests/unit/commands/list/resources/test_resources_context.py
+++ b/tests/unit/commands/list/resources/test_resources_context.py
@@ -325,7 +325,7 @@ class TestGetTranslatedDict(TestCase):
                 }
             },
         }
-        mock_get_translated_template_if_valid.side_effect = InvalidSamDocumentException()
+        mock_get_translated_template_if_valid.side_effect = InvalidSamDocumentException("")
         with self.assertRaises(InvalidSamTemplateException):
             resource_producer = ResourceMappingProducer(
                 stack_name=None,

--- a/tests/unit/commands/validate/test_cli.py
+++ b/tests/unit/commands/validate/test_cli.py
@@ -49,7 +49,9 @@ class TestValidateCli(TestCase):
         read_sam_file_patch.return_value = {"a": "b"}
 
         get_translated_template_if_valid_mock = Mock()
-        get_translated_template_if_valid_mock.get_translated_template_if_valid.side_effect = InvalidSamDocumentException("")
+        get_translated_template_if_valid_mock.get_translated_template_if_valid.side_effect = (
+            InvalidSamDocumentException("")
+        )
         template_valiadator.return_value = get_translated_template_if_valid_mock
 
         with self.assertRaises(InvalidSamTemplateException):

--- a/tests/unit/commands/validate/test_cli.py
+++ b/tests/unit/commands/validate/test_cli.py
@@ -49,7 +49,7 @@ class TestValidateCli(TestCase):
         read_sam_file_patch.return_value = {"a": "b"}
 
         get_translated_template_if_valid_mock = Mock()
-        get_translated_template_if_valid_mock.get_translated_template_if_valid.side_effect = InvalidSamDocumentException
+        get_translated_template_if_valid_mock.get_translated_template_if_valid.side_effect = InvalidSamDocumentException("")
         template_valiadator.return_value = get_translated_template_if_valid_mock
 
         with self.assertRaises(InvalidSamTemplateException):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
`InvalidSamDocumentException` not being a `UserException` cause `sam build` to throw a stack trace when there's any invalid template issue.

#### How does it address the issue?
Make `InvalidSamDocumentException` a subclass of `UserException`

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
