### PR TITLE
fix: Mark ssl_context as optional in the service constructor

### DIFF
--- a/samcli/commands/local/lib/local_lambda_service.py
+++ b/samcli/commands/local/lib/local_lambda_service.py
@@ -14,7 +14,7 @@ class LocalLambdaService:
     that are defined in a SAM file.
     """
 
-    def __init__(self, lambda_invoke_context, port, host, ssl_context):
+    def __init__(self, lambda_invoke_context, port, host, ssl_context=None):
         """
         Initialize the Local Lambda Invoke service.
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
`ssl_context` wasn't marked as optional, even though the doc string mentions that it is. This will cause errors since the other commands that use this service (`start lambda`) doesn't use this.

#### How does it address the issue?
Marks it as optional by setting `=None`.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
