### PR TITLE
Added the ability to specify --accountid parameter on the command line

### DIFF
--- a/samcli/cli/context.py
+++ b/samcli/cli/context.py
@@ -42,6 +42,7 @@ class Context:
         self._debug = False
         self._aws_region = None
         self._aws_profile = None
+        self._aws_accountid = None
         self._session_id = str(uuid.uuid4())
         self._experimental = False
         self._exception = None
@@ -109,6 +110,18 @@ class Context:
         Set AWS profile for credential resolution
         """
         self._aws_profile = value
+        self._refresh_session()
+
+    @property
+    def accountid(self):
+        return self._aws_accountid
+
+    @accountid.setter
+    def accountid(self, value):
+        """
+        Set AWS accountid for substitution
+        """
+        self._aws_accountid = value
         self._refresh_session()
 
     @property

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -11,7 +11,7 @@ from samcli import __version__
 from samcli.cli.command import BaseCommand
 from samcli.cli.context import Context
 from samcli.cli.global_config import GlobalConfig
-from samcli.cli.options import debug_option, profile_option, region_option
+from samcli.cli.options import accountid_option, debug_option, profile_option, region_option
 from samcli.commands._utils.experimental import experimental, get_all_experimental_env_vars
 from samcli.lib.utils.sam_logging import (
     LAMBDA_BULDERS_LOGGER_NAME,
@@ -45,6 +45,7 @@ def aws_creds_options(f):
     """
     f = region_option(f)
     f = profile_option(f)
+    f = accountid_option(f)
     return f
 
 

--- a/samcli/cli/options.py
+++ b/samcli/cli/options.py
@@ -76,3 +76,23 @@ def profile_option(f):
         help="Select a specific profile from your credential file to get AWS credentials.",
         callback=callback,
     )(f)
+
+
+def accountid_option(f):
+    """
+    Configures --accountid option for CLI
+
+    :param f: Callback Function to be passed to Click
+    """
+
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(Context)
+        state.accountid = value
+        return value
+
+    return click.option(
+        "--accountid",
+        expose_value=False,
+        help="Select an accountId to be substituted into template values.",
+        callback=callback,
+    )(f)

--- a/samcli/commands/build/core/options.py
+++ b/samcli/commands/build/core/options.py
@@ -11,7 +11,7 @@ from samcli.cli.core.options import ALL_COMMON_OPTIONS, SAVE_PARAMS_OPTIONS, add
 
 REQUIRED_OPTIONS: List[str] = ["template_file"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 CONTAINER_OPTION_NAMES: List[str] = [
     "use_container",

--- a/samcli/commands/deploy/core/options.py
+++ b/samcli/commands/deploy/core/options.py
@@ -13,7 +13,7 @@ REQUIRED_OPTIONS: List[str] = ["stack_name", "capabilities", "resolve_s3"]
 # Can be used instead of the options in the first list
 INTERACTIVE_OPTIONS: List[str] = ["guided"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 INFRASTRUCTURE_OPTION_NAMES: List[str] = [
     "parameter_overrides",

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -92,6 +92,7 @@ class InvokeContext:
         force_image_build: Optional[bool] = None,
         aws_region: Optional[str] = None,
         aws_profile: Optional[str] = None,
+        aws_accountid: Optional[str] = None,
         warm_container_initialization_mode: Optional[str] = None,
         debug_function: Optional[str] = None,
         shutdown: bool = False,
@@ -169,8 +170,12 @@ class InvokeContext:
         self._parameter_overrides = parameter_overrides
         # Override certain CloudFormation pseudo-parameters based on values provided by customer
         self._global_parameter_overrides: Optional[Dict] = None
-        if aws_region:
-            self._global_parameter_overrides = {"AWS::Region": aws_region}
+        if aws_region or aws_accountid:
+            self._global_parameter_overrides = {}
+            if aws_region:
+                self._global_parameter_overrides["AWS::Region"] = aws_region
+            if aws_accountid:
+                self._global_parameter_overrides["AWS::AccountId"] = aws_accountid
 
         self._layer_cache_basedir = layer_cache_basedir
         self._force_image_build = force_image_build

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -195,6 +195,7 @@ def do_cli(  # pylint: disable=R0914
             force_image_build=force_image_build,
             aws_region=ctx.region,
             aws_profile=ctx.profile,
+            aws_accountid=ctx.accountid,
             shutdown=shutdown,
             container_host=container_host,
             container_host_interface=container_host_interface,

--- a/samcli/commands/local/invoke/core/options.py
+++ b/samcli/commands/local/invoke/core/options.py
@@ -11,7 +11,7 @@ from samcli.cli.row_modifiers import RowDefinition
 
 REQUIRED_OPTIONS: List[str] = ["template_file"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 TEMPLATE_OPTIONS: List[str] = [
     "parameter_overrides",

--- a/samcli/commands/local/start_api/core/options.py
+++ b/samcli/commands/local/start_api/core/options.py
@@ -11,7 +11,7 @@ from samcli.cli.row_modifiers import RowDefinition
 
 REQUIRED_OPTIONS: List[str] = ["template_file"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 TEMPLATE_OPTIONS: List[str] = [
     "parameter_overrides",

--- a/samcli/commands/local/start_lambda/core/options.py
+++ b/samcli/commands/local/start_lambda/core/options.py
@@ -11,7 +11,7 @@ from samcli.cli.row_modifiers import RowDefinition
 
 REQUIRED_OPTIONS: List[str] = ["template_file"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 TEMPLATE_OPTIONS: List[str] = [
     "parameter_overrides",

--- a/samcli/commands/logs/core/options.py
+++ b/samcli/commands/logs/core/options.py
@@ -13,7 +13,7 @@ LOG_IDENTIFIER_OPTIONS: List[str] = ["stack_name", "cw_log_group", "name"]
 # Can be used instead of the options in the first list
 ADDITIONAL_OPTIONS: List[str] = ["include_traces", "filter", "output", "tail", "start_time", "end_time"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 CONFIGURATION_OPTION_NAMES: List[str] = ["config_env", "config_file"] + SAVE_PARAMS_OPTIONS
 

--- a/samcli/commands/package/core/options.py
+++ b/samcli/commands/package/core/options.py
@@ -10,7 +10,7 @@ from samcli.cli.row_modifiers import RowDefinition
 
 REQUIRED_OPTIONS: List[str] = ["s3_bucket", "resolve_s3"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 INFRASTRUCTURE_OPTION_NAMES: List[str] = [
     "s3_prefix",

--- a/samcli/commands/remote/invoke/core/options.py
+++ b/samcli/commands/remote/invoke/core/options.py
@@ -15,7 +15,7 @@ INPUT_EVENT_OPTIONS: List[str] = ["event", "event_file", "test_event_name"]
 
 ADDITIONAL_OPTIONS: List[str] = ["parameter", "output"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 CONFIGURATION_OPTION_NAMES: List[str] = ["config_env", "config_file"] + SAVE_PARAMS_OPTIONS
 

--- a/samcli/commands/remote/test_event/core/base_options.py
+++ b/samcli/commands/remote/test_event/core/base_options.py
@@ -10,7 +10,7 @@ from samcli.cli.row_modifiers import RowDefinition
 
 INFRASTRUCTURE_OPTION_NAMES: List[str] = ["stack_name"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 CONFIGURATION_OPTION_NAMES: List[str] = ["config_env", "config_file"]
 

--- a/samcli/commands/validate/core/options.py
+++ b/samcli/commands/validate/core/options.py
@@ -11,7 +11,7 @@ from samcli.cli.row_modifiers import RowDefinition
 
 REQUIRED_OPTIONS: List[str] = ["template_file"]
 
-AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile"]
+AWS_CREDENTIAL_OPTION_NAMES: List[str] = ["region", "profile", "accountid"]
 
 LINT_OPTION_NAMES: List[str] = [
     "lint",

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -41,6 +41,7 @@ class TestCli(TestCase):
         self.shutdown = False
         self.region_name = "region"
         self.profile = "profile"
+        self.accountid = "accountid"
         self.container_host = "localhost"
         self.container_host_interface = "127.0.0.1"
         self.add_host = (["prod-na.host:10.11.12.13"],)
@@ -50,6 +51,7 @@ class TestCli(TestCase):
         self.ctx_mock = Mock()
         self.ctx_mock.region = self.region_name
         self.ctx_mock.profile = self.profile
+        self.ctx_mock.accountid = self.accountid
 
     def call_cli(self):
         invoke_cli(
@@ -108,6 +110,7 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             aws_region=self.region_name,
             aws_profile=self.profile,
+            aws_accountid=self.accountid,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
@@ -148,6 +151,7 @@ class TestCli(TestCase):
             shutdown=self.shutdown,
             aws_region=self.region_name,
             aws_profile=self.profile,
+            aws_accountid=self.accountid,
             container_host=self.container_host,
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#2325


#### Why is this change necessary?
Because currently if you have !Sub xxx`${AWS::AccountId}`xxx in, for example, a layer definition, SAM uses a default substitution which doesn't reference the correct Account ID

#### How does it address the issue?
It adds the ability to specify a command line option( --accountid ). This parameter is then used during the substitution of parameters in the CloudFormation template to replace ${AWS::AccountId} rather than using a hardcoded default (123456789012) 

#### What side effects does this change have?
None that I can see

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [n/a] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [n/a ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [n/a] Write/update integration tests
- [n/a] Write/update functional tests if needed
- [x] `make pr` passes
- [n/a] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation
      -  parameter description added to 'AWS Credential Options' section for --help

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
