### PR TITLE
Moving appveyor integration test terraform installation to only the C…

### DIFF
--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -85,14 +85,6 @@ install:
   # get testing env vars
   - sh: "sudo apt install -y jq"
 
-  # install Terraform
-  - sh: "sudo apt update --allow-releaseinfo-change"
-  - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
-  - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
-  - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
-  - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
-  - sh: "terraform -version"
-
   # install Rust
   - sh: "curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL https://sh.rustup.rs | sh -s -- --default-toolchain none -y > /dev/null 2>&1"
   - sh: "source $HOME/.cargo/env"
@@ -194,6 +186,14 @@ for:
         - configuration: LocalZipTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Local ZIP  Terraform Build In Container  integ testing
@@ -203,6 +203,14 @@ for:
         - configuration: LocalZipTerraformBuildInContainerIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build integ testing
@@ -221,6 +229,14 @@ for:
         - configuration: S3ZipTerraformBuildInContainerIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Other Terraform Build In Container integ testing
@@ -230,6 +246,14 @@ for:
         - configuration: OtherTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Integ testing deploy

--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -220,6 +220,14 @@ for:
         - configuration: S3ZipTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build In Container integ testing

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -77,14 +77,6 @@ install:
   # get testing env vars
   - sh: "sudo apt install -y jq"
 
-  # install Terraform
-  - sh: "sudo apt update --allow-releaseinfo-change"
-  - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
-  - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
-  - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
-  - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
-  - sh: "terraform -version"
-
   # install Rust
   - sh: "curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL https://sh.rustup.rs | sh -s -- --default-toolchain none -y > /dev/null 2>&1"
   - sh: "source $HOME/.cargo/env"
@@ -182,6 +174,14 @@ for:
         - configuration: LocalZipTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Local ZIP  Terraform Build In Container  integ testing
@@ -191,6 +191,14 @@ for:
         - configuration: LocalZipTerraformBuildInContainerIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build integ testing
@@ -200,6 +208,14 @@ for:
         - configuration: S3ZipTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build In Container integ testing
@@ -209,6 +225,14 @@ for:
         - configuration: S3ZipTerraformBuildInContainerIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Other Terraform Build In Container integ testing
@@ -218,6 +242,14 @@ for:
         - configuration: OtherTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Integ testing deploy

--- a/appveyor-windows-binary.yml
+++ b/appveyor-windows-binary.yml
@@ -77,10 +77,6 @@ install:
   - "docker info"
   - "docker version"
 
-  # install Terraform CLI
-  - "choco install terraform"
-  - "terraform -version"
-
   # Upgrade setuptools, wheel and virtualenv
   - "python -m pip install --upgrade setuptools wheel virtualenv"
   # Install pip for the python versions which is used by the tests
@@ -213,6 +209,10 @@ for:
         - configuration: LocalZipTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Local ZIP  Terraform Build In Container  integ testing
@@ -221,6 +221,10 @@ for:
         - configuration: LocalZipTerraformBuildInContainerIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build integ testing
@@ -229,6 +233,10 @@ for:
         - configuration: S3ZipTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build In Container integ testing
@@ -237,6 +245,10 @@ for:
         - configuration: S3ZipTerraformBuildInContainerIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Other Terraform Build integ testing
@@ -245,6 +257,10 @@ for:
         - configuration: OtherTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   #Integ testing deploy

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -76,10 +76,6 @@ install:
   - "docker info"
   - "docker version"
 
-  # install Terraform CLI
-  - "choco install terraform"
-  - "terraform -version"
-
   # Upgrade setuptools, wheel and virtualenv
   - "python -m pip install --upgrade setuptools wheel virtualenv"
   # Install pip for the python versions which is used by the tests
@@ -204,6 +200,10 @@ for:
         - configuration: LocalZipTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Local ZIP  Terraform Build In Container  integ testing
@@ -212,6 +212,10 @@ for:
         - configuration: LocalZipTerraformBuildInContainerIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndLocalBackend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build integ testing
@@ -220,6 +224,10 @@ for:
         - configuration: S3ZipTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_0 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # S3 ZIP  Terraform Build In Container integ testing
@@ -228,6 +236,10 @@ for:
         - configuration: S3ZipTerraformBuildInContainerIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv tests/integration/buildcmd/test_build_terraform_applications.py::TestBuildTerraformApplicationsWithZipBasedLambdaFunctionAndS3Backend_1 --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   # Other Terraform Build integ testing
@@ -236,6 +248,10 @@ for:
         - configuration: OtherTerraformBuildIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
   #Integ testing deploy


### PR DESCRIPTION
…onfigurations that need it

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Terraform is installed all integration test configs regardless it is needed. This can hide potential issue that some SAM CLI commands might not need Terraform at all but accidentally invokes it.

#### How does it address the issue?
Move the installation of Terraform into the Configurations whereas it's strictly needed.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
