### PR TITLE
fix: copy resource metadata before normalizing the information in it

### DIFF
--- a/samcli/lib/samlib/resource_metadata_normalizer.py
+++ b/samcli/lib/samlib/resource_metadata_normalizer.py
@@ -5,6 +5,7 @@ Class that Normalizes a Template based on Resource Metadata
 import json
 import logging
 import re
+from copy import deepcopy
 from pathlib import Path
 from typing import Dict
 
@@ -61,10 +62,8 @@ class ResourceMetadataNormalizer:
         resources = template_dict.get(RESOURCES_KEY, {})
 
         for logical_id, resource in resources.items():
-            resource_metadata = resource.get(METADATA_KEY)
-            if resource_metadata is None:
-                resource_metadata = {}
-                resource[METADATA_KEY] = resource_metadata
+            # copy metadata to another variable, change its values and assign it back in the end
+            resource_metadata = deepcopy(resource.get(METADATA_KEY)) or {}
 
             is_normalized = resource_metadata.get(SAM_IS_NORMALIZED, False)
             if not is_normalized:
@@ -97,6 +96,7 @@ class ResourceMetadataNormalizer:
                 resource_metadata,
                 {SAM_RESOURCE_ID_KEY: ResourceMetadataNormalizer.get_resource_id(resource, logical_id)},
             )
+            resource[METADATA_KEY] = resource_metadata
 
         # This is a work around to allow the customer to use sam deploy or package commands without the need to provide
         # values for the CDK auto generated asset parameters. The suggested solution is to let CDK add some metadata to

--- a/tests/unit/lib/samlib/test_resource_metadata_normalizer.py
+++ b/tests/unit/lib/samlib/test_resource_metadata_normalizer.py
@@ -457,7 +457,7 @@ class TestResourceMetadataNormalizer(TestCase):
         self.assertEqual("new path", template_data["Resources"]["Function1"]["Properties"]["Code"])
         self.assertEqual("Function1", template_data["Resources"]["Function1"]["Metadata"]["SamResourceId"])
 
-    def test_referenced_data(self):
+    def test_with_referenced_metadata(self):
         input_template = """
         Resources:
           FirstFunction:
@@ -487,9 +487,6 @@ class TestResourceMetadataNormalizer(TestCase):
         """
         template_dict = yaml_parse(input_template)
         ResourceMetadataNormalizer.normalize(template_dict)
-
-        def _extract_sam_resource_id(template, resource_id):
-            return template.get("Resources", {}).get(resource_id, {}).get("Metadata", {}).get("SamResourceId")
 
         self.assertEqual(
             template_dict.get("Resources", {}).get("FirstFunction", {}).get("Metadata", {}).get("SamResourceId"),

--- a/tests/unit/lib/samlib/test_resource_metadata_normalizer.py
+++ b/tests/unit/lib/samlib/test_resource_metadata_normalizer.py
@@ -3,6 +3,7 @@ from parameterized import parameterized
 from unittest import TestCase
 
 from samcli.lib.samlib.resource_metadata_normalizer import ResourceMetadataNormalizer
+from samcli.yamlhelper import yaml_parse
 
 
 class TestResourceMetadataNormalizer(TestCase):
@@ -455,6 +456,53 @@ class TestResourceMetadataNormalizer(TestCase):
         ResourceMetadataNormalizer.normalize(template_data)
         self.assertEqual("new path", template_data["Resources"]["Function1"]["Properties"]["Code"])
         self.assertEqual("Function1", template_data["Resources"]["Function1"]["Metadata"]["SamResourceId"])
+
+    def test_referenced_data(self):
+        input_template = """
+        Resources:
+          FirstFunction:
+            Type: AWS::Serverless::Function
+            Metadata: &GoFunctionMetadata
+              BuildMethod: go1.x
+              BuildProperties:
+                TrimGoPath: true
+            Properties:
+              CodeUri: dummy
+              Handler: bootstrap
+              Runtime: provided.al2
+          SecondFunction:
+            Type: AWS::Serverless::Function
+            Metadata: *GoFunctionMetadata
+            Properties:
+              CodeUri: dummy
+              Handler: bootstrap
+              Runtime: provided.al2
+          ThirdFunction:
+            Type: AWS::Serverless::Function
+            Metadata: *GoFunctionMetadata
+            Properties:
+              CodeUri: dummy
+              Handler: bootstrap
+              Runtime: provided.al2
+        """
+        template_dict = yaml_parse(input_template)
+        ResourceMetadataNormalizer.normalize(template_dict)
+
+        def _extract_sam_resource_id(template, resource_id):
+            return template.get("Resources", {}).get(resource_id, {}).get("Metadata", {}).get("SamResourceId")
+
+        self.assertEqual(
+            template_dict.get("Resources", {}).get("FirstFunction", {}).get("Metadata", {}).get("SamResourceId"),
+            "FirstFunction",
+        )
+        self.assertEqual(
+            template_dict.get("Resources", {}).get("SecondFunction", {}).get("Metadata", {}).get("SamResourceId"),
+            "SecondFunction",
+        )
+        self.assertEqual(
+            template_dict.get("Resources", {}).get("ThirdFunction", {}).get("Metadata", {}).get("SamResourceId"),
+            "ThirdFunction",
+        )
 
 
 class TestResourceMetadataNormalizerGetResourceId(TestCase):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5901


#### Why is this change necessary?
When using value references in yaml file, the objects that is been created are the same instance. For that reason, changing one value from one instance will also affect the other instances.

The behaviour above causes issues when updating/normalizing resource metadata information. With that, we are adding `SamResourceId` information, but if `Metadata` information is been shared between resources, then it updates for all of them, which creates issues down the road when we are extracting functions.


#### How does it address the issue?
This change copies metadata before starting changes, and assigns it back once it is finalized, so that it won't affect all of the references.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
