### PR TITLE
feat: Added environment variable validation for Terraform arguments

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -234,9 +234,14 @@ def _generate_plan_file(skip_prepare_infra: bool, terraform_application_dir: str
     return dict(json.loads(result.stdout))
 
 
-def _validate_environment_variables():
+def _validate_environment_variables() -> None:
     """
     Validate that the Terraform environment variables do not contain blocked arguments.
+
+    Raises
+    ------
+    UnallowedEnvironmentVariableArgumentException
+        Raised when a Terraform related environment variable contains a blocked value
     """
     for env_var in TF_ENVIRONMENT_VARIABLES:
         env_value = os.environ.get(env_var, "")

--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -12,7 +12,11 @@ from typing import Any, Dict
 
 from samcli.hook_packages.terraform.hooks.prepare.constants import CFN_CODE_PROPERTIES
 from samcli.hook_packages.terraform.hooks.prepare.translate import translate_to_cfn
-from samcli.lib.hook.exceptions import PrepareHookException, TerraformCloudException
+from samcli.lib.hook.exceptions import (
+    PrepareHookException,
+    TerraformCloudException,
+    UnallowedEnvironmentVariableArgumentException,
+)
 from samcli.lib.utils import osutils
 from samcli.lib.utils.subprocess_utils import LoadingPatternError, invoke_subprocess_with_loading_pattern
 
@@ -31,6 +35,17 @@ TF_CLOUD_HELP_MESSAGE = (
     "To use AWS SAM CLI with Terraform Cloud applications, provide "
     "a plan file using the --terraform-plan-file flag."
 )
+
+TF_BLOCKED_ARGUMENTS = [
+    "-target",
+    "-destroy",
+]
+TF_ENVIRONMENT_VARIABLE_DELIM = "="
+TF_ENVIRONMENT_VARIABLES = [
+    "TF_CLI_ARGS",
+    "TF_CLI_ARGS_plan",
+    "TF_CLI_ARGS_apply",
+]
 
 
 def prepare(params: dict) -> dict:
@@ -54,6 +69,8 @@ def prepare(params: dict) -> dict:
 
     if not output_dir_path:
         raise PrepareHookException("OutputDirPath was not supplied")
+
+    _validate_environment_variables()
 
     LOG.debug("Normalize the terraform application root module directory path %s", terraform_application_dir)
     if not os.path.isabs(terraform_application_dir):
@@ -215,3 +232,31 @@ def _generate_plan_file(skip_prepare_infra: bool, terraform_application_dir: str
         raise PrepareHookException(f"Error occurred when invoking a process:\n{e}") from e
 
     return dict(json.loads(result.stdout))
+
+
+def _validate_environment_variables():
+    """
+    Validate that the Terraform environment variables do not contain blocked arguments.
+    """
+    for env_var in TF_ENVIRONMENT_VARIABLES:
+        env_value = os.environ.get(env_var, "")
+
+        trimmed_arguments = []
+        # get all trimmed arguments in a list and split on delim
+        # eg.
+        # "-foo=bar -hello" => ["-foo", "-hello"]
+        for argument in env_value.split(" "):
+            cleaned_argument = argument.strip()
+            cleaned_argument = cleaned_argument.split(TF_ENVIRONMENT_VARIABLE_DELIM)[0]
+
+            trimmed_arguments.append(cleaned_argument)
+
+        if any([argument in TF_BLOCKED_ARGUMENTS for argument in trimmed_arguments]):
+            message = (
+                "Environment variable '%s' contains a blocked argument, please validate it does not contain: %s"
+                % (
+                    env_var,
+                    TF_BLOCKED_ARGUMENTS,
+                )
+            )
+            raise UnallowedEnvironmentVariableArgumentException(message)

--- a/samcli/lib/hook/exceptions.py
+++ b/samcli/lib/hook/exceptions.py
@@ -24,3 +24,7 @@ class PrepareHookException(UserException):
 
 class TerraformCloudException(UserException):
     pass
+
+
+class UnallowedEnvironmentVariableArgumentException(UserException):
+    pass

--- a/tests/integration/buildcmd/test_build_terraform_applications_other_cases.py
+++ b/tests/integration/buildcmd/test_build_terraform_applications_other_cases.py
@@ -548,3 +548,37 @@ class TestBuildTerraformApplicationsSourceCodeAndModulesAreNotInRootModuleDirect
             overrides=None,
             expected_result={"statusCode": 200, "body": expected_output},
         )
+
+
+@skipIf(
+    (not RUN_BY_CANARY and not CI_OVERRIDE),
+    "Skip Terraform test cases unless running in CI",
+)
+class TestBuildTerraformApplicationsWithBlockedEnvironVariables(BuildTerraformApplicationIntegBase):
+    terraform_application = Path("terraform/simple_application")
+
+    @parameterized.expand(
+        [
+            ("TF_CLI_ARGS", "-destroy"),
+            ("TF_CLI_ARGS", "-target=some.module"),
+            ("TF_CLI_ARGS_plan", "-destroy"),
+            ("TF_CLI_ARGS_plan", "-target=some.module"),
+            ("TF_CLI_ARGS_apply", "-destroy"),
+            ("TF_CLI_ARGS_apply", "-target=some.module"),
+        ]
+    )
+    def test_blocked_env_variables(self, env_name, env_value):
+        cmdlist = self.get_command_list(hook_name="terraform", beta_features=True)
+
+        env_variables = os.environ.copy()
+        env_variables[env_name] = env_value
+
+        _, stderr, return_code = self.run_command(cmdlist, env=env_variables)
+
+        process_stderr = stderr.strip()
+        self.assertRegex(
+            process_stderr.decode("utf-8"),
+            "Error: Environment variable '%s' contains a blocked argument, please validate it does not contain: ['-destroy', '-target']"
+            % env_name,
+        )
+        self.assertNotEqual(return_code, 0)

--- a/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
+++ b/tests/unit/hook_packages/terraform/hooks/prepare/test_hook.py
@@ -6,12 +6,18 @@ from parameterized import parameterized
 from tests.unit.hook_packages.terraform.hooks.prepare.prepare_base import PrepareHookUnitBase
 
 from samcli.hook_packages.terraform.hooks.prepare.hook import (
+    TF_ENVIRONMENT_VARIABLES,
+    _validate_environment_variables,
     prepare,
     _update_resources_paths,
     TF_CLOUD_EXCEPTION_MESSAGE,
     TF_CLOUD_HELP_MESSAGE,
 )
-from samcli.lib.hook.exceptions import PrepareHookException, TerraformCloudException
+from samcli.lib.hook.exceptions import (
+    PrepareHookException,
+    TerraformCloudException,
+    UnallowedEnvironmentVariableArgumentException,
+)
 from samcli.lib.utils.subprocess_utils import LoadingPatternError
 
 
@@ -492,3 +498,38 @@ class TestPrepareHook(PrepareHookUnitBase):
             prepare(self.prepare_params)
 
         self.assertEqual(ex.exception.message, TF_CLOUD_HELP_MESSAGE)
+
+    @parameterized.expand(
+        [
+            ("-destroy",),
+            ("-target=my.module.resource",),
+            ("-destroy -target=my.module.resource",),
+            ("-target=my.module.resource -destroy",),
+        ]
+    )
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook.os")
+    def test_environment_variable_check_fails(self, argument, get_mock):
+        get_mock.environ.get.return_value = argument
+
+        with self.assertRaises(UnallowedEnvironmentVariableArgumentException):
+            _validate_environment_variables()
+
+    @parameterized.expand(
+        [
+            ("-not-actually-argument",),
+            ("something",),
+            ("",),
+        ]
+    )
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook.os")
+    def test_environment_variable_check_passes(self, argument, get_mock):
+        get_mock.environ.get.return_value = argument
+
+        _validate_environment_variables()
+
+    @patch("samcli.hook_packages.terraform.hooks.prepare.hook._validate_environment_variables")
+    def test_prepare_method_fails_environment_variables(self, validate_mock):
+        validate_mock.side_effect = [UnallowedEnvironmentVariableArgumentException("message")]
+
+        with self.assertRaises(UnallowedEnvironmentVariableArgumentException):
+            prepare(self.prepare_params)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
Validates that the environment variables that are passed in when running commands do not override anything we define or set.

#### How does it address the issue?
Checks if the environment variables contain blocked arguments. If they do, exit and display a message letting the user know to omit them.

This check happens in both the Makefile script and the prepare hook logic.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
