### PR TITLE
test: bump AWS::Serverless::Function runtime to nodejs18.x

### DIFF
--- a/tests/functional/commands/validate/lib/models/api_merge_definitions_global.yaml
+++ b/tests/functional/commands/validate/lib/models/api_merge_definitions_global.yaml
@@ -31,7 +31,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/functional/commands/validate/lib/models/api_merge_definitions_with_conflicting_auth.yaml
+++ b/tests/functional/commands/validate/lib/models/api_merge_definitions_with_conflicting_auth.yaml
@@ -28,7 +28,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/functional/commands/validate/lib/models/api_merge_definitions_with_conflicting_methods.yaml
+++ b/tests/functional/commands/validate/lib/models/api_merge_definitions_with_conflicting_methods.yaml
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/functional/commands/validate/lib/models/api_merge_definitions_with_conflicting_request_models.yaml
+++ b/tests/functional/commands/validate/lib/models/api_merge_definitions_with_conflicting_request_models.yaml
@@ -35,7 +35,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/functional/commands/validate/lib/models/api_merge_definitions_with_different_methods.yaml
+++ b/tests/functional/commands/validate/lib/models/api_merge_definitions_with_different_methods.yaml
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/functional/commands/validate/lib/models/api_merge_definitions_with_full_properties.yaml
+++ b/tests/functional/commands/validate/lib/models/api_merge_definitions_with_full_properties.yaml
@@ -49,7 +49,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/functional/commands/validate/lib/models/api_with_custom_domains_regional_latency_routing.yaml
+++ b/tests/functional/commands/validate/lib/models/api_with_custom_domains_regional_latency_routing.yaml
@@ -41,7 +41,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/functional/commands/validate/lib/models/api_with_custom_domains_regional_latency_routing_ipv6.yaml
+++ b/tests/functional/commands/validate/lib/models/api_with_custom_domains_regional_latency_routing_ipv6.yaml
@@ -42,7 +42,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/functional/commands/validate/lib/models/congito_userpool_with_sms_configuration.yaml
+++ b/tests/functional/commands/validate/lib/models/congito_userpool_with_sms_configuration.yaml
@@ -4,7 +4,7 @@ Resources:
     Properties:
       CodeUri: s3://bucket/key
       Handler: app.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         CognitoUserPoolPreSignup:
           Type: Cognito

--- a/tests/functional/commands/validate/lib/models/connector_api_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_api_to_function.yaml
@@ -34,7 +34,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -58,7 +58,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/functional/commands/validate/lib/models/connector_api_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_api_to_function.yaml
@@ -37,7 +37,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };
@@ -62,7 +61,6 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
           };

--- a/tests/functional/commands/validate/lib/models/connector_api_to_multiple_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_api_to_multiple_function.yaml
@@ -7,7 +7,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -31,7 +31,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/functional/commands/validate/lib/models/connector_api_to_multiple_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_api_to_multiple_function.yaml
@@ -10,7 +10,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };
@@ -35,7 +34,6 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
           };

--- a/tests/functional/commands/validate/lib/models/connector_appsync_to_lambda.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_appsync_to_lambda.yaml
@@ -19,7 +19,7 @@ Resources:
           return "Hello World"
         }
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
 
   AppSyncApi:
     Type: AWS::AppSync::GraphQLApi

--- a/tests/functional/commands/validate/lib/models/connector_bucket_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_bucket_to_function.yaml
@@ -2,7 +2,7 @@ Resources:
   Function:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_bucket_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_bucket_to_function.yaml
@@ -5,7 +5,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log("function")
         };

--- a/tests/functional/commands/validate/lib/models/connector_function_to_location.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_location.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_function_to_location.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_location.yaml
@@ -5,7 +5,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };

--- a/tests/functional/commands/validate/lib/models/connector_function_to_multiple_s3.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_multiple_s3.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_function_to_multiple_s3.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_multiple_s3.yaml
@@ -5,7 +5,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };

--- a/tests/functional/commands/validate/lib/models/connector_function_to_s3.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_s3.yaml
@@ -2,7 +2,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_function_to_s3.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_s3.yaml
@@ -5,7 +5,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };

--- a/tests/functional/commands/validate/lib/models/connector_function_to_sqs.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_sqs.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |
@@ -30,7 +30,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_function_to_sqs.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_sqs.yaml
@@ -19,7 +19,6 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
           };
@@ -33,7 +32,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };

--- a/tests/functional/commands/validate/lib/models/connector_function_to_table.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_table.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |
@@ -32,7 +32,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_function_to_table.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_function_to_table.yaml
@@ -19,11 +19,13 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
+          const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+          const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
-            const docClient = new AWS.DynamoDB.DocumentClient();
-            await docClient.scan({ TableName: process.env.TABLE_NAME, }).promise();
+            const docClient = DynamoDBDocument.from(new DynamoDB());
+            await docClient.scan({ TableName: process.env.TABLE_NAME, });
           };
       Environment:
         Variables:
@@ -35,11 +37,13 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+        const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
-          const docClient = new AWS.DynamoDB.DocumentClient();
-          await docClient.scan({ TableName: process.env.TABLE_NAME, }).promise();
+          const docClient = DynamoDBDocument.from(new DynamoDB());
+          await docClient.scan({ TableName: process.env.TABLE_NAME, });
         };
       Environment:
         Variables:

--- a/tests/functional/commands/validate/lib/models/connector_mix_destination.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_mix_destination.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -54,7 +54,7 @@ Resources:
   Function:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_mix_destination.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_mix_destination.yaml
@@ -6,18 +6,18 @@ Resources:
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { EventBridge } = require('@aws-sdk/client-eventbridge');
         const { SQS } = require('@aws-sdk/client-sqs');
 
         exports.handler = async (event) => {
-          const eb = new AWS.EventBridge();
+          const eb = new EventBridge();
           const response = await eb.putEvents({
             Entries: [{
               Source: process.env.EVENT_SOURCE,
               Detail: "{}",
               DetailType: "Test",
             }]
-          }).promise();
+          });
 
           const sqs = new SQS();
           const data = await sqs.getQueueAttributes({

--- a/tests/functional/commands/validate/lib/models/connector_mix_destination.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_mix_destination.yaml
@@ -7,6 +7,7 @@ Resources:
       Timeout: 10  # in case eb has delay
       InlineCode: |
         const AWS = require('aws-sdk');
+        const { SQS } = require('@aws-sdk/client-sqs');
 
         exports.handler = async (event) => {
           const eb = new AWS.EventBridge();
@@ -18,11 +19,11 @@ Resources:
             }]
           }).promise();
 
-          const sqs = new AWS.SQS();
+          const sqs = new SQS();
           const data = await sqs.getQueueAttributes({
             QueueUrl: process.env.QUEUE_URL,
             AttributeNames: ['ApproximateNumberOfMessages']
-          }).promise();
+          });
 
           if (data.Attributes.ApproximateNumberOfMessages < 2) {
             throw 'Not enough messages in the queue!';
@@ -57,14 +58,14 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { SQS } = require('@aws-sdk/client-sqs');
 
         exports.handler = async (event) => {
-          const sqs = new AWS.SQS();
+          const sqs = new SQS();
           await sqs.sendMessage({
             QueueUrl: process.env.QUEUE_URL,
             MessageBody: "test"
-          }).promise();
+          });
         };
       Environment:
         Variables:

--- a/tests/functional/commands/validate/lib/models/connector_sfn_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sfn_to_function.yaml
@@ -19,7 +19,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_sfn_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sfn_to_function.yaml
@@ -22,7 +22,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };

--- a/tests/functional/commands/validate/lib/models/connector_sfn_to_function_without_policy.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sfn_to_function_without_policy.yaml
@@ -16,7 +16,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         exports.handler = async (event) => {

--- a/tests/functional/commands/validate/lib/models/connector_sns_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sns_to_function.yaml
@@ -18,7 +18,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/functional/commands/validate/lib/models/connector_sns_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sns_to_function.yaml
@@ -22,7 +22,6 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
           };

--- a/tests/functional/commands/validate/lib/models/connector_sqs_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sqs_to_function.yaml
@@ -5,7 +5,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -39,7 +39,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_sqs_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sqs_to_function.yaml
@@ -9,19 +9,20 @@ Resources:
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { SQS } = require('@aws-sdk/client-sqs');
+
         exports.handler = async (event) => {
           var params = {
             QueueUrl: process.env.QUEUE_URL,
             MessageBody: "test queue"
           };
-          var sqs = new AWS.SQS();
-          await sqs.sendMessage(params).promise();
+          var sqs = new SQS();
+          await sqs.sendMessage(params);
 
           const data = await sqs.receiveMessage({
             QueueUrl: process.env.VERIFICATION_QUEUE_URL,
             WaitTimeSeconds: 5,
-          }).promise();
+          });
           if (data.Messages.length == 0) {
             throw 'No messages in the queue!';
           }
@@ -42,13 +43,14 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { SQS } = require('@aws-sdk/client-sqs');
+
         exports.handler = async (event) => {
-          const sqs = new AWS.SQS();
+          const sqs = new SQS();
           await sqs.sendMessage({
             QueueUrl: process.env.VERIFICATION_QUEUE_URL,
             MessageBody: "test"
-          }).promise();
+          });
         };
       Environment:
         Variables:

--- a/tests/functional/commands/validate/lib/models/connector_sqs_to_multiple_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sqs_to_multiple_function.yaml
@@ -5,7 +5,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -26,7 +26,7 @@ Resources:
   InvokedFunction2:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_sqs_to_multiple_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_sqs_to_multiple_function.yaml
@@ -8,13 +8,14 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { SQS } = require('@aws-sdk/client-sqs');
+
         exports.handler = async (event) => {
-          const sqs = new AWS.SQS();
+          const sqs = new SQS();
           await sqs.sendMessage({
             QueueUrl: process.env.VERIFICATION_QUEUE_URL,
             MessageBody: "test"
-          }).promise();
+          });
         };
       Environment:
         Variables:
@@ -29,13 +30,14 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { SQS } = require('@aws-sdk/client-sqs');
+
         exports.handler = async (event) => {
-          const sqs = new AWS.SQS();
+          const sqs = new SQS();
           await sqs.sendMessage({
             QueueUrl: process.env.VERIFICATION_QUEUE_URL,
             MessageBody: "test"
-          }).promise();
+          });
         };
       Environment:
         Variables:

--- a/tests/functional/commands/validate/lib/models/connector_table_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_table_to_function.yaml
@@ -15,7 +15,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/functional/commands/validate/lib/models/connector_table_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_table_to_function.yaml
@@ -19,7 +19,6 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
           };

--- a/tests/functional/commands/validate/lib/models/connector_table_to_function_read.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_table_to_function_read.yaml
@@ -2,7 +2,7 @@ Resources:
   TriggerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
@@ -36,7 +36,7 @@ Resources:
   InvokedFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/connector_table_to_function_read.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_table_to_function_read.yaml
@@ -7,6 +7,8 @@ Resources:
       Timeout: 10  # in case eb has delay
       InlineCode: |
         const AWS = require('aws-sdk');
+        const { SQS } = require('@aws-sdk/client-sqs');
+
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
           const docClient = new AWS.DynamoDB.DocumentClient();
@@ -17,10 +19,10 @@ Resources:
             }
           }).promise();
 
-          const data = await new AWS.SQS().receiveMessage({
+          const data = await new SQS().receiveMessage({
             QueueUrl: process.env.VERIFICATION_QUEUE_URL,
             WaitTimeSeconds: 5,
-          }).promise();
+          });
           if (data.Messages.length == 0) {
             throw 'No messages in the queue!';
           }
@@ -39,13 +41,14 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { SQS } = require('@aws-sdk/client-sqs');
+
         exports.handler = async (event) => {
-          const sqs = new AWS.SQS();
+          const sqs = new SQS();
           await sqs.sendMessage({
             QueueUrl: process.env.VERIFICATION_QUEUE_URL,
             MessageBody: "test"
-          }).promise();
+          });
         };
       Environment:
         Variables:

--- a/tests/functional/commands/validate/lib/models/connector_table_to_function_read.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_table_to_function_read.yaml
@@ -6,18 +6,19 @@ Resources:
       Handler: index.handler
       Timeout: 10  # in case eb has delay
       InlineCode: |
-        const AWS = require('aws-sdk');
+        const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+        const { DynamoDB } = require('@aws-sdk/client-dynamodb');
         const { SQS } = require('@aws-sdk/client-sqs');
 
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
-          const docClient = new AWS.DynamoDB.DocumentClient();
+          const docClient = DynamoDBDocument.from(new DynamoDB());
           const response = await docClient.put({ 
             TableName: process.env.TABLE_NAME, 
             Item: {
               Id: 'TestInput1234'
             }
-          }).promise();
+          });
 
           const data = await new SQS().receiveMessage({
             QueueUrl: process.env.VERIFICATION_QUEUE_URL,

--- a/tests/functional/commands/validate/lib/models/connector_with_non_id_source_and_destination.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_with_non_id_source_and_destination.yaml
@@ -16,7 +16,7 @@ Resources:
   SamFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Role: !GetAtt MyRole.Arn
       InlineCode: |

--- a/tests/functional/commands/validate/lib/models/connector_with_non_id_source_and_destination.yaml
+++ b/tests/functional/commands/validate/lib/models/connector_with_non_id_source_and_destination.yaml
@@ -20,7 +20,6 @@ Resources:
       Handler: index.handler
       Role: !GetAtt MyRole.Arn
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };

--- a/tests/functional/commands/validate/lib/models/embedded_connector_function_to_multi_dest.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connector_function_to_multi_dest.yaml
@@ -11,7 +11,7 @@ Resources:
           - Read
           - Write
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/embedded_connector_function_to_multi_dest.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connector_function_to_multi_dest.yaml
@@ -14,7 +14,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_api_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_api_to_function.yaml
@@ -49,7 +49,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -73,7 +73,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |-

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_api_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_api_to_function.yaml
@@ -52,7 +52,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };
@@ -77,7 +76,6 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |-
-          const AWS = require('aws-sdk');
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
           };

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_function_to.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_function_to.yaml
@@ -45,7 +45,7 @@ Resources:
           - Read
           - Write
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');
@@ -79,7 +79,7 @@ Resources:
           - Write
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_function_to.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_function_to.yaml
@@ -48,7 +48,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };
@@ -83,7 +82,6 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
           };

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_sfn_to.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_sfn_to.yaml
@@ -47,7 +47,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         const AWS = require('aws-sdk');

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_sfn_to.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_sfn_to.yaml
@@ -50,7 +50,6 @@ Resources:
       Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
-        const AWS = require('aws-sdk');
         exports.handler = async (event) => {
           console.log(JSON.stringify(event));
         };

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_sns_to.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_sns_to.yaml
@@ -21,7 +21,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: " const AWS = require('aws-sdk'); exports.handler = async (event)\
         \ => { console.log(JSON.stringify(event)); };"

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_sns_to.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_sns_to.yaml
@@ -23,5 +23,5 @@ Resources:
     Properties:
       Runtime: nodejs18.x
       Handler: index.handler
-      InlineCode: " const AWS = require('aws-sdk'); exports.handler = async (event)\
+      InlineCode: "exports.handler = async (event)\
         \ => { console.log(JSON.stringify(event)); };"

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_table_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_table_to_function.yaml
@@ -2,7 +2,7 @@ Resources:
   MyServerlessFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       InlineCode: |
         exports.handler = async (event) => {
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt MyRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Code:
         ZipFile: |

--- a/tests/functional/commands/validate/lib/models/embedded_connectors_table_to_function.yaml
+++ b/tests/functional/commands/validate/lib/models/embedded_connectors_table_to_function.yaml
@@ -17,7 +17,6 @@ Resources:
       Handler: index.handler
       Code:
         ZipFile: |
-          const AWS = require('aws-sdk');
           exports.handler = async (event) => {
             console.log(JSON.stringify(event));
           };

--- a/tests/functional/commands/validate/lib/models/event_bridge_rule_super_long_id.yaml
+++ b/tests/functional/commands/validate/lib/models/event_bridge_rule_super_long_id.yaml
@@ -5,7 +5,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       InlineCode: |
         exports.handler = async (event, context, callback) => {
           return {

--- a/tests/functional/commands/validate/lib/models/function_with_mq.yaml
+++ b/tests/functional/commands/validate/lib/models/function_with_mq.yaml
@@ -137,7 +137,7 @@ Resources:
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: s3://bucket/key
       Role:

--- a/tests/functional/commands/validate/lib/models/http_api_with_custom_domains_regional_latency_routing.yaml
+++ b/tests/functional/commands/validate/lib/models/http_api_with_custom_domains_regional_latency_routing.yaml
@@ -41,7 +41,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/functional/commands/validate/lib/models/http_api_with_custom_domains_regional_latency_routing_ipv6.yaml
+++ b/tests/functional/commands/validate/lib/models/http_api_with_custom_domains_regional_latency_routing_ipv6.yaml
@@ -42,7 +42,7 @@ Resources:
           return response;
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         ImplicitGet:
           Type: Api

--- a/tests/functional/commands/validate/lib/models/http_api_with_default_stage_name_and_fail_on_warnings.yaml
+++ b/tests/functional/commands/validate/lib/models/http_api_with_default_stage_name_and_fail_on_warnings.yaml
@@ -9,7 +9,7 @@ Resources:
     Properties:
       InlineCode: foo
       Handler: bar
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Events:
         AppHandler:
           Type: HttpApi

--- a/tests/functional/commands/validate/lib/models/schema_validation_1.yaml
+++ b/tests/functional/commands/validate/lib/models/schema_validation_1.yaml
@@ -59,7 +59,7 @@ Resources:
       - ResourceName: Function
       CodeUri: s3://src/Function
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       MemorySize: 3008
       Timeout: 30
       Tracing: Active

--- a/tests/functional/commands/validate/lib/models/schema_validation_5.yaml
+++ b/tests/functional/commands/validate/lib/models/schema_validation_5.yaml
@@ -33,6 +33,6 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: foo
       InlineCode: bar

--- a/tests/functional/commands/validate/lib/models/state_machine_with_schedule_target_id.yaml
+++ b/tests/functional/commands/validate/lib/models/state_machine_with_schedule_target_id.yaml
@@ -7,7 +7,7 @@ Resources:
           console.log("Hello world!")
         };
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
 
   StateMachineIdWith30Characters:
     Type: AWS::Serverless::StateMachine

--- a/tests/integration/testdata/invoke/cdk/runtime_function_constructs.yaml
+++ b/tests/integration/testdata/invoke/cdk/runtime_function_constructs.yaml
@@ -144,7 +144,7 @@ Resources:
         Variables:
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
     DependsOn:
       - NodejsFunctionServiceRole92FAD13F
     Metadata:

--- a/tests/integration/testdata/validate/default_yaml/template.yaml
+++ b/tests/integration/testdata/validate/default_yaml/template.yaml
@@ -7,4 +7,4 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: app.lambdaHandler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x

--- a/tests/integration/testdata/validate/default_yaml/templateError.yaml
+++ b/tests/integration/testdata/validate/default_yaml/templateError.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: app.lambdaHandler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
 
   HelloWorldFunction:
     Type: AWS::Serverless::Api

--- a/tests/integration/testdata/validate/multiple_files/template.yaml
+++ b/tests/integration/testdata/validate/multiple_files/template.yaml
@@ -7,4 +7,4 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: app.lambdaHandler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x

--- a/tests/unit/lib/iac/cdk/test_data/non_cdk_cfn.yaml
+++ b/tests/unit/lib/iac/cdk/test_data/non_cdk_cfn.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       CodeUri: hello-world/
       Handler: app.lambdaHandler
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Architectures:
         - x86_64
       Events:


### PR DESCRIPTION
#### Which issue(s) does this change fix?

Fixes: https://github.com/aws/aws-sam-cli/issues/6195

#### Why is this change necessary?

Lambda nodejs14.x creation will be stopped on [Nov 27, 2023](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).

#### How does it address the issue?

Bumps AWS::Serverless::Function runtime to nodejs18.x

#### What side effects does this change have?

N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
