### PR TITLE
fix: Require file label to run before maintainers

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,6 +14,7 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
   apply-internal-external-label:
     needs: apply-file-based-labels
+    if: ${{ always() }}
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,6 +13,7 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
   apply-internal-external-label:
+    needs: apply-file-based-labels
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None

#### Why is this change necessary?
If the file labeller is ran after the maintainers labeller job, the file labels will replace the existing labels instead of appending them.

#### How does it address the issue?
Requires that that the file labeling job runs before the maintainer job.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
