### PR TITLE
Handle docker container creation error

### DIFF
--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -16,7 +16,11 @@ from samcli.commands.local.invoke.core.command import InvokeCommand
 from samcli.commands.local.lib.exceptions import InvalidIntermediateImageError
 from samcli.lib.telemetry.metric import track_command
 from samcli.lib.utils.version_checker import check_newer_version
-from samcli.local.docker.exceptions import ContainerNotStartableException, PortAlreadyInUse
+from samcli.local.docker.exceptions import (
+    ContainerNotStartableException,
+    DockerContainerCreationFailedException,
+    PortAlreadyInUse,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -220,7 +224,7 @@ def do_cli(  # pylint: disable=R0914
         PortAlreadyInUse,
     ) as ex:
         raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex
-    except DockerImagePullFailedException as ex:
+    except (DockerImagePullFailedException, DockerContainerCreationFailedException) as ex:
         raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex
     except ContainerNotStartableException as ex:
         raise UserException(str(ex), wrapped_from=ex.__class__.__name__) from ex

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -30,6 +30,7 @@ from samcli.local.apigw.exceptions import (
 from samcli.local.apigw.path_converter import PathConverter
 from samcli.local.apigw.route import Route
 from samcli.local.apigw.service_error_responses import ServiceErrorResponses
+from samcli.local.docker.exceptions import DockerContainerCreationFailedException
 from samcli.local.events.api_event import (
     ContextHTTP,
     ContextIdentity,
@@ -730,6 +731,8 @@ class LocalApigwService(BaseLocalService):
             )
         except LambdaResponseParseException:
             endpoint_service_error = ServiceErrorResponses.lambda_body_failure_response()
+        except DockerContainerCreationFailedException as ex:
+            endpoint_service_error = ServiceErrorResponses.container_creation_failed(ex.message)
 
         if endpoint_service_error:
             return endpoint_service_error

--- a/samcli/local/apigw/service_error_responses.py
+++ b/samcli/local/apigw/service_error_responses.py
@@ -101,3 +101,12 @@ class ServiceErrorResponses:
         """
         response_data = jsonify(ServiceErrorResponses._MISSING_AUTHENTICATION)
         return make_response(response_data, ServiceErrorResponses.HTTP_STATUS_CODE_403)
+
+    @staticmethod
+    def container_creation_failed(message):
+        """
+        Constuct a Flask Response for when container creation fails for a Lambda Function
+        :return: a Flask Response
+        """
+        response_data = jsonify({"message": message})
+        return make_response(response_data, ServiceErrorResponses.HTTP_STATUS_CODE_501)

--- a/samcli/local/docker/exceptions.py
+++ b/samcli/local/docker/exceptions.py
@@ -37,3 +37,9 @@ class InvalidRuntimeException(UserException):
     """
     Raised when an invalid runtime is specified for a Lambda Function
     """
+
+
+class DockerContainerCreationFailedException(UserException):
+    """
+    Docker Container Creation failed. It could be due to invalid template
+    """

--- a/samcli/local/lambda_service/lambda_error_responses.py
+++ b/samcli/local/lambda_service/lambda_error_responses.py
@@ -21,6 +21,8 @@ class LambdaErrorResponses:
 
     NotImplementedException = ("NotImplemented", 501)
 
+    ContainerCreationFailed = ("ContainerCreationFailed", 501)
+
     PathNotFoundException = ("PathNotFoundLocally", 404)
 
     MethodNotAllowedException = ("MethodNotAllowedLocally", 405)
@@ -202,6 +204,29 @@ class LambdaErrorResponses:
             ),
             LambdaErrorResponses._construct_headers(exception_tuple[0]),
             exception_tuple[1],
+        )
+
+    @staticmethod
+    def container_creation_failed(message):
+        """
+        Creates a Container Creation Failed response
+        Parameters
+        ----------
+        args list
+            List of arguments Flask passes to the method
+        Returns
+        -------
+        Flask.Response
+            A response object representing the ContainerCreationFailed Error
+        """
+        error_type, status_code = LambdaErrorResponses.ContainerCreationFailed
+        return BaseLocalService.service_response(
+            LambdaErrorResponses._construct_error_response_body(
+                LambdaErrorResponses.LOCAL_SERVICE_ERROR,
+                message,
+            ),
+            LambdaErrorResponses._construct_headers(error_type),
+            status_code,
         )
 
     @staticmethod

--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -9,6 +9,7 @@ from werkzeug.routing import BaseConverter
 
 from samcli.commands.local.lib.exceptions import UnsupportedInlineCodeError
 from samcli.lib.utils.stream_writer import StreamWriter
+from samcli.local.docker.exceptions import DockerContainerCreationFailedException
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser
 
@@ -178,6 +179,8 @@ class LocalLambdaInvokeService(BaseLocalService):
             return LambdaErrorResponses.not_implemented_locally(
                 "Inline code is not supported for sam local commands. Please write your code in a separate file."
             )
+        except DockerContainerCreationFailedException as ex:
+            return LambdaErrorResponses.container_creation_failed(ex.message)
 
         lambda_response, is_lambda_user_error_response = LambdaOutputParser.get_lambda_output(
             stdout_stream_string, stdout_stream_bytes

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -16,7 +16,7 @@ from samcli.lib.utils.file_observer import LambdaFunctionObserver
 from samcli.lib.utils.packagetype import ZIP
 from samcli.local.docker.container import Container
 from samcli.local.docker.container_analyzer import ContainerAnalyzer
-from samcli.local.docker.exceptions import ContainerFailureError
+from samcli.local.docker.exceptions import ContainerFailureError, DockerContainerCreationFailedException
 from samcli.local.docker.lambda_container import LambdaContainer
 
 from ...lib.providers.provider import LayerVersion
@@ -115,6 +115,10 @@ class LambdaRuntime:
             # create the container.
             self._container_manager.create(container)
             return container
+
+        except DockerContainerCreationFailedException:
+            LOG.warning("Failed to create container for function %s", function_config.full_path)
+            raise
 
         except KeyboardInterrupt:
             LOG.debug("Ctrl+C was pressed. Aborting container creation")

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -6,7 +6,11 @@ from unittest import TestCase
 from unittest.mock import patch, Mock
 from parameterized import parameterized, param
 
-from samcli.local.docker.exceptions import ContainerNotStartableException, PortAlreadyInUse
+from samcli.local.docker.exceptions import (
+    ContainerNotStartableException,
+    PortAlreadyInUse,
+    DockerContainerCreationFailedException,
+)
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.lib.providers.exceptions import InvalidLayerReference
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
@@ -262,6 +266,10 @@ class TestCli(TestCase):
             param(
                 PortAlreadyInUse("Container cannot be started, provided port already in use"),
                 "Container cannot be started, provided port already in use",
+            ),
+            param(
+                DockerContainerCreationFailedException("Container creation failed, check template for potential issue"),
+                "Container creation failed, check template for potential issue",
             ),
         ]
     )

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -23,6 +23,7 @@ from samcli.local.apigw.exceptions import (
     LambdaResponseParseException,
     PayloadFormatVersionValidateException,
 )
+from samcli.local.docker.exceptions import DockerContainerCreationFailedException
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.local.lib.exceptions import UnsupportedInlineCodeError
 
@@ -456,6 +457,26 @@ class TestApiGatewayService(TestCase):
         response = self.api_service._request_handler()
 
         self.assertEqual(response, not_implemented_response_mock)
+
+    @patch.object(LocalApigwService, "get_request_methods_endpoints")
+    @patch("samcli.local.apigw.local_apigw_service.ServiceErrorResponses")
+    @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._generate_lambda_event")
+    def test_request_handles_error_when_container_creation_failed(
+        self, generate_mock, service_error_responses_patch, request_mock
+    ):
+        generate_mock.return_value = {}
+        container_creation_failed_response_mock = Mock()
+        self.api_service._get_current_route = MagicMock()
+        self.api_service._get_current_route.return_value.payload_format_version = "2.0"
+        self.api_service._get_current_route.return_value.authorizer_object = None
+        self.api_service._get_current_route.methods = []
+
+        service_error_responses_patch.container_creation_failed.return_value = container_creation_failed_response_mock
+
+        self.lambda_runner.invoke.side_effect = DockerContainerCreationFailedException("container creation failed")
+        request_mock.return_value = ("test", "test")
+        response = self.api_service._request_handler()
+        self.assertEqual(response, container_creation_failed_response_mock)
 
     @patch.object(LocalApigwService, "get_request_methods_endpoints")
     def test_request_throws_when_invoke_fails(self, request_mock):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#6510


#### Why is this change necessary?
To catch and handle docker container creation errors when running `sam local invoke`, `sam local start-api` and `sam local start-lambda`


#### How does it address the issue?
Catch the error and propagate it to CLI


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
