### PR TITLE
fix(test): Increase max execution time for timeout tests

### DIFF
--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -160,7 +160,9 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
         # validate the time of the cli (timeout is set to 5s)
         self.assertGreater(wall_clock_cli_duration, 5)
-        self.assertLess(wall_clock_cli_duration, 20)
+        # validate the the duration is roughly under the timeout (with some additional
+        # time to take in account time for SAM CLI to do work)
+        self.assertLess(wall_clock_cli_duration, 25)
 
         self.assertEqual(process.returncode, 0)
         self.assertEqual(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
none

#### Why is this change necessary?
Occasional tests would fail with just over 20s for out max duration when timeout is set on Windows. This change adjusts that time period from 20s to 25

#### How does it address the issue?
Updates the timeout in the test assert

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
