### PR TITLE
fix: Pass network mode to image build method

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -412,8 +412,12 @@ class ApplicationBuilder:
             "platform": get_docker_platform(architecture),
             "rm": True,
         }
+
         if docker_build_target:
             build_args["target"] = cast(str, docker_build_target)
+
+        if self._container_manager and self._container_manager.docker_network_id:
+            build_args["network_mode"] = cast(str, self._container_manager.docker_network_id)
 
         try:
             (build_image, build_logs) = self._docker_client.images.build(**build_args)

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -1703,6 +1703,36 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
         with self.assertRaises(DockerBuildFailed):
             self.builder._build_lambda_image("Name", {}, X86_64)
 
+    def test_docker_network_specified_build_lambda_image(self):
+        metadata = {
+            "Dockerfile": "Dockerfile",
+            "DockerContext": "context",
+            "DockerTag": "Tag",
+            "DockerBuildArgs": {"a": "b"},
+        }
+
+        network_name = "foo"
+
+        self.builder._container_manager = Mock()
+        self.builder._container_manager.docker_network_id = network_name
+
+        self.docker_client_mock.images.build.return_value = (Mock(), [])
+
+        self.builder._build_lambda_image("FunctionName", metadata, X86_64)
+
+        self.assertEqual(
+            self.docker_client_mock.images.build.call_args,
+            call(
+                path=ANY,
+                dockerfile="Dockerfile",
+                tag="functionname:Tag",
+                buildargs={"a": "b"},
+                platform="linux/amd64",
+                rm=True,
+                network_mode=network_name,
+            ),
+        )
+
 
 class TestApplicationBuilder_build_function(TestCase):
     def setUp(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#3609

#### Why is this change necessary?
Previously, `--network-mode` was only being passed to functions and layers that are Zip based when container builds were enabled. When an Image based function was being built, the network mode was not being passed down to the Docker API call.

#### How does it address the issue?
Checks if there is a container manager and if the Docker network was set. If it was, include it in the build arguments when building images. 

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
