### PR TITLE
fix: crashing if handler is missing

### DIFF
--- a/samcli/lib/build/exceptions.py
+++ b/samcli/lib/build/exceptions.py
@@ -3,6 +3,9 @@ Build Related Exceptions.
 """
 
 
+from samcli.commands.exceptions import UserException
+
+
 class UnsupportedBuilderLibraryVersionError(Exception):
     def __init__(self, container_name: str, error_msg: str) -> None:
         msg = (
@@ -40,6 +43,11 @@ class DockerBuildFailed(BuildError):
 class MissingBuildMethodException(BuildError):
     def __init__(self, msg: str) -> None:
         BuildError.__init__(self, "MissingBuildMethodException", msg)
+
+
+class MissingFunctionHandlerException(UserException):
+    def __init__(self, msg: str) -> None:
+        UserException.__init__(self, msg, "MissingFunctionHandlerException")
 
 
 class InvalidBuildGraphException(Exception):

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -446,9 +446,7 @@ class SamFunctionProvider(SamBaseProvider):
             codeuri = SamLocalStackProvider.normalize_resource_path(stack.location, codeuri)
 
         package_type = resource_properties.get("PackageType", ZIP)
-        if package_type == ZIP and (
-            resource_properties.get("Handler") is None or resource_properties.get("Handler") == ""
-        ):
+        if package_type == ZIP and not resource_properties.get("Handler"):
             raise MissingFunctionHandlerException(f"Could not find handler for function: {name}")
 
         function_build_info = get_function_build_info(

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -446,7 +446,9 @@ class SamFunctionProvider(SamBaseProvider):
             codeuri = SamLocalStackProvider.normalize_resource_path(stack.location, codeuri)
 
         package_type = resource_properties.get("PackageType", ZIP)
-        if package_type == ZIP and resource_properties.get("Handler") is None:
+        if package_type == ZIP and (
+            resource_properties.get("Handler") is None or resource_properties.get("Handler") == ""
+        ):
             raise MissingFunctionHandlerException(f"Could not find handler for function: {name}")
 
         function_build_info = get_function_build_info(

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -8,6 +8,7 @@ from samtranslator.policy_template_processor.exceptions import TemplateNotFoundE
 
 from samcli.commands._utils.template import TemplateFailedParsingException
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
+from samcli.lib.build.exceptions import MissingFunctionHandlerException
 from samcli.lib.providers.exceptions import InvalidLayerReference
 from samcli.lib.utils.colors import Colored, Colors
 from samcli.lib.utils.file_observer import FileObserver
@@ -445,6 +446,9 @@ class SamFunctionProvider(SamBaseProvider):
             codeuri = SamLocalStackProvider.normalize_resource_path(stack.location, codeuri)
 
         package_type = resource_properties.get("PackageType", ZIP)
+        if package_type == ZIP and resource_properties.get("Handler") is None:
+            raise MissingFunctionHandlerException(f"Could not find handler for function: {name}")
+
         function_build_info = get_function_build_info(
             get_full_path(stack.stack_path, function_id), package_type, inlinecode, codeuri, metadata
         )

--- a/tests/unit/commands/deploy/test_auth_utils.py
+++ b/tests/unit/commands/deploy/test_auth_utils.py
@@ -168,6 +168,7 @@ class TestAuthUtils(TestCase):
                                     OrderedDict(
                                         [
                                             ("FunctionUrlConfig", OrderedDict([("AuthType", "NONE")])),
+                                            ("Handler", "FakeHandler"),
                                         ]
                                     ),
                                 ),
@@ -207,6 +208,7 @@ class TestAuthUtils(TestCase):
                             "Events",
                             OrderedDict(events),
                         ),
+                        ("Handler", "FakeHandler"),
                     ]
                 ),
             ),

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -1530,7 +1530,7 @@ class TestSamFunctionProvider_convert_sam_function_resource(TestCase):
 
     def test_must_skip_non_existent_properties(self):
         name = "myname"
-        properties = {"CodeUri": "/usr/local"}
+        properties = {"CodeUri": "/usr/local", "Handler": "FakeHandler"}
 
         expected = Function(
             function_id="myname",
@@ -1539,7 +1539,7 @@ class TestSamFunctionProvider_convert_sam_function_resource(TestCase):
             runtime=None,
             memory=None,
             timeout=None,
-            handler=None,
+            handler="FakeHandler",
             codeuri="/usr/local",
             environment=None,
             rolearn=None,
@@ -1563,7 +1563,7 @@ class TestSamFunctionProvider_convert_sam_function_resource(TestCase):
 
     def test_must_default_missing_code_uri(self):
         name = "myname"
-        properties = {"Runtime": "myruntime"}
+        properties = {"Runtime": "myruntime", "Handler": "FakeHandler"}
 
         result = SamFunctionProvider._convert_sam_function_resource(STACK, name, properties, [])
         self.assertEqual(result.codeuri, ".")  # Default value
@@ -1655,7 +1655,8 @@ class TestSamFunctionProvider_convert_sam_function_resource(TestCase):
             "CodeUri": {
                 # CodeUri is some dictionary
                 "a": "b"
-            }
+            },
+            "Handler": "FakeHandler",
         }
 
         result = SamFunctionProvider._convert_sam_function_resource(STACK, name, properties, [])
@@ -1748,7 +1749,7 @@ class TestSamFunctionProvider_convert_lambda_function_resource(TestCase):
 
     def test_must_skip_non_existent_properties(self):
         name = "myname"
-        properties = {"Code": {"Bucket": "bucket"}}
+        properties = {"Code": {"Bucket": "bucket"}, "Handler": "FakeHandler"}
 
         expected = Function(
             function_id="myname",
@@ -1757,7 +1758,7 @@ class TestSamFunctionProvider_convert_lambda_function_resource(TestCase):
             runtime=None,
             memory=None,
             timeout=None,
-            handler=None,
+            handler="FakeHandler",
             codeuri=".",
             environment=None,
             rolearn=None,

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from unittest.mock import patch, PropertyMock, Mock, call
 
 from parameterized import parameterized
+from samcli.lib.build.exceptions import MissingFunctionHandlerException
 
 from samcli.lib.utils.architecture import X86_64, ARM64
 
@@ -1779,6 +1780,23 @@ class TestSamFunctionProvider_convert_lambda_function_resource(TestCase):
         result = SamFunctionProvider._convert_lambda_function_resource(STACK, name, properties, [])
 
         self.assertEqual(expected, result)
+
+
+class TestSamFunctionProvider_build_function_configuration(TestCase):
+    def test_must_convert(self):
+        name = "myname"
+        id = "id"
+        properties = {
+            "Code": {"Bucket": "bucket"},
+            "Runtime": "myruntime",
+            "MemorySize": "mymemorysize",
+            "Timeout": "30",
+            "Environment": "myenvironment",
+            "Role": "myrole",
+            "Layers": ["Layer1", "Layer2"],
+        }
+        with self.assertRaises(MissingFunctionHandlerException):
+            SamFunctionProvider._build_function_configuration(STACK, id, name, None, properties, [], None, None, False)
 
 
 class TestSamFunctionProvider_parse_layer_info(TestCase):

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -1783,29 +1783,15 @@ class TestSamFunctionProvider_convert_lambda_function_resource(TestCase):
 
 
 class TestSamFunctionProvider_build_function_configuration(TestCase):
-    def test_raise_error_on_missing_handler(self):
+    @parameterized.expand([(None), ("")])
+    def test_raise_error_on_missing_handler(self, handler):
         name = "myname"
         id = "id"
         properties = {
             "Code": {"Bucket": "bucket"},
             "Runtime": "myruntime",
             "MemorySize": "mymemorysize",
-            "Timeout": "30",
-            "Environment": "myenvironment",
-            "Role": "myrole",
-            "Layers": ["Layer1", "Layer2"],
-        }
-        with self.assertRaises(MissingFunctionHandlerException):
-            SamFunctionProvider._build_function_configuration(STACK, id, name, None, properties, [], None, None, False)
-
-    def test_raise_error_on_empty_handler(self):
-        name = "myname"
-        id = "id"
-        properties = {
-            "Code": {"Bucket": "bucket"},
-            "Runtime": "myruntime",
-            "MemorySize": "mymemorysize",
-            "Handler": "",
+            "Handler": handler,
             "Timeout": "30",
             "Environment": "myenvironment",
             "Role": "myrole",

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -1783,13 +1783,29 @@ class TestSamFunctionProvider_convert_lambda_function_resource(TestCase):
 
 
 class TestSamFunctionProvider_build_function_configuration(TestCase):
-    def test_must_convert(self):
+    def test_raise_error_on_missing_handler(self):
         name = "myname"
         id = "id"
         properties = {
             "Code": {"Bucket": "bucket"},
             "Runtime": "myruntime",
             "MemorySize": "mymemorysize",
+            "Timeout": "30",
+            "Environment": "myenvironment",
+            "Role": "myrole",
+            "Layers": ["Layer1", "Layer2"],
+        }
+        with self.assertRaises(MissingFunctionHandlerException):
+            SamFunctionProvider._build_function_configuration(STACK, id, name, None, properties, [], None, None, False)
+
+    def test_raise_error_on_empty_handler(self):
+        name = "myname"
+        id = "id"
+        properties = {
+            "Code": {"Bucket": "bucket"},
+            "Runtime": "myruntime",
+            "MemorySize": "mymemorysize",
+            "Handler": "",
             "Timeout": "30",
             "Environment": "myenvironment",
             "Role": "myrole",

--- a/tests/unit/commands/sync/test_command.py
+++ b/tests/unit/commands/sync/test_command.py
@@ -809,6 +809,7 @@ class TestDisableADL(TestCase):
                     "test": {
                         "Properties": {
                             "Environment": {"Variables": {"NODE_OPTIONS": ["--something"]}},
+                            "Handler": "FakeHandler",
                         },
                         "Metadata": {"BuildMethod": "esbuild", "BuildProperties": {"Sourcemap": True}},
                         "Type": "AWS::Serverless::Function",
@@ -821,6 +822,7 @@ class TestDisableADL(TestCase):
                     "test": {
                         "Properties": {
                             "Environment": {"Variables": {"NODE_OPTIONS": ["--something"]}},
+                            "Handler": "FakeHandler",
                         },
                         "Type": "AWS::Serverless::Function",
                     }

--- a/tests/unit/lib/bootstrap/nested_stack/test_nested_stack_manager.py
+++ b/tests/unit/lib/bootstrap/nested_stack/test_nested_stack_manager.py
@@ -63,7 +63,12 @@ class TestNestedStackManager(TestCase):
         self.assertEqual(template, result)
 
     def test_unsupported_runtime(self):
-        resources = {"MyFunction": {"Type": AWS_SERVERLESS_FUNCTION, "Properties": {"Runtime": "unsupported_runtime"}}}
+        resources = {
+            "MyFunction": {
+                "Type": AWS_SERVERLESS_FUNCTION,
+                "Properties": {"Runtime": "unsupported_runtime", "Handler": "FakeHandler"},
+            }
+        }
         self.stack.resources = resources
         template = {"Resources": resources}
         app_build_result = ApplicationBuildResult(Mock(), {"MyFunction": "path/to/build/dir"})
@@ -75,7 +80,12 @@ class TestNestedStackManager(TestCase):
         self.assertEqual(template, result)
 
     def test_no_function_build_definition(self):
-        resources = {"MyFunction": {"Type": AWS_SERVERLESS_FUNCTION, "Properties": {"Runtime": "python3.8"}}}
+        resources = {
+            "MyFunction": {
+                "Type": AWS_SERVERLESS_FUNCTION,
+                "Properties": {"Runtime": "python3.8", "Handler": "FakeHandler"},
+            }
+        }
         self.stack.resources = resources
         template = {"Resources": resources}
         build_graph = Mock()
@@ -89,7 +99,12 @@ class TestNestedStackManager(TestCase):
         self.assertEqual(template, result)
 
     def test_function_build_definition_without_dependencies_dir(self):
-        resources = {"MyFunction": {"Type": AWS_SERVERLESS_FUNCTION, "Properties": {"Runtime": "python3.8"}}}
+        resources = {
+            "MyFunction": {
+                "Type": AWS_SERVERLESS_FUNCTION,
+                "Properties": {"Runtime": "python3.8", "Handler": "FakeHandler"},
+            }
+        }
         self.stack.resources = resources
         template = {"Resources": resources}
         build_graph = Mock()
@@ -106,7 +121,12 @@ class TestNestedStackManager(TestCase):
     @patch("samcli.lib.bootstrap.nested_stack.nested_stack_manager.osutils")
     @patch("samcli.lib.bootstrap.nested_stack.nested_stack_manager.os.path.isdir")
     def test_with_zip_function(self, patched_isdir, patched_osutils, patched_move_template):
-        resources = {"MyFunction": {"Type": AWS_SERVERLESS_FUNCTION, "Properties": {"Runtime": "python3.8"}}}
+        resources = {
+            "MyFunction": {
+                "Type": AWS_SERVERLESS_FUNCTION,
+                "Properties": {"Runtime": "python3.8", "Handler": "FakeHandler"},
+            }
+        }
         self.stack.resources = resources
         template = {"Resources": resources}
 

--- a/tests/unit/lib/build_module/test_bundler.py
+++ b/tests/unit/lib/build_module/test_bundler.py
@@ -140,6 +140,7 @@ class EsbuildBundler_esbuild_configured(TestCase):
                     "test": {
                         "Properties": {
                             "Environment": {"Variables": {"NODE_OPTIONS": ["--something"]}},
+                            "Handler": "FakeHandler",
                         },
                         "Metadata": {"BuildMethod": "esbuild", "BuildProperties": {"Sourcemap": True}},
                         "Type": "AWS::Serverless::Function",
@@ -152,6 +153,7 @@ class EsbuildBundler_esbuild_configured(TestCase):
                     "test": {
                         "Properties": {
                             "Environment": {"Variables": {"NODE_OPTIONS": ["--something"]}},
+                            "Handler": "FakeHandler",
                         },
                         "Metadata": {"BuildMethod": "Makefile", "BuildProperties": {"Sourcemap": True}},
                         "Type": "AWS::Serverless::Function",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#6253 

#### Why is this change necessary?
There is currently no validation on if the handler is defined within a template

#### How does it address the issue?
Checks if the handler is defined before trying to access and assign it

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
