### PR TITLE
fix: fix processing lambda container response if nothing returned

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -331,7 +331,7 @@ class Container:
             data=event.encode("utf-8"),
             timeout=(self.RAPID_CONNECTION_TIMEOUT, None),
         )
-        return json.dumps(json.loads(resp.content), ensure_ascii=False)
+        return json.dumps(json.loads(resp.content), ensure_ascii=False) if resp.content else ""
 
     def wait_for_result(self, full_path, event, stdout, stderr, start_timer=None):
         # NOTE(sriram-mv): Let logging happen in its own thread, so that a http request can be sent.

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -47,6 +47,21 @@ class TestSamPython37HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(process.returncode, 0)
 
+    @pytest.mark.flaky(reruns=3)
+    def test_invoke_no_response_returncode_is_zero(self):
+        command_list = InvokeIntegBase.get_command_list(
+            "NoResponseServerlessFunction", template_path=self.template_path, event_path=self.event_path
+        )
+
+        process = Popen(command_list, stdout=PIPE)
+        try:
+            process.communicate(timeout=TIMEOUT)
+        except TimeoutExpired:
+            process.kill()
+            raise
+
+        self.assertEqual(process.returncode, 0)
+
     # https://github.com/aws/aws-sam-cli/issues/2494
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_utf8_event(self):

--- a/tests/integration/testdata/invoke/main.py
+++ b/tests/integration/testdata/invoke/main.py
@@ -56,3 +56,7 @@ def execute_git(event, context):
     assert return_code == 0
 
     return "git init passed"
+
+
+def no_response(event, context):
+    print("lambda called")

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -35,6 +35,14 @@ Resources:
       CodeUri: .
       Timeout: 600
 
+  NoResponseServerlessFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.no_response
+      Runtime: python3.9
+      CodeUri: .
+      Timeout: 600
+
   HelloWorldLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#5766


#### Why is this change necessary?
to allow customer test lambda functions that does not return any response.

#### How does it address the issue?
skip parsing the container response as JSON object if there is no response.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
