### PR TITLE
feat: Prompt users to use TFC workaround

### DIFF
--- a/samcli/lib/hook/exceptions.py
+++ b/samcli/lib/hook/exceptions.py
@@ -20,3 +20,7 @@ class InvalidHookPackageConfigException(UserException):
 
 class PrepareHookException(UserException):
     pass
+
+
+class TerraformCloudException(UserException):
+    pass

--- a/tests/unit/lib/utils/test_subprocess_utils.py
+++ b/tests/unit/lib/utils/test_subprocess_utils.py
@@ -1,4 +1,4 @@
-from subprocess import DEVNULL
+from subprocess import DEVNULL, PIPE
 
 import logging
 from io import StringIO
@@ -9,7 +9,7 @@ import sys
 from unittest import TestCase
 
 from parameterized import parameterized
-from unittest.mock import patch, Mock, call, ANY
+from unittest.mock import patch, Mock, call
 
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.lib.utils.subprocess_utils import (
@@ -17,23 +17,20 @@ from samcli.lib.utils.subprocess_utils import (
     invoke_subprocess_with_loading_pattern,
     LoadingPatternError,
     _check_and_process_bytes,
-    _check_and_convert_stream_to_string,
 )
 
 
 class TestSubprocessUtils(TestCase):
-    @patch("samcli.lib.utils.subprocess_utils._check_and_convert_stream_to_string")
     @patch("samcli.lib.utils.subprocess_utils._check_and_process_bytes")
     @patch("samcli.lib.utils.subprocess_utils.LOG")
     @patch("samcli.lib.utils.subprocess_utils.Popen")
-    def test_loader_stream_logs_when_debug_level(
-        self, patched_Popen, patched_log, patched_check_and_process_byes, patched_check_and_convert_stream_to_string
-    ):
+    def test_loader_stream_logs_when_debug_level(self, patched_Popen, patched_log, patched_check_and_process_byes):
         expected_output = f"Line 1{os.linesep}Line 2"
         patched_log.getEffectiveLevel.return_value = logging.DEBUG
         mock_process = Mock()
         mock_process.wait.return_value = 0
         mock_process.stdout = StringIO(expected_output)
+        mock_process.stderr = []
         patched_Popen.return_value.__enter__.return_value = mock_process
         mock_pattern = Mock()
         mock_stream_writer = Mock()
@@ -41,26 +38,23 @@ class TestSubprocessUtils(TestCase):
         actual_output = invoke_subprocess_with_loading_pattern({"args": ["ls"]}, mock_pattern, mock_stream_writer)
         patched_check_and_process_byes.assert_has_calls([call(f"Line 1{os.linesep}"), call("Line 2")])
         mock_pattern.assert_not_called()
-        self.assertEqual(patched_check_and_convert_stream_to_string.call_count, 1)
         self.assertEqual(actual_output, expected_output)
 
-    @patch("samcli.lib.utils.subprocess_utils._check_and_convert_stream_to_string")
     @patch("samcli.lib.utils.subprocess_utils._check_and_process_bytes")
     @patch("samcli.lib.utils.subprocess_utils.LOG")
     @patch("samcli.lib.utils.subprocess_utils.Popen")
-    def test_loader_stream_uses_passed_in_stdout(
-        self, patched_Popen, patched_log, patched_check_and_process_byes, patched_check_and_convert_stream_to_string
-    ):
+    def test_loader_stream_uses_passed_in_stdout(self, patched_Popen, patched_log, patched_check_and_process_byes):
         expected_output = f"Line 1{os.linesep}Line 2"
         mock_pattern = Mock()
         mock_stream_writer = Mock()
         mock_process = Mock()
         mock_process.stdout = StringIO(expected_output)
         mock_process.wait.return_value = 0
+        mock_process.stderr = []
         patched_Popen.return_value.__enter__.return_value = mock_process
         patched_log.getEffectiveLevel.return_value = logging.INFO
         invoke_subprocess_with_loading_pattern({"args": ["ls"], "stdout": DEVNULL}, mock_pattern, mock_stream_writer)
-        patched_Popen.assert_called_once_with(args=["ls"], stdout=DEVNULL)
+        patched_Popen.assert_called_once_with(args=["ls"], stdout=DEVNULL, stderr=PIPE)
 
     @patch("samcli.lib.utils.subprocess_utils.Popen")
     def test_loader_raises_exception_non_zero_exit_code(self, patched_Popen):
@@ -69,7 +63,7 @@ class TestSubprocessUtils(TestCase):
         mock_process = Mock()
         mock_process.returncode = 1
         mock_process.stdout = None
-        mock_process.stderr.read.return_value = standard_error
+        mock_process.stderr = [standard_error]
         mock_pattern = Mock()
         patched_Popen.return_value.__enter__.return_value = mock_process
         with self.assertRaises(LoadingPatternError) as ex:
@@ -117,20 +111,8 @@ class TestSubprocessUtils(TestCase):
         self.assertIsInstance(output, str)
         self.assertEqual(output, expected_output)
 
-    @patch("samcli.lib.utils.subprocess_utils._check_and_process_bytes")
-    def test_check_and_convert_stream_to_string(self, patched_check_and_process_bytes):
-        sample_input_output = "hello"
-        sample_stream = StringIO(sample_input_output)
-        patched_check_and_process_bytes.return_value = sample_input_output
-        output = _check_and_convert_stream_to_string(sample_stream)
-        patched_check_and_process_bytes.assert_called_once_with(sample_input_output)
-        self.assertEqual(output, sample_input_output)
-
-    @patch("samcli.lib.utils.subprocess_utils._check_and_process_bytes")
-    def test_check_and_convert_stream_to_string_none_stream(self, patched_check_and_process_bytes):
-        sample_input_output = ""
-        sample_stream = None
-        patched_check_and_process_bytes.return_value = sample_input_output
-        output = _check_and_convert_stream_to_string(sample_stream)
-        patched_check_and_process_bytes.assert_not_called()
-        self.assertEqual(output, sample_input_output)
+    @parameterized.expand([("hello   ".encode("utf-8"), "hello   "), ("hello", "hello")])
+    def test_check_and_process_bytes_preserve_whitespace(self, sample_input, expected_output):
+        output = _check_and_process_bytes(sample_input, preserve_whitespace=True)
+        self.assertIsInstance(output, str)
+        self.assertEqual(output, expected_output)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Prompt users to use the Terraform Cloud workaround when they encounter the TFC error.

#### How does it address the issue?
1. Fixes the loading dot subprocess loader to store and return data from stderr
2. Reads the stderr data, checking for the TFC error message and returns an appropriate help message if found.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
