### PR TITLE
Add logging for files pulled from S3 + enable RIE debug for flaky test

### DIFF
--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -99,7 +99,7 @@ class TestHelloWorldDefaultEndToEnd(EndToEndBase):
             ]
             self._run_tests(stages)
 
-        os.environ.pop('SAM_CLI_RIE_DEV', None)
+        os.environ.pop("SAM_CLI_RIE_DEV", None)
 
 
 @skipIf(SKIP_E2E_TESTS, "Skip E2E tests in CI/CD only")

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -77,6 +77,7 @@ class TestHelloWorldDefaultEndToEnd(EndToEndBase):
     app_template = "hello-world"
 
     def test_hello_world_default_workflow(self):
+        os.environ["SAM_CLI_RIE_DEV"] = "1"
         stack_name = self._method_to_stack_name(self.id())
         function_name = "HelloWorldFunction"
         event = '{"hello": "world"}'
@@ -97,6 +98,8 @@ class TestHelloWorldDefaultEndToEnd(EndToEndBase):
                 DefaultDeleteStage(BaseValidator(e2e_context), e2e_context, delete_command_list, stack_name),
             ]
             self._run_tests(stages)
+
+        os.environ.pop('SAM_CLI_RIE_DEV', None)
 
 
 @skipIf(SKIP_E2E_TESTS, "Skip E2E tests in CI/CD only")

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -77,7 +77,6 @@ class TestHelloWorldDefaultEndToEnd(EndToEndBase):
     app_template = "hello-world"
 
     def test_hello_world_default_workflow(self):
-        os.environ["SAM_CLI_RIE_DEV"] = "1"
         stack_name = self._method_to_stack_name(self.id())
         function_name = "HelloWorldFunction"
         event = '{"hello": "world"}'
@@ -99,7 +98,6 @@ class TestHelloWorldDefaultEndToEnd(EndToEndBase):
             ]
             self._run_tests(stages)
 
-        os.environ.pop("SAM_CLI_RIE_DEV", None)
 
 
 @skipIf(SKIP_E2E_TESTS, "Skip E2E tests in CI/CD only")
@@ -118,6 +116,7 @@ class TestHelloWorldZipPackagePermissionsEndToEnd(EndToEndBase):
     app_template = "hello-world"
 
     def test_hello_world_workflow(self):
+        os.environ["SAM_CLI_RIE_DEV"] = "1"
         function_name = "HelloWorldFunction"
         with EndToEndTestContext(self.app_name) as e2e_context:
             self.template_path = e2e_context.template_path
@@ -136,6 +135,7 @@ class TestHelloWorldZipPackagePermissionsEndToEnd(EndToEndBase):
                 EndToEndBaseStage(LocalInvokeValidator(e2e_context), e2e_context, local_command_list),
             ]
             self._run_tests(stages)
+        os.environ.pop("SAM_CLI_RIE_DEV", None)
 
 
 @skipIf(SKIP_E2E_TESTS, "Skip E2E tests in CI/CD only")

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -99,7 +99,6 @@ class TestHelloWorldDefaultEndToEnd(EndToEndBase):
             self._run_tests(stages)
 
 
-
 @skipIf(SKIP_E2E_TESTS, "Skip E2E tests in CI/CD only")
 @parameterized_class(
     ("runtime", "dependency_manager"),

--- a/tests/end_to_end/test_stages.py
+++ b/tests/end_to_end/test_stages.py
@@ -115,8 +115,8 @@ class PackageDownloadZipFunctionStage(EndToEndBaseStage):
                 file_list = zip_refzip.namelist()
 
                 for extracted_file in file_list:
-                    permission_mask = oct(os.stat(extracted_file).st_mode[-3:])
-                    LOG.debug("Exctracted file %s, with permission mask %s", extracted_file, permission_mask)
+                    permission_mask = oct(os.stat(os.path.join(built_function_path, extracted_file)).st_mode)[-3:]
+                    LOG.info("Extracted file %s, with permission mask %s", extracted_file, permission_mask)
 
 
 class DefaultSyncStage(EndToEndBaseStage):

--- a/tests/end_to_end/test_stages.py
+++ b/tests/end_to_end/test_stages.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from unittest import TestCase
 
+import logging
 import boto3
 import zipfile
 import json
@@ -15,6 +16,8 @@ from filelock import FileLock
 from samcli.lib.utils.s3 import parse_s3_url
 from tests.end_to_end.end_to_end_context import EndToEndTestContext
 from tests.testing_utils import CommandResult, run_command, run_command_with_input
+
+LOG = logging.getLogger(__name__)
 
 
 class BaseValidator(TestCase):
@@ -108,6 +111,12 @@ class PackageDownloadZipFunctionStage(EndToEndBaseStage):
 
             with zipfile.ZipFile(zip_file_path, "r") as zip_refzip:
                 zip_refzip.extractall(path=built_function_path)
+
+                file_list = zip_refzip.namelist()
+
+                for extracted_file in file_list:
+                    permission_mask = oct(os.stat(extracted_file).st_mode[-3:])
+                    LOG.debug("Exctracted file %s, with permission mask %s",extracted_file, permission_mask)
 
 
 class DefaultSyncStage(EndToEndBaseStage):

--- a/tests/end_to_end/test_stages.py
+++ b/tests/end_to_end/test_stages.py
@@ -116,7 +116,7 @@ class PackageDownloadZipFunctionStage(EndToEndBaseStage):
 
                 for extracted_file in file_list:
                     permission_mask = oct(os.stat(extracted_file).st_mode[-3:])
-                    LOG.debug("Exctracted file %s, with permission mask %s",extracted_file, permission_mask)
+                    LOG.debug("Exctracted file %s, with permission mask %s", extracted_file, permission_mask)
 
 
 class DefaultSyncStage(EndToEndBaseStage):


### PR DESCRIPTION
#### Why is this change necessary?
Purposes of debugging the flaky golang test 

```
tests/end_to_end/test_runtimes_e2e.py::TestHelloWorldZipPackagePermissionsEndToEnd_0_go1_x::test_hello_world_workflow
```

#### How does it address the issue?
Add logging for files pulled from S3, since this is a unique component of this test and there could be permission issues preventing the lambda from invoking properly.

Enable RIE debug environment variable to get more information

#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
