### PR TITLE
fix: read terraform hook parameters from samconfig file

### DIFF
--- a/samcli/commands/_utils/custom_options/hook_name_option.py
+++ b/samcli/commands/_utils/custom_options/hook_name_option.py
@@ -61,7 +61,7 @@ class HookNameOption(click.Option):
             return super().handle_parse_result(ctx, opts, args)
 
         try:
-            self._call_prepare_hook(iac_hook_wrapper, opts)
+            self._call_prepare_hook(iac_hook_wrapper, opts, ctx)
         except Exception as ex:
             # capture exceptions from prepare hook to emit in track_command
             c = Context.get_current_context()
@@ -69,7 +69,7 @@ class HookNameOption(click.Option):
 
         return super().handle_parse_result(ctx, opts, args)
 
-    def _call_prepare_hook(self, iac_hook_wrapper, opts):
+    def _call_prepare_hook(self, iac_hook_wrapper, opts, ctx):
         # call prepare hook
         built_template_path = DEFAULT_BUILT_TEMPLATE_PATH
         if not self._force_prepare and os.path.exists(built_template_path):
@@ -82,14 +82,12 @@ class HookNameOption(click.Option):
             if not os.path.exists(output_dir_path):
                 os.makedirs(output_dir_path, exist_ok=True)
 
-            debug = opts.get("debug", False)
-            aws_profile = opts.get("profile")
-            aws_region = opts.get("region")
-            skip_prepare_infra = opts.get("skip_prepare_infra", False)
-            plan_file = opts.get("terraform_plan_file")
-            project_root_dir = opts.get(
-                "terraform_project_root_path",
-            )
+            debug = _read_parameter_value("debug", opts, ctx, False)
+            aws_profile = _read_parameter_value("profile", opts, ctx)
+            aws_region = _read_parameter_value("region", opts, ctx)
+            skip_prepare_infra = _read_parameter_value("skip_prepare_infra", opts, ctx, False)
+            plan_file = _read_parameter_value("terraform_plan_file", opts, ctx)
+            project_root_dir = _read_parameter_value("terraform_project_root_path", opts, ctx)
 
             metadata_file = iac_hook_wrapper.prepare(
                 output_dir_path,
@@ -210,3 +208,10 @@ def _get_iac_support_experimental_prompt_message(hook_name: str, command: str) -
         )
     }
     return supported_iacs_messages.get(hook_name, "")
+
+
+def _read_parameter_value(param_name, opts, ctx, default_value=None):
+    """
+    Read SAM CLI parameter value either from the parameters list or from the samconfig values
+    """
+    return opts.get(param_name, ctx.default_map.get(param_name, default_value))

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -731,7 +731,7 @@ def skip_prepare_infra_click_option():
     Click option to skip the hook preparation stage
     """
     return click.option(
-        "--skip-prepare-infra",
+        "--skip-prepare-infra/--prepare-infra",
         is_flag=True,
         required=False,
         callback=skip_prepare_infra_callback,

--- a/tests/integration/buildcmd/test_build_terraform_applications_other_cases.py
+++ b/tests/integration/buildcmd/test_build_terraform_applications_other_cases.py
@@ -479,7 +479,9 @@ class TestBuildTerraformApplicationsSourceCodeAndModulesAreNotInRootModuleDirect
     (not RUN_BY_CANARY and not CI_OVERRIDE),
     "Skip Terraform test cases unless running in CI",
 )
-class TestBuildTerraformApplicationsSourceCodeAndModulesAreNotInRootModuleDirectoryGetParametersFromSamConfig(BuildTerraformApplicationIntegBase):
+class TestBuildTerraformApplicationsSourceCodeAndModulesAreNotInRootModuleDirectoryGetParametersFromSamConfig(
+    BuildTerraformApplicationIntegBase
+):
     terraform_application = Path("terraform/application_outside_root_directory")
 
     functions = [

--- a/tests/integration/buildcmd/test_build_terraform_applications_other_cases.py
+++ b/tests/integration/buildcmd/test_build_terraform_applications_other_cases.py
@@ -412,6 +412,13 @@ class TestBuildGoFunctionAndKeepPermissions(BuildTerraformApplicationIntegBase):
     (not RUN_BY_CANARY and not CI_OVERRIDE),
     "Skip Terraform test cases unless running in CI",
 )
+@parameterized_class(
+    ("build_in_container",),
+    [
+        (False,),
+        (True,),
+    ],
+)
 class TestBuildTerraformApplicationsSourceCodeAndModulesAreNotInRootModuleDirectory(BuildTerraformApplicationIntegBase):
     terraform_application = Path("terraform/application_outside_root_directory")
 
@@ -438,6 +445,62 @@ class TestBuildTerraformApplicationsSourceCodeAndModulesAreNotInRootModuleDirect
             "hook_name": "terraform",
             "function_identifier": function_identifier,
             "project_root_dir": "./..",
+        }
+        if self.build_in_container:
+            command_list_parameters["use_container"] = True
+            command_list_parameters["build_image"] = self.docker_tag
+        build_cmd_list = self.get_command_list(**command_list_parameters)
+        LOG.info("command list: %s", build_cmd_list)
+        stdout, stderr, return_code = self.run_command(build_cmd_list)
+        terraform_beta_feature_prompted_text = (
+            f"Supporting Terraform applications is a beta feature.{os.linesep}"
+            f"Please confirm if you would like to proceed using AWS SAM CLI with terraform application.{os.linesep}"
+            "You can also enable this beta feature with 'sam build --beta-features'."
+        )
+        experimental_warning = (
+            f"{os.linesep}Experimental features are enabled for this session.{os.linesep}"
+            f"Visit the docs page to learn more about the AWS Beta terms "
+            f"https://aws.amazon.com/service-terms/.{os.linesep}"
+        )
+        self.assertNotRegex(stdout.decode("utf-8"), terraform_beta_feature_prompted_text)
+        self.assertIn(Colored().yellow(experimental_warning), stderr.decode("utf-8"))
+        LOG.info("sam build stdout: %s", stdout.decode("utf-8"))
+        LOG.info("sam build stderr: %s", stderr.decode("utf-8"))
+        self.assertEqual(return_code, 0)
+
+        self._verify_invoke_built_function(
+            function_logical_id=function_identifier,
+            overrides=None,
+            expected_result={"statusCode": 200, "body": expected_output},
+        )
+
+
+@skipIf(
+    (not RUN_BY_CANARY and not CI_OVERRIDE),
+    "Skip Terraform test cases unless running in CI",
+)
+class TestBuildTerraformApplicationsSourceCodeAndModulesAreNotInRootModuleDirectoryGetParametersFromSamConfig(BuildTerraformApplicationIntegBase):
+    terraform_application = Path("terraform/application_outside_root_directory")
+
+    functions = [
+        ("aws_lambda_function.function1", "hello world 1"),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.project_dir = self.working_dir
+        self.working_dir = f"{self.working_dir}/root_module"
+
+    def tearDown(self):
+        if self.project_dir:
+            self.working_dir = self.project_dir
+        super().tearDown()
+
+    @parameterized.expand(functions)
+    def test_build_and_invoke_lambda_functions(self, function_identifier, expected_output):
+        command_list_parameters = {
+            "config_file": "input_samconfig.yaml",
+            "function_identifier": function_identifier,
         }
         build_cmd_list = self.get_command_list(**command_list_parameters)
         LOG.info("command list: %s", build_cmd_list)

--- a/tests/integration/buildcmd/test_build_terraform_applications_other_cases.py
+++ b/tests/integration/buildcmd/test_build_terraform_applications_other_cases.py
@@ -412,13 +412,6 @@ class TestBuildGoFunctionAndKeepPermissions(BuildTerraformApplicationIntegBase):
     (not RUN_BY_CANARY and not CI_OVERRIDE),
     "Skip Terraform test cases unless running in CI",
 )
-@parameterized_class(
-    ("build_in_container",),
-    [
-        (False,),
-        (True,),
-    ],
-)
 class TestBuildTerraformApplicationsSourceCodeAndModulesAreNotInRootModuleDirectory(BuildTerraformApplicationIntegBase):
     terraform_application = Path("terraform/application_outside_root_directory")
 

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory/root_module/input_samconfig.yaml
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory/root_module/input_samconfig.yaml
@@ -1,0 +1,9 @@
+version: 0.1
+default:
+  global:
+    parameters:
+      beta_features: true
+      hook_name: terraform
+  build:
+    parameters:
+      terraform_project_root_path: ./..

--- a/tests/unit/commands/_utils/custom_options/test_hook_package_id_option.py
+++ b/tests/unit/commands/_utils/custom_options/test_hook_package_id_option.py
@@ -86,6 +86,7 @@ class TestHookPackageIdOption(TestCase):
             invalid_coexist_options=self.invalid_coexist_options,
         )
         ctx = MagicMock()
+        ctx.default_map = {}
         opts = {
             "hook_name": self.terraform,
         }
@@ -121,12 +122,15 @@ class TestHookPackageIdOption(TestCase):
             invalid_coexist_options=self.invalid_coexist_options,
         )
         ctx = MagicMock()
+        ctx.default_map = {}
         opts = {
             "hook_name": self.terraform,
             "debug": True,
             "profile": "test",
             "region": "us-east-1",
             "terraform_project_root_path": "/path/path",
+            "skip_prepare_infra": True,
+            "terraform_plan_file": "/path/plan/file",
         }
         args = []
         hook_name_option.handle_parse_result(ctx, opts, args)
@@ -136,8 +140,50 @@ class TestHookPackageIdOption(TestCase):
             True,
             "test",
             "us-east-1",
-            False,
-            None,
+            True,
+            "/path/plan/file",
+            "/path/path",
+        )
+        self.assertEqual(opts.get("template_file"), self.metadata_path)
+
+    @patch("samcli.commands._utils.custom_options.hook_name_option.update_experimental_context")
+    @patch("samcli.commands._utils.custom_options.hook_name_option.prompt_experimental")
+    @patch("samcli.commands._utils.custom_options.hook_name_option.os.getcwd")
+    @patch("samcli.commands._utils.custom_options.hook_name_option.IacHookWrapper")
+    def test_valid_hook_package_with_other_options_from_sam_config(
+        self, iac_hook_wrapper_mock, getcwd_mock, prompt_experimental_mock, update_experimental_context_mock
+    ):
+        iac_hook_wrapper_mock.return_value = self.iac_hook_wrapper_instance_mock
+        prompt_experimental_mock.return_value = True
+
+        getcwd_mock.return_value = self.cwd_path
+
+        hook_name_option = HookNameOption(
+            param_decls=(self.name, self.opt),
+            force_prepare=True,
+            invalid_coexist_options=self.invalid_coexist_options,
+        )
+        ctx = MagicMock()
+        ctx.default_map = {
+            "hook_name": self.terraform,
+            "debug": True,
+            "profile": "test",
+            "region": "us-east-1",
+            "terraform_project_root_path": "/path/path",
+            "skip_prepare_infra": True,
+            "terraform_plan_file": "/path/plan/file",
+        }
+        opts = {}
+        args = []
+        hook_name_option.handle_parse_result(ctx, opts, args)
+        self.iac_hook_wrapper_instance_mock.prepare.assert_called_once_with(
+            os.path.join(self.cwd_path, ".aws-sam-iacs", "iacs_metadata"),
+            self.cwd_path,
+            True,
+            "test",
+            "us-east-1",
+            True,
+            "/path/plan/file",
             "/path/path",
         )
         self.assertEqual(opts.get("template_file"), self.metadata_path)
@@ -272,6 +318,7 @@ class TestHookPackageIdOption(TestCase):
             invalid_coexist_options=self.invalid_coexist_options,
         )
         ctx = MagicMock()
+        ctx.default_map = {}
         opts = {
             "hook_name": self.terraform,
             "beta_features": True,
@@ -420,6 +467,7 @@ class TestHookPackageIdOption(TestCase):
             invalid_coexist_options=self.invalid_coexist_options,
         )
         ctx = MagicMock()
+        ctx.default_map = {}
         opts = {
             "hook_name": self.terraform,
         }
@@ -463,6 +511,7 @@ class TestHookPackageIdOption(TestCase):
             invalid_coexist_options=self.invalid_coexist_options,
         )
         ctx = MagicMock()
+        ctx.default_map = {}
         ctx.command.name = "build"
         opts = {
             "hook_name": self.terraform,
@@ -586,6 +635,7 @@ class TestHookPackageIdOption(TestCase):
             invalid_coexist_options=self.invalid_coexist_options,
         )
         ctx = MagicMock()
+        ctx.default_map = {}
         ctx.command.name = "build"
         opts = {
             "hook_name": self.terraform,
@@ -634,6 +684,7 @@ class TestHookPackageIdOption(TestCase):
             invalid_coexist_options=self.invalid_coexist_options,
         )
         ctx = MagicMock()
+        ctx.default_map = {}
         ctx.command.name = "build"
         opts = {
             "hook_name": self.terraform,
@@ -679,6 +730,7 @@ class TestHookPackageIdOption(TestCase):
             invalid_coexist_options=self.invalid_coexist_options,
         )
         ctx = MagicMock()
+        ctx.default_map = {}
         ctx.command.name = "build"
         opts = {
             "hook_name": self.terraform,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
During testing I found that we ignore reading Terraform hooks parameters like (`--terraform-project-root-path` or `--terraform-plan-file`) from the sam config file.

I fixed this part to get the hook parameters from both command options, and if not in this list, we try to get it from the config file.

I also added the option `--prepare-infra` so customers can set in the default behaviour in config file to skip the infrastructure preparation, and if needed they can overwrite that behaviour by using the new option `--prepare-infra`

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [X] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
