### PR TITLE
fix: Revert pytest update breaking e2e testing, catch duplicate port error

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,7 +24,10 @@ types-requests==2.31.0.6
 types-urllib3==1.26.25.14
 
 # Test requirements
-pytest~=8.2.0
+
+# Bumping pytest to >= 8.2.0 results in E2E test no starting up on python3.8
+pytest==8.1.1
+
 parameterized==0.9.0
 pytest-xdist==3.6.1
 pytest-forked==1.6.0

--- a/tests/integration/local/common_utils.py
+++ b/tests/integration/local/common_utils.py
@@ -25,7 +25,7 @@ def wait_for_local_process(process, port, collect_output=False) -> str:
             LOG.info(f"{line_as_str}")
             if collect_output:
                 output += f"{line_as_str}\n"
-        if "Address already in use" in line_as_str:
+        if "Address already in use" in line_as_str or "port is already allocated" in line_as_str:
             LOG.info(f"Attempted to start port on {port} but it is already in use, restarting on a new port.")
             raise InvalidAddressException()
         if "Press CTRL+C to quit" in line_as_str or "Error: " in line_as_str:

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -307,6 +307,12 @@ class TestWarmContainersBaseClass(StartLambdaIntegBaseClass):
                 running_containers += 1
         return running_containers
 
+    def tearDown(self) -> None:
+        # Use a new container test UUID for the next test run to avoid
+        # counting additional containers in the event of a retry
+        self.mode_env_variable = str(uuid.uuid4())
+        super().tearDown()
+
 
 @parameterized_class(
     ("template_path",),


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
Our E2E tests have been seeing errors in pytest with tests failing to start-up after the latest version update to 8.2.0, specifically on python3.8. I've tested with newer version of python and it seems to work fine.

There is an additional (or new) log statement that is printed when a duplicate error is encountered in a `sam local start...` test, handle retries for that case.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
