### PR TITLE
test: fix flaky remote invoke sqs tests

### DIFF
--- a/tests/integration/remote/invoke/test_remote_invoke.py
+++ b/tests/integration/remote/invoke/test_remote_invoke.py
@@ -13,6 +13,8 @@ from tests.testing_utils import run_command
 from pathlib import Path
 import pytest
 
+SQS_WAIT_TIME_SECONDS = 20
+
 
 @pytest.mark.xdist_group(name="sam_remote_invoke_single_lambda_resource")
 class TestSingleLambdaInvoke(RemoteInvokeIntegBase):
@@ -209,7 +211,7 @@ class TestSQSPriorityInvoke(RemoteInvokeIntegBase):
         self.assertIn("MessageId", remote_invoke_result_stdout)
 
         received_message_response = self.sqs_client.receive_message(
-            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=20
+            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=SQS_WAIT_TIME_SECONDS
         ).get("Messages")
         self.assertEqual(len(received_message_response), 1)
         received_message = received_message_response[0]
@@ -231,7 +233,7 @@ class TestSQSPriorityInvoke(RemoteInvokeIntegBase):
         self.assertIn("MessageId", remote_invoke_result_stdout)
 
         received_message_response = self.sqs_client.receive_message(
-            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=20
+            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=SQS_WAIT_TIME_SECONDS
         ).get("Messages")
         self.assertEqual(len(received_message_response), 1)
         received_message = received_message_response[0]
@@ -250,7 +252,7 @@ class TestSQSPriorityInvoke(RemoteInvokeIntegBase):
         self.assertIn("MessageId", remote_invoke_result_stdout)
 
         received_message_response = self.sqs_client.receive_message(
-            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=20
+            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=SQS_WAIT_TIME_SECONDS
         ).get("Messages")
         self.assertEqual(len(received_message_response), 1)
         received_message = received_message_response[0]
@@ -274,7 +276,7 @@ class TestSQSPriorityInvoke(RemoteInvokeIntegBase):
         self.assertIn("MessageId", remote_invoke_result_stdout)
 
         received_message_response = self.sqs_client.receive_message(
-            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=20
+            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=SQS_WAIT_TIME_SECONDS
         ).get("Messages")
         self.assertEqual(len(received_message_response), 1)
         received_message = received_message_response[0]
@@ -312,7 +314,10 @@ class TestSQSPriorityInvoke(RemoteInvokeIntegBase):
 
         time.sleep(1)  # Required as DelaySeconds is set to 1 and message cannot be received before this.
         received_message_response = self.sqs_client.receive_message(
-            QueueUrl=self.sqs_queue_url, MaxNumberOfMessages=1, MessageAttributeNames=["All"], WaitTimeSeconds=20
+            QueueUrl=self.sqs_queue_url,
+            MaxNumberOfMessages=1,
+            MessageAttributeNames=["All"],
+            WaitTimeSeconds=SQS_WAIT_TIME_SECONDS,
         ).get("Messages")
 
         self.assertEqual(len(received_message_response), 1)
@@ -629,7 +634,7 @@ class TestMultipleResourcesInvoke(RemoteInvokeIntegBase):
         self.assertIn("MessageId", remote_invoke_result_stdout)
 
         received_message_response = self.sqs_client.receive_message(
-            QueueUrl=sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=20
+            QueueUrl=sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=SQS_WAIT_TIME_SECONDS
         ).get("Messages")
         self.assertEqual(len(received_message_response), 1)
         received_message = received_message_response[0]
@@ -661,7 +666,7 @@ class TestMultipleResourcesInvoke(RemoteInvokeIntegBase):
         self.assertIn("MessageId", remote_invoke_result_stdout)
 
         received_message_response = self.sqs_client.receive_message(
-            QueueUrl=sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=20
+            QueueUrl=sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=SQS_WAIT_TIME_SECONDS
         ).get("Messages")
         self.assertEqual(len(received_message_response), 1)
         received_message = received_message_response[0]
@@ -694,7 +699,7 @@ class TestMultipleResourcesInvoke(RemoteInvokeIntegBase):
         self.assertIn("ResponseMetadata", remote_invoke_result_stdout)
 
         received_message_response = self.sqs_client.receive_message(
-            QueueUrl=sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=20
+            QueueUrl=sqs_queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=SQS_WAIT_TIME_SECONDS
         ).get("Messages")
 
         self.assertEqual(len(received_message_response), 1)

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -142,7 +142,8 @@ class TestValidate(TestCase):
             "nodejs18.x",
             "provided",
             "provided.al2",
-            "provided.al2023",
+            # Note(hnnasit): provided.al2023 is not supported by cfn-lint yet. Uncomment once it is supported.
+            # "provided.al2023",
             "python3.7",
             "python3.8",
             "python3.9",

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -142,8 +142,7 @@ class TestValidate(TestCase):
             "nodejs18.x",
             "provided",
             "provided.al2",
-            # Note(hnnasit): provided.al2023 is not supported by cfn-lint yet. Uncomment once it is supported.
-            # "provided.al2023",
+            "provided.al2023",
             "python3.7",
             "python3.8",
             "python3.9",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
remote invoke tests for SQS are flaky due to the message being added back to the queue after consumption and the other tests picking up wrong messages.

cfn-lint does not support provided.al2023 yet and the `sam validate` integ test fails. Commenting it out for now.

#### How does it address the issue?
Adds a WaitTimeSeconds parameter to poll longer until a message becomes available. Also deletes a message after consumption.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
