### PR TITLE
chore: Revert temporarily skipped tests

### DIFF
--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -28,7 +28,6 @@ from tests.testing_utils import (
     SKIP_DOCKER_MESSAGE,
     run_command_with_input,
     UpdatableSARTemplate,
-    RUNNING_ON_GITHUB_ACTIONS,
 )
 from .build_integ_base import (
     BuildIntegBase,
@@ -465,9 +464,6 @@ class TestBuildCommand_PythonFunctions_WithoutDocker(BuildIntegPythonBase):
     use_container = False
 
     def test_with_default_requirements(self):
-        if IS_WINDOWS and self.runtime == "python3.9" and RUNNING_ON_GITHUB_ACTIONS:
-            self.skipTest("Skipping python3.9 tests on Windows until GHA issue is resolved.")
-
         self._test_with_default_requirements(
             self.runtime,
             self.codeuri,


### PR DESCRIPTION
Reverts tests that were temporarily skipped on GitHub actions as Lambda Builders failed to find a python3.9 executable with pip. 

Issue is resolved by https://github.com/aws/aws-lambda-builders/pull/549

This PR can be merged once the `aws_lambda_builders==1.39.0` version bump is merged into AWS SAM CLI.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
