### PR TITLE
chore: Remove Python versions from Appveyor Ubuntu runs

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -19,6 +19,8 @@ configuration:
   - OtherTesting
 
 environment:
+  PYTHON_HOME: "$HOME/venv3.8/bin"
+  PYTHON_VERSION: '3.8'
   AWS_DEFAULT_REGION: us-east-1
   SAM_CLI_DEV: 1
   NODE_VERSION: "14.17.6"
@@ -29,17 +31,6 @@ environment:
   NOSE_PARAMETERIZED_NO_WARN: 1
   APPVEYOR_CONSOLE_DISABLE_PTY: false
   APPVEYOR_DETAILED_SHELL_LOGGING: true
-
-  matrix:
-
-    - PYTHON_HOME: "$HOME/venv3.7/bin"
-      PYTHON_VERSION: '3.7'
-
-    - PYTHON_HOME: "$HOME/venv3.8/bin"
-      PYTHON_VERSION: '3.8'
-
-    - PYTHON_HOME: "$HOME/venv3.11/bin"
-      PYTHON_VERSION: '3.11'
 
 install:
   # AppVeyor's apt-get cache might be outdated, and the package could potentially be 404.


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
To free up AppVeyor workers, we need to remove some of the versions we run. Now that we have the binary canaries, we can just test the minimally supported Python version to validate pip-based installations.

#### How does it address the issue?
Update the Ubuntu AppVeyor configuration to remove the matrixed Python versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
