### PR TITLE
fix: stream logs for build

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -414,13 +414,14 @@ class ApplicationBuilder:
             "buildargs": docker_build_args,
             "platform": get_docker_platform(architecture),
             "rm": True,
+            "decode": True,
         }
         if docker_build_target:
             build_args["target"] = cast(str, docker_build_target)
 
         try:
-            (build_image, build_logs) = self._docker_client.images.build(**build_args)
-            LOG.debug("%s image is built for %s function", build_image, function_name)
+            build_logs = self._docker_client.api.build(**build_args)
+            LOG.debug("image is built for %s function", "poop", function_name)
         except docker.errors.BuildError as ex:
             LOG.error("Failed building function %s", function_name)
             raise DockerBuildFailed(str(ex)) from ex

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -421,7 +421,7 @@ class ApplicationBuilder:
 
         try:
             build_logs = self._docker_client.api.build(**build_args)
-            LOG.debug("image is built for %s function", "poop", function_name)
+            LOG.debug("image is built for %s function", function_name)
         except docker.errors.BuildError as ex:
             LOG.error("Failed building function %s", function_name)
             raise DockerBuildFailed(str(ex)) from ex

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -1556,7 +1556,7 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
                 "DockerBuildArgs": {"a": "b"},
             }
 
-            self.docker_client_mock.images.build.return_value = (Mock(), [{"error": "Function building failed"}])
+            self.docker_client_mock.api.build.return_value = [{"error": "Function building failed"}]
 
             self.builder._build_lambda_image("Name", metadata, X86_64)
 
@@ -1591,7 +1591,7 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
             error_mock = Mock()
             error_mock.side_effect = docker.errors.APIError("Bad Request", explanation="Some explanation")
             self.builder._stream_lambda_image_build_logs = error_mock
-            self.docker_client_mock.images.build.return_value = (Mock(), [])
+            self.docker_client_mock.api.build.return_value = []
 
             self.builder._build_lambda_image("Name", metadata, X86_64)
 
@@ -1603,7 +1603,7 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
             "DockerBuildArgs": {"a": "b"},
         }
 
-        self.docker_client_mock.images.build.return_value = (Mock(), [])
+        self.docker_client_mock.api.build.return_value = []
 
         result = self.builder._build_lambda_image("Name", metadata, X86_64)
 
@@ -1644,7 +1644,7 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
     def test_can_build_image_function_without_tag(self):
         metadata = {"Dockerfile": "Dockerfile", "DockerContext": "context", "DockerBuildArgs": {"a": "b"}}
 
-        self.docker_client_mock.images.build.return_value = (Mock(), [])
+        self.docker_client_mock.api.build.return_value = []
         result = self.builder._build_lambda_image("Name", metadata, X86_64)
 
         self.assertEqual(result, "name:latest")
@@ -1659,12 +1659,12 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
             "DockerBuildArgs": {"a": "b"},
         }
 
-        self.docker_client_mock.images.build.return_value = (Mock, [])
+        self.docker_client_mock.api.build.return_value = []
 
         result = self.builder._build_lambda_image("Name", metadata, X86_64)
         self.assertEqual(result, "name:Tag-debug")
         self.assertEqual(
-            self.docker_client_mock.images.build.call_args,
+            self.docker_client_mock.api.build.call_args,
             # NOTE (sriram-mv): path set to ANY to handle platform differences.
             call(
                 path=ANY,
@@ -1673,6 +1673,7 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
                 buildargs={"a": "b", "SAM_BUILD_MODE": "debug"},
                 platform="linux/amd64",
                 rm=True,
+                decode=True,
             ),
         )
 
@@ -1687,12 +1688,12 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
             "DockerBuildTarget": "stage",
         }
 
-        self.docker_client_mock.images.build.return_value = (Mock(), [])
+        self.docker_client_mock.api.build.return_value = []
 
         result = self.builder._build_lambda_image("Name", metadata, X86_64)
         self.assertEqual(result, "name:Tag-debug")
         self.assertEqual(
-            self.docker_client_mock.images.build.call_args,
+            self.docker_client_mock.api.build.call_args,
             call(
                 path=ANY,
                 dockerfile="Dockerfile",
@@ -1701,6 +1702,7 @@ class TestApplicationBuilder_build_lambda_image_function(TestCase):
                 target="stage",
                 platform="linux/amd64",
                 rm=True,
+                decode=True,
             ),
         )
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
https://github.com/aws/aws-sam-cli/issues/6507

#### Why is this change necessary?
The images.build call is blocking so no logs are streamed. Using the lower level api.build lets us stream the logs

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
