### PR TITLE
fix: Flaky integration tests

### DIFF
--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -48,10 +48,6 @@ init:
   - ps: New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
   - ps: git config --system core.longpaths true
 
-cache:
-  - C:\ProgramData\chocolatey\bin -> appveyor.yml
-  - C:\ProgramData\chocolatey\lib -> appveyor.yml
-
 install:
   # upgrade chocolately
   - choco upgrade chocolatey

--- a/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
+++ b/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import platform
 import tempfile
 
 from subprocess import Popen, PIPE, TimeoutExpired
@@ -39,6 +40,10 @@ class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
         command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.events_file_path
         )
+        
+        # Temporarily skip al2023 tests on Windows 
+        if function_name == "Java21Function" and platform.system().lower() == "windows":
+            self.skipTest("Skipping AL2023 test on Windows")
 
         process = Popen(command_list, stdout=PIPE)
         try:

--- a/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
+++ b/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
@@ -40,8 +40,8 @@ class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
         command_list = InvokeIntegBase.get_command_list(
             function_name, template_path=self.template_path, event_path=self.events_file_path
         )
-        
-        # Temporarily skip al2023 tests on Windows 
+
+        # Temporarily skip al2023 tests on Windows
         if function_name == "Java21Function" and platform.system().lower() == "windows":
             self.skipTest("Skipping AL2023 test on Windows")
 

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -7,7 +7,6 @@ import random
 from pathlib import Path
 from typing import Dict
 
-import docker.errors
 import requests
 from http.client import HTTPConnection
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -2141,6 +2140,12 @@ class TestWarmContainersBaseClass(StartApiIntegBaseClass):
             if f"MODE={self.mode_env_variable}" in str(output):
                 running_containers += 1
         return running_containers
+    
+    def tearDown(self) -> None:
+        # Use a new container test UUID for the next test run to avoid
+        # counting additional containers in the event of a retry
+        self.mode_env_variable = str(uuid.uuid4())
+        super().tearDown()
 
 
 @parameterized_class(

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -2140,7 +2140,7 @@ class TestWarmContainersBaseClass(StartApiIntegBaseClass):
             if f"MODE={self.mode_env_variable}" in str(output):
                 running_containers += 1
         return running_containers
-    
+
     def tearDown(self) -> None:
         # Use a new container test UUID for the next test run to avoid
         # counting additional containers in the event of a retry


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Fixes several flaky integration tests including:
1. Java21 (AL2023) test being run on Windows
2. SIgterm test failing re-runs due to reuse of UUID
3. Windows AppVeyor using invalid chocolatey cache

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
