### PR TITLE
Chore: Use the latest stack event timestamp as a marker to get the new deployment events

### DIFF
--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -267,8 +267,11 @@ class DeployContext:
                     if not click.confirm(f"{self.MSG_CONFIRM_CHANGESET}", default=False):
                         return
 
+                marker_time = self.deployer.get_last_event_time(stack_name, 0)
                 self.deployer.execute_changeset(result["Id"], stack_name, disable_rollback)
-                self.deployer.wait_for_execute(stack_name, changeset_type, disable_rollback, self.on_failure)
+                self.deployer.wait_for_execute(
+                    stack_name, changeset_type, disable_rollback, self.on_failure, marker_time
+                )
                 click.echo(self.MSG_EXECUTE_SUCCESS.format(stack_name=stack_name, region=region))
 
             except deploy_exceptions.ChangeEmptyError as ex:

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -647,7 +647,6 @@ class Deployer:
                 kwargs["DisableRollback"] = disable_rollback  # type: ignore
                 # get the latest stack event, and use 0 in case if the stack does not exist
                 marker_time = self.get_last_event_time(stack_name, 0)
-                print(f">>>>>>> {marker_time}")
                 result = self.update_stack(**kwargs)
                 self.wait_for_execute(
                     stack_name, "UPDATE", disable_rollback, on_failure=on_failure, time_stamp_marker=marker_time

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -385,7 +385,7 @@ class Deployer:
         while stack_change_in_progress and retry_attempts <= self.max_attempts:
             try:
                 # Only sleep if there have been no retry_attempts
-                LOG.debug("Trail # %d to get the stack %s create events", retry_attempts, stack_name)
+                LOG.debug("Trial # %d to get the stack %s create events", retry_attempts, stack_name)
                 time.sleep(0 if retry_attempts else self.client_sleep)
                 paginator = self._client.get_paginator("describe_stack_events")
                 response_iterator = paginator.paginate(StackName=stack_name)

--- a/tests/unit/commands/deploy/test_deploy_context.py
+++ b/tests/unit/commands/deploy/test_deploy_context.py
@@ -257,6 +257,7 @@ class TestSamDeployCommand(TestCase):
     @patch.object(Deployer, "execute_changeset", MagicMock())
     @patch.object(Deployer, "wait_for_execute", MagicMock())
     @patch.object(Deployer, "create_and_wait_for_changeset", MagicMock(return_value=({"Id": "test"}, "CREATE")))
+    @patch.object(Deployer, "get_last_event_time", MagicMock(return_value=1000))
     def test_on_failure_do_nothing(self, mock_session, mock_client):
         with tempfile.NamedTemporaryFile(delete=False) as template_file:
             template_file.write(b"{}")
@@ -268,5 +269,5 @@ class TestSamDeployCommand(TestCase):
             self.deploy_command_context.run()
 
             self.deploy_command_context.deployer.wait_for_execute.assert_called_with(
-                ANY, "CREATE", False, FailureMode.DO_NOTHING
+                ANY, "CREATE", False, FailureMode.DO_NOTHING, 1000
             )

--- a/tests/unit/lib/deploy/test_deployer.py
+++ b/tests/unit/lib/deploy/test_deployer.py
@@ -420,10 +420,11 @@ class TestDeployer(CustomTestCase):
         self.assertEqual(self.deployer.get_last_event_time("test"), utc_to_timestamp(timestamp))
 
     def test_get_last_event_time_unknown_last_time(self):
-        current_timestamp = datetime.utcnow()
+        time_float = time.time()
+        current_timestamp = to_datetime(time_float * 1000)
         self.deployer._client.describe_stack_events = MagicMock(side_effect=KeyError)
         # Convert to milliseconds from seconds
-        last_stack_event_timestamp = to_datetime(self.deployer.get_last_event_time("test") * 1000)
+        last_stack_event_timestamp = to_datetime(self.deployer.get_last_event_time("test", time_float) * 1000)
         self.assertEqual(last_stack_event_timestamp.year, current_timestamp.year)
         self.assertEqual(last_stack_event_timestamp.month, current_timestamp.month)
         self.assertEqual(last_stack_event_timestamp.day, current_timestamp.day)
@@ -1384,7 +1385,7 @@ class TestDeployer(CustomTestCase):
 
         self.assertEqual(self.deployer._client.rollback_stack.call_count, 1)
         self.assertEqual(self.deployer._client.delete_stack.call_count, 1)
-        self.assertEqual(self.deployer._client.describe_stack_events.call_count, 0)
+        self.assertEqual(self.deployer._client.describe_stack_events.call_count, 2)
 
     def test_rollback_invalid_stack_name(self):
         self.deployer._client.describe_stacks = MagicMock(


### PR DESCRIPTION
add some logs to deploy command to investigate issue # https://github.com/aws/aws-sam-cli/issues/5109

The problem in that issue is the WSL environment clock is not in sync with the actual time, it was 3 minutes ahead, and so the loop we use to describe the deployment events never ends, as it is not able to find any new events.

I updated the wait_for_execute method that wait for a change set to be executed, to take a time_stamp_marker as an extra parameter to use it to determine the events to be printed. The value of this marker will be the latest stack event if the stack exists, or 0 in case if the stack does not exist. 

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
