### PR TITLE
fix: Recursively call method on directory children

### DIFF
--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -62,7 +62,7 @@ def create_tarball(
         tarballfile.close()
 
 
-def _validate_destinations_exists(tar_paths: List[Union[str, Path]]) -> bool:
+def _validate_destinations_exists(tar_paths: Union[List[Union[str, Path]], List[Path]]) -> bool:
     """
     Validates whether the destination of a symlink exists by resolving the link
     and checking the resolved path.

--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -79,7 +79,14 @@ def _validate_destinations_exists(tar_paths: Union[List[Union[str, Path]], List[
     """
     for file in tar_paths:
         file_path_obj = Path(file)
-        resolved_path = file_path_obj.resolve()
+
+        try:
+            resolved_path = file_path_obj.resolve()
+        except OSError:
+            # this exception will occur on Windows and will return
+            # a WinError 123
+            LOG.warning("Failed to determine the file on the system")
+            return False
 
         if file_path_obj.is_dir():
             # recursively call this method to validate the children are not symlinks to empty locations

--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -85,7 +85,7 @@ def _validate_destinations_exists(tar_paths: Union[List[Union[str, Path]], List[
         except OSError:
             # this exception will occur on Windows and will return
             # a WinError 123
-            LOG.warning("Failed to determine the file on the system")
+            LOG.warning(f"Failed to resolve file {file_path_obj} on the host machine")
             return False
 
         if file_path_obj.is_dir():

--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -81,7 +81,13 @@ def _validate_destinations_exists(tar_paths: List[Union[str, Path]]) -> bool:
         file_path_obj = Path(file)
         resolved_path = file_path_obj.resolve()
 
-        if file_path_obj.is_symlink() and not resolved_path.exists():
+        if file_path_obj.is_dir():
+            # recursively call this method to validate the children are not symlinks to empty locations
+            children = list(file_path_obj.iterdir())
+            if not _validate_destinations_exists(children):
+                # exits early
+                return False
+        elif file_path_obj.is_symlink() and not resolved_path.exists():
             LOG.warning(f"Symlinked file {file_path_obj} -> {resolved_path} does not exist!")
             return False
 

--- a/tests/unit/lib/utils/test_tar.py
+++ b/tests/unit/lib/utils/test_tar.py
@@ -196,9 +196,32 @@ class TestTar(TestCase):
         mock_path_object.resolve.return_value = mock_resolved_object
         mock_path_object.is_symlink = Mock()
         mock_path_object.is_symlink.return_value = True
+        mock_path_object.is_dir.return_value = False
 
         path_mock.return_value = mock_path_object
 
         result = _validate_destinations_exists(["mock_path"])
 
         self.assertEqual(result, does_resolved_exist)
+
+    @patch("samcli.lib.utils.tar.Path")
+    def test_validating_symlinked_tar_path_directory(self, path_mock):
+        mock_child_resolve = Mock()
+        mock_child_resolve.exists.return_value = False
+
+        mock_child = Mock()
+        mock_child.is_symlink.return_value = True
+        mock_child.is_dir.return_value = False
+        mock_child.resolve.return_value = mock_child_resolve
+
+        mock_dir_object = Mock()
+        mock_dir_object.is_symlink.return_value = False
+        mock_dir_object.is_dir.return_value = True
+        mock_dir_object.iterdir.return_value = ["mock_child"]
+        mock_dir_object.resolve = Mock()
+
+        path_mock.side_effect = [mock_dir_object, mock_child]
+
+        result = _validate_destinations_exists(["mock_folder"])
+
+        self.assertEqual(result, False)

--- a/tests/unit/lib/utils/test_tar.py
+++ b/tests/unit/lib/utils/test_tar.py
@@ -204,10 +204,16 @@ class TestTar(TestCase):
 
         self.assertEqual(result, does_resolved_exist)
 
+    @parameterized.expand(
+        [
+            (True,),
+            (False,),
+        ]
+    )
     @patch("samcli.lib.utils.tar.Path")
-    def test_validating_symlinked_tar_path_directory(self, path_mock):
+    def test_validating_symlinked_tar_path_directory(self, file_exists, path_mock):
         mock_child_resolve = Mock()
-        mock_child_resolve.exists.return_value = False
+        mock_child_resolve.exists.return_value = file_exists
 
         mock_child = Mock()
         mock_child.is_symlink.return_value = True
@@ -224,4 +230,4 @@ class TestTar(TestCase):
 
         result = _validate_destinations_exists(["mock_folder"])
 
-        self.assertEqual(result, False)
+        self.assertEqual(result, file_exists)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
A previous fix did not check the contents of directories since the path list only contained the parent folders, not the individual files.

#### How does it address the issue?
Recursively checks the children if the path is a folder.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
