### PR TITLE
update sanity-check to use python runtime app template based on avail…

### DIFF
--- a/.github/workflows/validate_pyinstaller.yml
+++ b/.github/workflows/validate_pyinstaller.yml
@@ -21,10 +21,6 @@ jobs:
       # due to glibc requirement from github actions 
       # see example failure: https://github.com/aws/aws-sam-cli/actions/runs/6102715182/job/16561754862?pr=5887
       - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.20"
       - name: Build PyInstaller
         run: |
           chmod +x ./installer/pyinstaller/build-linux.sh
@@ -52,15 +48,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.8"
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.20"
       - name: Build PyInstaller
         run: |
           chmod +x ./installer/pyinstaller/build-mac.sh
           ./installer/pyinstaller/build-mac.sh aws-sam-cli-macos-x86_64.zip
       - name: Basic tests for PyInstaller
+        env:
+          SAM_INIT_RUNTIME: "python3.8"
         run: |
           unzip .build/output/aws-sam-cli-macos-x86_64.zip -d sam-installation
           sudo ./sam-installation/install

--- a/tests/sanity-check.sh
+++ b/tests/sanity-check.sh
@@ -2,6 +2,12 @@
 set -xeo pipefail
 
 export SAM_CLI_TELEMETRY="${SAM_CLI_TELEMETRY:-0}"
+export SAM_INIT_ARCH="${SAM_INIT_ARCH:-x86_64}"
+export PYTHON_VERSION=`python -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}".format(*version))'`
+export SAM_INIT_RUNTIME="${SAM_INIT_RUNTIME:-python${PYTHON_VERSION}}"
+export SAM_INIT_DEPENDENCY_MANAGER="${SAM_INIT_DEPENDENCY_MANAGER:-pip}"
+export SAM_INIT_APP_TEMPLATE="${SAM_INIT_APP_TEMPLATE:-hello-world}"
+export SAM_INIT_PACKAGE_TYPE="${SAM_INIT_PACKAGE_TYPE:-Zip}"
 
 if [ "$CI_OVERRIDE" = "1" ]; then
     sam_binary="sam-beta"
@@ -37,7 +43,7 @@ fi
 
 echo "Starting testing sam binary"
 rm -rf sam-app-testing
-"$sam_binary" init --no-interactive -n sam-app-testing --dependency-manager mod --runtime go1.x --app-template hello-world --package-type Zip --architecture x86_64
+"$sam_binary" init --no-interactive -n sam-app-testing --dependency-manager "$SAM_INIT_DEPENDENCY_MANAGER" --runtime "$SAM_INIT_RUNTIME" --app-template "$SAM_INIT_APP_TEMPLATE" --package-type "$SAM_INIT_PACKAGE_TYPE" --architecture "$SAM_INIT_ARCH"
 cd sam-app-testing
 GOFLAGS="-buildvcs=false" "$sam_binary" build
 "$sam_binary" validate

--- a/tests/sanity-check.sh
+++ b/tests/sanity-check.sh
@@ -3,8 +3,7 @@ set -xeo pipefail
 
 export SAM_CLI_TELEMETRY="${SAM_CLI_TELEMETRY:-0}"
 export SAM_INIT_ARCH="${SAM_INIT_ARCH:-x86_64}"
-export PYTHON_VERSION=`python -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}".format(*version))'`
-export SAM_INIT_RUNTIME="${SAM_INIT_RUNTIME:-python${PYTHON_VERSION}}"
+export SAM_INIT_RUNTIME="${SAM_INIT_RUNTIME:-python3.11}"
 export SAM_INIT_DEPENDENCY_MANAGER="${SAM_INIT_DEPENDENCY_MANAGER:-pip}"
 export SAM_INIT_APP_TEMPLATE="${SAM_INIT_APP_TEMPLATE:-hello-world}"
 export SAM_INIT_PACKAGE_TYPE="${SAM_INIT_PACKAGE_TYPE:-Zip}"


### PR DESCRIPTION
…able python version

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Since go1.x runtime is being deprecated, `tests/sanity-check.sh` will break as it tries to run `sam init` to create a go1.x template.

#### How does it address the issue?
As we can safely assume python is available where sanity-check.sh is run, the fix is to change the `sam init` to create a python sam project based on the python version in the running environment

#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
