### PR TITLE
fix: use correct openssl when building python

### DIFF
--- a/.github/workflows/validate_pyinstaller.yml
+++ b/.github/workflows/validate_pyinstaller.yml
@@ -39,7 +39,7 @@ jobs:
 
   build-for-mac:
     name: build-pyinstaller-macos
-    runs-on: macos-13
+    runs-on: macos-latest
     if: github.repository_owner == 'aws'
     strategy:
       fail-fast: false

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -92,7 +92,9 @@ echo "Installing Python"
 curl "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz" --output python.tgz
 tar -xzf python.tgz
 cd Python-"$python_version"
-./configure --enable-shared
+./configure \
+    --enable-shared \
+    --with-openssl=/usr/local
 make -j8
 sudo make -j8 install
 cd ..


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
our mac pyinstaller build does not specify the openssl directory so we are unable to install packages through pip

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
