### PR TITLE
fix: Don't run hook if help text option is provided

### DIFF
--- a/samcli/commands/_utils/custom_options/hook_name_option.py
+++ b/samcli/commands/_utils/custom_options/hook_name_option.py
@@ -35,13 +35,19 @@ class HookNameOption(click.Option):
 
     def __init__(self, *args, **kwargs):
         self.hook_name_option_name = "hook_name"
+        self.help_option_name = "help"
         self._force_prepare = kwargs.pop("force_prepare", True)
         self._invalid_coexist_options = kwargs.pop("invalid_coexist_options", [])
         super().__init__(*args, **kwargs)
 
     def handle_parse_result(self, ctx, opts, args):
         opt_name = self.hook_name_option_name.replace("_", "-")
-        if self.hook_name_option_name not in opts and self.hook_name_option_name not in ctx.default_map:
+        if (
+            self.hook_name_option_name not in opts
+            and self.hook_name_option_name not in ctx.default_map
+            or self.help_option_name in opts
+            or self.help_option_name in ctx.default_map
+        ):
             return super().handle_parse_result(ctx, opts, args)
         command_name = ctx.command.name
         if command_name in ["invoke", "start-lambda", "start-api"]:

--- a/tests/unit/commands/_utils/custom_options/test_hook_package_id_option.py
+++ b/tests/unit/commands/_utils/custom_options/test_hook_package_id_option.py
@@ -160,6 +160,38 @@ class TestHookPackageIdOption(TestCase):
         record_hook_telemetry_mock.assert_called_once()
 
     @patch("samcli.commands._utils.custom_options.hook_name_option.record_hook_telemetry")
+    @patch("samcli.commands._utils.custom_options.hook_name_option.prompt_experimental")
+    @patch("samcli.commands._utils.custom_options.hook_name_option.os.getcwd")
+    @patch("samcli.commands._utils.custom_options.hook_name_option.IacHookWrapper")
+    def test_skips_hook_package_with_help_option(
+            self,
+            iac_hook_wrapper_mock,
+            getcwd_mock,
+            prompt_experimental_mock,
+            record_hook_telemetry_mock,
+    ):
+        iac_hook_wrapper_mock.return_value = self.iac_hook_wrapper_instance_mock
+        prompt_experimental_mock.return_value = True
+
+        getcwd_mock.return_value = self.cwd_path
+
+        hook_name_option = HookNameOption(
+            param_decls=(self.name, self.opt),
+            force_prepare=True,
+            invalid_coexist_options=self.invalid_coexist_options,
+        )
+        ctx = MagicMock()
+        ctx.default_map = {}
+        opts = {
+            "hook_name": self.terraform,
+            "help": True,
+        }
+        args = []
+        hook_name_option.handle_parse_result(ctx, opts, args)
+        self.iac_hook_wrapper_instance_mock.prepare.assert_not_called()
+        record_hook_telemetry_mock.assert_not_called()
+
+    @patch("samcli.commands._utils.custom_options.hook_name_option.record_hook_telemetry")
     @patch("samcli.commands._utils.custom_options.hook_name_option.update_experimental_context")
     @patch("samcli.commands._utils.custom_options.hook_name_option.prompt_experimental")
     @patch("samcli.commands._utils.custom_options.hook_name_option.os.getcwd")

--- a/tests/unit/commands/_utils/custom_options/test_hook_package_id_option.py
+++ b/tests/unit/commands/_utils/custom_options/test_hook_package_id_option.py
@@ -164,11 +164,11 @@ class TestHookPackageIdOption(TestCase):
     @patch("samcli.commands._utils.custom_options.hook_name_option.os.getcwd")
     @patch("samcli.commands._utils.custom_options.hook_name_option.IacHookWrapper")
     def test_skips_hook_package_with_help_option(
-            self,
-            iac_hook_wrapper_mock,
-            getcwd_mock,
-            prompt_experimental_mock,
-            record_hook_telemetry_mock,
+        self,
+        iac_hook_wrapper_mock,
+        getcwd_mock,
+        prompt_experimental_mock,
+        record_hook_telemetry_mock,
     ):
         iac_hook_wrapper_mock.return_value = self.iac_hook_wrapper_instance_mock
         prompt_experimental_mock.return_value = True


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
There is a bug where the hook package is executed even if the customer provides a help text flag.

#### How does it address the issue?
Add an additional condition to avoid running the hook if the help text option is provided.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
