### PR TITLE
chore(tests): Enable build tests

### DIFF
--- a/tests/integration/buildcmd/test_build_in_source.py
+++ b/tests/integration/buildcmd/test_build_in_source.py
@@ -10,7 +10,6 @@ from tests.integration.buildcmd.build_integ_base import BuildIntegProvidedBase, 
 LOG = logging.getLogger(__name__)
 
 
-@skip("Building in source option is not exposed yet. Stop skipping once it is.")
 class TestBuildCommand_BuildInSource_Makefile(BuildIntegProvidedBase):
     template = "template.yaml"
     is_nested_parent = False
@@ -50,9 +49,9 @@ class TestBuildCommand_BuildInSource_Makefile(BuildIntegProvidedBase):
         )
 
 
-@skip("Building in source option is not exposed yet. Stop skipping once it is.")
 class TestBuildCommand_BuildInSource_Esbuild(BuildIntegEsbuildBase):
     is_nested_parent = False
+    template = "template_with_metadata_esbuild.yaml"
 
     def setUp(self):
         super().setUp()
@@ -73,7 +72,6 @@ class TestBuildCommand_BuildInSource_Esbuild(BuildIntegEsbuildBase):
     )
     @pytest.mark.flaky(reruns=3)
     def test_builds_successfully_without_local_dependencies(self, build_in_source, dependencies_expected_in_source):
-        self.template_path = os.path.join(self.test_data_path, "template_with_metadata.yaml")
         codeuri = os.path.join(self.test_data_path, "Esbuild", "Node")
         self.source_directories = [codeuri]
 
@@ -92,7 +90,6 @@ class TestBuildCommand_BuildInSource_Esbuild(BuildIntegEsbuildBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_builds_successfully_with_local_dependency(self):
-        self.template_path = os.path.join(self.test_data_path, "template_with_metadata.yaml")
         codeuri = os.path.join(self.test_data_path, "Esbuild", "NodeWithLocalDependency")
         self.source_directories = [codeuri]
         runtime = "nodejs16.x"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
The build command's build in source tests were disabled back then since the Click option for build in source was not created yet.

#### How does it address the issue?
Removes the skip decorator that skips the integration tests from running and repairs the broken template link.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
