### PR TITLE
chore: Fix PR labeler GH action

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -27,7 +27,7 @@ jobs:
               'aws-sam-cli-bot',
               'hawflau', 'mndeveci',
               'mildaniel', 'marekaiv',
-              'lucashuy', 'hnnasit', 'jysheng123', 'bentvelj', 'sidhujus', dependabot[bot]'
+              'lucashuy', 'hnnasit', 'jysheng123', 'bentvelj', 'sidhujus', 'dependabot[bot]'
             ]
             if (maintainers.includes(context.payload.sender.login)) {
               github.rest.issues.addLabels({


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

Note: The job is still failing as it looks like it picks up the scripts defined in the develop branch instead of the PR.

#### Why is this change necessary?
PR labeler GH action is failing due to missing `'` for `dependabot[bot]` maintainer. This change did not give errors when the PR to update the script was created as it used the older script to run the GH action.

#### How does it address the issue?
Described above.

#### What side effects does this change have?
No side effects

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
