### PR TITLE
chore: use provided.al2023 for glibc requirements

### DIFF
--- a/tests/integration/testdata/buildcmd/terraform/go_lambda_function_check_keep_permissions/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/go_lambda_function_check_keep_permissions/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.51.0"
+      version = "~> 5.29.0"
     }
   }
 }
@@ -19,7 +19,7 @@ resource "null_resource" "build_lambda_function" {
   }
 
   provisioner "local-exec" {
-    command = substr(pathexpand("~"), 0, 1) == "/"? "go build -trimpath -o bin/hello_world main.go && chmod 777 bin/* && zip -r hello_world.zip bin/*" : "powershell $ENV:GOARCH='amd64' ; $Env:GOOS='linux' ; go build -trimpath -o bin\\hello_world . ; Compress-Archive -Path bin -DestinationPath hello_world.zip"
+    command = substr(pathexpand("~"), 0, 1) == "/"? "go build -trimpath -o bootstrap main.go && chmod 777 bootstrap && zip -r hello_world.zip bootstrap" : "powershell $ENV:GOARCH='amd64' ; $Env:GOOS='linux' ; go build -trimpath -o bootstrap . ; Compress-Archive -Path bootstrap -DestinationPath hello_world.zip"
   }
 }
 
@@ -45,9 +45,10 @@ resource "aws_lambda_function" "this" {
   function_name = "hello-world-function"
   role          = aws_iam_role.this.arn
 
-  runtime  = "go1.x"
-  handler  = "bin/hello_world"
+  runtime  = "provided.al2023"
+  handler  = "bootstrap"
   filename = "hello_world.zip"
+  timeout  = 30
 
   depends_on = [
     null_resource.build_lambda_function


### PR DESCRIPTION
New Appveyor image has newer glibc version. When building Go applications, they won't work in older `provided.al2` image since minimum required glibc version can't be satisfied.

With this change, we are bumping the runtime to `provided.al2023` (which has newer glibc included) as well as aws terraform provider to include this new runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
