### PR TITLE
fix: Fix Win integ tests for remote test events

### DIFF
--- a/tests/integration/remote/test_event/test_remote_test_event.py
+++ b/tests/integration/remote/test_event/test_remote_test_event.py
@@ -1,5 +1,6 @@
-import uuid
 import json
+import os
+import uuid
 
 import pytest
 from pathlib import Path
@@ -60,7 +61,7 @@ class TestRemoteTestEvent(RemoteTestEventIntegBase):
         self.get_event_and_check(self.stack_name, function_to_check, "event2", json.dumps(event_contents2))
 
         # Check two events
-        self.list_events_and_check(self.stack_name, function_to_check, "event1\nevent2")
+        self.list_events_and_check(self.stack_name, function_to_check, os.linesep.join(["event1", "event2"]))
 
         # Invoke with two events (function returns the same event that it receives)
         self.remote_invoke_and_check(self.stack_name, function_to_check, "event1", event_contents1)


### PR DESCRIPTION
Fix Win integ tests for remote test events

- Line separator in Windows is different

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
