### PR TITLE
fix: supporting nested apis for v1 method, integration, and integration response resources.

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resource_linking.py
@@ -1205,9 +1205,16 @@ def _link_gateway_resource_to_gateway_resource_call_back(
         return
 
     logical_id = referenced_gateway_resource_values[0]
-    gateway_resource_cfn_resource["Properties"]["ResourceId"] = (
-        {"Ref": logical_id.value} if isinstance(logical_id, LogicalIdReference) else logical_id.value
-    )
+    if isinstance(logical_id, LogicalIdReference):
+        if logical_id.resource_type == TF_AWS_API_GATEWAY_REST_API:
+            gateway_resource_cfn_resource["Properties"]["ResourceId"] = {
+                "Fn::GetAtt": [logical_id.value, "RootResourceId"]
+            }
+        else:
+            gateway_resource_cfn_resource["Properties"]["ResourceId"] = {"Ref": logical_id.value}
+
+    else:
+        gateway_resource_cfn_resource["Properties"]["ResourceId"] = logical_id.value
 
 
 def _link_gateway_resource_to_parent_resource_call_back(
@@ -1330,7 +1337,7 @@ def _link_gateway_stage_to_rest_api(
 def _link_gateway_method_to_gateway_resource(
     gateway_method_config_resources: Dict[str, TFResource],
     gateway_method_config_address_cfn_resources_map: Dict[str, List],
-    gateway_resources_terraform_resources: Dict[str, Dict],
+    gateway_resources_or_rest_apis_terraform_resources: Dict[str, Dict],
 ):
     """
     Iterate through all the resources and link the corresponding
@@ -1342,8 +1349,8 @@ def _link_gateway_method_to_gateway_resource(
         Dictionary of configuration Gateway Methods
     gateway_method_config_address_cfn_resources_map: Dict[str, List]
         Dictionary containing resolved configuration addresses matched up to the cfn Gateway Stage
-    gateway_resources_terraform_resources: Dict[str, Dict]
-        Dictionary of all actual terraform Rest API resources (not configuration resources).
+    gateway_resources_or_rest_apis_terraform_resources: Dict[str, Dict]
+        Dictionary of all actual terraform Rest API or gateway resource resources (not configuration resources).
         The dictionary's key is the calculated logical id for each resource.
     """
     exceptions = ResourcePairExceptions(
@@ -1353,11 +1360,15 @@ def _link_gateway_method_to_gateway_resource(
     resource_linking_pair = ResourceLinkingPair(
         source_resource_cfn_resource=gateway_method_config_address_cfn_resources_map,
         source_resource_tf_config=gateway_method_config_resources,
-        destination_resource_tf=gateway_resources_terraform_resources,
+        destination_resource_tf=gateway_resources_or_rest_apis_terraform_resources,
         expected_destinations=[
             ResourcePairExceptedDestination(
                 terraform_resource_type_prefix=API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
                 terraform_attribute_name="id",
+            ),
+            ResourcePairExceptedDestination(
+                terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+                terraform_attribute_name="root_resource_id",
             ),
         ],
         terraform_link_field_name="resource_id",
@@ -1412,7 +1423,7 @@ def _link_gateway_integrations_to_gateway_rest_apis(
 def _link_gateway_integrations_to_gateway_resource(
     gateway_integrations_config_resources: Dict[str, TFResource],
     gateway_integrations_config_address_cfn_resources_map: Dict[str, List],
-    gateway_resources_terraform_resources: Dict[str, Dict],
+    gateway_resources_or_rest_apis_terraform_resources: Dict[str, Dict],
 ):
     """
     Iterate through all the resources and link the corresponding
@@ -1424,9 +1435,9 @@ def _link_gateway_integrations_to_gateway_resource(
         Dictionary of configuration Gateway Integrations
     gateway_integrations_config_address_cfn_resources_map: Dict[str, List]
         Dictionary containing resolved configuration addresses matched up to the cfn Gateway Integration
-    gateway_resources_terraform_resources: Dict[str, Dict]
-        Dictionary of all actual terraform Rest API resources (not configuration resources). The dictionary's key is the
-        calculated logical id for each resource.
+    gateway_resources_or_rest_apis_terraform_resources: Dict[str, Dict]
+        Dictionary of all actual terraform Rest API or gateway resource resources (not configuration resources). The
+        dictionary's key is the calculated logical id for each resource.
     """
 
     exceptions = ResourcePairExceptions(
@@ -1436,11 +1447,15 @@ def _link_gateway_integrations_to_gateway_resource(
     resource_linking_pair = ResourceLinkingPair(
         source_resource_cfn_resource=gateway_integrations_config_address_cfn_resources_map,
         source_resource_tf_config=gateway_integrations_config_resources,
-        destination_resource_tf=gateway_resources_terraform_resources,
+        destination_resource_tf=gateway_resources_or_rest_apis_terraform_resources,
         expected_destinations=[
             ResourcePairExceptedDestination(
                 terraform_resource_type_prefix=API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
                 terraform_attribute_name="id",
+            ),
+            ResourcePairExceptedDestination(
+                terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+                terraform_attribute_name="root_resource_id",
             ),
         ],
         terraform_link_field_name="resource_id",
@@ -1579,10 +1594,11 @@ def _link_gateway_integration_responses_to_gateway_rest_apis(
 def _link_gateway_integration_responses_to_gateway_resource(
     gateway_integration_responses_config_resources: Dict[str, TFResource],
     gateway_integration_responses_config_address_cfn_resources_map: Dict[str, List],
-    gateway_resources_terraform_resources: Dict[str, Dict],
+    gateway_resources_or_rest_apis_terraform_resources: Dict[str, Dict],
 ):
     """
-    Iterate through all the resources and link the corresponding Gateway Resource resource to each Gateway Integration
+    Iterate through all the resour
+    ces and link the corresponding Gateway Resource resource to each Gateway Integration
     Response resource.
     Parameters
     ----------
@@ -1591,9 +1607,9 @@ def _link_gateway_integration_responses_to_gateway_resource(
     gateway_integration_responses_config_address_cfn_resources_map: Dict[str, List]
         Dictionary containing resolved configuration addresses matched up to the internal mapped cfn Gateway
         Integration Response.
-    gateway_resources_terraform_resources: Dict[str, Dict]
-        Dictionary of all actual terraform Rest API resources (not configuration resources). The dictionary's key is the
-        calculated logical id for each resource.
+    gateway_resources_or_rest_apis_terraform_resources: Dict[str, Dict]
+        Dictionary of all actual terraform Rest API or gateway resource resources (not configuration resources). The
+        dictionary's key is the calculated logical id for each resource.
     """
 
     exceptions = ResourcePairExceptions(
@@ -1603,11 +1619,15 @@ def _link_gateway_integration_responses_to_gateway_resource(
     resource_linking_pair = ResourceLinkingPair(
         source_resource_cfn_resource=gateway_integration_responses_config_address_cfn_resources_map,
         source_resource_tf_config=gateway_integration_responses_config_resources,
-        destination_resource_tf=gateway_resources_terraform_resources,
+        destination_resource_tf=gateway_resources_or_rest_apis_terraform_resources,
         expected_destinations=[
             ResourcePairExceptedDestination(
                 terraform_resource_type_prefix=API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
                 terraform_attribute_name="id",
+            ),
+            ResourcePairExceptedDestination(
+                terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+                terraform_attribute_name="root_resource_id",
             ),
         ],
         terraform_link_field_name="resource_id",

--- a/samcli/hook_packages/terraform/hooks/prepare/resources/resource_links.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/resources/resource_links.py
@@ -50,19 +50,9 @@ RESOURCE_LINKS: List[LinkingPairCaller] = [
         source=TF_AWS_API_GATEWAY_STAGE, dest=TF_AWS_API_GATEWAY_REST_API, linking_func=_link_gateway_stage_to_rest_api
     ),
     LinkingPairCaller(
-        source=TF_AWS_API_GATEWAY_METHOD,
-        dest=TF_AWS_API_GATEWAY_RESOURCE,
-        linking_func=_link_gateway_method_to_gateway_resource,
-    ),
-    LinkingPairCaller(
         source=TF_AWS_API_GATEWAY_INTEGRATION,
         dest=TF_AWS_API_GATEWAY_REST_API,
         linking_func=_link_gateway_integrations_to_gateway_rest_apis,
-    ),
-    LinkingPairCaller(
-        source=TF_AWS_API_GATEWAY_INTEGRATION,
-        dest=TF_AWS_API_GATEWAY_RESOURCE,
-        linking_func=_link_gateway_integrations_to_gateway_resource,
     ),
     LinkingPairCaller(
         source=TF_AWS_API_GATEWAY_INTEGRATION,
@@ -73,11 +63,6 @@ RESOURCE_LINKS: List[LinkingPairCaller] = [
         source=TF_AWS_API_GATEWAY_INTEGRATION_RESPONSE,
         dest=TF_AWS_API_GATEWAY_REST_API,
         linking_func=_link_gateway_integration_responses_to_gateway_rest_apis,
-    ),
-    LinkingPairCaller(
-        source=TF_AWS_API_GATEWAY_INTEGRATION_RESPONSE,
-        dest=TF_AWS_API_GATEWAY_RESOURCE,
-        linking_func=_link_gateway_integration_responses_to_gateway_resource,
     ),
     LinkingPairCaller(
         source=TF_AWS_API_GATEWAY_AUTHORIZER,
@@ -101,5 +86,20 @@ MULTIPLE_DESTINATIONS_RESOURCE_LINKS: List[LinkingMultipleDestinationsOptionsCal
         source=TF_AWS_API_GATEWAY_RESOURCE,
         destinations=[TF_AWS_API_GATEWAY_REST_API, TF_AWS_API_GATEWAY_RESOURCE],
         linking_func=_link_gateway_resources_to_parents,
+    ),
+    LinkingMultipleDestinationsOptionsCaller(
+        source=TF_AWS_API_GATEWAY_METHOD,
+        destinations=[TF_AWS_API_GATEWAY_REST_API, TF_AWS_API_GATEWAY_RESOURCE],
+        linking_func=_link_gateway_method_to_gateway_resource,
+    ),
+    LinkingMultipleDestinationsOptionsCaller(
+        source=TF_AWS_API_GATEWAY_INTEGRATION,
+        destinations=[TF_AWS_API_GATEWAY_REST_API, TF_AWS_API_GATEWAY_RESOURCE],
+        linking_func=_link_gateway_integrations_to_gateway_resource,
+    ),
+    LinkingMultipleDestinationsOptionsCaller(
+        source=TF_AWS_API_GATEWAY_INTEGRATION_RESPONSE,
+        destinations=[TF_AWS_API_GATEWAY_REST_API, TF_AWS_API_GATEWAY_RESOURCE],
+        linking_func=_link_gateway_integration_responses_to_gateway_resource,
     ),
 ]

--- a/tests/integration/local/start_api/test_start_api_with_terraform_application.py
+++ b/tests/integration/local/start_api/test_start_api_with_terraform_application.py
@@ -98,7 +98,7 @@ class TerraformStartApiIntegrationApplyBase(TerraformStartApiIntegrationBase):
     [
         {
             "terraform_application": "terraform-v1-nested-apis",
-            "testing_urls": ["parent/hello", "parent"],
+            "testing_urls": ["", "parent/hello", "parent"],
         },
         {
             "terraform_application": "terraform-v1-api-simple",
@@ -185,7 +185,7 @@ class TestStartApiTerraformApplicationLimitations(TerraformStartApiIntegrationBa
     [
         {
             "terraform_application": "terraform-v1-nested-apis",
-            "testing_urls": ["parent/hello", "parent"],
+            "testing_urls": ["", "parent/hello", "parent"],
         },
         {
             "terraform_application": "terraform-v1-api-simple",

--- a/tests/integration/testdata/start_api/terraform/terraform-v1-nested-apis/main.tf
+++ b/tests/integration/testdata/start_api/terraform/terraform-v1-nested-apis/main.tf
@@ -124,6 +124,13 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
   depends_on = [aws_api_gateway_method.GetMethod]
 }
 
+resource "aws_api_gateway_method_response" "MyDemoIntegration_response_200" {
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.ChildResource.id
+  http_method = aws_api_gateway_method.GetMethod.http_method
+  status_code = "200"
+}
+
 resource "aws_api_gateway_method" "ParentResource_GetMethod" {
   rest_api_id    = aws_api_gateway_rest_api.MyDemoAPI.id
   resource_id    = aws_api_gateway_resource.ParentResource.id
@@ -140,4 +147,36 @@ resource "aws_api_gateway_integration" "ParentResource_GetMethod_Integration" {
   content_handling = "CONVERT_TO_TEXT"
   uri              = aws_lambda_function.HelloWorldFunction.invoke_arn
   depends_on = [aws_api_gateway_method.ParentResource_GetMethod]
+}
+
+resource "aws_api_gateway_method_response" "ParentResource_GetMethod_Integration_response_200" {
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_resource.ParentResource.id
+  http_method = aws_api_gateway_method.ParentResource_GetMethod.http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_method" "API_GetMethod" {
+  rest_api_id    = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id    = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
+  http_method    = "GET"
+  authorization  = "NONE"
+}
+
+resource "aws_api_gateway_integration" "API_GetMethod_Integration" {
+  rest_api_id      = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id      = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
+  http_method      = aws_api_gateway_method.ParentResource_GetMethod.http_method
+  integration_http_method = "POST"
+  type             = "AWS_PROXY"
+  content_handling = "CONVERT_TO_TEXT"
+  uri              = aws_lambda_function.HelloWorldFunction.invoke_arn
+  depends_on = [aws_api_gateway_method.ParentResource_GetMethod]
+}
+
+resource "aws_api_gateway_method_response" "API_GetMethod_Integration_response_200" {
+  rest_api_id = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id = aws_api_gateway_rest_api.MyDemoAPI.root_resource_id
+  http_method = aws_api_gateway_method.ParentResource_GetMethod.http_method
+  status_code = "200"
 }

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_resource_linking.py
@@ -1877,6 +1877,10 @@ class TestResourceLinker(TestCase):
                     terraform_resource_type_prefix=API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
                     terraform_attribute_name="id",
                 ),
+                ResourcePairExceptedDestination(
+                    terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+                    terraform_attribute_name="root_resource_id",
+                ),
             ],
             terraform_link_field_name="resource_id",
             cfn_link_field_name="ResourceId",
@@ -1956,6 +1960,10 @@ class TestResourceLinker(TestCase):
                 ResourcePairExceptedDestination(
                     terraform_resource_type_prefix=API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
                     terraform_attribute_name="id",
+                ),
+                ResourcePairExceptedDestination(
+                    terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+                    terraform_attribute_name="root_resource_id",
                 ),
             ],
             terraform_link_field_name="resource_id",
@@ -2072,6 +2080,14 @@ class TestResourceLinker(TestCase):
                 [LogicalIdReference(value="Resource1", resource_type=TF_AWS_API_GATEWAY_RESOURCE)],
                 {"Ref": "Resource1"},
             ),
+            (
+                {
+                    "Type": "AWS::ApiGateway::Method",
+                    "Properties": {"HttpMethod": "post"},
+                },
+                [LogicalIdReference(value="api1", resource_type=TF_AWS_API_GATEWAY_REST_API)],
+                {"Fn::GetAtt": ["api1", "RootResourceId"]},
+            ),
         ]
     )
     def test_link_gateway_method_to_gateway_resource_call_back(
@@ -2108,9 +2124,17 @@ class TestResourceLinker(TestCase):
                 [LogicalIdReference(value="RestApi", resource_type=TF_AWS_API_GATEWAY_REST_API)],
                 {"Fn::GetAtt": ["RestApi", "RootResourceId"]},
             ),
+            (
+                {
+                    "Type": "AWS::ApiGateway::Resource",
+                    "Properties": {},
+                },
+                [LogicalIdReference(value="resource1", resource_type=TF_AWS_API_GATEWAY_RESOURCE)],
+                {"Ref": "resource1"},
+            ),
         ]
     )
-    def test_link_gateway_resource_to_gateway_rest_api_parent_id_call_back(
+    def test_link_gateway_resource_to_parent_resource_call_back(
         self, input_gateway_resource, logical_ids, expected_rest_api
     ):
         gateway_resource = deepcopy(input_gateway_resource)
@@ -2279,6 +2303,10 @@ class TestResourceLinker(TestCase):
                 ResourcePairExceptedDestination(
                     terraform_resource_type_prefix=API_GATEWAY_RESOURCE_RESOURCE_ADDRESS_PREFIX,
                     terraform_attribute_name="id",
+                ),
+                ResourcePairExceptedDestination(
+                    terraform_resource_type_prefix=API_GATEWAY_REST_API_RESOURCE_ADDRESS_PREFIX,
+                    terraform_attribute_name="root_resource_id",
                 ),
             ],
             terraform_link_field_name="resource_id",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
follow up on PR https://github.com/aws/aws-sam-cli/pull/5697 to fix issue https://github.com/aws/aws-sam-cli/issues/5639


#### Why is this change necessary?
Customers are not able to run SAM CLI commands on Terraform projects that contains nested V1 APIs definition

#### How does it address the issue?
It allowed the following resources to be linked to multiple destinations (Rest API, and Gateway Resource):
 -  aws_api_gateway_method
 -  aws_api_gateway_integration
 - aws_api_gateway_method_response

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [X] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
