### PR TITLE
fix: validate architecture before trying to pull the build image

### DIFF
--- a/samcli/local/docker/lambda_build_container.py
+++ b/samcli/local/docker/lambda_build_container.py
@@ -9,10 +9,19 @@ import pathlib
 from typing import List
 from uuid import uuid4
 
+from samcli.commands.exceptions import UserException
+from samcli.lib.utils.architecture import X86_64, ARM64
 from samcli.commands._utils.experimental import get_enabled_experimental_flags
 from samcli.local.docker.container import Container
 
 LOG = logging.getLogger(__name__)
+
+
+class InvalidArchitectureForImage(UserException):
+    """
+    Raised when architecture that is provided for the image is invalid
+    """
+    pass
 
 
 class LambdaBuildContainer(Container):
@@ -297,4 +306,8 @@ class LambdaBuildContainer(Container):
         str
             Image tag
         """
+        if architecture not in [X86_64, ARM64]:
+            raise InvalidArchitectureForImage(
+                f"'{architecture}' is not a valid architecture, it should be either '{X86_64}' or '{ARM64}'"
+            )
         return f"{LambdaBuildContainer._IMAGE_TAG}-{architecture}"

--- a/tests/unit/local/docker/test_lambda_build_container.py
+++ b/tests/unit/local/docker/test_lambda_build_container.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from parameterized import parameterized
 
 from samcli.lib.utils.architecture import X86_64, ARM64
-from samcli.local.docker.lambda_build_container import LambdaBuildContainer
+from samcli.local.docker.lambda_build_container import LambdaBuildContainer, InvalidArchitectureForImage
 
 
 class TestLambdaBuildContainer_init(TestCase):
@@ -216,6 +216,10 @@ class TestLambdaBuildContainer_get_image_tag(TestCase):
     )
     def test_must_get_image_tag(self, architecture, expected_image_tag):
         self.assertEqual(expected_image_tag, LambdaBuildContainer.get_image_tag(architecture))
+
+    def test_must_raise_an_error_for_invalid_architecture(self):
+        with self.assertRaises(InvalidArchitectureForImage):
+            LambdaBuildContainer.get_image_tag("invalid-architecture")
 
 
 class TestLambdaBuildContainer_get_entrypoint(TestCase):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#6110


#### Why is this change necessary?
AWS Lambda Function's architecture is used during building inside container to decide what would be the tag for the container (either `latest-x86_64` or `latest-arm64`). Today there is no validation with this field, which ends up in en error while trying to pull the image.

#### How does it address the issue?
This change addresses that issue by adding validation of the architecture before pulling the image.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
