### PR TITLE
fix: pass unpatched runtime to lambda builder

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -866,7 +866,7 @@ class ApplicationBuilder:
             application_framework=config.application_framework,
         )
 
-        runtime = patch_runtime(runtime)
+        runtime_patched = patch_runtime(runtime)
 
         try:
             builder.build(
@@ -874,7 +874,8 @@ class ApplicationBuilder:
                 artifacts_dir,
                 scratch_dir,
                 manifest_path,
-                runtime=runtime,
+                runtime=runtime_patched,
+                unpatched_runtime=runtime,
                 executable_search_paths=config.executable_search_paths,
                 mode=self._mode,
                 options=options,

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -2559,6 +2559,7 @@ class TestApplicationBuilder_build_function_in_process(TestCase):
             "scratch_dir",
             "manifest_path",
             runtime="runtime",
+            unpatched_runtime="runtime",
             executable_search_paths=config_mock.executable_search_paths,
             mode="mode",
             options=None,
@@ -2572,6 +2573,63 @@ class TestApplicationBuilder_build_function_in_process(TestCase):
         )
 
         patch_runtime_mock.assert_called_with("runtime")
+
+    @parameterized.expand([("provided.al2",), ("provided.al2023",)])
+    @patch("samcli.lib.telemetry.event.EventType.get_accepted_values")
+    @patch("samcli.lib.build.app_builder.LambdaBuilder")
+    @patch("samcli.lib.build.app_builder.get_enabled_experimental_flags")
+    def test_pass_unpatched_runtime_to_lambda_builder(
+        self,
+        runtime,
+        experimental_flags_mock,
+        lambda_builder_mock,
+        event_mock,
+    ):
+        experimental_flags_mock.return_value = ["experimental_flags"]
+        config_mock = Mock()
+        builder_instance_mock = lambda_builder_mock.return_value = Mock()
+        event_mock.return_value = [runtime]
+
+        result = self.builder._build_function_in_process(
+            config_mock,
+            "source_dir",
+            "artifacts_dir",
+            "scratch_dir",
+            "manifest_path",
+            runtime,
+            X86_64,
+            None,
+            None,
+            True,
+            True,
+            is_building_layer=False,
+        )
+        self.assertEqual(result, "artifacts_dir")
+
+        lambda_builder_mock.assert_called_with(
+            language=config_mock.language,
+            dependency_manager=config_mock.dependency_manager,
+            application_framework=config_mock.application_framework,
+        )
+
+        builder_instance_mock.build.assert_called_with(
+            "source_dir",
+            "artifacts_dir",
+            "scratch_dir",
+            "manifest_path",
+            runtime="provided",
+            unpatched_runtime=runtime,
+            executable_search_paths=config_mock.executable_search_paths,
+            mode="mode",
+            options=None,
+            architecture=X86_64,
+            dependencies_dir=None,
+            download_dependencies=True,
+            combine_dependencies=True,
+            is_building_layer=False,
+            experimental_flags=["experimental_flags"],
+            build_in_source=False,
+        )
 
     @patch("samcli.lib.build.app_builder.LambdaBuilder")
     def test_must_raise_on_error(self, lambda_builder_mock):
@@ -2626,6 +2684,7 @@ class TestApplicationBuilder_build_function_in_process(TestCase):
                     "scratch_dir",
                     "manifest_path",
                     runtime="runtime",
+                    unpatched_runtime="runtime",
                     executable_search_paths=ANY,
                     mode="mode",
                     options=None,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
can be merged after https://github.com/aws/aws-lambda-builders/pull/640 is. Which will fix the issue of building rust lambda functions with an incorrect version of `GLIBC`

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
