### PR TITLE
fix: Update the json schema type for tags option for deploy and sync commands

### DIFF
--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -195,7 +195,7 @@ class CfnTags(click.ParamType):
 
     _pattern = r"{tag}={tag}".format(tag=_generate_match_regex(match_pattern=TAG_REGEX, delim=" "))
 
-    name = "list"
+    name = "string,list"
 
     def convert(self, value, param, ctx):
         result = {}

--- a/schema/samcli.json
+++ b/schema/samcli.json
@@ -1202,7 +1202,10 @@
                 },
                 "tags": {
                   "title": "tags",
-                  "type": "array",
+                  "type": [
+                    "array",
+                    "string"
+                  ],
                   "description": "List of tags to associate with the stack.",
                   "items": {
                     "type": "string"
@@ -1731,7 +1734,10 @@
                 },
                 "tags": {
                   "title": "tags",
-                  "type": "array",
+                  "type": [
+                    "array",
+                    "string"
+                  ],
                   "description": "List of tags to associate with the stack.",
                   "items": {
                     "type": "string"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
https://github.com/aws/aws-sam-cli/issues/6851

#### Why is this change necessary?
The tags option can either be a string or list but the SAM CLI schema specifies the type as List right now.


#### How does it address the issue?
Makes the type either a string or list for tags


#### What side effects does this change have?
No side effects

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
