### PR TITLE
fix: skip file opened event for template watcher

### DIFF
--- a/samcli/lib/utils/resource_trigger.py
+++ b/samcli/lib/utils/resource_trigger.py
@@ -1,4 +1,5 @@
 """ResourceTrigger Classes for Creating PathHandlers According to a Resource"""
+
 import logging
 import platform
 import re

--- a/samcli/lib/utils/resource_trigger.py
+++ b/samcli/lib/utils/resource_trigger.py
@@ -1,5 +1,5 @@
 """ResourceTrigger Classes for Creating PathHandlers According to a Resource"""
-
+import logging
 import platform
 import re
 from abc import ABC, abstractmethod
@@ -17,6 +17,10 @@ from samcli.lib.utils.definition_validator import DefinitionValidator
 from samcli.lib.utils.path_observer import PathHandler
 from samcli.lib.utils.resources import RESOURCES_WITH_LOCAL_PATHS
 from samcli.local.lambdafn.exceptions import FunctionNotFound, ResourceNotFound
+
+
+LOG = logging.getLogger(__name__)
+
 
 DEFAULT_WATCH_IGNORED_RESOURCES = ["^.*\\.aws-sam.*$", "^.*node_modules.*$"]
 
@@ -134,6 +138,9 @@ class TemplateTrigger(ResourceTrigger):
         ----------
         event : Optional[FileSystemEvent], optional
         """
+        LOG.debug(
+            "Template watcher ({}) for stack ({}) got file event {}", self._template_file, self._stack_name, event
+        )
         if self._validator.validate_change():
             self._on_template_change(event)
 

--- a/samcli/lib/utils/resource_trigger.py
+++ b/samcli/lib/utils/resource_trigger.py
@@ -139,7 +139,7 @@ class TemplateTrigger(ResourceTrigger):
         event : Optional[FileSystemEvent], optional
         """
         LOG.debug(
-            "Template watcher ({}) for stack ({}) got file event {}", self._template_file, self._stack_name, event
+            "Template watcher (%s) for stack (%s) got file event %s", self._template_file, self._stack_name, event
         )
         if self._validator.validate_change():
             self._on_template_change(event)

--- a/samcli/lib/utils/resource_trigger.py
+++ b/samcli/lib/utils/resource_trigger.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
 from typing_extensions import Protocol
-from watchdog.events import FileSystemEvent, RegexMatchingEventHandler, EVENT_TYPE_OPENED
+from watchdog.events import EVENT_TYPE_OPENED, FileSystemEvent, RegexMatchingEventHandler
 
 from samcli.lib.providers.exceptions import InvalidTemplateFile, MissingCodeUri, MissingLocalDefinition
 from samcli.lib.providers.provider import Function, LayerVersion, ResourceIdentifier, Stack, get_resource_by_id
@@ -17,7 +17,6 @@ from samcli.lib.utils.definition_validator import DefinitionValidator
 from samcli.lib.utils.path_observer import PathHandler
 from samcli.lib.utils.resources import RESOURCES_WITH_LOCAL_PATHS
 from samcli.local.lambdafn.exceptions import FunctionNotFound, ResourceNotFound
-
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unit/lib/utils/test_resource_trigger.py
+++ b/tests/unit/lib/utils/test_resource_trigger.py
@@ -91,6 +91,18 @@ class TestTemplateTrigger(TestCase):
         trigger = TemplateTrigger("template.yaml", "stack", on_template_change_mock)
         trigger._validator_wrapper(event_mock)
         on_template_change_mock.assert_called_once_with(event_mock)
+    
+    @patch("samcli.lib.utils.resource_trigger.DefinitionValidator")
+    @patch("samcli.lib.utils.resource_trigger.Path")
+    def test_validator_wrapper(self, path_mock, validator_mock):
+        validator_mock.return_value.raw_validate.return_value = True
+        on_template_change_mock = MagicMock()
+        event_mock = MagicMock()
+        event_mock.event_type = EVENT_TYPE_OPENED
+        validator_mock.return_value.raw_validate.return_value = True
+        trigger = TemplateTrigger("template.yaml", "stack", on_template_change_mock)
+        trigger._validator_wrapper(event_mock)
+        on_template_change_mock.assert_not_called()
 
 
 class TestCodeResourceTrigger(TestCase):

--- a/tests/unit/lib/utils/test_resource_trigger.py
+++ b/tests/unit/lib/utils/test_resource_trigger.py
@@ -94,7 +94,7 @@ class TestTemplateTrigger(TestCase):
     
     @patch("samcli.lib.utils.resource_trigger.DefinitionValidator")
     @patch("samcli.lib.utils.resource_trigger.Path")
-    def test_validator_wrapper(self, path_mock, validator_mock):
+    def test_validator_wrapper_for_file_opened_event(self, path_mock, validator_mock):
         validator_mock.return_value.raw_validate.return_value = True
         on_template_change_mock = MagicMock()
         event_mock = MagicMock()

--- a/tests/unit/lib/utils/test_resource_trigger.py
+++ b/tests/unit/lib/utils/test_resource_trigger.py
@@ -92,7 +92,7 @@ class TestTemplateTrigger(TestCase):
         trigger = TemplateTrigger("template.yaml", "stack", on_template_change_mock)
         trigger._validator_wrapper(event_mock)
         on_template_change_mock.assert_called_once_with(event_mock)
-    
+
     @patch("samcli.lib.utils.resource_trigger.DefinitionValidator")
     @patch("samcli.lib.utils.resource_trigger.Path")
     def test_validator_wrapper_for_file_opened_event(self, path_mock, validator_mock):

--- a/tests/unit/lib/utils/test_resource_trigger.py
+++ b/tests/unit/lib/utils/test_resource_trigger.py
@@ -2,6 +2,7 @@ import re
 from parameterized import parameterized
 from unittest.case import TestCase
 from unittest.mock import MagicMock, Mock, patch, ANY
+from watchdog.events import EVENT_TYPE_OPENED
 from samcli.lib.utils.resource_trigger import (
     DEFAULT_WATCH_IGNORED_RESOURCES,
     CodeResourceTrigger,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#7058


#### Why is this change necessary?
When watching the `template.yaml` file, file opened event gets triggered indefinitely for some cases on Linux systems, which causes high CPU usage.

#### How does it address the issue?
We already skipping file opened event for some other file watchers for the `sam sync`, this PR also applies same fix to the template listener as well.


#### What side effects does this change have?
Since file opened event is already skipped in other places, this shouldn't have any side affects for this usage as well. 


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
