### PR TITLE
fix(test): Fix integration test failure on Windows

### DIFF
--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -1205,15 +1205,16 @@ class TestInvokeFunctionWithError(InvokeIntegBase):
             function_to_invoke="RaiseExceptionFunction", template_path=self.template_path
         )
 
-        expected_stack_trace = (
-            f"[ERROR] Exception: Lambda is raising an exception{os.linesep}"
-            f"Traceback (most recent call last):{os.linesep}"
-            f'\xa0\xa0File "/var/task/main.py", line 51, in raise_exception{os.linesep}'
-            f'\xa0\xa0\xa0\xa0raise Exception("Lambda is raising an exception")'
-        )
+        stack_trace_lines = [
+            "[ERROR] Exception: Lambda is raising an exception",
+            "Traceback (most recent call last):",
+            '\xa0\xa0File "/var/task/main.py", line 51, in raise_exception',
+            '\xa0\xa0\xa0\xa0raise Exception("Lambda is raising an exception")',
+        ]
 
         result = run_command(command_list)
         stderr = result.stderr.decode("utf-8").strip()
 
         self.assertEqual(result.process.returncode, 0)
-        self.assertIn(expected_stack_trace, stderr)
+        for line in stack_trace_lines:
+            self.assertIn(line, stderr)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Fixes an integration test failure that started to occur due to line endings not matching on Windows with recent PR to write string instead of bytes.

#### How does it address the issue?
Don't attempt to compare line endings since we really just care about the contents of the stack trace.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
