### PR TITLE
Pass Function_name to aws_lambda_builder

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -789,6 +789,7 @@ class ApplicationBuilder:
         if language == "rust" and "Binary" in build_props:
             options = options if options else {}
             options["artifact_executable_name"] = build_props["Binary"]
+        options = options if options else {}
         options["function_name"] = function_name
         return options
 

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -789,6 +789,7 @@ class ApplicationBuilder:
         if language == "rust" and "Binary" in build_props:
             options = options if options else {}
             options["artifact_executable_name"] = build_props["Binary"]
+        options["function_name"] = function_name
         return options
 
     @staticmethod


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#5369 


#### Why is this change necessary?
Not necessary, but a QOL change for developers running -parallel builds so they can understand logs easier

#### How does it address the issue?
Adds the function_name at the start of each log for lambda_builder so developer can differentiate between each log.

#### What side effects does this change have?
No side effects on it's own

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
