### PR TITLE
fix(test): Force reading file with utf8 in tests for windows

### DIFF
--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -306,7 +306,7 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
         process_stdout = stdout.strip()
 
-        with open(self.event_utf8_path) as f:
+        with open(self.event_utf8_path, encoding="utf8") as f:
             expected_output = json.dumps(json.load(f), ensure_ascii=False)
 
         self.assertEqual(process.returncode, 0)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
None

#### Why is this change necessary?
Forcing reading a utf8 file in utf8 which caused integration tests to fail on windows

#### How does it address the issue?
Enforces reading the encoding correctly

#### What side effects does this change have?
Shouldn't have any.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
