### PR TITLE
chore: install dotnet8 in CI (appveyor)

### DIFF
--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -67,6 +67,10 @@ install:
   - sh: "PATH=/opt/gradle/gradle-8.4/bin:$PATH"
   - sh: "gradle --version"
 
+  # Install dotnet8 SDK
+  - sh: "sudo apt-get update"
+  - sh: "sudo apt-get install -y dotnet-sdk-8.0"
+
   # Install AWS CLI
   - sh: "virtualenv aws_cli"
   - sh: "./aws_cli/bin/python -m pip install awscli"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -68,6 +68,10 @@ install:
   - sh: "PATH=/opt/gradle/gradle-8.4/bin:$PATH"
   - sh: "gradle --version"
 
+  # Install dotnet8 SDK
+  - sh: "sudo apt-get update"
+  - sh: "sudo apt-get install -y dotnet-sdk-8.0"
+
   # Install AWS CLI
   - sh: "virtualenv aws_cli"
   - sh: "./aws_cli/bin/python -m pip install awscli"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
To update CI for it to be ready for testing dotnet8 runtimes (https://github.com/aws/aws-sam-cli/pull/6429)
Windows is not needed because it already has dotnet8 (https://www.appveyor.com/docs/windows-images-software/#net-framework)

#### How does it address the issue?
Install dotnet8 sdk via apt-get

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
