### PR TITLE
Fix handling of non-json-deserializable response from RIE

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -210,7 +210,6 @@ class Container:
             kwargs["mem_limit"] = "{}m".format(self._memory_limit_mb)
 
         real_container = self.docker_client.containers.create(self._image, **kwargs)
-        LOG.debug("container: %s, kwargs: %s", self._image, kwargs)
         self.id = real_container.id
 
         self._logs_thread = None

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -1,11 +1,13 @@
 """
 Unit test for Container class
 """
-import docker
-from docker.errors import NotFound, APIError
+import json
 from unittest import TestCase
 from unittest.mock import Mock, call, patch, ANY
+from parameterized import parameterized
 
+import docker
+from docker.errors import NotFound, APIError
 from requests import RequestException
 
 from samcli.lib.utils.packagetype import IMAGE
@@ -577,9 +579,22 @@ class TestContainer_wait_for_result(TestCase):
         self.socket_mock = Mock()
         self.socket_mock.connect_ex.return_value = 0
 
+    @parameterized.expand(
+        [
+            (
+                True,
+                b'{"hello":"world"}',
+            ),
+            (
+                False,
+                b"non-json-deserializable",
+            ),
+            (False, b""),
+        ]
+    )
     @patch("socket.socket")
     @patch("samcli.local.docker.container.requests")
-    def test_wait_for_result_no_error(self, mock_requests, patched_socket):
+    def test_wait_for_result_no_error(self, response_deserializable, rie_response, mock_requests, patched_socket):
         self.container.is_created.return_value = True
 
         real_container_mock = Mock()
@@ -590,9 +605,11 @@ class TestContainer_wait_for_result(TestCase):
         self.container._write_container_output = Mock()
 
         stdout_mock = Mock()
+        stdout_mock.write_str = Mock()
+        stdout_mock.write_bytes = Mock()
         stderr_mock = Mock()
         response = Mock()
-        response.content = b'{"hello":"world"}'
+        response.content = rie_response
         mock_requests.post.return_value = response
 
         patched_socket.return_value = self.socket_mock
@@ -619,6 +636,10 @@ class TestContainer_wait_for_result(TestCase):
             data=b"{}",
             timeout=(self.container.RAPID_CONNECTION_TIMEOUT, None),
         )
+        if response_deserializable:
+            stdout_mock.write_str.assert_called_with(json.dumps(json.loads(rie_response), ensure_ascii=False))
+        else:
+            stdout_mock.write_bytes.assert_called_with(rie_response)
 
     @patch("socket.socket")
     @patch("samcli.local.docker.container.requests")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5799 

#### Why is this change necessary?
In some rare occasion, RIE response cannot be deserialized by `json.loads`, resulting in `JSONDecodeError`

#### How does it address the issue?
Handle `JSONDecodeError`, and update `stdout` to write response with `write_str` or `write_bytes` based on response type.

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
