### PR TITLE
fix: gracefully handle when git executable can't be found

### DIFF
--- a/samcli/lib/utils/git_repo.py
+++ b/samcli/lib/utils/git_repo.py
@@ -93,7 +93,8 @@ class GitRepo:
                 LOG.warning("Unable to find executable %s", executable, exc_info=ex)
 
         raise GitExecutableNotFoundException(
-            f"This command requires git but we couldn't find the executable, was looking with following names: {executables}"
+            "This command requires git but we couldn't find the executable, "
+            f"was looking with following names: {executables}"
         )
 
     def clone(self, clone_dir: Path, clone_name: str, replace_existing: bool = False, commit: str = "") -> Path:

--- a/samcli/lib/utils/git_repo.py
+++ b/samcli/lib/utils/git_repo.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from subprocess import check_output
 from typing import Optional
 
+from samcli.commands.exceptions import UserException
 from samcli.lib.utils import osutils
 from samcli.lib.utils.osutils import rmtree_callback
 
@@ -33,6 +34,12 @@ class CloneRepoUnstableStateException(CloneRepoException):
 class ManifestNotFoundException(Exception):
     """
     Exception class when request Manifest file return 404.
+    """
+
+
+class GitExecutableNotFoundException(UserException):
+    """
+    Used to thrown when git executable not found in the system
     """
 
 
@@ -83,9 +90,11 @@ class GitRepo:
                     # No exception. Let's pick this
                     return executable
             except OSError as ex:
-                LOG.debug("Unable to find executable %s", executable, exc_info=ex)
+                LOG.warning("Unable to find executable %s", executable, exc_info=ex)
 
-        raise OSError("Cannot find git, was looking at executables: {}".format(executables))
+        raise GitExecutableNotFoundException(
+            f"This command requires git but we couldn't find the executable, was looking with following names: {executables}"
+        )
 
     def clone(self, clone_dir: Path, clone_name: str, replace_existing: bool = False, commit: str = "") -> Path:
         """

--- a/tests/unit/lib/utils/test_git_repo.py
+++ b/tests/unit/lib/utils/test_git_repo.py
@@ -3,7 +3,13 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch, MagicMock, ANY, call
 import os
-from samcli.lib.utils.git_repo import GitRepo, rmtree_callback, CloneRepoException, CloneRepoUnstableStateException
+from samcli.lib.utils.git_repo import (
+    GitRepo,
+    rmtree_callback,
+    CloneRepoException,
+    CloneRepoUnstableStateException,
+    GitExecutableNotFoundException,
+)
 
 REPO_URL = "REPO URL"
 REPO_NAME = "REPO NAME"
@@ -44,7 +50,7 @@ class TestGitRepo(TestCase):
     @patch("samcli.lib.utils.git_repo.subprocess.Popen")
     def test_git_executable_fails(self, mock_popen):
         mock_popen.side_effect = OSError("fail")
-        with self.assertRaises(OSError):
+        with self.assertRaises(GitExecutableNotFoundException):
             self.repo.git_executable()
 
     @patch("samcli.lib.utils.git_repo.Path.exists")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/issues/5983


#### Why is this change necessary?
When checking `git` executable, SAM CLI raises `OSError` which causes hard fail.

#### How does it address the issue?
This replaces `OSError` with a custom one which extends from `UserError`. This will display a better warning message rather than splitting the whole exception trace.

#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
