### PR TITLE
fix: fix CORS handling for REST API.

### DIFF
--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -8,7 +8,7 @@ import os
 import posixpath
 from collections import namedtuple
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, NamedTuple, Optional, Set, Union, cast
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Union, cast
 
 from samcli.commands.local.cli_common.user_exceptions import (
     InvalidFunctionPropertyType,
@@ -23,10 +23,7 @@ from samcli.lib.samlib.resource_metadata_normalizer import (
 )
 from samcli.lib.utils.architecture import X86_64
 from samcli.lib.utils.packagetype import IMAGE
-
-if TYPE_CHECKING:  # pragma: no cover
-    # avoid circular import, https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING
-    from samcli.local.apigw.route import Route
+from samcli.local.apigw.route import Route
 
 LOG = logging.getLogger(__name__)
 
@@ -481,7 +478,9 @@ _CorsTuple.__new__.__defaults__ = (
 
 class Cors(_CorsTuple):
     @staticmethod
-    def cors_to_headers(cors: Optional["Cors"], request_origin: Optional[str]) -> Dict[str, Union[int, str]]:
+    def cors_to_headers(
+        cors: Optional["Cors"], request_origin: Optional[str], event_type: str
+    ) -> Dict[str, Union[int, str]]:
         """
         Convert CORS object to headers dictionary
         Parameters
@@ -490,6 +489,8 @@ class Cors(_CorsTuple):
             CORS configuration objcet
         request_origin str
             Origin of the request, e.g. https://example.com:8080
+        event_type str
+            The type of the APIGateway resource that contain the route, either Api, or HttpApi
         Returns
         -------
             Dictionary with CORS headers
@@ -497,33 +498,44 @@ class Cors(_CorsTuple):
         if not cors:
             return {}
 
-        # Resource processing start here.
-        # The following code is based on the following spec:
-        # https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-processing-model
+        if event_type == Route.API:
+            # the CORS behaviour in Rest API gateway is to return whatever defined in the ResponseParameters of
+            # the method integration resource
+            headers = {
+                CORS_ORIGIN_HEADER: cors.allow_origin,
+                CORS_METHODS_HEADER: cors.allow_methods,
+                CORS_HEADERS_HEADER: cors.allow_headers,
+                CORS_CREDENTIALS_HEADER: cors.allow_credentials,
+                CORS_MAX_AGE_HEADER: cors.max_age,
+            }
+        else:
+            # Resource processing start here.
+            # The following code is based on the following spec:
+            # https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-processing-model
 
-        if not request_origin:
-            return {}
+            if not request_origin:
+                return {}
 
-        # cors.allow_origin can be either a single origin or comma separated list of origins
-        allowed_origins = cors.allow_origin.split(",") if cors.allow_origin else list()
-        allowed_origins = [origin.strip() for origin in allowed_origins]
+            # cors.allow_origin can be either a single origin or comma separated list of origins
+            allowed_origins = cors.allow_origin.split(",") if cors.allow_origin else list()
+            allowed_origins = [origin.strip() for origin in allowed_origins]
 
-        matched_origin = None
-        if "*" in allowed_origins:
-            matched_origin = "*"
-        elif request_origin in allowed_origins:
-            matched_origin = request_origin
+            matched_origin = None
+            if "*" in allowed_origins:
+                matched_origin = "*"
+            elif request_origin in allowed_origins:
+                matched_origin = request_origin
 
-        if matched_origin is None:
-            return {}
+            if matched_origin is None:
+                return {}
 
-        headers = {
-            CORS_ORIGIN_HEADER: matched_origin,
-            CORS_METHODS_HEADER: cors.allow_methods,
-            CORS_HEADERS_HEADER: cors.allow_headers,
-            CORS_CREDENTIALS_HEADER: cors.allow_credentials,
-            CORS_MAX_AGE_HEADER: cors.max_age,
-        }
+            headers = {
+                CORS_ORIGIN_HEADER: matched_origin,
+                CORS_METHODS_HEADER: cors.allow_methods,
+                CORS_HEADERS_HEADER: cors.allow_headers,
+                CORS_CREDENTIALS_HEADER: cors.allow_credentials,
+                CORS_MAX_AGE_HEADER: cors.max_age,
+            }
         # Filters out items in the headers dictionary that isn't empty.
         # This is required because the flask Headers dict will send an invalid 'None' string
         return {h_key: h_value for h_key, h_value in headers.items() if h_value is not None}

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -641,7 +641,7 @@ class LocalApigwService(BaseLocalService):
         route: Route = self._get_current_route(request)
 
         request_origin = request.headers.get("Origin")
-        cors_headers = Cors.cors_to_headers(self.api.cors, request_origin)
+        cors_headers = Cors.cors_to_headers(self.api.cors, request_origin, route.event_type)
 
         lambda_authorizer = route.authorizer_object
 

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -11,7 +11,6 @@ from werkzeug.datastructures import Headers
 from samcli.lib.providers.provider import Api
 from samcli.lib.providers.provider import Cors
 from samcli.lib.telemetry.event import EventName, EventTracker, UsedFeature
-from samcli.local.apigw.event_constructor import construct_v1_event, construct_v2_event_http
 from samcli.local.apigw.authorizers.lambda_authorizer import LambdaAuthorizer
 from samcli.local.apigw.route import Route
 from samcli.local.apigw.local_apigw_service import (
@@ -1844,11 +1843,12 @@ class TestServiceParsingV2PayloadFormatLambdaOutput(TestCase):
 
 
 class TestServiceCorsToHeaders(TestCase):
-    def test_basic_conversion(self):
+    @parameterized.expand([Route.HTTP, Route.API])
+    def test_basic_conversion_per_event_type(self, event_type):
         cors = Cors(
             allow_origin="*", allow_methods=",".join(["POST", "OPTIONS"]), allow_headers="UPGRADE-HEADER", max_age=6
         )
-        headers = Cors.cors_to_headers(cors, "https://abc")
+        headers = Cors.cors_to_headers(cors, "https://abc", event_type)
         self.assertEqual(
             headers,
             {
@@ -1861,7 +1861,7 @@ class TestServiceCorsToHeaders(TestCase):
 
     def test_empty_elements(self):
         cors = Cors(allow_origin="www.domain.com", allow_methods=",".join(["GET", "POST", "OPTIONS"]))
-        headers = Cors.cors_to_headers(cors, "www.domain.com")
+        headers = Cors.cors_to_headers(cors, "www.domain.com", Route.HTTP)
 
         self.assertEqual(
             headers,
@@ -1871,19 +1871,19 @@ class TestServiceCorsToHeaders(TestCase):
     def test_missing_request_origin(self):
         cors = Cors(allow_origin="www.domain.com", allow_methods=",".join(["GET", "POST", "OPTIONS"]))
 
-        self.assertEqual(Cors.cors_to_headers(cors, None), {})
-        self.assertEqual(Cors.cors_to_headers(cors, ""), {})
-        self.assertEqual(Cors.cors_to_headers(cors, list()), {})
+        self.assertEqual(Cors.cors_to_headers(cors, None, Route.HTTP), {})
+        self.assertEqual(Cors.cors_to_headers(cors, "", Route.HTTP), {})
+        self.assertEqual(Cors.cors_to_headers(cors, list(), Route.HTTP), {})
 
     def test_missing_config_origin(self):
         cors = Cors(allow_methods="GET")
-        self.assertEqual(Cors.cors_to_headers(cors, None), {})
-        self.assertEqual(Cors.cors_to_headers(cors, "http://abc"), {})
+        self.assertEqual(Cors.cors_to_headers(cors, None, Route.HTTP), {})
+        self.assertEqual(Cors.cors_to_headers(cors, "http://abc", Route.HTTP), {})
 
 
 class TestServiceCorsToHeadersMultiOrigin(TestCase):
     def assert_cors(self, cors):
-        headers_abc = Cors.cors_to_headers(cors, "https://abc")
+        headers_abc = Cors.cors_to_headers(cors, "https://abc", Route.HTTP)
         self.assertEqual(
             {
                 "Access-Control-Allow-Origin": "https://abc",
@@ -1892,7 +1892,7 @@ class TestServiceCorsToHeadersMultiOrigin(TestCase):
             headers_abc,
         )
 
-        headers_xyz = Cors.cors_to_headers(cors, "https://xyz")
+        headers_xyz = Cors.cors_to_headers(cors, "https://xyz", Route.HTTP)
         self.assertEqual(
             {
                 "Access-Control-Allow-Origin": "https://xyz",
@@ -1901,7 +1901,7 @@ class TestServiceCorsToHeadersMultiOrigin(TestCase):
             headers_xyz,
         )
 
-        headers_unknown = Cors.cors_to_headers(cors, "https://unknown")
+        headers_unknown = Cors.cors_to_headers(cors, "https://unknown", Route.HTTP)
         self.assertEqual({}, headers_unknown)
 
     def test_multiple_origins_conversion(self):
@@ -1911,6 +1911,44 @@ class TestServiceCorsToHeadersMultiOrigin(TestCase):
     def test_multiple_origins_whitespace(self):
         cors = Cors(allow_origin=" https://abc , https://xyz ", allow_methods=",".join(["POST", "OPTIONS"]))
         self.assert_cors(cors)
+
+
+class TestRestServiceCorsToHeadersMultiOrigin(TestCase):
+    def assert_cors(self, cors, origins):
+        headers_abc = Cors.cors_to_headers(cors, "https://abc", Route.API)
+        self.assertEqual(
+            {
+                "Access-Control-Allow-Origin": origins,
+                "Access-Control-Allow-Methods": "POST,OPTIONS",
+            },
+            headers_abc,
+        )
+
+        headers_xyz = Cors.cors_to_headers(cors, "https://xyz", Route.API)
+        self.assertEqual(
+            {
+                "Access-Control-Allow-Origin": origins,
+                "Access-Control-Allow-Methods": "POST,OPTIONS",
+            },
+            headers_xyz,
+        )
+
+        headers_unknown = Cors.cors_to_headers(cors, "https://unknown", Route.API)
+        self.assertEqual(
+            {
+                "Access-Control-Allow-Origin": origins,
+                "Access-Control-Allow-Methods": "POST,OPTIONS",
+            },
+            headers_unknown,
+        )
+
+    def test_multiple_origins_conversion(self):
+        cors = Cors(allow_origin=" https://abc ,https://xyz", allow_methods=",".join(["POST", "OPTIONS"]))
+        self.assert_cors(cors, " https://abc ,https://xyz")
+
+    def test_multiple_origins_whitespace(self):
+        cors = Cors(allow_origin=" https://abc , https://xyz ", allow_methods=",".join(["POST", "OPTIONS"]))
+        self.assert_cors(cors, " https://abc , https://xyz ")
 
 
 class TestRouteEqualsHash(TestCase):


### PR DESCRIPTION
This PR is to add some missing logic to this PR https://github.com/aws/aws-sam-cli/pull/5619 that was merged to fix this issue https://github.com/aws/aws-sam-cli/issues/4161

The previous PR fixed the CORS handling for the HTTP API gateway where the CORS headers changes based on the request origin header. But, for REST API resources, CORS Headers will always return as defined in the ResponseParameters configuration of the method integration resource.

In this PR, I update the `cors_to_headers` method to accept the `event_type` parameter, so we can determine if this route is defined in a Http Api, or Rest Api, then we can return the CORS Headers based as expected for each type.

I also updated the integration and unit test cases to test both resource types.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [X] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
