### PR TITLE
fix: compare handlers when comparing build definitions

### DIFF
--- a/samcli/lib/build/build_graph.py
+++ b/samcli/lib/build/build_graph.py
@@ -49,6 +49,9 @@ ARCHITECTURE_FIELD = "architecture"
 HANDLER_FIELD = "handler"
 SHARED_CODEURI_SUFFIX = "Shared"
 
+# Compiled runtimes that we need to compare handlers for
+COMPILED_RUNTIMES = ["go1.x"]
+
 
 def _function_build_definition_to_toml_table(
     function_build_definition: "FunctionBuildDefinition",
@@ -677,6 +680,12 @@ class FunctionBuildDefinition(AbstractBuildDefinition):
             if self.handler != other.handler:
                 return False
 
+        if self.runtime in COMPILED_RUNTIMES:
+            # For compiled languages, we need to check if handlers within the same CodeUri are the same
+            # if they are different, it should create a separate build definition
+            if self.handler != other.handler:
+                return False
+
         return (
             self.runtime == other.runtime
             and self.codeuri == other.codeuri
@@ -684,5 +693,4 @@ class FunctionBuildDefinition(AbstractBuildDefinition):
             and self.metadata == other.metadata
             and self.env_vars == other.env_vars
             and self.architecture == other.architecture
-            and self.handler == other.handler
         )

--- a/samcli/lib/build/build_graph.py
+++ b/samcli/lib/build/build_graph.py
@@ -684,4 +684,5 @@ class FunctionBuildDefinition(AbstractBuildDefinition):
             and self.metadata == other.metadata
             and self.env_vars == other.env_vars
             and self.architecture == other.architecture
+            and self.handler == other.handler
         )

--- a/tests/unit/lib/build_module/test_build_graph.py
+++ b/tests/unit/lib/build_module/test_build_graph.py
@@ -482,63 +482,6 @@ class TestBuildGraph(TestCase):
             self.assertEqual(len(build_definitions[1].functions), 1)
             self.assertEqual(build_definitions[1].functions[0], function2)
 
-    def test_functions_with_only_different_handlers_added_to_build_graph(self):
-        with osutils.mkdir_temp() as temp_base_dir:
-            build_dir = Path(temp_base_dir, ".aws-sam", "build")
-            build_dir.mkdir(parents=True)
-
-            build_graph_path = Path(build_dir.parent, "build.toml")
-            build_graph_path.write_text(TestBuildGraph.BUILD_GRAPH_CONTENTS)
-
-            build_graph = BuildGraph(str(build_dir))
-
-            build_definition1 = FunctionBuildDefinition(
-                TestBuildGraph.RUNTIME,
-                TestBuildGraph.CODEURI,
-                TestBuildGraph.ZIP,
-                TestBuildGraph.ARCHITECTURE_FIELD,
-                TestBuildGraph.METADATA,
-                TestBuildGraph.HANDLER,
-                TestBuildGraph.SOURCE_HASH,
-                TestBuildGraph.MANIFEST_HASH,
-                TestBuildGraph.ENV_VARS,
-            )
-            function1 = generate_function(
-                runtime=TestBuildGraph.RUNTIME,
-                codeuri=TestBuildGraph.CODEURI,
-                metadata=TestBuildGraph.METADATA,
-            )
-            build_graph.put_function_build_definition(build_definition1, function1)
-
-            build_definitions = build_graph.get_function_build_definitions()
-            self.assertEqual(len(build_definitions), 1)
-            self.assertEqual(len(build_definitions[0].functions), 1)
-            self.assertEqual(build_definitions[0].functions[0], function1)
-            self.assertEqual(build_definitions[0].uuid, TestBuildGraph.UUID)
-
-            build_definition2 = FunctionBuildDefinition(
-                TestBuildGraph.RUNTIME,
-                TestBuildGraph.CODEURI,
-                TestBuildGraph.ZIP,
-                TestBuildGraph.ARCHITECTURE_FIELD,
-                TestBuildGraph.METADATA,
-                "different.handler",
-                TestBuildGraph.SOURCE_HASH,
-                TestBuildGraph.MANIFEST_HASH,
-                TestBuildGraph.ENV_VARS,
-            )
-            function2 = generate_function(
-                runtime=TestBuildGraph.RUNTIME,
-                codeuri=TestBuildGraph.CODEURI,
-                metadata=TestBuildGraph.METADATA,
-            )
-            build_graph.put_function_build_definition(build_definition2, function2)
-
-            build_definitions = build_graph.get_function_build_definitions()
-            self.assertEqual(len(build_definitions), 2)
-            self.assertEqual(len(build_definitions[1].functions), 1)
-            self.assertEqual(build_definitions[1].functions[0], function2)
-
     def test_layers_should_be_added_existing_build_graph(self):
         with osutils.mkdir_temp() as temp_base_dir:
             build_dir = Path(temp_base_dir, ".aws-sam", "build")
@@ -1033,3 +976,28 @@ class TestBuildDefinition(TestCase):
         copied_build_definitions = copy.deepcopy(build_definitions)
 
         self.assertEqual(copied_build_definitions, build_definitions)
+
+    def test_go_runtime_different_handlers_are_not_equal(self):
+        build_graph = BuildGraph("build/path")
+        metadata = {}
+        build_definition1 = FunctionBuildDefinition(
+            "go1.x", "codeuri", ZIP, ARM64, metadata, "handler", "source_hash", "manifest_hash"
+        )
+        function1 = generate_function(
+            runtime="go1.x", codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler"
+        )
+        build_definition2 = FunctionBuildDefinition(
+            "go1.x", "codeuri", ZIP, ARM64, metadata, "handler.new", "source_hash", "manifest_hash"
+        )
+        function2 = generate_function(
+            runtime="go1.x", codeuri=TestBuildGraph.CODEURI, metadata=metadata, handler="handler.new"
+        )
+        build_graph.put_function_build_definition(build_definition1, function1)
+        build_graph.put_function_build_definition(build_definition2, function2)
+
+        build_definitions = build_graph.get_function_build_definitions()
+
+        self.assertNotEqual(build_definition1, build_definition2)
+        self.assertEqual(len(build_definitions), 2)
+        self.assertEqual(len(build_definition1.functions), 1)
+        self.assertEqual(len(build_definition2.functions), 1)

--- a/tests/unit/lib/build_module/test_build_graph.py
+++ b/tests/unit/lib/build_module/test_build_graph.py
@@ -482,6 +482,63 @@ class TestBuildGraph(TestCase):
             self.assertEqual(len(build_definitions[1].functions), 1)
             self.assertEqual(build_definitions[1].functions[0], function2)
 
+    def test_functions_with_only_different_handlers_added_to_build_graph(self):
+        with osutils.mkdir_temp() as temp_base_dir:
+            build_dir = Path(temp_base_dir, ".aws-sam", "build")
+            build_dir.mkdir(parents=True)
+
+            build_graph_path = Path(build_dir.parent, "build.toml")
+            build_graph_path.write_text(TestBuildGraph.BUILD_GRAPH_CONTENTS)
+
+            build_graph = BuildGraph(str(build_dir))
+
+            build_definition1 = FunctionBuildDefinition(
+                TestBuildGraph.RUNTIME,
+                TestBuildGraph.CODEURI,
+                TestBuildGraph.ZIP,
+                TestBuildGraph.ARCHITECTURE_FIELD,
+                TestBuildGraph.METADATA,
+                TestBuildGraph.HANDLER,
+                TestBuildGraph.SOURCE_HASH,
+                TestBuildGraph.MANIFEST_HASH,
+                TestBuildGraph.ENV_VARS,
+            )
+            function1 = generate_function(
+                runtime=TestBuildGraph.RUNTIME,
+                codeuri=TestBuildGraph.CODEURI,
+                metadata=TestBuildGraph.METADATA,
+            )
+            build_graph.put_function_build_definition(build_definition1, function1)
+
+            build_definitions = build_graph.get_function_build_definitions()
+            self.assertEqual(len(build_definitions), 1)
+            self.assertEqual(len(build_definitions[0].functions), 1)
+            self.assertEqual(build_definitions[0].functions[0], function1)
+            self.assertEqual(build_definitions[0].uuid, TestBuildGraph.UUID)
+
+            build_definition2 = FunctionBuildDefinition(
+                TestBuildGraph.RUNTIME,
+                TestBuildGraph.CODEURI,
+                TestBuildGraph.ZIP,
+                TestBuildGraph.ARCHITECTURE_FIELD,
+                TestBuildGraph.METADATA,
+                "different.handler",
+                TestBuildGraph.SOURCE_HASH,
+                TestBuildGraph.MANIFEST_HASH,
+                TestBuildGraph.ENV_VARS,
+            )
+            function2 = generate_function(
+                runtime=TestBuildGraph.RUNTIME,
+                codeuri=TestBuildGraph.CODEURI,
+                metadata=TestBuildGraph.METADATA,
+            )
+            build_graph.put_function_build_definition(build_definition2, function2)
+
+            build_definitions = build_graph.get_function_build_definitions()
+            self.assertEqual(len(build_definitions), 2)
+            self.assertEqual(len(build_definitions[1].functions), 1)
+            self.assertEqual(build_definitions[1].functions[0], function2)
+
     def test_layers_should_be_added_existing_build_graph(self):
         with osutils.mkdir_temp() as temp_base_dir:
             build_dir = Path(temp_base_dir, ".aws-sam", "build")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#6117 


#### Why is this change necessary?
The FunctionBuildDefinition currently does not compare handlers in the __eq__ method of the class which means if everything else is the same it'll consider the build definitions to be the same and result in only one handler being used for multiple functions.

#### How does it address the issue?
compare handlers in the __eq__ method

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
