### PR TITLE
fix: getting logging information from lambda

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 chevron~=0.12
 click~=8.1
 Flask<3.1
-boto3>=1.26.109,<2
+boto3>=1.29.2,<2
 jmespath~=1.0.1
 ruamel_yaml~=0.18.5
 PyYAML~=6.0,>=6.0.1

--- a/samcli/lib/observability/cw_logs/cw_log_group_provider.py
+++ b/samcli/lib/observability/cw_logs/cw_log_group_provider.py
@@ -53,8 +53,9 @@ class LogGroupProvider:
         """
         log_group_name = ""
         try:
-            function_configuration = (
-                boto_client_provider("lambda").get_function_configuration(FunctionName=function_name))
+            function_configuration = boto_client_provider("lambda").get_function_configuration(
+                FunctionName=function_name
+            )
             logging_config = function_configuration.get("LoggingConfig")
             if logging_config:
                 log_group_name = logging_config.get("LogGroup")

--- a/samcli/lib/observability/cw_logs/cw_log_group_provider.py
+++ b/samcli/lib/observability/cw_logs/cw_log_group_provider.py
@@ -53,7 +53,8 @@ class LogGroupProvider:
         """
         log_group_name = ""
         try:
-            function_configuration = boto_client_provider("lambda").get_function_configuration(function_name)
+            function_configuration = (
+                boto_client_provider("lambda").get_function_configuration(FunctionName=function_name))
             logging_config = function_configuration.get("LoggingConfig")
             if logging_config:
                 log_group_name = logging_config.get("LogGroup")

--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -230,6 +230,7 @@ class LogsIntegTestCases(LogsIntegBase):
 REGULAR_STACK_FUNCTION_LIST = [
     "ApiGwFunction",
     "SfnFunction",
+    "FunctionWithCustomLoggingConfig",
 ]
 REGULAR_STACK_APIGW_LIST = [
     "HelloWorldServerlessApi",

--- a/tests/integration/testdata/logs/nested-python-apigw-sfn/child-stack/function-with-custom-logging/app.py
+++ b/tests/integration/testdata/logs/nested-python-apigw-sfn/child-stack/function-with-custom-logging/app.py
@@ -1,0 +1,5 @@
+
+def handler(event, context):
+    print("Hello world from ChildStack/FunctionWithCustomLoggingConfig function")
+    print("this should be filtered ChildStackFunctionWithCustomLoggingConfig")
+    return {}

--- a/tests/integration/testdata/logs/nested-python-apigw-sfn/child-stack/grand-child-stack/function-with-custom-logging/app.py
+++ b/tests/integration/testdata/logs/nested-python-apigw-sfn/child-stack/grand-child-stack/function-with-custom-logging/app.py
@@ -1,0 +1,5 @@
+
+def handler(event, context):
+    print("Hello world from ChildStack/GrandChildStack/FunctionWithCustomLoggingConfig function")
+    print("this should be filtered ChildStackGrandChildStackFunctionWithCustomLoggingConfig")
+    return {}

--- a/tests/integration/testdata/logs/nested-python-apigw-sfn/child-stack/grand-child-stack/template.yaml
+++ b/tests/integration/testdata/logs/nested-python-apigw-sfn/child-stack/grand-child-stack/template.yaml
@@ -113,6 +113,17 @@ Resources:
       ManagedPolicyArns:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 
+  FunctionWithCustomLoggingConfig:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: function-with-custom-logging/
+      Handler: app.handler
+      Runtime: python3.9
+      Tracing: Active
+      LoggingConfig:
+        LogFormat: JSON
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}
+
 Outputs:
   HelloWorldServerlessApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"

--- a/tests/integration/testdata/logs/nested-python-apigw-sfn/child-stack/template.yaml
+++ b/tests/integration/testdata/logs/nested-python-apigw-sfn/child-stack/template.yaml
@@ -113,6 +113,17 @@ Resources:
       ManagedPolicyArns:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 
+  FunctionWithCustomLoggingConfig:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: function-with-custom-logging/
+      Handler: app.handler
+      Runtime: python3.9
+      Tracing: Active
+      LoggingConfig:
+        LogFormat: JSON
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}
+
   GrandChildStack:
     Type: AWS::Serverless::Application
     Properties:

--- a/tests/integration/testdata/logs/nested-python-apigw-sfn/function-with-custom-logging/app.py
+++ b/tests/integration/testdata/logs/nested-python-apigw-sfn/function-with-custom-logging/app.py
@@ -1,0 +1,5 @@
+
+def handler(event, context):
+    print("Hello world from FunctionWithCustomLoggingConfig function")
+    print("this should be filtered FunctionWithCustomLoggingConfig")
+    return {}

--- a/tests/integration/testdata/logs/nested-python-apigw-sfn/template.yaml
+++ b/tests/integration/testdata/logs/nested-python-apigw-sfn/template.yaml
@@ -113,6 +113,17 @@ Resources:
       ManagedPolicyArns:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 
+  FunctionWithCustomLoggingConfig:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: function-with-custom-logging/
+      Handler: app.handler
+      Runtime: python3.9
+      Tracing: Active
+      LoggingConfig:
+        LogFormat: JSON
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}
+
   ChildStack:
     Type: AWS::Serverless::Application
     Properties:

--- a/tests/integration/testdata/logs/python-apigw-sfn/function-with-custom-logging/app.py
+++ b/tests/integration/testdata/logs/python-apigw-sfn/function-with-custom-logging/app.py
@@ -1,0 +1,5 @@
+
+def handler(event, context):
+    print("Hello world from FunctionWithCustomLoggingConfig function")
+    print("this should be filtered FunctionWithCustomLoggingConfig")
+    return {}

--- a/tests/integration/testdata/logs/python-apigw-sfn/template.yaml
+++ b/tests/integration/testdata/logs/python-apigw-sfn/template.yaml
@@ -113,6 +113,17 @@ Resources:
       ManagedPolicyArns:
         - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 
+  FunctionWithCustomLoggingConfig:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: function-with-custom-logging/
+      Handler: app.handler
+      Runtime: python3.9
+      Tracing: Active
+      LoggingConfig:
+        LogFormat: JSON
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}
+
 Outputs:
   HelloWorldServerlessApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"

--- a/tests/unit/lib/observability/cw_logs/test_cw_log_group_provider.py
+++ b/tests/unit/lib/observability/cw_logs/test_cw_log_group_provider.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import Mock, ANY
+from unittest.mock import Mock, ANY, call
 
 from parameterized import parameterized
 
@@ -26,6 +26,9 @@ class TestLogGroupProvider_for_lambda_function(TestCase):
         result = LogGroupProvider.for_lambda_function(given_client_provider, "my_function_name")
 
         self.assertEqual(expected, result)
+        given_client_provider.assert_has_calls(
+            [call("lambda").get_function_configuration(FunctionName="my_function_name")]
+        )
 
     def test_must_return_default_log_group_name_with_exception_raised(self):
         expected = "/aws/lambda/my_function_name"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#6466 


#### Why is this change necessary?
`sam logs` fails to pull the log for a function which has `LoggingConfig` set.

#### How does it address the issue?
By fixing the API call and updating boto3 library which contains this information.


#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
