### PR TITLE
fix: change rvm to rbenv

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -53,7 +53,6 @@ install:
   - sh: "mvn --version"
 
   - sh: "source ${HOME}/venv${PYTHON_VERSION}/bin/activate"
-  # - sh: "rvm reinstall ruby-3.2.2 --with-openssl-dir=/usr/lib/x86_64-linux-gnu" # reinstall ruby3.2 to fix OpenSSL issue
   - sh: "rbenv global 3.2.3"
   - sh: "ruby --version"
   - sh: "docker info"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -54,7 +54,6 @@ install:
 
   - sh: "source ${HOME}/venv${PYTHON_VERSION}/bin/activate"
   # - sh: "rvm reinstall ruby-3.2.2 --with-openssl-dir=/usr/lib/x86_64-linux-gnu" # reinstall ruby3.2 to fix OpenSSL issue
-  # - sh: "rvm use 3.2.2"
   - sh: "rbenv global 3.2.3"
   - sh: "ruby --version"
   - sh: "docker info"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -53,8 +53,10 @@ install:
   - sh: "mvn --version"
 
   - sh: "source ${HOME}/venv${PYTHON_VERSION}/bin/activate"
-  - sh: "rvm reinstall ruby-3.2.2 --with-openssl-dir=/usr/lib/x86_64-linux-gnu" # reinstall ruby3.2 to fix OpenSSL issue
-  - sh: "rvm use 3.2.2"
+  # - sh: "rvm reinstall ruby-3.2.2 --with-openssl-dir=/usr/lib/x86_64-linux-gnu" # reinstall ruby3.2 to fix OpenSSL issue
+  # - sh: "rvm use 3.2.2"
+  - sh: "rbenv global 3.2.3"
+  - sh: "ruby --version"
   - sh: "docker info"
   - sh: "docker version"
   - sh: "nvm install ${NODE_VERSION}"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
changing ruby version manager

#### Why is this change necessary?
appveyor no longer uses rvm in their image

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
