### PR TITLE
test: Add integration tests for sqs remote invoke

### DIFF
--- a/tests/integration/remote/invoke/remote_invoke_integ_base.py
+++ b/tests/integration/remote/invoke/remote_invoke_integ_base.py
@@ -58,6 +58,7 @@ class RemoteInvokeIntegBase(TestCase):
         cls.lambda_client = boto_client_provider("lambda")
         cls.stepfunctions_client = boto_client_provider("stepfunctions")
         cls.xray_client = boto_client_provider("xray")
+        cls.sqs_client = boto_client_provider("sqs")
 
     @staticmethod
     def get_command_list(

--- a/tests/integration/testdata/remote_invoke/template-multiple-resources.yaml
+++ b/tests/integration/testdata/remote_invoke/template-multiple-resources.yaml
@@ -95,3 +95,15 @@ Resources:
       CodeUri: lambda-fns/
       Handler: main.stock_buyer
       Runtime: python3.9
+  
+  MySQSQueue:
+    Type: AWS::SQS::Queue
+
+  MyFIFOSQSQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      FifoQueue: true
+
+Outputs:
+  MySQSQueueArn:
+    Value: !GetAtt MySQSQueue.Arn

--- a/tests/integration/testdata/remote_invoke/template-sqs-priority.yaml
+++ b/tests/integration/testdata/remote_invoke/template-sqs-priority.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: A hello world application with a step function.
+
+Resources:
+  MySQSQueue:
+    Type: AWS::SQS::Queue


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
This PR adds integration tests for `sam remote invoke` for SQS service. The tests have been disables until the support for the service is available.

#### How does it address the issue?
Described above.

#### What side effects does this change have?
No side effects

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
