### PR TITLE
test: bump AWS::Serverless::Function runtime nodejs8.10 to nodejs18.x

### DIFF
--- a/tests/functional/commands/validate/lib/models/api_with_swagger_authorizer_none.yaml
+++ b/tests/functional/commands/validate/lib/models/api_with_swagger_authorizer_none.yaml
@@ -61,7 +61,7 @@ Resources:
           }
         }
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
 
   MyFn:
     Type: AWS::Serverless::Function
@@ -75,7 +75,7 @@ Resources:
           }
         }
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Events:
         Cognito:
           Type: Api

--- a/tests/smoke/templates/sar/alexa-skills-kit-nodejs-basic-welcome-template.yaml
+++ b/tests/smoke/templates/sar/alexa-skills-kit-nodejs-basic-welcome-template.yaml
@@ -25,7 +25,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: c2a2bfe5-753b-4711-943e-09ec3aca7a10
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Events:
         AlexaTrigger:
           Type: AlexaSkill

--- a/tests/smoke/templates/sar/alexa-skills-kit-nodejs-premium-facts-skill-template.yaml
+++ b/tests/smoke/templates/sar/alexa-skills-kit-nodejs-premium-facts-skill-template.yaml
@@ -67,7 +67,7 @@ Resources:
       Layers:
       - arn:aws:lambda:us-east-1:173334852312:layer:ask-sdk-for-nodejs:5
       MemorySize: 128
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Timeout: 8
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/smoke/templates/sar/amazon-cloudfront-access-logs-queries-template.yaml
+++ b/tests/smoke/templates/sar/amazon-cloudfront-access-logs-queries-template.yaml
@@ -55,7 +55,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 2a2aff54-276a-41c4-9b28-827b44403bfe
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Events:
         AccessLogsUploadedEvent:
           Type: S3
@@ -111,7 +111,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 2a2aff54-276a-41c4-9b28-827b44403bfe
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Events:
         HourlyEvt:
           Type: Schedule
@@ -406,7 +406,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 2a2aff54-276a-41c4-9b28-827b44403bfe
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Events:
         HourlyEvt:
           Type: Schedule

--- a/tests/smoke/templates/sar/api-gateway-dev-portal-template.yaml
+++ b/tests/smoke/templates/sar/api-gateway-dev-portal-template.yaml
@@ -1132,7 +1132,7 @@ Resources:
         Fn::GetAtt:
         - BackendLambdaExecutionRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Timeout: 30
       Environment:
         Variables:
@@ -1180,7 +1180,7 @@ Resources:
         Fn::GetAtt:
         - BackendLambdaExecutionRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Timeout: 30
   CognitoUserPoolsConfirmationStrategyFunction:
     Type: AWS::Serverless::Function
@@ -1194,7 +1194,7 @@ Resources:
         Fn::GetAtt:
         - CognitoStrategyLambdaExecutionRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Timeout: 3
   CognitoUserPool:
     Type: AWS::Cognito::UserPool
@@ -1254,7 +1254,7 @@ Resources:
   CognitoUserPoolClientSettingsBackingFn:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 300
       CodeUri:
@@ -1363,7 +1363,7 @@ Resources:
   CognitoUserPoolDomainBackingFn:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 300
       CodeUri:
@@ -1522,7 +1522,7 @@ Resources:
         Fn::GetAtt:
         - CatalogUpdaterLambdaExecutionRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Timeout: 20
       Environment:
         Variables:
@@ -1551,7 +1551,7 @@ Resources:
         Fn::GetAtt:
         - AssetUploaderLambdaExecutionRole
         - Arn
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Timeout: 300
       Environment:
         Variables:

--- a/tests/smoke/templates/sar/sumologic-guardduty-events-processor-template.yaml
+++ b/tests/smoke/templates/sar/sumologic-guardduty-events-processor-template.yaml
@@ -25,7 +25,7 @@ Resources:
       CodeUri:
         Bucket: <%REPO_BUCKET%>
         Key: 80f76ed0-fd51-47c6-aecd-3d1e71672c7e
-      Runtime: nodejs8.10
+      Runtime: nodejs18.x
       Events:
         CloudWatchEventTrigger:
           Type: CloudWatchEvent


### PR DESCRIPTION
#### Which issue(s) does this change fix?

Refs: https://github.com/aws/aws-sam-cli/issues/6195

#### Why is this change necessary?

Lambda nodejs8.10 was deprecated on [Mar 6, 2020](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)

#### How does it address the issue?

Bumps AWS::Serverless::Function runtime nodejs8.10 to nodejs18.x

#### What side effects does this change have?

N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
