### PR TITLE
Fix: ignore imageuri if not a path

### DIFF
--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -25,6 +25,7 @@ from samcli.lib.samlib.resource_metadata_normalizer import (
 )
 from samcli.lib.utils.architecture import X86_64
 from samcli.lib.utils.packagetype import IMAGE
+from samcli.lib.utils.path_utils import check_path_valid_type
 from samcli.local.apigw.route import Route
 
 LOG = logging.getLogger(__name__)
@@ -977,7 +978,7 @@ def get_function_build_info(
         dockerfile = cast(str, metadata.get("Dockerfile", ""))
         docker_context = cast(str, metadata.get("DockerContext", ""))
         buildable = dockerfile and docker_context
-        loadable = imageuri and Path(imageuri).is_file()
+        loadable = imageuri and check_path_valid_type(imageuri) and Path(imageuri).is_file()
         if not buildable and not loadable:
             LOG.debug(
                 "Skip Building %s function, as it is missing either Dockerfile or DockerContext "

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -15,6 +15,7 @@ from samcli.lib.providers.exceptions import InvalidLayerReference
 from samcli.lib.utils.colors import Colored, Colors
 from samcli.lib.utils.file_observer import FileObserver
 from samcli.lib.utils.packagetype import IMAGE, ZIP
+from samcli.lib.utils.path_utils import check_path_valid_type
 from samcli.lib.utils.resources import (
     AWS_LAMBDA_FUNCTION,
     AWS_LAMBDA_LAYERVERSION,
@@ -447,7 +448,7 @@ class SamFunctionProvider(SamBaseProvider):
             LOG.debug("--base-dir is not presented, adjusting uri %s relative to %s", codeuri, stack.location)
             codeuri = SamLocalStackProvider.normalize_resource_path(stack.location, codeuri)
 
-        if imageuri and codeuri != ".":
+        if imageuri and check_path_valid_type(imageuri) and codeuri != ".":
             normalized_image_uri = SamLocalStackProvider.normalize_resource_path(stack.location, imageuri)
             if Path(normalized_image_uri).is_file():
                 LOG.debug("--base-dir is not presented, adjusting uri %s relative to %s", codeuri, stack.location)

--- a/samcli/lib/utils/path_utils.py
+++ b/samcli/lib/utils/path_utils.py
@@ -2,7 +2,11 @@
 Common Path related utilities
 """
 
+import logging
+import os
 from pathlib import PureWindowsPath
+
+LOG = logging.getLogger(__name__)
 
 
 def convert_path_to_unix_path(path: str) -> str:
@@ -19,3 +23,22 @@ def convert_path_to_unix_path(path: str) -> str:
         the path in unix format
     """
     return PureWindowsPath(path).as_posix()
+
+
+def check_path_valid_type(path) -> bool:
+    """
+    Checks the input to see if is a valid type to be a path, returning false if otherwise
+    Parameters
+    ----------
+    path: str
+        the path to be checked
+
+    Returns
+    -------
+    bool
+        if the input is a valid path type
+    """
+    if isinstance(path, (bytes, str, os.PathLike, int)):
+        return True
+    LOG.debug("Type error when trying to use input {} as Path, not string, int, bytes or os.PathLike ".format(path))
+    return False

--- a/tests/unit/lib/utils/test_path_utils.py
+++ b/tests/unit/lib/utils/test_path_utils.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from parameterized import parameterized
 
-from samcli.lib.utils.path_utils import convert_path_to_unix_path
+from samcli.lib.utils.path_utils import convert_path_to_unix_path, check_path_valid_type
 
 
 class TestPathUtilities(TestCase):
@@ -22,3 +22,15 @@ class TestPathUtilities(TestCase):
     def test_convert_path_to_unix_path(self, input_path, expected_path):
         output_path = convert_path_to_unix_path(input_path)
         self.assertEqual(output_path, expected_path)
+
+    @parameterized.expand(
+        [
+            ("C:\\windows\\like\\path", True),
+            ("test", True),
+            (123456, True),
+            ({"test": "test"}, False),
+            ([1, 2, 3], False),
+        ]
+    )
+    def test_check_valid_path(self, input_path, expected):
+        self.assertEqual(check_path_valid_type(input_path), expected)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
[Issue](https://github.com/aws/aws-sam-cli/issues/7117)
This issues occurred when this [PR](https://github.com/aws/aws-sam-cli/pull/6930/files) got merged, it treated `imageUri` as constantly a string when in the case when the intrinsic resolver fails from some case, leaves it as not a string, resulting in a panic. 
#### Why is this change necessary?
This is a regressions because before in the event of the intrinsic resolver failing it does not crash as we had no code depending on the actual types of the resources like this

#### How does it address the issue?
We check if the type is correct for imageUri and if it isn't we skip the code that would cause it to panic

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
