### PR TITLE
fix(test): Don't execute change set instead of waiting for prompt

### DIFF
--- a/tests/integration/delete/test_delete_command.py
+++ b/tests/integration/delete/test_delete_command.py
@@ -479,17 +479,12 @@ class TestDelete(DeleteIntegBase):
             s3_bucket=self.bucket_name,
             s3_prefix=self.s3_prefix,
             force_upload=True,
-            no_execute_changeset=False,
-            confirm_changeset=True,
+            no_execute_changeset=True,
             region=self._session.region_name,
         )
 
-        # run deploy command and wait for it to ask about change set
-        deploy_process = start_persistent_process(deploy_command)
-        read_until_string(deploy_process, "Deploy this changeset? [y/N]:")
-
-        # kill the deploy process so that the stack is stuck in REVIEW_IN_PROGRESS
-        kill_process(deploy_process)
+        # run deploy command but don't execute changeset to force it in REVIEW_IN_PROGRESS
+        run_command(deploy_command)
 
         delete_command = self.get_delete_command_list(
             stack_name=stack_name, region=self._session.region_name, no_prompts=True


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None

#### Why is this change necessary?
The integration test was stuck on Linux machines due to the process waiting for a prompt that never appears when running the `deploy` commands as a persistent command.

#### How does it address the issue?
Uses the existing `--no-execute-changeset` flag to create a change set and exit, instead of waiting for the prompt and killing the process.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
