### PR TITLE
feat: Added event tracking for feature

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -239,7 +239,7 @@ class BuildContext:
 
         self._stacks = self._handle_build_pre_processing()
 
-        caught_exception = None
+        caught_exception: Optional[Exception] = None
 
         try:
             # boolean value indicates if mount with write or not, defaults to READ ONLY
@@ -278,7 +278,7 @@ class BuildContext:
             self._check_rust_cargo_experimental_flag()
 
             for f in self.get_resources_to_build().functions:
-                EventTracker.track_event(EventName.BUILD_FUNCTION_RUNTIME, f.runtime)
+                EventTracker.track_event(EventName.BUILD_FUNCTION_RUNTIME.value, f.runtime)
 
             self._build_result = builder.build()
 
@@ -333,7 +333,9 @@ class BuildContext:
         finally:
             if self.build_in_source:
                 exception_name = type(caught_exception).__name__ if caught_exception else None
-                EventTracker.track_event(EventName.USED_FEATURE, UsedFeature.BUILD_IN_SOURCE, exception_name)
+                EventTracker.track_event(
+                    EventName.USED_FEATURE.value, UsedFeature.BUILD_IN_SOURCE.value, exception_name
+                )
 
     def _is_sam_template(self) -> bool:
         """Check if a given template is a SAM template"""

--- a/samcli/lib/telemetry/event.py
+++ b/samcli/lib/telemetry/event.py
@@ -39,6 +39,7 @@ class UsedFeature(Enum):
     INIT_WITH_APPLICATION_INSIGHTS = "InitWithApplicationInsights"
     CFNLint = "CFNLint"
     INVOKED_CUSTOM_LAMBDA_AUTHORIZERS = "InvokedLambdaAuthorizers"
+    BUILD_IN_SOURCE = "BuildInSource"
 
 
 class EventType:

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -1273,7 +1273,9 @@ class TestBuildContext_run(TestCase):
         with self.assertRaises(UserException):
             context.run()
 
-        mock_track_event.assert_called_with(EventName.USED_FEATURE, UsedFeature.BUILD_IN_SOURCE, "FunctionNotFound")
+        mock_track_event.assert_called_with(
+            EventName.USED_FEATURE.value, UsedFeature.BUILD_IN_SOURCE.value, "FunctionNotFound"
+        )
 
 
 class TestBuildContext_is_sam_template(TestCase):

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -18,6 +18,7 @@ from samcli.lib.build.build_graph import DEFAULT_DEPENDENCIES_DIR
 from samcli.lib.build.bundler import EsbuildBundlerManager
 from samcli.lib.build.workflow_config import UnsupportedRuntimeException
 from samcli.lib.providers.provider import Function, get_function_build_info
+from samcli.lib.telemetry.event import EventName, UsedFeature
 from samcli.lib.utils.osutils import BUILD_DIR_PERMISSIONS
 from samcli.lib.utils.packagetype import ZIP, IMAGE
 from samcli.local.lambdafn.exceptions import FunctionNotFound
@@ -1244,6 +1245,35 @@ class TestBuildContext_run(TestCase):
                 build_context.run()
 
         self.assertEqual(str(ctx.exception), "Function Not Found")
+
+    @patch("samcli.commands.build.build_context.BuildContext._is_sam_template")
+    @patch("samcli.commands.build.build_context.BuildContext.get_resources_to_build")
+    @patch("samcli.commands.build.build_context.BuildContext._check_exclude_warning")
+    @patch("samcli.commands.build.build_context.BuildContext._check_rust_cargo_experimental_flag")
+    @patch("samcli.lib.build.app_builder.ApplicationBuilder.build")
+    @patch("samcli.lib.telemetry.event.EventTracker.track_event")
+    def test_build_in_source_event_sent(
+        self, mock_track_event, mock_builder, mock_rust, mock_warning, mock_get_resources, mock_is_sam_template
+    ):
+        mock_builder.side_effect = [FunctionNotFound()]
+
+        context = BuildContext(
+            resource_identifier="",
+            template_file="template_file",
+            base_dir="base_dir",
+            build_dir="build_dir",
+            cache_dir="cache_dir",
+            cached=False,
+            clean=False,
+            parallel=False,
+            mode="mode",
+            build_in_source=True,
+        )
+
+        with self.assertRaises(UserException):
+            context.run()
+
+        mock_track_event.assert_called_with(EventName.USED_FEATURE, UsedFeature.BUILD_IN_SOURCE, "FunctionNotFound")
 
 
 class TestBuildContext_is_sam_template(TestCase):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
There is currently no indicators that a project used the building in source feature.

#### How does it address the issue?
Adds a new `UsedFeature` event to track build in source usages. This is done by only sending the event if the build in source click option was passed in.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
