### PR TITLE
Add capabilities for Managed Stack

### DIFF
--- a/samcli/lib/utils/managed_cloudformation_stack.py
+++ b/samcli/lib/utils/managed_cloudformation_stack.py
@@ -253,7 +253,7 @@ def _create_stack(
         Tags=[{"Key": "ManagedStackSource", "Value": "AwsSamCli"}],
         ChangeSetType="CREATE",
         ChangeSetName=change_set_name,  # this must be unique for the stack, but we only create so that's fine
-        Capabilities=["CAPABILITY_IAM"],
+        Capabilities=["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"],
         Parameters=parameters,
     )
     stack_id = change_set_resp["StackId"]


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#6243


#### Why is this change necessary?
Some regions (need to investigate why this is the case) have some flaky runs where sometimes the managed stack need special permissions to create that it does not need in normal regions. Note that I say flaky here because I was not able to recreate the error but a fellow developer was able to so there is some mismatch there.

#### How does it address the issue?
Add the capabilities needed so that it does not matter what region is the stack is being deployed in

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
