### PR TITLE
fix: wrongful IMAGE function options validation (aws#2934)

### DIFF
--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -523,18 +523,15 @@ class TestSamConfigForAllCommands(TestCase):
             )
 
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
     @patch("samcli.commands._utils.options.get_template_artifacts_format")
     @patch("samcli.commands.package.command.do_cli")
     def test_package(
         self,
         do_cli_mock,
         get_template_artifacts_format_mock,
-        cli_validation_artifacts_format_mock,
         is_all_image_funcs_provided_mock,
     ):
         is_all_image_funcs_provided_mock.return_value = True
-        cli_validation_artifacts_format_mock.return_value = [ZIP]
         get_template_artifacts_format_mock.return_value = [ZIP]
         config_values = {
             "template_file": "mytemplate.yaml",
@@ -611,14 +608,12 @@ class TestSamConfigForAllCommands(TestCase):
 
             self.assertIsNotNone(result.exception)
 
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
     @patch("samcli.commands._utils.template.get_template_artifacts_format")
     @patch("samcli.commands._utils.options.get_template_artifacts_format")
     @patch("samcli.commands.deploy.command.do_cli")
-    def test_deploy(self, do_cli_mock, template_artifacts_mock1, template_artifacts_mock2, template_artifacts_mock3):
+    def test_deploy(self, do_cli_mock, template_artifacts_mock1, template_artifacts_mock2):
         template_artifacts_mock1.return_value = [ZIP]
         template_artifacts_mock2.return_value = [ZIP]
-        template_artifacts_mock3.return_value = [ZIP]
         config_values = {
             "template_file": "mytemplate.yaml",
             "stack_name": "mystack",
@@ -722,16 +717,14 @@ class TestSamConfigForAllCommands(TestCase):
             result = runner.invoke(cli, [])
             self.assertIsNotNone(result.exception)
 
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
     @patch("samcli.commands._utils.options.get_template_artifacts_format")
     @patch("samcli.commands._utils.template.get_template_artifacts_format")
     @patch("samcli.commands.deploy.command.do_cli")
     def test_deploy_different_parameter_override_format(
-        self, do_cli_mock, template_artifacts_mock1, template_artifacts_mock2, template_artifacts_mock3
+        self, do_cli_mock, template_artifacts_mock1, template_artifacts_mock2
     ):
         template_artifacts_mock1.return_value = [ZIP]
         template_artifacts_mock2.return_value = [ZIP]
-        template_artifacts_mock3.return_value = [ZIP]
 
         config_values = {
             "template_file": "mytemplate.yaml",
@@ -928,7 +921,6 @@ class TestSamConfigForAllCommands(TestCase):
 
     @patch("samcli.commands._utils.experimental.is_experimental_enabled")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
     @patch("samcli.commands._utils.template.get_template_artifacts_format")
     @patch("samcli.commands._utils.options.get_template_artifacts_format")
     @patch("samcli.commands.sync.command.do_cli")
@@ -937,13 +929,11 @@ class TestSamConfigForAllCommands(TestCase):
         do_cli_mock,
         template_artifacts_mock1,
         template_artifacts_mock2,
-        template_artifacts_mock3,
         is_all_image_funcs_provided_mock,
         experimental_mock,
     ):
         template_artifacts_mock1.return_value = [ZIP]
         template_artifacts_mock2.return_value = [ZIP]
-        template_artifacts_mock3.return_value = [ZIP]
         is_all_image_funcs_provided_mock.return_value = True
         experimental_mock.return_value = True
 

--- a/tests/unit/lib/cli_validation/test_image_repository_validation.py
+++ b/tests/unit/lib/cli_validation/test_image_repository_validation.py
@@ -33,11 +33,10 @@ class TestImageRepositoryValidation(TestCase):
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
-    def test_image_repository_validation_success_ZIP(
-        self, mock_artifacts, is_all_image_funcs_provided_mock, mock_click
+    def test_image_repository_validation_success_no_image_repository_required(
+        self, is_all_image_funcs_provided_mock, mock_click
     ):
-        mock_artifacts.return_value = [ZIP]
+
         is_all_image_funcs_provided_mock.return_value = True
         mock_context = MagicMock()
         mock_context.params.get.side_effect = [False, False, False, False, False, None, MagicMock()]
@@ -47,12 +46,11 @@ class TestImageRepositoryValidation(TestCase):
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
     def test_image_repository_validation_success_IMAGE_image_repository(
-        self, mock_artifacts, is_all_image_funcs_provided_mock, mock_click
+        self, is_all_image_funcs_provided_mock, mock_click
     ):
-        mock_artifacts.return_value = [IMAGE]
-        is_all_image_funcs_provided_mock.return_value = True
+
+        is_all_image_funcs_provided_mock.return_value = False
         mock_context = MagicMock()
         mock_context.params.get.side_effect = [
             False,
@@ -69,11 +67,10 @@ class TestImageRepositoryValidation(TestCase):
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
     def test_image_repository_validation_success_IMAGE_image_repositories(
-        self, mock_artifacts, is_all_image_funcs_provided_mock, mock_click
+        self, is_all_image_funcs_provided_mock, mock_click
     ):
-        mock_artifacts.return_value = [IMAGE]
+
         is_all_image_funcs_provided_mock.return_value = True
         mock_context = MagicMock()
         mock_context.params.get.side_effect = [
@@ -90,12 +87,11 @@ class TestImageRepositoryValidation(TestCase):
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
     def test_image_repository_validation_failure_IMAGE_image_repositories_and_image_repository(
-        self, mock_artifacts, is_all_image_funcs_provided_mock, mock_click
+        self, is_all_image_funcs_provided_mock, mock_click
     ):
         mock_click.BadOptionUsage = click.BadOptionUsage
-        mock_artifacts.return_value = [IMAGE]
+
         is_all_image_funcs_provided_mock.return_value = True
         mock_context = MagicMock()
         mock_context.params.get.side_effect = [
@@ -124,12 +120,11 @@ class TestImageRepositoryValidation(TestCase):
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
     def test_image_repository_validation_failure_IMAGE_image_repositories_incomplete(
-        self, mock_artifacts, is_all_image_funcs_provided_mock, mock_click
+        self, is_all_image_funcs_provided_mock, mock_click
     ):
         mock_click.BadOptionUsage = click.BadOptionUsage
-        mock_artifacts.return_value = [IMAGE]
+
         is_all_image_funcs_provided_mock.return_value = False
         mock_context = MagicMock()
         mock_context.params.get.side_effect = [
@@ -149,12 +144,11 @@ class TestImageRepositoryValidation(TestCase):
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
-    def test_image_repository_validation_failure_IMAGE_missing_image_repositories(
-        self, mock_artifacts, is_all_image_funcs_provided_mock, mock_click
+    def test_image_repository_validation_failure_IMAGE_no_image_repository_with_no_all_image_func_provided(
+        self, is_all_image_funcs_provided_mock, mock_click
     ):
         mock_click.BadOptionUsage = click.BadOptionUsage
-        mock_artifacts.return_value = [IMAGE]
+
         is_all_image_funcs_provided_mock.return_value = False
         mock_context = MagicMock()
         mock_context.params.get.side_effect = [False, False, False, None, False, None, MagicMock()]
@@ -175,13 +169,37 @@ class TestImageRepositoryValidation(TestCase):
 
     @patch("samcli.lib.cli_validation.image_repository_validation.click")
     @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
-    @patch("samcli.lib.cli_validation.image_repository_validation.get_template_artifacts_format")
+    def test_image_repository_validation_failure_IMAGE_missing_image_repositories(
+        self, is_all_image_funcs_provided_mock, mock_click
+    ):
+        mock_click.BadOptionUsage = click.BadOptionUsage
+
+        is_all_image_funcs_provided_mock.return_value = False
+        mock_context = MagicMock()
+        mock_context.params.get.side_effect = [False, False, False, None, False, None, MagicMock()]
+        mock_click.get_current_context.return_value = mock_context
+
+        with self.assertRaises(click.BadOptionUsage) as ex:
+            self.foobar()
+        if self.support_resolve_image_repos:
+            self.assertIn(
+                "Missing option '--image-repositories', '--image-repository', '--resolve-image-repos'",
+                ex.exception.message,
+            )
+        else:
+            self.assertIn(
+                "Missing option '--image-repositories', '--image-repository'",
+                ex.exception.message,
+            )
+
+    @patch("samcli.lib.cli_validation.image_repository_validation.click")
+    @patch("samcli.lib.cli_validation.image_repository_validation._is_all_image_funcs_provided")
     def test_image_repository_validation_success_missing_image_repositories_guided(
-        self, mock_artifacts, is_all_image_funcs_provided_mock, mock_click
+        self, is_all_image_funcs_provided_mock, mock_click
     ):
         # Guided allows for filling of the image repository values.
         mock_click.BadOptionUsage = click.BadOptionUsage
-        mock_artifacts.return_value = [IMAGE]
+
         is_all_image_funcs_provided_mock.return_value = False
         mock_context = MagicMock()
         mock_context.params.get.side_effect = [True, True, False, None, False, None, MagicMock()]


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

Issue #2934

#### Why is this change necessary?

- `sam deploy` fails with error `Error: Missing option '--image-repositories', '--image-repository', '--resolve-image-repos'`, even when only valid ECRs `IMAGE` Lambdas are configured;
- Finally resolves issues from #2934 , introduced in PR #2935;

#### How does it address the issue?

- Reuses the newly introduced `_is_all_image_funcs_provided` function, which validates that any buildable IMAGE Lambda has a valid ECR location provided; instead of only checking for any IMAGE lambdas in the template.
- Error prompt should only show if: no `--image-repositories` option is set and no ` '--image-repository'` or no `'--resolve-image-repos'` is set if the `_is_all_image_funcs_provided` function returns a falsy result
  
#### What side effects does this change have?

- Extensive refactoring to `samconfig` and `cli_validation` unit tests;
- Change in CLI options validation for many commands including `package`, `deploy`, `sync` (Both `ZIP` and `Image` lambdas);

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
