### PR TITLE
fix(tests): Update integration tests to test against the new --on-failure exit code

### DIFF
--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -1441,7 +1441,7 @@ to create a managed default bucket, or run sam deploy --guided",
         )
 
         deploy_process_execute = self.run_command(deploy_command_list)
-        self.assertEqual(deploy_process_execute.process.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
 
         # Check if the stack is deleted from CloudFormation
         stack_exists = True
@@ -1499,7 +1499,7 @@ to create a managed default bucket, or run sam deploy --guided",
         )
 
         deploy_process_execute = self.run_command(deploy_command_list)
-        self.assertEqual(deploy_process_execute.process.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
 
         # Check if the stack rolled back successfully
         result = self.cfn_client.describe_stacks(StackName=stack_name)
@@ -1552,7 +1552,7 @@ to create a managed default bucket, or run sam deploy --guided",
         )
 
         deploy_process_execute = self.run_command(deploy_command_list)
-        self.assertEqual(deploy_process_execute.process.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
 
         # Check if the stack is deleted from CloudFormation
         stack_exists = True


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
Recent change was made to `--on-failure`'s behaviour so that the exit code represents the status of the deployment, not the status of command execution. This causes the integration tests to fail since they were not updated.

#### How does it address the issue?
Updates our tests to check for exit code 1 for the command runs that attempt to deploy a broken stack.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
