### PR TITLE
test: Add integration tests for running remote invoke on kinesis service

### DIFF
--- a/tests/integration/remote/invoke/remote_invoke_integ_base.py
+++ b/tests/integration/remote/invoke/remote_invoke_integ_base.py
@@ -59,6 +59,35 @@ class RemoteInvokeIntegBase(TestCase):
         cls.stepfunctions_client = boto_client_provider("stepfunctions")
         cls.xray_client = boto_client_provider("xray")
         cls.sqs_client = boto_client_provider("sqs")
+        cls.kinesis_client = boto_client_provider("kinesis")
+
+    def get_kinesis_records(self, shard_id, sequence_number, stream_name):
+        """Helper function to get kinesis records using the provided shard_id and sequence_number
+
+        Parameters
+        ----------
+        shard_id: string
+            Shard Id to fetch the record from
+        sequence_number: string
+            Sequence number to get the record for
+        stream_name: string
+            Name of the kinesis stream to get records from
+        Returns
+        -------
+        list
+            Returns a list of records received from the kinesis data stream
+        """
+        response = self.kinesis_client.get_shard_iterator(
+            StreamName=stream_name,
+            ShardId=shard_id,
+            ShardIteratorType="AT_SEQUENCE_NUMBER",
+            StartingSequenceNumber=sequence_number,
+        )
+        shard_iter = response["ShardIterator"]
+        response = self.kinesis_client.get_records(ShardIterator=shard_iter, Limit=1)
+        records = response["Records"]
+
+        return records
 
     @staticmethod
     def get_command_list(

--- a/tests/integration/testdata/remote_invoke/template-kinesis-priority.yaml
+++ b/tests/integration/testdata/remote_invoke/template-kinesis-priority.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: AWS Kinesis Data Stream
+
+Resources:
+  # Define an AWS Kinesis Data Stream
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 1
+            
+Outputs:
+  # Kinesis Data Stream name
+  KinesisStream:
+    Description: Kinesis Data Stream name
+    Value: !Ref KinesisStream

--- a/tests/integration/testdata/remote_invoke/template-multiple-resources.yaml
+++ b/tests/integration/testdata/remote_invoke/template-multiple-resources.yaml
@@ -103,7 +103,16 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       FifoQueue: true
+  
+  # Define an AWS Kinesis Data Stream
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 3
 
 Outputs:
   MySQSQueueArn:
     Value: !GetAtt MySQSQueue.Arn
+  KinesisStreamArn:
+    Description: Kinesis Data Stream name
+    Value: !GetAtt KinesisStream.Arn


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
This PR adds integration tests for sam remote invoke for Kinesis service. The tests have been disables until the support for the service is available.

#### How does it address the issue?
Tests run locally:
```
tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_asynchronous_using_boto_parameter@sam_remote_invoke_single_lambda_resource 
tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_boto_parameters@sam_remote_invoke_sfn_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_boto_parameters@sam_remote_invoke_kinesis_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_boto_parameters@sam_remote_invoke_sqs_resource_priority 
[gw1] [  1%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_boto_parameters@sam_remote_invoke_sfn_resource_priority 
[gw2] [  3%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_boto_parameters@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_empty_event_provided@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_empty_event_provided@sam_remote_invoke_sfn_resource_priority 
[gw1] [  5%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_empty_event_provided@sam_remote_invoke_sfn_resource_priority 
[gw2] [  7%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_empty_event_provided@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_event_file_provided@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_with_event_file_provided@sam_remote_invoke_sfn_resource_priority 
[gw1] [  9%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_with_event_file_provided@sam_remote_invoke_sfn_resource_priority 
[gw2] [ 11%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_event_file_provided@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_with_event_provided_0__is_developer_false_@sam_remote_invoke_sfn_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_event_provided_0__foo_bar_@sam_remote_invoke_sqs_resource_priority 
[gw1] [ 13%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_with_event_provided_0__is_developer_false_@sam_remote_invoke_sfn_resource_priority 
[gw2] [ 15%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_event_provided_0__foo_bar_@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_event_provided_1_Hello_World@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_with_event_provided_1__is_developer_true_@sam_remote_invoke_sfn_resource_priority 
[gw1] [ 17%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSFNPriorityInvoke::test_invoke_with_event_provided_1__is_developer_true_@sam_remote_invoke_sfn_resource_priority 
[gw2] [ 19%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_event_provided_1_Hello_World@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_event_provided_2__heading_Reminder_heading_@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_empty_event_provided@sam_remote_invoke_multiple_resources 
[gw2] [ 21%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_event_provided_2__heading_Reminder_heading_@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_physical_id_provided_as_resource_id@sam_remote_invoke_sqs_resource_priority 
[gw2] [ 23%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestSQSPriorityInvoke::test_invoke_with_physical_id_provided_as_resource_id@sam_remote_invoke_sqs_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_empty_event_provided_0_ChildStack_HelloWorldFunction@sam_remote_invoke_nested_resources 
[gw3] [ 25%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_boto_parameters@sam_remote_invoke_kinesis_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_empty_event_provided@sam_remote_invoke_kinesis_resource_priority 
[gw3] [ 26%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_empty_event_provided@sam_remote_invoke_kinesis_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_event_file_provided@sam_remote_invoke_kinesis_resource_priority 
[gw3] [ 28%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_event_file_provided@sam_remote_invoke_kinesis_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_event_provided_0__foo_bar_@sam_remote_invoke_kinesis_resource_priority 
[gw3] [ 30%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_event_provided_0__foo_bar_@sam_remote_invoke_kinesis_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_event_provided_1__Hello_World_@sam_remote_invoke_kinesis_resource_priority 
[gw3] [ 32%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_event_provided_1__Hello_World_@sam_remote_invoke_kinesis_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_event_provided_2__hello_world_foo_1_bar_@sam_remote_invoke_kinesis_resource_priority 
[gw3] [ 34%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_event_provided_2__hello_world_foo_1_bar_@sam_remote_invoke_kinesis_resource_priority 
tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_physical_id_provided_as_resource_id@sam_remote_invoke_kinesis_resource_priority 
[gw0] [ 36%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_asynchronous_using_boto_parameter@sam_remote_invoke_single_lambda_resource 
tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_dryrun_using_boto_parameter@sam_remote_invoke_single_lambda_resource 
[gw3] [ 38%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestKinesisPriorityInvoke::test_invoke_with_physical_id_provided_as_resource_id@sam_remote_invoke_kinesis_resource_priority 
[gw0] [ 40%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_dryrun_using_boto_parameter@sam_remote_invoke_single_lambda_resource 
tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_empty_event_provided@sam_remote_invoke_single_lambda_resource 
[gw0] [ 42%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_empty_event_provided@sam_remote_invoke_single_lambda_resource 
tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_response_json_output_format@sam_remote_invoke_single_lambda_resource 
[gw0] [ 44%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_response_json_output_format@sam_remote_invoke_single_lambda_resource 
tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_with_event_file_provided@sam_remote_invoke_single_lambda_resource 
[gw2] [ 46%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_empty_event_provided_0_ChildStack_HelloWorldFunction@sam_remote_invoke_nested_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_empty_event_provided_1_ChildStack_HelloWorldStateMachine@sam_remote_invoke_nested_resources 
[gw2] [ 48%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_empty_event_provided_1_ChildStack_HelloWorldStateMachine@sam_remote_invoke_nested_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_event_file_provided@sam_remote_invoke_nested_resources 
[gw0] [ 50%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_with_event_file_provided@sam_remote_invoke_single_lambda_resource 
tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_with_event_provided@sam_remote_invoke_single_lambda_resource 
[gw2] [ 51%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_event_file_provided@sam_remote_invoke_nested_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_with_event_provided_0_ChildStack_HelloWorldFunction@sam_remote_invoke_nested_resources 
[gw0] [ 53%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_with_event_provided@sam_remote_invoke_single_lambda_resource 
tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_with_resource_id_provided_as_arn@sam_remote_invoke_single_lambda_resource 
[gw2] [ 55%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_with_event_provided_0_ChildStack_HelloWorldFunction@sam_remote_invoke_nested_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_with_event_provided_1_ChildStack_HelloWorldStateMachine@sam_remote_invoke_nested_resources 
[gw2] [ 57%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestNestedTemplateResourcesInvoke::test_invoke_with_event_provided_1_ChildStack_HelloWorldStateMachine@sam_remote_invoke_nested_resources 
[gw0] [ 59%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestSingleLambdaInvoke::test_invoke_with_resource_id_provided_as_arn@sam_remote_invoke_single_lambda_resource 
[gw1] [ 61%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_empty_event_provided@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_0_HelloWorldServerlessFunction@sam_remote_invoke_multiple_resources 
[gw1] [ 63%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_0_HelloWorldServerlessFunction@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_1_EchoCustomEnvVarFunction@sam_remote_invoke_multiple_resources 
[gw1] [ 65%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_1_EchoCustomEnvVarFunction@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_2_EchoEventFunction@sam_remote_invoke_multiple_resources 
[gw1] [ 67%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_2_EchoEventFunction@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_3_StockPriceGuideStateMachine@sam_remote_invoke_multiple_resources 
[gw1] [ 69%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_3_StockPriceGuideStateMachine@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_4_StockPriceGuideStateMachine@sam_remote_invoke_multiple_resources 
[gw1] [ 71%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_invoke_with_only_event_provided_4_StockPriceGuideStateMachine@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_kinesis_invoke_with_boto_parameters@sam_remote_invoke_multiple_resources 
[gw1] [ 73%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_kinesis_invoke_with_boto_parameters@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_kinesis_invoke_with_resource_id_and_stack_name@sam_remote_invoke_multiple_resources 
[gw1] [ 75%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_kinesis_invoke_with_resource_id_and_stack_name@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_kinesis_invoke_with_resource_id_provided_as_arn@sam_remote_invoke_multiple_resources 
[gw1] [ 76%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_kinesis_invoke_with_resource_id_provided_as_arn@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_invoke_client_context_boto_parameter@sam_remote_invoke_multiple_resources 
[gw1] [ 78%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_invoke_client_context_boto_parameter@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_invoke_with_resource_id_provided_as_arn_0_HelloWorldServerlessFunction@sam_remote_invoke_multiple_resources 
[gw1] [ 80%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_invoke_with_resource_id_provided_as_arn_0_HelloWorldServerlessFunction@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_invoke_with_resource_id_provided_as_arn_1_EchoCustomEnvVarFunction@sam_remote_invoke_multiple_resources 
[gw1] [ 82%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_invoke_with_resource_id_provided_as_arn_1_EchoCustomEnvVarFunction@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_invoke_with_resource_id_provided_as_arn_2_EchoEventFunction@sam_remote_invoke_multiple_resources 
[gw1] [ 84%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_invoke_with_resource_id_provided_as_arn_2_EchoEventFunction@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_raises_exception_invoke@sam_remote_invoke_multiple_resources 
[gw1] [ 86%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_raises_exception_invoke@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_writes_to_stderr_invoke@sam_remote_invoke_multiple_resources 
[gw1] [ 88%] PASSED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_lambda_writes_to_stderr_invoke@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sfn_invoke_boto_parameters@sam_remote_invoke_multiple_resources 
[gw1] [ 90%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sfn_invoke_boto_parameters@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sfn_invoke_execution_fails@sam_remote_invoke_multiple_resources 
[gw1] [ 92%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sfn_invoke_execution_fails@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sfn_invoke_with_resource_id_provided_as_arn@sam_remote_invoke_multiple_resources 
[gw1] [ 94%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sfn_invoke_with_resource_id_provided_as_arn@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sqs_invoke_boto_parameters_fifo_queue@sam_remote_invoke_multiple_resources 
[gw1] [ 96%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sqs_invoke_boto_parameters_fifo_queue@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sqs_invoke_with_resource_id_and_stack_name@sam_remote_invoke_multiple_resources 
[gw1] [ 98%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sqs_invoke_with_resource_id_and_stack_name@sam_remote_invoke_multiple_resources 
tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sqs_invoke_with_resource_id_provided_as_arn@sam_remote_invoke_multiple_resources 
[gw1] [100%] SKIPPED tests/integration/remote/invoke/test_remote_invoke.py::TestMultipleResourcesInvoke::test_sqs_invoke_with_resource_id_provided_as_arn@sam_remote_invoke_multiple_resources
================================= 30 passed, 22 skipped, 5 warnings in 118.63s (0:01:58) =================================
```

#### What side effects does this change have?
No side effects

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
