### PR TITLE
fix: handle index error if the image info returned from docker client contains any empty list for `RepoDigests` attribute

### DIFF
--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -527,8 +527,8 @@ class LambdaImage:
             Image digest, including `sha256:` prefix
         """
         image_info = self.docker_client.images.get(image_name)
-        full_digest: str = image_info.attrs.get("RepoDigests", [None])[0]
         try:
+            full_digest: str = image_info.attrs.get("RepoDigests", [None])[0]
             return full_digest.split("@")[1]
         except (AttributeError, IndexError):
             return None


### PR DESCRIPTION
Some customers got the following exception, when they execute `sam local invoke` command
```
Error: list index out of range
Traceback:
  File "click/core.py", line 1055, in main
  File "click/core.py", line 1657, in invoke
  File "click/core.py", line 1657, in invoke
  File "click/core.py", line 1404, in invoke
  File "click/core.py", line 760, in invoke
  File "click/decorators.py", line 84, in new_func
  File "click/core.py", line 760, in invoke
  File "samcli/lib/telemetry/metric.py", line 184, in wrapped
  File "samcli/lib/telemetry/metric.py", line 149, in wrapped
  File "samcli/lib/utils/version_checker.py", line 42, in wrapped
  File "samcli/cli/main.py", line 95, in wrapper
  File "samcli/commands/local/invoke/cli.py", line 100, in cli
  File "samcli/commands/local/invoke/cli.py", line 206, in do_cli
  File "samcli/commands/local/lib/local_lambda.py", line 144, in invoke
  File "samcli/lib/telemetry/metric.py", line 324, in wrapped_func
  File "samcli/local/lambdafn/runtime.py", line 189, in invoke
  File "samcli/local/lambdafn/runtime.py", line 85, in create
  File "samcli/local/docker/lambda_container.py", line 94, in __init__
  File "samcli/local/docker/lambda_container.py", line 237, in _get_image
  File "samcli/local/docker/lambda_image.py", line 197, in build
  File "samcli/local/docker/lambda_image.py", line 471, in _check_base_image_is_current
  File "samcli/local/docker/lambda_image.py", line 495, in is_base_image_current
  File "samcli/local/docker/lambda_image.py", line 530, in get_local_image_digest

An unexpected error was encountered while executing "sam local invoke".
Search for an existing issue:
https://github.com/aws/aws-sam-cli/issues?q=is%3Aissue+is%3Aopen+Bug%3A%20sam%20local%20invoke%20-%20IndexError
Or create a bug report:
https://github.com/aws/aws-sam-cli/issues/new?template=Bug_report.md&title=Bug%3A%20sam%20local%20invoke%20-%20IndexError
```
It seems for some reason, the docker client returns an empty list while SAM CLI tries to get the `RepoDigests` attribute of the emulation local image, although this should not be a valid value, it should return a list contains one item which is contains the hash value of the emulation image's parent.

https://github.com/aws/aws-sam-cli/blob/da9f1b5a5e18ffe3bf5313560f355877e5ef052f/samcli/local/docker/lambda_image.py#L481-L534


This pr is to add a safe guard against this problem, and to prevent SAM CLI from crashing, and it will recreate the emulation image in case of this issue happen.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
