### PR TITLE
To supply target architecture when building PyInstaller binary

### DIFF
--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -120,7 +120,7 @@ fi
 echo "samcli-mac.spec content is:"
 cat installer/pyinstaller/samcli-mac.spec
 # Note: onefile/onedir options are not valid when spec file is used on mac
-../venv/bin/python -m PyInstaller --clean installer/pyinstaller/samcli-mac.spec
+../venv/bin/python -m PyInstaller --clean --target-arch ${mac_arch} installer/pyinstaller/samcli-mac.spec
 
 # Organizing the pyinstaller-output folder
 mkdir pyinstaller-output


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#5649


#### Why is this change necessary?
To prevent Rosetta 2 installation prompt when installing SAM CLI using PKG installer

#### How does it address the issue?
To supply `target-arch` to `PyInstaller`.

#### What side effects does this change have?
Nil

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
