### PR TITLE
fix: Boto3 reads AWS_DEFAULT_REGION not AWS_REGION

### DIFF
--- a/samcli/lib/bootstrap/companion_stack/companion_stack_manager.py
+++ b/samcli/lib/bootstrap/companion_stack/companion_stack_manager.py
@@ -64,7 +64,7 @@ class CompanionStackManager:
         except NoRegionError as ex:
             raise RegionError(
                 "Error Setting Up Managed Stack Client: Unable to resolve a region. "
-                "Please provide a region via the --region parameter or by the AWS_REGION environment variable."
+                "Please provide a region via the --region parameter or by the AWS_DEFAULT_REGION environment variable."
             ) from ex
 
     def set_functions(

--- a/samcli/lib/utils/managed_cloudformation_stack.py
+++ b/samcli/lib/utils/managed_cloudformation_stack.py
@@ -84,7 +84,7 @@ def update_stack(
     except NoRegionError as ex:
         raise RegionError(
             "Error Setting Up Managed Stack Client: Unable to resolve a region. "
-            "Please provide a region via the --region parameter or by the AWS_REGION environment variable."
+            "Please provide a region via the --region parameter or by the AWS_DEFAULT_REGION environment variable."
         ) from ex
     return _create_or_update_stack(cloudformation_client, stack_name, template_body, parameter_overrides)
 
@@ -140,7 +140,7 @@ def manage_stack(
     except NoRegionError as ex:
         raise RegionError(
             "Error Setting Up Managed Stack Client: Unable to resolve a region. "
-            "Please provide a region via the --region parameter or by the AWS_REGION environment variable."
+            "Please provide a region via the --region parameter or by the AWS_DEFAULT_REGION environment variable."
         ) from ex
     return _create_or_get_stack(cloudformation_client, stack_name, template_body, parameter_overrides)
 


### PR DESCRIPTION
When we deploy the managed stack and SAM CLI deploys the stack, if there is no region found we state to set the AWS_REGION. Boto3 only reads the AWS_DEFAULT_REGION, causing customer confusion

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None

#### Why is this change necessary?
Updates the output of an error to be accurate.

#### How does it address the issue?
Updates the output of an error to be accurate.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
