### PR TITLE
chore: Skip ruby3.3 win tests as its based on al2023

### DIFF
--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -816,6 +816,8 @@ class TestBuildCommand_RubyFunctions(BuildIntegRubyBase):
     @parameterized.expand(["ruby3.2", "ruby3.3"])
     @skipIf(SKIP_DOCKER_TESTS or SKIP_DOCKER_BUILD, SKIP_DOCKER_MESSAGE)
     def test_building_ruby_in_container(self, runtime):
+        if IS_WINDOWS and not runtime_supported_by_docker(f"{runtime}"):
+            self.skipTest(RUNTIME_NOT_SUPPORTED_BY_DOCKER_MSG)
         self._test_with_default_gemfile(runtime, "use_container", "Ruby", self.test_data_path)
 
     @parameterized.expand(["ruby3.2"])
@@ -829,10 +831,14 @@ class TestBuildCommand_RubyFunctions_With_Architecture(BuildIntegRubyBase):
     @parameterized.expand([("ruby3.2", "Ruby32"), ("ruby3.3", "Ruby33")])
     @skipIf(SKIP_DOCKER_TESTS or SKIP_DOCKER_BUILD, SKIP_DOCKER_MESSAGE)
     def test_building_ruby_in_container_with_specified_architecture(self, runtime, codeuri):
+        if IS_WINDOWS and not runtime_supported_by_docker(f"{runtime}"):
+            self.skipTest(RUNTIME_NOT_SUPPORTED_BY_DOCKER_MSG)
         self._test_with_default_gemfile(runtime, "use_container", codeuri, self.test_data_path, "x86_64")
 
     @parameterized.expand([("ruby3.2", "Ruby32"), ("ruby3.3", "Ruby33")])
     def test_building_ruby_in_process_with_specified_architecture(self, runtime, codeuri):
+        if IS_WINDOWS and not runtime_supported_by_docker(f"{runtime}"):
+            self.skipTest(RUNTIME_NOT_SUPPORTED_BY_DOCKER_MSG)
         self._test_with_default_gemfile(runtime, False, codeuri, self.test_data_path, "x86_64")
 
 


### PR DESCRIPTION
#### Why is this change necessary?

`ruby3.3` is based on `AL2023` runtime and the tests are expected to fail on windows until we switch to the new appveyor image.


#### How does it address the issue?

Skips the tests for now

#### What side effects does this change have?

No side effects

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
