### PR TITLE
test: bump AWS::Serverless::Function runtime nodejs10.x to nodejs18.x

### DIFF
--- a/tests/integration/testdata/package/aws-lambda-function.yaml
+++ b/tests/integration/testdata/package/aws-lambda-function.yaml
@@ -12,5 +12,5 @@ Resources:
           - "LambdaExecutionRole"
           - "Arn"
       Code: "."
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Timeout: 25

--- a/tests/smoke/templates/sar/Contact-Us-template.yaml
+++ b/tests/smoke/templates/sar/Contact-Us-template.yaml
@@ -39,7 +39,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 345c4115-4060-43bd-be8e-7f70aee9b3bf
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         PostEvent:
           Type: Api

--- a/tests/smoke/templates/sar/DVSA-template.yaml
+++ b/tests/smoke/templates/sar/DVSA-template.yaml
@@ -928,7 +928,7 @@ Resources:
               - Ref: AWS::AccountId
               - function:*
         Version: '2012-10-17'
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Timeout: 30
     Type: AWS::Serverless::Function
   OrderNewFunction:

--- a/tests/smoke/templates/sar/Geocode-template.yaml
+++ b/tests/smoke/templates/sar/Geocode-template.yaml
@@ -31,7 +31,7 @@ Resources:
             Path: /geocode/{searchtext}
           Type: Api
       Handler: geocode.geocodeGET
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
     Type: AWS::Serverless::Function
   GeocodeSuggestFunction:
     Properties:
@@ -52,6 +52,6 @@ Resources:
             Path: /geocodesuggest/{query}
           Type: Api
       Handler: geocodesuggest.geocodesuggestGET
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/acloudguru-alexadevs-leaderboard-template.yaml
+++ b/tests/smoke/templates/sar/acloudguru-alexadevs-leaderboard-template.yaml
@@ -9,7 +9,7 @@ Resources:
         Key: 72571b00-7b1e-4e28-bf57-6bbd36bb70d0
       Handler: index.handler
       Description: Episode 4 - customise your leaderboard for the Echo Show and Spot
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         AlexaSkillEvent:
           Type: AlexaSkill

--- a/tests/smoke/templates/sar/acloudguru-alexadevs-triviaskill-template.yaml
+++ b/tests/smoke/templates/sar/acloudguru-alexadevs-triviaskill-template.yaml
@@ -9,7 +9,7 @@ Resources:
         Key: f8b0837c-e68a-41d5-ab0a-13b1071b7c56
       Handler: index.handler
       Description: Demonstrate a basic trivia skill built with the ASK NodeJS SDK
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         AlexaSkillEvent:
           Type: AlexaSkill

--- a/tests/smoke/templates/sar/alexa-anagram-template.yaml
+++ b/tests/smoke/templates/sar/alexa-anagram-template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       Description: Alexa responds with the count and anagrams for a requested word
       Handler: src/index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: a44a03c9-ccb1-4ddc-b196-8e2c9fdeec35

--- a/tests/smoke/templates/sar/alexa-skills-kit-color-expert-template.yaml
+++ b/tests/smoke/templates/sar/alexa-skills-kit-color-expert-template.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: cc257676-15a1-4bb3-98eb-a0bdf0b46ca1

--- a/tests/smoke/templates/sar/alexa-skills-kit-nodejs-factskill-template.yaml
+++ b/tests/smoke/templates/sar/alexa-skills-kit-nodejs-factskill-template.yaml
@@ -12,7 +12,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 947732d3-cec1-4e80-9596-37206a195f9d
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Events:
         AlexaTrigger:

--- a/tests/smoke/templates/sar/alexa-skills-kit-nodejs-hello-world-template.yaml
+++ b/tests/smoke/templates/sar/alexa-skills-kit-nodejs-hello-world-template.yaml
@@ -17,7 +17,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: a3adadbb-f261-42e4-a1cc-5a83f2a7e052
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Policies:
       - Statement:

--- a/tests/smoke/templates/sar/alexa-skills-kit-nodejs-howtoskill-template.yaml
+++ b/tests/smoke/templates/sar/alexa-skills-kit-nodejs-howtoskill-template.yaml
@@ -12,7 +12,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 5eb72e41-efab-405a-a429-ac765d3c08ca
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Events:
         AlexaTrigger:

--- a/tests/smoke/templates/sar/alexa-skills-kit-nodejs-triviaskill-template.yaml
+++ b/tests/smoke/templates/sar/alexa-skills-kit-nodejs-triviaskill-template.yaml
@@ -12,7 +12,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 96c9d503-9cfe-4000-809f-2c8b8a3736d0
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Events:
         AlexaTrigger:

--- a/tests/smoke/templates/sar/alexa-smart-home-skill-adapter-template.yaml
+++ b/tests/smoke/templates/sar/alexa-smart-home-skill-adapter-template.yaml
@@ -23,6 +23,6 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 2c1547a5-be00-41e2-aec5-5bbcccb28ce5
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/amazon-cognito-passwordless-email-auth-template.yaml
+++ b/tests/smoke/templates/sar/amazon-cognito-passwordless-email-auth-template.yaml
@@ -38,7 +38,7 @@ Resources:
           Effect: Allow
           Resource: '*'
         Version: '2012-10-17'
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
     Type: AWS::Serverless::Function
   CreateAuthChallengeInvocationPermission:
     Properties:
@@ -59,7 +59,7 @@ Resources:
         Bucket: <%REPO_BUCKET%>
         Key: 2addf0d2-5ce9-4741-b1a7-34a25470bbfc
       Handler: define-auth-challenge.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
     Type: AWS::Serverless::Function
   DefineAuthChallengeInvocationPermission:
     Properties:
@@ -80,7 +80,7 @@ Resources:
         Bucket: <%REPO_BUCKET%>
         Key: cbbd73aa-965e-4170-8a3f-72670fc0f81d
       Handler: pre-sign-up.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
     Type: AWS::Serverless::Function
   PreSignUpInvocationPermission:
     Properties:
@@ -151,7 +151,7 @@ Resources:
         Bucket: <%REPO_BUCKET%>
         Key: 750580f0-e0a5-4250-9f57-70e8cbf49203
       Handler: verify-auth-challenge-response.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
     Type: AWS::Serverless::Function
   VerifyAuthChallengeResponseInvocationPermission:
     Properties:

--- a/tests/smoke/templates/sar/api-gateway-authorizer-nodejs-template.yaml
+++ b/tests/smoke/templates/sar/api-gateway-authorizer-nodejs-template.yaml
@@ -23,6 +23,6 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: e52b633b-f6c5-481b-acbc-b0d94aac32cb
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 256
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/api-lambda-get-all-dynamodb-template.yaml
+++ b/tests/smoke/templates/sar/api-lambda-get-all-dynamodb-template.yaml
@@ -53,7 +53,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 69e05eaf-b8f1-4a29-b379-0fb064226b03
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         OptionsApi:
           Type: Api

--- a/tests/smoke/templates/sar/api-lambda-get-one-dynamodb-template.yaml
+++ b/tests/smoke/templates/sar/api-lambda-get-one-dynamodb-template.yaml
@@ -90,7 +90,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 6353ff98-b2cd-44af-8ef5-c6e0383e464b
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         Api:
           Type: Api

--- a/tests/smoke/templates/sar/api-lambda-save-dynamodb-template.yaml
+++ b/tests/smoke/templates/sar/api-lambda-save-dynamodb-template.yaml
@@ -114,7 +114,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: fb1a3a5a-28d6-415a-85f4-0e358a30383f
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         SaveApi:
           Type: Api

--- a/tests/smoke/templates/sar/api-lambda-send-email-ses-template.yaml
+++ b/tests/smoke/templates/sar/api-lambda-send-email-ses-template.yaml
@@ -50,7 +50,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 18fa6025-1f7a-43b0-8715-37d55e17b71f
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         EmailApi:
           Type: Api

--- a/tests/smoke/templates/sar/api-lambda-update-dynamodb-template.yaml
+++ b/tests/smoke/templates/sar/api-lambda-update-dynamodb-template.yaml
@@ -116,7 +116,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 70d2c77a-a692-40b1-8c78-4eb25649afcf
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         Api:
           Type: Api

--- a/tests/smoke/templates/sar/cloudfront-http-redirect-template.yaml
+++ b/tests/smoke/templates/sar/cloudfront-http-redirect-template.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: f5f8769e-fdae-4778-a078-828efebe97c1

--- a/tests/smoke/templates/sar/cloudfront-modify-response-header-template.yaml
+++ b/tests/smoke/templates/sar/cloudfront-modify-response-header-template.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 7e855ca1-e613-4e4f-b733-43ddd337b55b

--- a/tests/smoke/templates/sar/cloudfront-response-generation-template.yaml
+++ b/tests/smoke/templates/sar/cloudfront-response-generation-template.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: d4b73f19-7bd5-47a3-aa66-be568b0ea9e1

--- a/tests/smoke/templates/sar/cloudwatch-alarm-to-slack-template.yaml
+++ b/tests/smoke/templates/sar/cloudwatch-alarm-to-slack-template.yaml
@@ -33,7 +33,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 5005d2f4-1627-41fd-9cef-bb27b804f7f7
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         SNS1:
           Type: SNS

--- a/tests/smoke/templates/sar/dynamodb-display-template.yaml
+++ b/tests/smoke/templates/sar/dynamodb-display-template.yaml
@@ -118,7 +118,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 664d7928-e50c-403a-9f59-d9bf93bc5c9b
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         GetApi:
           Type: Api
@@ -163,4 +163,4 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 664d7928-e50c-403a-9f59-d9bf93bc5c9b
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x

--- a/tests/smoke/templates/sar/dynamodb-lex-template.yaml
+++ b/tests/smoke/templates/sar/dynamodb-lex-template.yaml
@@ -76,5 +76,5 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 2658129b-dbc7-49f1-97dd-f7a21ed3aa2f
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Description: Log Lex intent to a DynamoDB table

--- a/tests/smoke/templates/sar/hello-world-template.yaml
+++ b/tests/smoke/templates/sar/hello-world-template.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: e492b2b5-8e5b-499e-9e60-6d6dbb9acd65

--- a/tests/smoke/templates/sar/helloWorldLex-template.yaml
+++ b/tests/smoke/templates/sar/helloWorldLex-template.yaml
@@ -8,5 +8,5 @@ Resources:
         Bucket: <%REPO_BUCKET%>
         Key: 1831d44b-8ccb-4610-b4f2-1ee88282bb42
       Handler: lambda.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
 Description: A hello world application for a Lex based chatbot

--- a/tests/smoke/templates/sar/https-request-template.yaml
+++ b/tests/smoke/templates/sar/https-request-template.yaml
@@ -23,6 +23,6 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 92c64a18-abe6-4481-899b-6146fb8bec50
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/image-processing-service-template.yaml
+++ b/tests/smoke/templates/sar/image-processing-service-template.yaml
@@ -23,6 +23,6 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: e1281f99-d6f1-4d54-8c31-947a673bf8d5
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 512
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/image-resizer-service-template.yaml
+++ b/tests/smoke/templates/sar/image-resizer-service-template.yaml
@@ -110,7 +110,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 9c739c4e-7e28-4b71-bd0d-d0270e7bc9bc
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         AuthorizerApiRoot:
           Type: Api

--- a/tests/smoke/templates/sar/lambda-web-page-example-template.yaml
+++ b/tests/smoke/templates/sar/lambda-web-page-example-template.yaml
@@ -30,7 +30,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 54b95c42-b951-409a-aaab-1cf9576f207e
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         GetApi:
           Type: Api

--- a/tests/smoke/templates/sar/lambdium-template.yaml
+++ b/tests/smoke/templates/sar/lambdium-template.yaml
@@ -14,6 +14,6 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 9d35d21b-e9f4-4e59-8650-a2f9db304462
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       FunctionName: lambdium
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/lex-book-trip-template.yaml
+++ b/tests/smoke/templates/sar/lex-book-trip-template.yaml
@@ -22,6 +22,6 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 261ca18d-3e71-49ed-9fb8-d50a124f78d3
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/microservice-http-endpoint-template.yaml
+++ b/tests/smoke/templates/sar/microservice-http-endpoint-template.yaml
@@ -9,7 +9,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: d8f1a87b-7933-44b9-93f7-3afc739b616d

--- a/tests/smoke/templates/sar/pipeline-dashboard-template.yaml
+++ b/tests/smoke/templates/sar/pipeline-dashboard-template.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       Description: Create CloudWatch metrics from AWS CodePipeline events
       Handler: index.handlePipelineEvent
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: aca8822e-f832-499e-8a12-21a72beb392f
@@ -37,7 +37,7 @@ Resources:
     Properties:
       Description: Build CloudWatch dashboard from CloudWatch metrics
       Handler: index.generateDashboard
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: aca8822e-f832-499e-8a12-21a72beb392f

--- a/tests/smoke/templates/sar/resize-template.yaml
+++ b/tests/smoke/templates/sar/resize-template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       Description: Transforms images by resizing to a configured max dimension
       Handler: src/index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 6556286d-fa63-425c-a64d-633c32689d3b

--- a/tests/smoke/templates/sar/s3-get-object-template.yaml
+++ b/tests/smoke/templates/sar/s3-get-object-template.yaml
@@ -10,7 +10,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 56e25b67-d55d-4343-b672-8313fd6461cb

--- a/tests/smoke/templates/sar/s3-lambda-publisher-sns-template.yaml
+++ b/tests/smoke/templates/sar/s3-lambda-publisher-sns-template.yaml
@@ -37,7 +37,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 28da0e39-14e9-40e1-9c63-936d252ce64f
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         S3BucketEvent:
           Type: S3

--- a/tests/smoke/templates/sar/s3-lambda-save-dynamodb-template.yaml
+++ b/tests/smoke/templates/sar/s3-lambda-save-dynamodb-template.yaml
@@ -56,7 +56,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 8aaad0a6-d8fd-4bbe-b85e-49de11742aea
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         S3BucketEvent:
           Type: S3

--- a/tests/smoke/templates/sar/serverless-goat-template.yaml
+++ b/tests/smoke/templates/sar/serverless-goat-template.yaml
@@ -77,7 +77,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: ab45a1db-fcf2-4ded-b3c0-9097db4019c1
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         ApiConvert:
           Type: Api
@@ -96,7 +96,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 2fd9ca0f-61a7-4c87-9324-8c85b1b4de93
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         ApiConvert:
           Type: Api

--- a/tests/smoke/templates/sar/serverless-todo-template.yaml
+++ b/tests/smoke/templates/sar/serverless-todo-template.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       Description: React TodoMVC with a Serverless backend
       Handler: src/index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 75ed4bf0-8b24-41f0-bb68-9e61b630d76e

--- a/tests/smoke/templates/sar/signalfx-lambda-example-nodejs-template.yaml
+++ b/tests/smoke/templates/sar/signalfx-lambda-example-nodejs-template.yaml
@@ -15,5 +15,5 @@ Resources:
           SIGNALFX_AUTH_TOKEN:
             Ref: SignalFxAuthToken
       Handler: handler.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/simple-mobile-backend-template.yaml
+++ b/tests/smoke/templates/sar/simple-mobile-backend-template.yaml
@@ -30,6 +30,6 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 7e8aa805-1054-4bfe-9f84-d48793b444f3
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/simple-websockets-chat-app-template.yaml
+++ b/tests/smoke/templates/sar/simple-websockets-chat-app-template.yaml
@@ -127,7 +127,7 @@ Resources:
         Key: 07a400a4-d13f-4d23-ac71-8b244284d184
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           TABLE_NAME:
@@ -154,7 +154,7 @@ Resources:
         Key: 0832c5f6-a81c-40dd-8f84-de6abe2e5401
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           TABLE_NAME:
@@ -181,7 +181,7 @@ Resources:
         Key: d1638bef-3e9c-4b79-ade6-37cb03f25b2a
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           TABLE_NAME:

--- a/tests/smoke/templates/sar/skill-sample-nodejs-salesforce-template.yaml
+++ b/tests/smoke/templates/sar/skill-sample-nodejs-salesforce-template.yaml
@@ -69,7 +69,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 5d45f176-8801-4f34-a33e-1c57cc0bc896
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         AlexaSkillEvent:
           Type: AlexaSkill

--- a/tests/smoke/templates/sar/sns-message-template.yaml
+++ b/tests/smoke/templates/sar/sns-message-template.yaml
@@ -10,7 +10,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 7a0f16cd-f381-4f6f-ad5b-adca35470d11
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Events:
         SNS1:

--- a/tests/smoke/templates/sar/splunk-kinesis-stream-processor-template.yaml
+++ b/tests/smoke/templates/sar/splunk-kinesis-stream-processor-template.yaml
@@ -64,7 +64,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 3ce0c1ed-73b6-4f01-9916-c99b71e31688
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Events:
         KinesisStream:
           Type: Kinesis

--- a/tests/smoke/templates/sar/sqs-poller-template.yaml
+++ b/tests/smoke/templates/sar/sqs-poller-template.yaml
@@ -32,5 +32,5 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: c1574e73-6807-416d-8df0-4c96a2452ad2
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/standard-redirects-for-cloudfront-template.yaml
+++ b/tests/smoke/templates/sar/standard-redirects-for-cloudfront-template.yaml
@@ -16,7 +16,7 @@ Resources:
       Description: Standard Redirects for CloudFront by Digital Sailors via the Serverless Application Repository.
       Handler: index.handler
       MemorySize: 128
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       Timeout: 3
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/uploader-template.yaml
+++ b/tests/smoke/templates/sar/uploader-template.yaml
@@ -11,7 +11,7 @@ Resources:
     Properties:
       Description: Serverless web application for uploading files to S3
       Handler: src/index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 63450f0c-68e6-4fe5-98e4-ca1adde7512c


### PR DESCRIPTION
#### Which issue(s) does this change fix?

Refs: https://github.com/aws/aws-sam-cli/issues/6195

#### Why is this change necessary?

Lambda nodejs10.x creation was stopped on [Jul 30, 2021](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)

#### How does it address the issue?

Bumps AWS::Serverless::Function runtime nodejs10.x to nodejs18.x

#### What side effects does this change have?

N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
