### PR TITLE
chore: Build bzip2 from source for Linux Pyinstaller builds

### DIFF
--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -43,7 +43,7 @@ curl "https://www.openssl.org/source/openssl-1.1.1w.tar.gz" --output openssl-1.1
 tar xzf openssl-1.1.1.tar.gz
 cd openssl-1.1.1w
 ./config --prefix=/opt/openssl && make -j8 && make install
-cd ../../..
+cd ../../
 
 echo "Building zlib"
 curl https://www.zlib.net/zlib-1.3.1.tar.gz --output zlib.tar.gz
@@ -63,6 +63,9 @@ git fetch origin 6a8690fc8d26c815e798c588f796eabe9d684cf0
 git reset --hard FETCH_HEAD
 make -j8 -f Makefile-libbz2_so
 make -j8 install
+cd ../
+
+# Return to `.build/` folder
 cd ../
 
 echo "Copying Source"

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -28,7 +28,7 @@ fi
 
 set -eux
 
-yum install -y libffi-devel bzip2-devel
+yum install -y libffi-devel
 
 echo "Making Folders"
 mkdir -p .build/src
@@ -50,6 +50,18 @@ curl https://www.zlib.net/zlib-1.3.1.tar.gz --output zlib.tar.gz
 tar xvf zlib.tar.gz
 cd zlib-1.3.1
 ./configure && make -j8 && make install
+cd ../
+
+echo "Building bzip2"
+mkdir bzip2 && cd bzip2
+git init
+git remote add origin https://gitlab.com/bzip2/bzip2.git
+# this is the 1.0.8 release
+# https://gitlab.com/bzip2/bzip2/-/tags
+# fetch specific commit as to not grab the entire git history
+git fetch origin 6a8690fc8d26c815e798c588f796eabe9d684cf0
+git reset --hard FETCH_HEAD
+make install
 cd ../
 
 echo "Copying Source"

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -52,6 +52,7 @@ echo "Building OpenSSL"
 curl "https://www.openssl.org/source/openssl-${openssl_version}.tar.gz" --output openssl.tar.gz
 tar xzf openssl.tar.gz
 cd openssl-${openssl_version}
+# install_sw installs OpenSSL without manual pages
 ./config --prefix=/opt/openssl && make -j8 && make -j8 install_sw
 cd ../../
 

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -61,7 +61,8 @@ git remote add origin https://gitlab.com/bzip2/bzip2.git
 # fetch specific commit as to not grab the entire git history
 git fetch origin 6a8690fc8d26c815e798c588f796eabe9d684cf0
 git reset --hard FETCH_HEAD
-make install
+make -j8 -f Makefile-libbz2_so
+make -j8 install
 cd ../
 
 echo "Copying Source"

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -4,6 +4,8 @@ python_library_zip_filename=$2
 build_binary_name=$3
 build_folder=$4
 python_version=$5
+openssl_version=$6
+zlib_version=$7
 
 if [ "$python_library_zip_filename" = "" ]; then
     python_library_zip_filename="python-libraries.zip";
@@ -11,6 +13,14 @@ fi
 
 if [ "$python_version" = "" ]; then
     python_version="3.11.8";
+fi
+
+if [ "$openssl_version" = "" ]; then
+    openssl_version="1.1.1w";
+fi
+
+if [ "$zlib_version" = "" ]; then
+    zlib_version="1.3.1";
 fi
 
 if [ "$CI_OVERRIDE" = "1" ]; then
@@ -39,17 +49,17 @@ mkdir -p .build/output/openssl
 cd .build/output/openssl
 
 echo "Building OpenSSL"
-curl "https://www.openssl.org/source/openssl-1.1.1w.tar.gz" --output openssl-1.1.1.tar.gz
-tar xzf openssl-1.1.1.tar.gz
-cd openssl-1.1.1w
-./config --prefix=/opt/openssl && make -j8 && make install
+curl "https://www.openssl.org/source/openssl-${openssl_version}.tar.gz" --output openssl.tar.gz
+tar xzf openssl.tar.gz
+cd openssl-${openssl_version}
+./config --prefix=/opt/openssl && make -j8 && make -j8 install_sw
 cd ../../
 
 echo "Building zlib"
-curl https://www.zlib.net/zlib-1.3.1.tar.gz --output zlib.tar.gz
+curl https://www.zlib.net/zlib-${zlib_version}.tar.gz --output zlib.tar.gz
 tar xvf zlib.tar.gz
-cd zlib-1.3.1
-./configure && make -j8 && make install
+cd zlib-${zlib_version}
+./configure && make -j8 && make -j8 install
 cd ../
 
 echo "Building bzip2"
@@ -62,6 +72,9 @@ git remote add origin https://gitlab.com/bzip2/bzip2.git
 git fetch origin 6a8690fc8d26c815e798c588f796eabe9d684cf0
 git reset --hard FETCH_HEAD
 make -j8 -f Makefile-libbz2_so
+cp libbz2.so.1.0.8 /usr/local/lib
+ln -s /usr/local/lib/libbz2.so.1.0.8 /usr/local/lib/libbz2.so.1.0
+ln -s /usr/local/lib/libbz2.so.1.0 /usr/local/lib/libbz2.so.1
 make -j8 install
 cd ../
 
@@ -97,7 +110,7 @@ cd Python-$python_version
     --with-openssl=/opt/openssl \
     --with-openssl-rpath=auto
 make -j8
-make install
+make -j8 install
 ldconfig
 cd ..
 

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -63,6 +63,7 @@ cd openssl-"$openssl_version"
 ./Configure --prefix=/usr/local --openssldir=/usr/local/openssl no-ssl3 no-ssl3-method no-zlib ${openssl_config_arch} enable-ec_nistp_64_gcc_128
 
 make -j8
+# install_sw installs OpenSSL without manual pages
 sudo make -j8 install_sw
 cd ..
 

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -62,8 +62,8 @@ cd openssl-"$openssl_version"
 # Openssl configure https://wiki.openssl.org/index.php/Compilation_and_Installation
 ./Configure --prefix=/usr/local --openssldir=/usr/local/openssl no-ssl3 no-ssl3-method no-zlib ${openssl_config_arch} enable-ec_nistp_64_gcc_128
 
-make
-sudo make install
+make -j8
+sudo make -j8 install_sw
 cd ..
 
 # Copying aws-sam-cli source code
@@ -93,7 +93,7 @@ tar -xzf python.tgz
 cd Python-"$python_version"
 ./configure --enable-shared
 make -j8
-sudo make install
+sudo make -j8 install
 cd ..
 
 echo "Installing Python Libraries"

--- a/installer/pyinstaller/samcli-mac.spec
+++ b/installer/pyinstaller/samcli-mac.spec
@@ -1,29 +1,35 @@
 # -*- mode: python -*-
 block_cipher = None
 exe_name = 'sam'
-analysis = Analysis(['../../samcli/__main__.py'],
-             binaries=[],
-             datas=[],
-             hiddenimports=[],
-             hookspath=['./installer/pyinstaller'],
-             runtime_hooks=[],
-             excludes=[],
-             cipher=block_cipher)
+analysis = Analysis(
+    ['../../samcli/__main__.py'],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=['./installer/pyinstaller'],
+    runtime_hooks=[],
+    excludes=[],
+    cipher=block_cipher
+)
 pyz = PYZ(analysis.pure, analysis.zipped_data, cipher=block_cipher)
-exe = EXE(pyz,
-          analysis.scripts,
-          [],
-          exclude_binaries=True,
-          name=exe_name,
-          debug=False,
-          bootloader_ignore_signals=False,
-          strip=False,
-          upx=True,
-          console=True )
-coll = COLLECT(exe,
-               analysis.binaries,
-               analysis.zipfiles,
-               analysis.datas,
-               strip=False,
-               upx=True,
-               name='sam')
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name=exe_name,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True
+)
+coll = COLLECT(
+    exe,
+    analysis.binaries,
+    analysis.zipfiles,
+    analysis.datas,
+    strip=False,
+    upx=True,
+    name='sam'
+)

--- a/installer/pyinstaller/samcli.spec
+++ b/installer/pyinstaller/samcli.spec
@@ -4,10 +4,7 @@ block_cipher = None
 exe_name = 'sam'
 analysis = Analysis(
     ['../../samcli/__main__.py'],
-    binaries=[
-        ('/usr/local/lib/libbz2.so.1', '.'),
-        ('/usr/local/lib/libcrypt.so.2', '.')
-    ],
+    binaries=[],
     datas=[],
     hiddenimports=[],
     hookspath=['./installer/pyinstaller'],

--- a/installer/pyinstaller/samcli.spec
+++ b/installer/pyinstaller/samcli.spec
@@ -3,7 +3,7 @@ import sys ; sys.setrecursionlimit(sys.getrecursionlimit() * 5)
 block_cipher = None
 exe_name = 'sam'
 analysis = Analysis(['../../samcli/__main__.py'],
-             binaries=[('/usr/local/lib/libcrypt.so.2', '.')],
+             binaries=[('/usr/lib64/libbz2.so.1', '.')],
              datas=[],
              hiddenimports=[],
              hookspath=['./installer/pyinstaller'],

--- a/installer/pyinstaller/samcli.spec
+++ b/installer/pyinstaller/samcli.spec
@@ -2,29 +2,38 @@
 import sys ; sys.setrecursionlimit(sys.getrecursionlimit() * 5)
 block_cipher = None
 exe_name = 'sam'
-analysis = Analysis(['../../samcli/__main__.py'],
-             binaries=[('/usr/local/lib/libbz2.so.1', '.')],
-             datas=[],
-             hiddenimports=[],
-             hookspath=['./installer/pyinstaller'],
-             runtime_hooks=[],
-             excludes=[],
-             cipher=block_cipher)
+analysis = Analysis(
+    ['../../samcli/__main__.py'],
+    binaries=[
+        ('/usr/local/lib/libbz2.so.1', '.'),
+        ('/usr/local/lib/libcrypt.so.2', '.')
+    ],
+    datas=[],
+    hiddenimports=[],
+    hookspath=['./installer/pyinstaller'],
+    runtime_hooks=[],
+    excludes=[],
+    cipher=block_cipher
+)
 pyz = PYZ(analysis.pure, analysis.zipped_data, cipher=block_cipher)
-exe = EXE(pyz,
-          analysis.scripts,
-          [],
-          exclude_binaries=True,
-          name=exe_name,
-          debug=False,
-          bootloader_ignore_signals=False,
-          strip=False,
-          upx=True,
-          console=True )
-coll = COLLECT(exe,
-               analysis.binaries,
-               analysis.zipfiles,
-               analysis.datas,
-               strip=False,
-               upx=True,
-               name='sam')
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name=exe_name,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True
+)
+coll = COLLECT(
+    exe,
+    analysis.binaries,
+    analysis.zipfiles,
+    analysis.datas,
+    strip=False,
+    upx=True,
+    name='sam'
+)

--- a/installer/pyinstaller/samcli.spec
+++ b/installer/pyinstaller/samcli.spec
@@ -3,7 +3,7 @@ import sys ; sys.setrecursionlimit(sys.getrecursionlimit() * 5)
 block_cipher = None
 exe_name = 'sam'
 analysis = Analysis(['../../samcli/__main__.py'],
-             binaries=[('/usr/lib64/libbz2.so.1', '.')],
+             binaries=[('/usr/local/lib/libbz2.so.1', '.')],
              datas=[],
              hiddenimports=[],
              hookspath=['./installer/pyinstaller'],


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
The version of `bzip2` used in the image that builds the Linux Pyinstaller artifacts are old. We need to update them to a newer version.

#### How does it address the issue?
Builds `bzip2` from source, consuming the `1.0.8` version instead of the `1.0.6` in the image.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
