### PR TITLE
fix: gracefully exit on not finding a local image

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -40,9 +40,10 @@ from samcli.lib.utils.colors import Colored, Colors
 from samcli.lib.utils import osutils
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.stream_writer import StreamWriter
+from samcli.local.docker.exceptions import ContainerNotStartableException
 from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 from samcli.local.docker.utils import is_docker_reachable, get_docker_platform
-from samcli.local.docker.manager import ContainerManager
+from samcli.local.docker.manager import ContainerManager, DockerImagePullFailedException
 from samcli.commands._utils.experimental import get_enabled_experimental_flags
 from samcli.lib.build.exceptions import (
     DockerConnectionError,
@@ -960,6 +961,10 @@ class ApplicationBuilder:
             # "/." is a Docker thing that instructions the copy command to download contents of the folder only
             result_dir_in_container = response["result"]["artifacts_dir"] + "/."
             container.copy(result_dir_in_container, artifacts_dir)
+
+        except DockerImagePullFailedException as ex:
+            raise BuildInsideContainerError(ex)
+
         finally:
             self._container_manager.stop(container)
 


### PR DESCRIPTION
- For `build` with `--use-container` and `--build-image`

#### Which issue(s) does this change fix?

https://github.com/aws/aws-sam-cli/issues/6023


#### Why is this change necessary?

Gracefully fail and not throw a traceback


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
