### PR TITLE
Add --debug to flaky test to get more information

### DIFF
--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -123,7 +123,7 @@ class TestHelloWorldZipPackagePermissionsEndToEnd(EndToEndBase):
             package_command_list = self._get_package_command(
                 s3_prefix="end-to-end-package-test", use_json=True, output_template_file="packaged_template.json"
             )
-            local_command_list = self._get_local_command(function_name)
+            local_command_list = self._get_local_command(function_name) + ['--debug']
             stages = [
                 DefaultInitStage(InitValidator(e2e_context), e2e_context, init_command_list, self.app_name),
                 EndToEndBaseStage(BuildValidator(e2e_context), e2e_context, build_command_list),

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -123,7 +123,7 @@ class TestHelloWorldZipPackagePermissionsEndToEnd(EndToEndBase):
             package_command_list = self._get_package_command(
                 s3_prefix="end-to-end-package-test", use_json=True, output_template_file="packaged_template.json"
             )
-            local_command_list = self._get_local_command(function_name) + ['--debug']
+            local_command_list = self._get_local_command(function_name) + ["--debug"]
             stages = [
                 DefaultInitStage(InitValidator(e2e_context), e2e_context, init_command_list, self.app_name),
                 EndToEndBaseStage(BuildValidator(e2e_context), e2e_context, build_command_list),


### PR DESCRIPTION
#### Which issue(s) does this change fix?


#### Why is this change necessary?
Yields some debug information for a flaky golang test. Hoping to run nightly canaries with this and use output to debug.

#### How does it address the issue?
Add debug flag to the `sam local invoke` run that is currently occasionally failing.


#### What side effects does this change have?
Extra output in canaries for this test.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
