### PR TITLE
chore: update ruff params according to warning message

### DIFF
--- a/Make.ps1
+++ b/Make.ps1
@@ -92,7 +92,7 @@ function Test {
 }
 
 function Lint {
-    ruff samcli
+    ruff check samcli schema
     mypy setup.py samcli tests
 }
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ smoke-test:
 
 lint:
 	# Linter performs static analysis to catch latent bugs
-	ruff samcli schema
+	ruff check samcli schema
 	# mypy performs type check
 	mypy --exclude /testdata/ --exclude /init/templates/ --no-incremental setup.py samcli tests schema
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = ["setuptools", "wheel"]  # PEP 508 specifications.
 [tool.ruff]
 line-length = 120
 
+[tool.ruff.lint]
 select = [
     "E",  # Pycodestyle
     "F",  # Pyflakes
@@ -12,12 +13,12 @@ select = [
 ]
 ignore = ["PLR0913"]
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-branches = 25
 max-returns = 8
 max-statements = 80
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "E501"]
 "integration_uri.py" = ["E501"] # ARNs are long.
 "app.py" = ["E501"] # Doc links are long.


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Running `make lint` is giving following warning message;
```
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'pylint' -> 'lint.pylint'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```


#### How does it address the issue?
Updates ruff command and its configuration accordingly

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
