### PR TITLE
Revert "chore(deps): bump actions/labeler from 4 to 5"

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,7 +9,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
   apply-internal-external-label:


### PR DESCRIPTION
Reverts aws/aws-sam-cli#6395

Labeler GHA has major version bump recently, which changed its configuration file.
But even with updating the configuration file as described in their documentation (see this PR https://github.com/aws/aws-sam-cli/pull/6411), it is still failing (see failure https://github.com/aws/aws-sam-cli/actions/runs/7122709971/job/19394326410 and related issue in GHA repo https://github.com/actions/labeler/issues/712).

This PR reverts version to v4 for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).