### PR TITLE
fix: Clean up lambda-testevent-schemas registry for remote test-event integ tests

### DIFF
--- a/tests/integration/remote/test_event/remote_test_event_integ_base.py
+++ b/tests/integration/remote/test_event/remote_test_event_integ_base.py
@@ -35,6 +35,7 @@ class RemoteTestEventIntegBase(TestCase):
         cls.delete_all_test_events()
         # Delete the deployed stack
         cls.cfn_client.delete_stack(StackName=cls.stack_name)
+        cls.schemas_client.delete_registry(RegistryName=LAMBDA_TEST_EVENT_REGISTRY)
 
     @classmethod
     def create_resources_and_boto_clients(cls):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Some `sam init` integ tests were failing as a new schema registry `lambda-testevent-schemas` was created from `sam remote test-event` command and the order of input for selecting schema changed. . This PR cleans up `lambda-testevent-schemas` registry after `remote test-event` integ tests are completed.

For reference: https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux/builds/48180259/job/sc6fyg77aimxuykb?fullLog=true

#### How does it address the issue?
As mentioned above.

#### What side effects does this change have?
No side effects.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
