### PR TITLE
fix: adding terraform to local commands integration testing job

### DIFF
--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -307,6 +307,14 @@ for:
         - configuration: LocalIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
   # End-to-end testing

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -295,6 +295,14 @@ for:
         - configuration: LocalIntegTesting
 
     test_script:
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
       - sh: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
   # End-to-end testing

--- a/appveyor-windows-binary.yml
+++ b/appveyor-windows-binary.yml
@@ -301,6 +301,10 @@ for:
         - configuration: LocalIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
   # End-to-end testing

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -292,6 +292,10 @@ for:
         - configuration: LocalIntegTesting
 
     test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
       - ps: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
   # End-to-end testing


### PR DESCRIPTION
fix the failing Local commands integration test cases due that terraform is missed.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
