### PR TITLE
chore(test): Group jobs to better distribute runners

### DIFF
--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -8,14 +8,12 @@ configuration:
   - BuildIntegTestingArm64
   - BuildIntegTestingArm64Java
   - AllTerraformBuildTesting
-  - DeployIntegTesting
-  - PackageIntegTesting
-  - DeleteIntegTesting
+  - PackageAndDeleteAndDeployIntegTesting
   - SyncIntegTesting
-  - LocalIntegTesting
-  - EndToEndTesting
+  - LocalInvokeIntegTesting
+  - LocalStartIntegTesting
   # other Integration testing, Dev, regression and smoke testing
-  - OtherTesting
+  - OtherAndEndToEndTesting
 
 environment:
   PYTHON_HOME: "$HOME/venv3.11/bin"
@@ -214,32 +212,14 @@ for:
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
-  # Integ testing deploy
+  # Integ testing package & delete
   -
     matrix:
       only:
-        - configuration: DeployIntegTesting
+        - configuration: PackageAndDeleteAndDeployIntegTesting
 
     test_script:
-      - sh: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --dist=loadgroup --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
-
-  # Integ testing package
-  -
-    matrix:
-      only:
-        - configuration: PackageIntegTesting
-
-    test_script:
-      - sh: "pytest -vv tests/integration/package -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package.json"
-
-  # Integ testing delete
-  -
-    matrix:
-      only:
-        - configuration: DeleteIntegTesting
-
-    test_script:
-      - sh: "pytest -vv tests/integration/delete -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-delete.json"
+      - sh: "pytest -vv tests/integration/package tests/integration/delete tests/integration/deploy --dist=loadgroup -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete-deploy.json"
 
   # Integ testing sync
   -
@@ -254,7 +234,7 @@ for:
   -
     matrix:
       only:
-        - configuration: LocalIntegTesting
+        - configuration: LocalInvokeIntegTesting
 
     test_script:
       # install Terraform
@@ -265,23 +245,32 @@ for:
       - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
       - sh: "terraform -version"
 
-      - sh: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
+      - sh: "pytest -vv tests/integration/local/invoke tests/integration/local/generate_event --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
-  # End-to-end testing
+  # Integ testing local
   -
     matrix:
       only:
-        - configuration: EndToEndTesting
+        - configuration: LocalStartIntegTesting
 
     test_script:
-      - sh: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
+      - sh: "pytest -vv tests/integration/local/start_api tests/integration/local/start_lambda --json-report --json-report-file=TEST_REPORT-integration-local-start.json"
 
   # Other testing
   -
     matrix:
       only:
-        - configuration: OtherTesting
+        - configuration: OtherAndEndToEndTesting
 
     test_script:
       - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
+      - sh: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
       - sh: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"

--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -271,6 +271,5 @@ for:
         - configuration: OtherAndEndToEndTesting
 
     test_script:
-      - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
-      - sh: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
+      - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration tests/end_to_end --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
       - sh: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -8,11 +8,10 @@ configuration:
   - BuildIntegTestingArm64
   - BuildIntegTestingArm64Java
   - AllTerraformBuildTesting
-  - DeployIntegTesting
-  - PackageAndDeleteIntegTesting
+  - PackageAndDeleteAndDeployIntegTesting
   - SyncIntegTesting
-  - LocalIntegTesting
-  - EndToEndTesting
+  - LocalInvokeIntegTesting
+  - LocalStartIntegTesting
   # other Integration testing, Dev, regression and smoke testing
   - OtherTesting
 
@@ -202,23 +201,14 @@ for:
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
       - sh: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
-  # Integ testing deploy
-  -
-    matrix:
-      only:
-        - configuration: DeployIntegTesting
-
-    test_script:
-      - sh: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --dist=loadgroup --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
-
   # Integ testing package & delete
   -
     matrix:
       only:
-        - configuration: PackageAndDeleteIntegTesting
+        - configuration: PackageAndDeleteAndDeployIntegTesting
 
     test_script:
-      - sh: "pytest -vv tests/integration/package tests/integration/delete -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete.json"
+      - sh: "pytest -vv tests/integration/package tests/integration/delete tests/integration/deploy -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete.json"
 
   # Integ testing sync
   -
@@ -233,7 +223,7 @@ for:
   -
     matrix:
       only:
-        - configuration: LocalIntegTesting
+        - configuration: LocalInvokeIntegTesting
 
     test_script:
       # install Terraform
@@ -244,16 +234,24 @@ for:
       - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
       - sh: "terraform -version"
 
-      - sh: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
+      - sh: "pytest -vv tests/integration/local/invoke tests/integration/local/generate_event --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
-  # End-to-end testing
+  # Integ testing local
   -
     matrix:
       only:
-        - configuration: EndToEndTesting
+        - configuration: LocalStartIntegTesting
 
     test_script:
-      - sh: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
+      # install Terraform
+      - sh: "sudo apt update --allow-releaseinfo-change"
+      - sh: "TER_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \\\"\\,\\v | awk '{$1=$1};1'`"
+      - sh: "wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp"
+      - sh: "sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip"
+      - sh: "sudo mv /opt/terraform/terraform /usr/local/bin/"
+      - sh: "terraform -version"
+
+      - sh: "pytest -vv tests/integration/local/start_api tests/integration/local/start_lambda --json-report --json-report-file=TEST_REPORT-integration-local-start.json"
 
   # Other testing
   -
@@ -263,4 +261,5 @@ for:
 
     test_script:
       - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
+      - sh: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
       - sh: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -260,6 +260,5 @@ for:
         - configuration: OtherAndEndToEndTesting
 
     test_script:
-      - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
-      - sh: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
+      - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration tests/end_to_end --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
       - sh: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -13,7 +13,7 @@ configuration:
   - LocalInvokeIntegTesting
   - LocalStartIntegTesting
   # other Integration testing, Dev, regression and smoke testing
-  - OtherTesting
+  - OtherAndEndToEndTesting
 
 environment:
   PYTHON_HOME: "$HOME/venv3.8/bin"
@@ -208,7 +208,7 @@ for:
         - configuration: PackageAndDeleteAndDeployIntegTesting
 
     test_script:
-      - sh: "pytest -vv tests/integration/package tests/integration/delete tests/integration/deploy -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete.json"
+      - sh: "pytest -vv tests/integration/package tests/integration/delete tests/integration/deploy --dist=loadgroup -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete-deploy.json"
 
   # Integ testing sync
   -
@@ -257,7 +257,7 @@ for:
   -
     matrix:
       only:
-        - configuration: OtherTesting
+        - configuration: OtherAndEndToEndTesting
 
     test_script:
       - sh: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"

--- a/appveyor-windows-binary.yml
+++ b/appveyor-windows-binary.yml
@@ -9,14 +9,13 @@ configuration:
   - BuildIntegTestingJavaPythonProvided
   - BuildIntegTestingArm64
   - AllTerraformBuildTesting
-  - DeployIntegTesting
-  - PackageIntegTesting
-  - DeleteIntegTesting
+  - PackageAndDeleteAndDeployIntegTesting
   - SyncIntegTesting
-  - LocalIntegTesting
-  - EndToEndTesting
+  - LocalInvokeIntegTesting
+  - LocalStartApiIntegTesting
+  - LocalStartLambdaIntegTesting
   # other Integration testing, Dev, regression and smoke testing
-  - OtherTesting
+  - OtherAndEndToEndTesting
 
 environment:
   AWS_DEFAULT_REGION: us-east-1
@@ -213,6 +212,23 @@ for:
       only:
         - configuration: BuildIntegTestingArm64
 
+    build_script:
+      # install Rust in build_script to not override the default "install" actions
+      - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+      - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain stable
+      - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+      - set RUST_BACKTRACE=1
+      - rustup toolchain install stable --profile minimal --no-self-update
+      - rustup default stable
+      - rustup target add x86_64-unknown-linux-gnu --toolchain stable
+      - rustup target add aarch64-unknown-linux-gnu --toolchain stable
+      - ps: "choco install zig"
+      - ps: Invoke-WebRequest -Uri https://github.com/cargo-lambda/cargo-lambda/releases/download/$env:CARGO_LAMBDA_VERSION/cargo-lambda-$env:CARGO_LAMBDA_VERSION.windows-x64.zip -OutFile C:\Users\appveyor\cargo-lambda.zip
+      - ps: Expand-Archive -DestinationPath C:\Users\appveyor\.cargo\bin C:\Users\appveyor\cargo-lambda.zip
+      - rustc -V
+      - cargo -V
+      - cargo lambda -V
+
     test_script:
       - ps: "pytest -vv --reruns 3 tests/integration/buildcmd/test_build_cmd_arm64.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd-arm64.json"
 
@@ -229,29 +245,13 @@ for:
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
-  #Integ testing deploy
+  # Integ testing package, delete and deploy
   - matrix:
       only:
-        - configuration: DeployIntegTesting
+        - configuration: PackageAndDeleteAndDeployIntegTesting
 
     test_script:
-      - ps: "pytest -vv tests/integration/deploy -n 4 --reruns 4 --dist=loadgroup --json-report --json-report-file=TEST_REPORT-integration-deploy.json"
-
-  # Integ testing package
-  - matrix:
-      only:
-        - configuration: PackageIntegTesting
-
-    test_script:
-      - ps: "pytest -vv tests/integration/package -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package.json"
-
-  # Integ testing delete
-  - matrix:
-      only:
-        - configuration: DeleteIntegTesting
-
-    test_script:
-      - ps: "pytest -vv tests/integration/delete -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-delete.json"
+      - ps: "pytest -vv tests/integration/package tests/integration/delete tests/integration/deploy --dist=loadgroup -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete.json"
 
   # Integ testing sync
   - matrix:
@@ -261,33 +261,50 @@ for:
     test_script:
       - ps: "pytest -vv tests/integration/sync -n 3 --reruns 3 --dist loadscope --json-report --json-report-file=TEST_REPORT-integration-sync.json"
 
-  #Integ testing local
+  #Integ testing local invoke and generate event
   - matrix:
       only:
-        - configuration: LocalIntegTesting
+        - configuration: LocalInvokeIntegTesting
 
     test_script:
       # install Terraform CLI
       - "choco install terraform"
       - "terraform -version"
 
-      - ps: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
+      - ps: "pytest -vv tests/integration/local/invoke tests/integration/local/generate_event --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
-  # End-to-end testing
+  #Integ testing local start-api
   - matrix:
       only:
-        - configuration: EndToEndTesting
+        - configuration: LocalStartApiIntegTesting
 
     test_script:
-      - ps: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
+      - ps: "pytest -vv tests/integration/local/start_api --json-report --json-report-file=TEST_REPORT-integration-local-api.json"
+
+  #Integ testing local start-lambda
+  - matrix:
+      only:
+        - configuration: LocalStartLambdaIntegTesting
+
+    test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
+      - ps: "pytest -vv tests/integration/local/start_lambda --json-report --json-report-file=TEST_REPORT-integration-local-lambda.json"
 
   #Other testing
   - matrix:
       only:
-        - configuration: OtherTesting
+        - configuration: OtherAndEndToEndTesting
 
     test_script:
       - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
+      - ps: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
       - ps: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"
 # Uncomment for RDP
 # on_finish:

--- a/appveyor-windows-binary.yml
+++ b/appveyor-windows-binary.yml
@@ -303,8 +303,7 @@ for:
         - configuration: OtherAndEndToEndTesting
 
     test_script:
-      - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
-      - ps: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
+      - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration tests/end_to_end --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
       - ps: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"
 # Uncomment for RDP
 # on_finish:

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -9,11 +9,11 @@ configuration:
   - BuildIntegTestingJavaPythonProvided
   - BuildIntegTestingArm64
   - AllTerraformBuildTesting
-  - DeployIntegTesting
-  - PackageAndDeleteIntegTesting
+  - PackageAndDeleteAndDeployIntegTesting
   - SyncIntegTesting
-  - LocalIntegTesting
-  - EndToEndTesting
+  - LocalInvokeIntegTesting
+  - LocalStartApiIntegTesting
+  - LocalStartLambdaIntegTesting
   # other Integration testing, Dev, regression and smoke testing
   - OtherTesting
 
@@ -239,10 +239,10 @@ for:
   # Integ testing package & delete
   - matrix:
       only:
-        - configuration: PackageAndDeleteIntegTesting
+        - configuration: PackageAndDeleteAndDeployIntegTesting
 
     test_script:
-      - ps: "pytest -vv tests/integration/package tests/integration/delete -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete.json"
+      - ps: "pytest -vv tests/integration/package tests/integration/delete tests/integration/deploy -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete.json"
 
   # Integ testing sync
   - matrix:
@@ -252,25 +252,41 @@ for:
     test_script:
       - ps: "pytest -vv tests/integration/sync -n 3 --reruns 3 --dist loadscope --json-report --json-report-file=TEST_REPORT-integration-sync.json"
 
-  #Integ testing local
+  #Integ testing local invoke and generate event
   - matrix:
       only:
-        - configuration: LocalIntegTesting
+        - configuration: LocalInvokeIntegTesting
 
     test_script:
       # install Terraform CLI
       - "choco install terraform"
       - "terraform -version"
 
-      - ps: "pytest -vv tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-local.json"
+      - ps: "pytest -vv tests/integration/local/invoke tests/integration/local/generate_event --json-report --json-report-file=TEST_REPORT-integration-local.json"
 
-  # End-to-end testing
+  #Integ testing local start-api
   - matrix:
       only:
-        - configuration: EndToEndTesting
+        - configuration: LocalStartApiIntegTesting
 
     test_script:
-      - ps: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
+      - ps: "pytest -vv tests/integration/local/start_api --json-report --json-report-file=TEST_REPORT-integration-local-api.json"
+
+  #Integ testing local start-lambda
+  - matrix:
+      only:
+        - configuration: LocalStartLambdaIntegTesting
+
+    test_script:
+      # install Terraform CLI
+      - "choco install terraform"
+      - "terraform -version"
+
+      - ps: "pytest -vv tests/integration/local/start_lambda --json-report --json-report-file=TEST_REPORT-integration-local-lambda.json"
 
   #Other testing
   - matrix:
@@ -279,6 +295,7 @@ for:
 
     test_script:
       - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
+      - ps: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
       - ps: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"
 # Uncomment for RDP
 # on_finish:

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -15,7 +15,7 @@ configuration:
   - LocalStartApiIntegTesting
   - LocalStartLambdaIntegTesting
   # other Integration testing, Dev, regression and smoke testing
-  - OtherTesting
+  - OtherAndEndToEndTesting
 
 environment:
   AWS_DEFAULT_REGION: us-east-1
@@ -236,13 +236,13 @@ for:
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
       - ps: "pytest -vv -n 4 tests/integration/buildcmd/test_build_terraform_applications_other_cases.py --json-report --json-report-file=TEST_REPORT-integration-buildcmd.json"
 
-  # Integ testing package & delete
+  # Integ testing package, delete and deploy
   - matrix:
       only:
         - configuration: PackageAndDeleteAndDeployIntegTesting
 
     test_script:
-      - ps: "pytest -vv tests/integration/package tests/integration/delete tests/integration/deploy -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete.json"
+      - ps: "pytest -vv tests/integration/package tests/integration/delete tests/integration/deploy --dist=loadgroup -n 4 --reruns 4 --json-report --json-report-file=TEST_REPORT-integration-package-delete.json"
 
   # Integ testing sync
   - matrix:
@@ -291,7 +291,7 @@ for:
   #Other testing
   - matrix:
       only:
-        - configuration: OtherTesting
+        - configuration: OtherAndEndToEndTesting
 
     test_script:
       - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -294,8 +294,7 @@ for:
         - configuration: OtherAndEndToEndTesting
 
     test_script:
-      - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
-      - ps: "pytest -vv -n 4 --reruns 5 --dist loadscope tests/end_to_end --json-report --json-report-file=TEST_REPORT-end-to-end.json"
+      - ps: "pytest -vv -n 4 --reruns 4 --dist loadgroup tests/integration tests/end_to_end --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others.json"
       - ps: "pytest -vv tests/regression --json-report --json-report-file=TEST_REPORT-regression.json"
 # Uncomment for RDP
 # on_finish:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
This change re-groups some jobs to have a better time distribution of workers. Currently, some jobs take far longer than others leading to canaries taking much longer overall. This re-distribution of workers should decrease the total canary duration from ~2.5 hours to ~1.5 hours.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
