### PR TITLE
fix: Catch readtimeout error when docker is not reachable

### DIFF
--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -78,11 +78,7 @@ def is_docker_reachable(docker_client):
     :param docker_client : docker.from_env() - docker client object
     :returns True, if Docker is available, False otherwise.
     """
-    errors = (
-        docker.errors.APIError,
-        requests.exceptions.ConnectionError,
-        requests.exceptions.ReadTimeout
-    )
+    errors = (docker.errors.APIError, requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout)
     if platform.system() == "Windows":
         import pywintypes  # pylint: disable=import-error
 

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -81,6 +81,7 @@ def is_docker_reachable(docker_client):
     errors = (
         docker.errors.APIError,
         requests.exceptions.ConnectionError,
+        requests.exceptions.ReadTimeout
     )
     if platform.system() == "Windows":
         import pywintypes  # pylint: disable=import-error

--- a/tests/unit/local/docker/test_manager.py
+++ b/tests/unit/local/docker/test_manager.py
@@ -324,6 +324,13 @@ class TestContainerManager_is_docker_reachable(TestCase):
 
         self.assertFalse(is_reachable)
 
+    def test_must_return_false_if_ping_raises_read_timout_error(self):
+        self.ping_mock.side_effect = requests.exceptions.ReadTimeout("error")
+
+        is_reachable = self.manager.is_docker_reachable
+
+        self.assertFalse(is_reachable)
+
     def test_must_return_false_if_ping_raises_pywintypes_error(self):
         with patch.dict("sys.modules", patched_modules()):
             import samcli.local.docker.manager as manager_module


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
https://github.com/aws/aws-sam-cli/issues/6885

#### Why is this change necessary?
Exit gracefully when docker 

#### How does it address the issue?
Catches the readtimeout error and exits gracefully

#### What side effects does this change have?
No side effect


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
