### PR TITLE
Fix sam remote invoke to take profile properly

### DIFF
--- a/samcli/commands/remote/invoke/cli.py
+++ b/samcli/commands/remote/invoke/cli.py
@@ -117,6 +117,12 @@ def do_cli(
     """
     Implementation of the ``cli`` method
     """
+    from botocore.exceptions import (
+        NoCredentialsError,
+        NoRegionError,
+        ProfileNotFound,
+    )
+
     from samcli.commands.exceptions import UserException
     from samcli.commands.remote.remote_invoke_context import RemoteInvokeContext
     from samcli.lib.remote_invoke.exceptions import (
@@ -127,9 +133,9 @@ def do_cli(
     from samcli.lib.remote_invoke.remote_invoke_executors import RemoteInvokeExecutionInfo
     from samcli.lib.utils.boto_utils import get_boto_client_provider_with_config, get_boto_resource_provider_with_config
 
-    boto_client_provider = get_boto_client_provider_with_config(region_name=region, profile=profile)
-    boto_resource_provider = get_boto_resource_provider_with_config(region_name=region, profile=profile)
     try:
+        boto_client_provider = get_boto_client_provider_with_config(region_name=region, profile=profile)
+        boto_resource_provider = get_boto_resource_provider_with_config(region_name=region, profile=profile)
         with RemoteInvokeContext(
             boto_client_provider=boto_client_provider,
             boto_resource_provider=boto_resource_provider,
@@ -142,5 +148,12 @@ def do_cli(
             )
 
             remote_invoke_context.run(remote_invoke_input=remote_invoke_input)
-    except (ErrorBotoApiCallException, InvalideBotoResponseException, InvalidResourceBotoParameterException) as ex:
+    except (
+        ErrorBotoApiCallException,
+        InvalideBotoResponseException,
+        InvalidResourceBotoParameterException,
+        ProfileNotFound,
+        NoCredentialsError,
+        NoRegionError,
+    ) as ex:
         raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex

--- a/samcli/commands/remote/invoke/cli.py
+++ b/samcli/commands/remote/invoke/cli.py
@@ -127,8 +127,8 @@ def do_cli(
     from samcli.lib.remote_invoke.remote_invoke_executors import RemoteInvokeExecutionInfo
     from samcli.lib.utils.boto_utils import get_boto_client_provider_with_config, get_boto_resource_provider_with_config
 
-    boto_client_provider = get_boto_client_provider_with_config(region_name=region)
-    boto_resource_provider = get_boto_resource_provider_with_config(region_name=region)
+    boto_client_provider = get_boto_client_provider_with_config(region_name=region, profile=profile)
+    boto_resource_provider = get_boto_resource_provider_with_config(region_name=region, profile=profile)
     try:
         with RemoteInvokeContext(
             boto_client_provider=boto_client_provider,

--- a/tests/unit/commands/remote/invoke/test_cli.py
+++ b/tests/unit/commands/remote/invoke/test_cli.py
@@ -3,6 +3,11 @@ from unittest.mock import patch, Mock
 
 from parameterized import parameterized
 
+from botocore.exceptions import (
+    ProfileNotFound,
+    NoCredentialsError,
+    NoRegionError,
+)
 from samcli.commands.remote.invoke.cli import do_cli
 from samcli.lib.remote_invoke.remote_invoke_executors import RemoteInvokeOutputFormat
 from samcli.lib.remote_invoke.exceptions import (
@@ -85,8 +90,8 @@ class TestRemoteInvokeCliCommand(TestCase):
             config_env=self.config_env,
         )
 
-        patched_get_boto_client_provider_with_config.assert_called_with(region_name=self.region)
-        patched_get_boto_resource_provider_with_config.assert_called_with(region_name=self.region)
+        patched_get_boto_client_provider_with_config.assert_called_with(region_name=self.region, profile=self.profile)
+        patched_get_boto_resource_provider_with_config.assert_called_with(region_name=self.region, profile=self.profile)
 
         mock_remote_invoke_context.assert_called_with(
             boto_client_provider=given_client_provider,
@@ -106,6 +111,9 @@ class TestRemoteInvokeCliCommand(TestCase):
             (InvalideBotoResponseException,),
             (ErrorBotoApiCallException,),
             (InvalidResourceBotoParameterException,),
+            (ProfileNotFound,),
+            (NoCredentialsError,),
+            (NoRegionError,),
         ]
     )
     @patch("samcli.commands.remote.remote_invoke_context.RemoteInvokeContext")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5820 

#### Why is this change necessary?
`sam remote invoke` missed to honor to provided `--profile` option.

#### How does it address the issue?
pass in provided profile into relevant boto3 client/resource providers

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
