### PR TITLE
fix: Add check for resolving symlinks when host_dir does not exist

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -251,7 +251,11 @@ class Container:
             on the container
         """
         mount_mode = "ro,delegated"
-        additional_volumes = {}
+        additional_volumes: Dict[str, Dict[str, str]] = {}
+
+        if not pathlib.Path(self._host_dir).exists():
+            LOG.debug("Host directory not found, skip resolving symlinks")
+            return additional_volumes
 
         with os.scandir(self._host_dir) as directory_iterator:
             for file in directory_iterator:

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -1066,13 +1066,8 @@ class TestContainer_create_mapped_symlink_files(TestCase):
         self.assertEqual(volumes, {})
 
     @patch("samcli.local.docker.container.pathlib.Path.exists")
-    @patch("samcli.local.docker.container.os.scandir")
-    def test_host_dir_does_not_exist_returns_empty_symlinks(self, mock_scandir, mock_exists):
-        mock_context = MagicMock()
-        mock_context.__enter__ = Mock(return_value=[self.mock_regular_file])
-        mock_scandir.return_value = mock_context
+    def test_host_dir_does_not_exist_returns_empty_symlinks(self, mock_exists):
         mock_exists.return_value = False
-
         volumes = self.container._create_mapped_symlink_files()
 
         self.assertEqual(volumes, {})


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#6516 

#### Why is this change necessary?
When the host directory does not exist and commands such as `sam build -u` or `sam local` commands tries to mount the directory, it throws a file not found error which crashes the commands.

#### How does it address the issue?
The symlinks logic is skipped when the host directory does not exist.

#### What side effects does this change have?
No side effects

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
