### PR TITLE
fix(tests): Keep original test data path in its own variable to avoid overwriting

### DIFF
--- a/tests/integration/deploy/deploy_integ_base.py
+++ b/tests/integration/deploy/deploy_integ_base.py
@@ -2,7 +2,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from enum import Enum, auto
-from typing import List, Optional
+from typing import Optional
 
 import boto3
 from botocore.config import Config
@@ -28,12 +28,11 @@ class DeployIntegBase(PackageIntegBase):
             ResourceType.IAM_ROLE: list(),
         }
         # make temp directory and move all test files into there for each test run
-        original_test_data_path = self.test_data_path
         self.test_data_path = Path(tempfile.mkdtemp())
 
         # copytree call below fails if root folder present, delete it first
         shutil.rmtree(self.test_data_path, ignore_errors=True)
-        shutil.copytree(original_test_data_path, self.test_data_path)
+        shutil.copytree(self.original_test_data_path, self.test_data_path)
 
         self.cfn_client = boto3.client("cloudformation")
         self.ecr_client = boto3.client("ecr")

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -60,6 +60,7 @@ class PackageIntegBase(TestCase):
         )
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "package")
+        cls.original_test_data_path = cls.test_data_path
 
         # Intialize S3 client
         s3 = boto3.resource("s3")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None.

#### Why is this change necessary?
For some of our integration tests, it looks we overwrite the testing data path with a new testing path. This won't work if the test failed and reran, since it'll replace the old temp folder, with a new empty temp folder, and attempt to copy the contents of the old temp folder into the new one.

The proper behaviour should be to create a new temp folder, and to copy the originally determined test data folder into this new temp folder.

#### How does it address the issue?
Save the path of the original test data folder in it's own class variable.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
