### PR TITLE
fix: Local lambda authorizer ARN matching

### DIFF
--- a/samcli/local/apigw/authorizers/lambda_authorizer.py
+++ b/samcli/local/apigw/authorizers/lambda_authorizer.py
@@ -355,7 +355,7 @@ class LambdaAuthorizer(Authorizer):
 
     def _is_resource_authorized(self, response: dict, method_arn: str) -> bool:
         """
-        Validate the if the current method ARN is actually authorized
+        Validate if the current method ARN is actually authorized
 
         Parameters
         ----------
@@ -387,7 +387,7 @@ class LambdaAuthorizer(Authorizer):
 
             for resource_arn in resource_list:
                 # form a regular expression from the possible wildcard resource ARN
-                regex_method_arn = resource_arn.replace("*", ".+").replace("?", ".")
+                regex_method_arn = resource_arn.replace("*", ".*").replace("?", ".")
                 regex_method_arn += "$"
 
                 if re.match(regex_method_arn, method_arn):

--- a/tests/integration/local/start_api/lambda_authorizers/test_swagger_authorizer_definitions.py
+++ b/tests/integration/local/start_api/lambda_authorizers/test_swagger_authorizer_definitions.py
@@ -10,6 +10,7 @@ from parameterized import parameterized_class
 @parameterized_class(
     ("template_path", "endpoint", "parameter_overrides"),
     [
+        ("/testdata/start_api/lambda_authorizers/swagger-api.yaml", "", {}),
         ("/testdata/start_api/lambda_authorizers/swagger-api.yaml", "requestauthorizerswaggertoken", {}),
         (
             "/testdata/start_api/lambda_authorizers/swagger-api.yaml",

--- a/tests/integration/testdata/start_api/lambda_authorizers/swagger-api.yaml
+++ b/tests/integration/testdata/start_api/lambda_authorizers/swagger-api.yaml
@@ -46,6 +46,14 @@ Resources:
               identityValidationExpression: !Ref ValidationString
               authorizerUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizerFunction.Arn}/invocations
         paths:
+          "/":
+            get:
+              security:
+                - ApiKeyAuthRequest: []
+              x-amazon-apigateway-integration:
+                httpMethod: GET
+                type: aws_proxy
+                uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HelloWorldFunction.Arn}/invocations
           "/requestauthorizerswaggerrequest":
             get:
               security:

--- a/tests/unit/local/apigw/test_lambda_authorizer.py
+++ b/tests/unit/local/apigw/test_lambda_authorizer.py
@@ -417,10 +417,30 @@ class TestLambdaAuthorizer(TestCase):
                 },
                 True,
             ),
+            (  # Wildcard authorizes root url
+                {
+                    "principalId": "123",
+                    "policyDocument": {
+                        "Statement": [
+                            {
+                                "Action": ["execute-api:Invoke"],
+                                "Effect": "Allow",
+                                "Resource": "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/*/*",
+                            }
+                        ]
+                    },
+                },
+                True,
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/",
+            ),
         ]
     )
-    def test_validate_is_resource_authorized(self, response, expected_result):
-        method_arn = "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/hello"
+    def test_validate_is_resource_authorized(
+        self,
+        response,
+        expected_result,
+        method_arn="arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/hello",
+    ):
 
         auth = LambdaAuthorizer(
             "my auth",


### PR DESCRIPTION
Update the matching logic to permit a wildcard to match an empty string. This allows a wildcard resource statement to match the root URL, which mimics the real behaviour of API Gateway.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5777 

#### Why is this change necessary?
Details on the issue

#### How does it address the issue?


#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
