### PR TITLE
Add `MemorySize` validation for function build

### DIFF
--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -200,6 +200,7 @@ def do_cli(  # pylint: disable=R0914
             container_host_interface=container_host_interface,
             add_host=add_host,
             invoke_images=processed_invoke_images,
+            ctx=ctx,
         ) as context:
             # Invoke the function
             context.local_lambda_runner.invoke(

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -253,6 +253,7 @@ def do_cli(  # pylint: disable=R0914
             container_host_interface=container_host_interface,
             invoke_images=processed_invoke_images,
             add_host=add_host,
+            ctx=ctx,
         ) as invoke_context:
             ssl_context = (ssl_cert_file, ssl_key_file) if ssl_cert_file else None
             service = LocalApiService(

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -205,6 +205,7 @@ def do_cli(  # pylint: disable=R0914
             container_host_interface=container_host_interface,
             add_host=add_host,
             invoke_images=processed_invoke_images,
+            ctx=ctx,
         ) as invoke_context:
             service = LocalLambdaService(lambda_invoke_context=invoke_context, port=port, host=host)
             service.start()

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -1254,12 +1254,15 @@ class TestInvokeFunctionWithError(InvokeIntegBase):
         for line in stack_trace_lines:
             self.assertIn(line, stderr)
 
+
 class TestRunValidateBeforeInvoke(InvokeIntegBase):
     template = Path("template-invalid-memorysize.yaml")
 
     def test_validation_exception(self):
         command_list = InvokeIntegBase.get_command_list(
-            function_to_invoke="HelloWorldFunction", template_path=self.template_path, parameter_overrides={"MemorySize": "1"}
+            function_to_invoke="HelloWorldFunction",
+            template_path=self.template_path,
+            parameter_overrides={"MemorySize": "1"},
         )
 
         result = run_command(command_list)

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -1253,3 +1253,14 @@ class TestInvokeFunctionWithError(InvokeIntegBase):
         self.assertEqual(result.process.returncode, 0)
         for line in stack_trace_lines:
             self.assertIn(line, stderr)
+
+class TestRunValidateBeforeInvoke(InvokeIntegBase):
+    template = Path("template-invalid-memorysize.yaml")
+
+    def test_validation_exception(self):
+        command_list = InvokeIntegBase.get_command_list(
+            function_to_invoke="HelloWorldFunction", template_path=self.template_path, parameter_overrides={"MemorySize": "1"}
+        )
+
+        result = run_command(command_list)
+        self.assertIn("E3034 Value has to be between 128 and 10240", result.stdout.decode("utf-8"))

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -19,6 +19,13 @@ from .start_api_integ_base import StartApiIntegBaseClass, WritableStartApiIntegB
 from ..invoke.layer_utils import LayerUtils
 
 
+# class TestInvalidTempate(StartApiIntegBaseClass):
+#     template_path = "/testdata/start_api/invalid-template.yaml"
+
+#     def test(self):
+#         self.assertIsNotNone(self.start_api_process.poll())
+
+
 @parameterized_class(
     ("template_path",),
     [

--- a/tests/integration/testdata/invoke/template-invalid-memorysize.yaml
+++ b/tests/integration/testdata/invoke/template-invalid-memorysize.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.9
+      Handler: handler
+      CodeUri: .
+      Timeout: 600
+      MemorySize: 1

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -112,7 +112,7 @@ class TestCli(TestCase):
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
             invoke_images={None: "amazon/aws-sam-cli-emulation-image-python3.9"},
-            ctx=self.ctx_mock
+            ctx=self.ctx_mock,
         )
 
         context_mock.local_lambda_runner.invoke.assert_called_with(
@@ -153,7 +153,7 @@ class TestCli(TestCase):
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
             invoke_images={None: "amazon/aws-sam-cli-emulation-image-python3.9"},
-            ctx=self.ctx_mock
+            ctx=self.ctx_mock,
         )
 
         get_event_mock.assert_not_called()

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -112,6 +112,7 @@ class TestCli(TestCase):
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
             invoke_images={None: "amazon/aws-sam-cli-emulation-image-python3.9"},
+            ctx=self.ctx_mock
         )
 
         context_mock.local_lambda_runner.invoke.assert_called_with(
@@ -152,6 +153,7 @@ class TestCli(TestCase):
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
             invoke_images={None: "amazon/aws-sam-cli-emulation-image-python3.9"},
+            ctx=self.ctx_mock
         )
 
         get_event_mock.assert_not_called()

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -97,7 +97,7 @@ class TestCli(TestCase):
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
             invoke_images={},
-            ctx=self.ctx_mock
+            ctx=self.ctx_mock,
         )
 
         local_api_service_mock.assert_called_with(

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -97,6 +97,7 @@ class TestCli(TestCase):
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
             invoke_images={},
+            ctx=self.ctx_mock
         )
 
         local_api_service_mock.assert_called_with(

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -84,6 +84,7 @@ class TestCli(TestCase):
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
             invoke_images={},
+            ctx=self.ctx_mock
         )
 
         local_lambda_service_mock.assert_called_with(lambda_invoke_context=context_mock, port=self.port, host=self.host)

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -84,7 +84,7 @@ class TestCli(TestCase):
             container_host_interface=self.container_host_interface,
             add_host=self.add_host,
             invoke_images={},
-            ctx=self.ctx_mock
+            ctx=self.ctx_mock,
         )
 
         local_lambda_service_mock.assert_called_with(lambda_invoke_context=context_mock, port=self.port, host=self.host)


### PR DESCRIPTION
Validate function `MemorySize` to be an integer within range `[128, 10240]` as per [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-memorysize).

Also had to fix a bunch of unit tests that previously had fake MemorySize.

#### Which issue(s) does this change fix?
#6510 


#### Why is this change necessary?
Customers were permitted to build Lambda functions with invalid MemorySize, causing late/unexpected failure


#### How does it address the issue?
Adds a validation step to tell the customer the MemorySize is invalid (not an integer, or outside the range `[128,10240]`)


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
