### PR TITLE
fix: mac validate pyinstaller workflow to not use latest mac image

### DIFF
--- a/.github/workflows/validate_pyinstaller.yml
+++ b/.github/workflows/validate_pyinstaller.yml
@@ -39,7 +39,7 @@ jobs:
 
   build-for-mac:
     name: build-pyinstaller-macos
-    runs-on: macos-latest
+    runs-on: macos-13
     if: github.repository_owner == 'aws'
     strategy:
       fail-fast: false


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Using MacOS14 leads to issues with python/pip not identifying the installed version of OpenSSL which causes errors when trying to install dependencies. This does not happen with MacOS13 so pinning the version to 13 to let the PR workflow pass 

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
