### PR TITLE
feat: Add link to TF Cloud documentation

### DIFF
--- a/samcli/hook_packages/terraform/hooks/prepare/hook.py
+++ b/samcli/hook_packages/terraform/hooks/prepare/hook.py
@@ -28,12 +28,17 @@ TERRAFORM_HOOK_METADATA = {
     "HookName": "terraform",
 }
 
+TF_CLOUD_LINK = (
+    "https://docs.aws.amazon.com/serverless-application-model/latest"
+    "/developerguide/gs-terraform-support.html#gs-terraform-support-cloud"
+)
 TF_CLOUD_EXCEPTION_MESSAGE = "Terraform Cloud does not support saving the generated execution plan"
 TF_CLOUD_HELP_MESSAGE = (
     "Terraform Cloud does not currently support generating local plan "
     "files that AWS SAM CLI uses to parse the Terraform project.\n"
     "To use AWS SAM CLI with Terraform Cloud applications, provide "
-    "a plan file using the --terraform-plan-file flag."
+    "a plan file using the --terraform-plan-file flag.\n\n"
+    f"For more information, follow the link: {TF_CLOUD_LINK}"
 )
 
 TF_BLOCKED_ARGUMENTS = [
@@ -227,7 +232,6 @@ def _generate_plan_file(skip_prepare_infra: bool, terraform_application_dir: str
         ) from e
     except LoadingPatternError as e:
         if TF_CLOUD_EXCEPTION_MESSAGE in e.message:
-            # TODO: Add link to TF Cloud documentation when that is ready
             raise TerraformCloudException(TF_CLOUD_HELP_MESSAGE)
         raise PrepareHookException(f"Error occurred when invoking a process:\n{e}") from e
 

--- a/tests/integration/local/start_lambda/test_start_lambda_terraform_applications.py
+++ b/tests/integration/local/start_lambda/test_start_lambda_terraform_applications.py
@@ -118,7 +118,6 @@ class TestLocalStartLambdaTerraformApplicationWithoutBuildCustomPlanFile(StartLa
     terraform_application = "/testdata/invoke/terraform/simple_application_no_building_logic"
     template_path = None
     hook_name = "terraform"
-    beta_features = True
     terraform_plan_file = "custom-plan.json"
 
     def setUp(self):


### PR DESCRIPTION
Link out to the Terraform Cloud documentation if a user runs into the Terraform Cloud exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
