### PR TITLE
fix: Raise UserException when an invalid runtime is specified

### DIFF
--- a/samcli/local/docker/exceptions.py
+++ b/samcli/local/docker/exceptions.py
@@ -25,3 +25,8 @@ class ContainerFailureError(UserException):
     """
     Raised when the invoke container fails execution
     """
+
+class InvalidRuntimeException(UserException):
+    """
+    Raised when an invalid runtime is specified for a Lambda Function
+    """

--- a/samcli/local/docker/exceptions.py
+++ b/samcli/local/docker/exceptions.py
@@ -26,6 +26,7 @@ class ContainerFailureError(UserException):
     Raised when the invoke container fails execution
     """
 
+
 class InvalidRuntimeException(UserException):
     """
     Raised when an invalid runtime is specified for a Lambda Function

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -7,6 +7,7 @@ import os
 from typing import List
 
 from samcli.lib.utils.packagetype import IMAGE
+from samcli.local.docker.exceptions import InvalidRuntimeException
 from samcli.local.docker.lambda_debug_settings import LambdaDebugSettings
 
 from .container import DEFAULT_CONTAINER_HOST_INTERFACE, Container
@@ -15,6 +16,7 @@ from .lambda_image import LambdaImage, Runtime
 LOG = logging.getLogger(__name__)
 
 RIE_LOG_LEVEL_ENV_VAR = "SAM_CLI_RIE_DEV"
+INVALID_RUNTIME_MESSAGE = "Unsupported Lambda runtime: {runtime}. For a list of supported runtimes, please visit https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
 
 
 class LambdaContainer(Container):
@@ -95,7 +97,7 @@ class LambdaContainer(Container):
             Optional. The function full path, unique in all stacks
         """
         if not Runtime.has_value(runtime) and not packagetype == IMAGE:
-            raise ValueError("Unsupported Lambda runtime {}".format(runtime))
+            raise InvalidRuntimeException(INVALID_RUNTIME_MESSAGE.format(runtime=runtime))
 
         image = LambdaContainer._get_image(
             lambda_image, runtime, packagetype, imageuri, layers, architecture, function_full_path

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -9,6 +9,7 @@ from parameterized import parameterized, param
 
 from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.lib.utils.packagetype import IMAGE, ZIP
+from samcli.local.docker.exceptions import InvalidRuntimeException
 from samcli.local.docker.lambda_container import LambdaContainer, Runtime, RIE_LOG_LEVEL_ENV_VAR
 from samcli.local.docker.lambda_debug_settings import DebuggingNotSupported
 from samcli.local.docker.lambda_image import RAPID_IMAGE_TAG_PREFIX
@@ -433,7 +434,7 @@ class TestLambdaContainer_init(TestCase):
 
         image_builder_mock = Mock()
 
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(InvalidRuntimeException) as context:
             LambdaContainer(
                 runtime=runtime,
                 imageuri=self.imageuri,
@@ -446,7 +447,10 @@ class TestLambdaContainer_init(TestCase):
                 architecture="x86_64",
             )
 
-        self.assertEqual(str(context.exception), "Unsupported Lambda runtime foo")
+        self.assertEqual(
+            str(context.exception),
+            "Unsupported Lambda runtime: foo. For a list of supported runtimes, please visit https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html",
+        )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#6558

#### Why is this change necessary?
Previously,  a Python `ValueError` was raised when an invalid runtime is specified in the template file a function. This causes a stack trace to be displayed, and the wrong error code to be emitted to customers.

#### How does it address the issue?
Raises a new custom `UserException` error instead.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
