### PR TITLE
fic: check available port for specific/intended interface

### DIFF
--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -7,6 +7,7 @@ import click
 
 from samcli.commands._utils.options import docker_click_options, parameter_override_click_option, template_click_option
 from samcli.commands.local.cli_common.invoke_context import ContainersInitializationMode
+from samcli.local.docker.container import DEFAULT_CONTAINER_HOST_INTERFACE
 
 
 def get_application_dir():
@@ -59,7 +60,7 @@ def local_common_options(f):
         ),
         click.option(
             "--container-host-interface",
-            default="127.0.0.1",
+            default=DEFAULT_CONTAINER_HOST_INTERFACE,
             show_default=True,
             help="IP address of the host network interface that container ports should bind to. "
             "Use 0.0.0.0 to bind to all interfaces.",

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -130,7 +130,9 @@ class Container:
         self._host_tmp_dir = host_tmp_dir
 
         try:
-            self.rapid_port_host = find_free_port(start=self._start_port_range, end=self._end_port_range)
+            self.rapid_port_host = find_free_port(
+                network_interface=self._container_host_interface, start=self._start_port_range, end=self._end_port_range
+            )
         except NoFreePortsError as ex:
             raise ContainerNotStartableException(str(ex)) from ex
 

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -28,6 +28,7 @@ from samcli.local.docker.utils import NoFreePortsError, find_free_port, to_posix
 LOG = logging.getLogger(__name__)
 
 CONTAINER_CONNECTION_TIMEOUT = float(os.environ.get("SAM_CLI_CONTAINER_CONNECTION_TIMEOUT", 20))
+DEFAULT_CONTAINER_HOST_INTERFACE = "127.0.0.1"
 
 
 class ContainerResponseException(Exception):
@@ -74,7 +75,7 @@ class Container:
         container_opts=None,
         additional_volumes=None,
         container_host="localhost",
-        container_host_interface="127.0.0.1",
+        container_host_interface=DEFAULT_CONTAINER_HOST_INTERFACE,
         mount_with_write: bool = False,
         host_tmp_dir: Optional[str] = None,
     ):

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -7,7 +7,7 @@ from typing import List
 from samcli.lib.utils.packagetype import IMAGE
 from samcli.local.docker.lambda_debug_settings import LambdaDebugSettings
 
-from .container import Container
+from .container import DEFAULT_CONTAINER_HOST_INTERFACE, Container
 from .lambda_image import LambdaImage, Runtime
 
 LOG = logging.getLogger(__name__)
@@ -48,7 +48,7 @@ class LambdaContainer(Container):
         env_vars=None,
         debug_options=None,
         container_host=None,
-        container_host_interface=None,
+        container_host_interface=DEFAULT_CONTAINER_HOST_INTERFACE,
         function_full_path=None,
     ):
         """

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -51,7 +51,7 @@ def to_posix_path(code_path):
     )
 
 
-def find_free_port(start=5000, end=9000):
+def find_free_port(network_interface="127.0.0.1", start=5000, end=9000):
     """
     Utility function which scans through a port range in a randomized manner
     and finds the first free port a socket can bind to.
@@ -62,7 +62,7 @@ def find_free_port(start=5000, end=9000):
     for port in port_range:
         try:
             s = socket.socket()
-            s.bind(("", port))
+            s.bind((network_interface, port))
             s.close()
             return port
         except OSError:

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -51,7 +51,7 @@ def to_posix_path(code_path):
     )
 
 
-def find_free_port(network_interface: str, start: int=5000, end: int=9000) -> int:
+def find_free_port(network_interface: str, start: int = 5000, end: int = 9000) -> int:
     """
     Utility function which scans through a port range in a randomized manner
     and finds the first free port a socket can bind to.

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -51,7 +51,7 @@ def to_posix_path(code_path):
     )
 
 
-def find_free_port(network_interface="127.0.0.1", start=5000, end=9000):
+def find_free_port(network_interface: str, start: int=5000, end: int=9000) -> int:
     """
     Utility function which scans through a port range in a randomized manner
     and finds the first free port a socket can bind to.
@@ -61,6 +61,7 @@ def find_free_port(network_interface="127.0.0.1", start=5000, end=9000):
     port_range = [random.randrange(start, end) for _ in range(start, end)]
     for port in port_range:
         try:
+            LOG.debug("Checking free port on %s:%s", network_interface, port)
             s = socket.socket()
             s.bind((network_interface, port))
             s.close()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

When finding available local port for binding AWS Runtime Interface Emulator, we first try to bind a local port to see if it is available. However that call is been made without providing any network interface that we are intended to.

With this change, when we are searching for available port, we are trying to bind a random port to specific host interface that is defined with `--container-host-interface` parameter of the `sam local` commands.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
