### PR TITLE
fix(tests): Clean up test data folder between runs

### DIFF
--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -57,12 +57,22 @@ class TestSyncWatchBase(SyncIntegBase):
     parameter_overrides: Dict[str, str] = {}
 
     def setUp(self):
+        # set up clean testing folder
+        self.test_data_path = Path(tempfile.mkdtemp())
+        original_test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "sync")
+
+        shutil.rmtree(self.test_data_path)
+        shutil.copytree(original_test_data_path, self.test_data_path)
+
         self.s3_prefix = uuid.uuid4().hex
         self.stack_name = self._method_to_stack_name(self.id())
         super().setUp()
         self._setup_verify_infra()
 
     def tearDown(self):
+        # clean up the old testing folder
+        shutil.rmtree(self.test_data_path, ignore_errors=True)
+
         kill_process(self.watch_process)
         for stack in self.stacks:
             # because of the termination protection, do not delete aws-sam-cli-managed-default stack


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
Testing folder and data was not being cleaned between test runs if the test were to fail and be retried.

#### How does it address the issue?
Updates the set up and tear down methods of the test watch base class to delete the contents of the previous test run before restarting the test.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
