### PR TITLE
fix: remove 1 sec delay on invoke

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -533,7 +533,7 @@ class Container:
 
         if isinstance(output_stream, io.TextIOWrapper):
             output_stream.buffer.write(output_str.encode("utf-8"))
-        if re.match(pattern, output_str) is not None and event is not None:
+        if re.match(pattern, output_str) is not None and event:
             event.set()
 
     # This method exists because otherwise when writing tests patching/mocking threading.Event breaks everything

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -400,7 +400,7 @@ class Container:
 
         # NOTE(jfuss): Adding a sleep after we get a response from the contianer but before we
         # we write the response to ensure the last thing written to stdout is the container response
-        #time.sleep(1)
+        # time.sleep(1)
         if isinstance(response, str):
             stdout.write_str(response)
         elif isinstance(response, bytes):

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -404,8 +404,6 @@ class Container:
         if timer:
             timer.cancel()
 
-        # NOTE(jfuss): Adding a sleep after we get a response from the contianer but before we
-        # we write the response to ensure the last thing written to stdout is the container response
         self._logs_thread_event.wait()
         if isinstance(response, str):
             stdout.write_str(response)

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -427,7 +427,7 @@ class Container:
         if not self.is_created():
             raise RuntimeError("Container does not exist. Cannot get logs for this container")
 
-        real_container = self.docker_client.containers.get(self.id)  #
+        real_container = self.docker_client.containers.get(self.id)
 
         # Fetch both stdout and stderr streams from Docker as a single iterator.
         logs_itr = real_container.attach(stream=True, logs=True, demux=True)

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -387,7 +387,7 @@ class Container:
         # the log thread will not be closed until the container itself got deleted,
         # so as long as the container is still there, no need to start a new log thread
         if not self._logs_thread or not self._logs_thread.is_alive():
-            self._logs_thread_event = threading.Event()
+            self._logs_thread_event = self._create_threading_event()
             self._logs_thread = threading.Thread(
                 target=self.wait_for_logs, args=(stderr, stderr, self._logs_thread_event), daemon=True
             )
@@ -537,6 +537,15 @@ class Container:
             output_stream.buffer.write(output_str.encode("utf-8"))
         if re.match(pattern, output_str) is not None and event is not None:
             event.set()
+
+    # This method exists because otherwise when writing tests patching/mocking threading.Event breaks everything
+    # this allows for the tests to exist as they do currently without any major refactoring
+    @staticmethod
+    def _create_threading_event():
+        """
+        returns a new threading.Event object.
+        """
+        return threading.Event()
 
     @property
     def network_id(self):

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -404,7 +404,7 @@ class Container:
         if timer:
             timer.cancel()
 
-        self._logs_thread_event.wait()
+        self._logs_thread_event.wait(timeout=1)
         if isinstance(response, str):
             stdout.write_str(response)
         elif isinstance(response, bytes):

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -400,7 +400,7 @@ class Container:
 
         # NOTE(jfuss): Adding a sleep after we get a response from the contianer but before we
         # we write the response to ensure the last thing written to stdout is the container response
-        time.sleep(1)
+        #time.sleep(1)
         if isinstance(response, str):
             stdout.write_str(response)
         elif isinstance(response, bytes):

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -584,8 +584,6 @@ class TestContainer_wait_for_result(TestCase):
         self.socket_mock = Mock()
         self.socket_mock.connect_ex.return_value = 0
 
-        self.event_mock = Mock()
-
     @parameterized.expand(
         [
             (

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -584,6 +584,8 @@ class TestContainer_wait_for_result(TestCase):
         self.socket_mock = Mock()
         self.socket_mock.connect_ex.return_value = 0
 
+        self.event_mock = Mock()
+
     @parameterized.expand(
         [
             (
@@ -608,6 +610,8 @@ class TestContainer_wait_for_result(TestCase):
         output_itr = Mock()
         real_container_mock.attach.return_value = output_itr
         self.container._write_container_output = Mock()
+        self.container._create_threading_event = Mock()
+        self.container._create_threading_event.return_value = Mock()
 
         stdout_mock = Mock()
         stdout_mock.write_str = Mock()
@@ -705,6 +709,8 @@ class TestContainer_wait_for_result(TestCase):
         output_itr = Mock()
         real_container_mock.attach.return_value = output_itr
         self.container._write_container_output = Mock()
+        self.container._create_threading_event = Mock()
+        self.container._create_threading_event.return_value = Mock()
 
         stdout_mock = Mock()
         stderr_mock = Mock()
@@ -794,7 +800,9 @@ class TestContainer_wait_for_logs(TestCase):
         self.container.wait_for_logs(stdout=stdout_mock, stderr=stderr_mock)
 
         real_container_mock.attach.assert_called_with(stream=True, logs=True, demux=True)
-        self.container._write_container_output.assert_called_with(output_itr, stdout=stdout_mock, stderr=stderr_mock)
+        self.container._write_container_output.assert_called_with(
+            output_itr, stdout=stdout_mock, stderr=stderr_mock, event=None
+        )
 
     def test_must_skip_if_no_stdout_and_stderr(self):
         self.container.wait_for_logs()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#6173 


#### Why is this change necessary?
Currently there is an explicit 1 second sleep in the code to work around a race condition and ensure that everything that is printed to the cli is done in the correct order.

The original race condition occurs when the main thread finishes its execution and prints the flask response to stdout, while there are still some things from the docker container that need to be printed.

This can be reproduced currently by the following steps (after removing the sleep in dev version of sam)
```
1. sam init a hello world template (I did any version of node.js)
2. change the lambda code to just print something
3. samdev local start-lambda -t template.yaml
4. aws lambda invoke --endpoint http://localhost:3001 --function-name HelloWorldFunction out.txt (in a separate console)
5. repeat step 4 until the ordering of the output is incorrect (The final thing printed is not the following)
6. 2023-12-07 14:41:35 127.0.0.1 - - [07/Dec/2023 14:41:35] "POST /2015-03-31/functions/HelloWorldFunction/invocations HTTP/1.1" 200

```

#### How does it address the issue?
using a threading.Event, that gets set only when the regex matches the pattern, to wait until it is safe to end the flask request

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
