### PR TITLE
fix(tests): Fix local test failing for account ID checks

### DIFF
--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -131,7 +131,7 @@ class InvokeIntegBase(TestCase):
             raise
 
 
-class IntegrationIntegBase(InvokeIntegBase):
+class IntegrationCliIntegBase(InvokeIntegBase):
     def assert_is_account_id_valid(self, account_id: str):
         try:
             int(account_id)

--- a/tests/integration/local/invoke/invoke_integ_base.py
+++ b/tests/integration/local/invoke/invoke_integ_base.py
@@ -129,3 +129,14 @@ class InvokeIntegBase(TestCase):
         except TimeoutExpired:
             process.kill()
             raise
+
+
+class IntegrationIntegBase(InvokeIntegBase):
+    def assert_is_account_id_valid(self, account_id: str):
+        try:
+            int(account_id)
+        except ValueError:
+            self.fail(f"Account ID '{account_id}' is not a valid number")
+
+        # AWS account IDs have length of 12
+        self.assertEqual(len(account_id), 12)

--- a/tests/integration/local/invoke/test_integration_cli_images.py
+++ b/tests/integration/local/invoke/test_integration_cli_images.py
@@ -10,7 +10,7 @@ from timeit import default_timer as timer
 import pytest
 import docker
 
-from tests.integration.local.invoke.invoke_integ_base import IntegrationIntegBase, InvokeIntegBase
+from tests.integration.local.invoke.invoke_integ_base import IntegrationCliIntegBase, InvokeIntegBase
 from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, CI_OVERRIDE
 
 from pathlib import Path
@@ -26,7 +26,7 @@ TIMEOUT = 300
     ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
     "Skip build tests on windows when running in CI unless overridden",
 )
-class TestSamPython36HelloWorldIntegrationImages(IntegrationIntegBase):
+class TestSamPython36HelloWorldIntegrationImages(IntegrationCliIntegBase):
     template = Path("template_image.yaml")
 
     @classmethod

--- a/tests/integration/local/invoke/test_integration_cli_images.py
+++ b/tests/integration/local/invoke/test_integration_cli_images.py
@@ -10,7 +10,7 @@ from timeit import default_timer as timer
 import pytest
 import docker
 
-from .invoke_integ_base import InvokeIntegBase
+from tests.integration.local.invoke.invoke_integ_base import IntegrationIntegBase, InvokeIntegBase
 from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, CI_OVERRIDE
 
 from pathlib import Path
@@ -26,7 +26,7 @@ TIMEOUT = 300
     ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
     "Skip build tests on windows when running in CI unless overridden",
 )
-class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
+class TestSamPython36HelloWorldIntegrationImages(IntegrationIntegBase):
     template = Path("template_image.yaml")
 
     @classmethod
@@ -275,7 +275,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
         environ = json.loads(process_stdout.decode("utf-8"))
 
         self.assertEqual(environ["Region"], "us-east-1")
-        self.assertEqual(environ["AccountId"], "123456789012")
+        self.assert_is_account_id_valid(environ["AccountId"])
         self.assertEqual(environ["Partition"], "aws")
         self.assertEqual(environ["StackName"], "local")
         self.assertEqual(
@@ -289,7 +289,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_using_parameters_with_custom_region(self):
-        custom_region = "my-custom-region"
+        custom_region = "us-west-2"
 
         command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path, region=custom_region
@@ -309,7 +309,7 @@ class TestSamPython36HelloWorldIntegrationImages(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_with_aws_creds(self):
-        custom_region = "my-custom-region"
+        custom_region = "us-west-2"
         key = "key"
         secret = "secret"
         session = "session"

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -32,6 +32,15 @@ TIMEOUT = 300
     ],
 )
 class TestSamPythonHelloWorldIntegration(InvokeIntegBase):
+    def assert_is_account_id_valid(self, account_id: str):
+        try:
+            self.assertTrue(int(account_id))
+        except ValueError:
+            self.fail(f"Account ID '{account_id}' is not a valid number")
+
+        # AWS account IDs have length of 12
+        self.assertEqual(len(account_id), 12)
+
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returncode_is_zero(self):
         command_list = InvokeIntegBase.get_command_list(
@@ -349,12 +358,12 @@ class TestSamPythonHelloWorldIntegration(InvokeIntegBase):
         environ = json.loads(process_stdout.decode("utf-8"))
 
         self.assertEqual(environ["Region"], "us-east-1")
-        self.assertEqual(environ["AccountId"], "123456789012")
+        self.assert_is_account_id_valid(environ["AccountId"])
         self.assertEqual(environ["Partition"], "aws")
         self.assertEqual(environ["StackName"], "local")
         self.assertEqual(
             environ["StackId"],
-            "arn:aws:cloudformation:us-east-1:123456789012:stack/" "local/51af3dc0-da77-11e4-872e-1234567db123",
+            "arn:aws:cloudformation:us-east-1:123456789012:stack/local/51af3dc0-da77-11e4-872e-1234567db123",
         )
 
         self.assertEqual(environ["URLSuffix"], "localhost")
@@ -364,7 +373,7 @@ class TestSamPythonHelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_using_parameters_with_custom_region(self):
-        custom_region = "my-custom-region"
+        custom_region = "us-west-2"
 
         command_list = InvokeIntegBase.get_command_list(
             "EchoEnvWithParameters", template_path=self.template_path, event_path=self.event_path, region=custom_region
@@ -384,7 +393,7 @@ class TestSamPythonHelloWorldIntegration(InvokeIntegBase):
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_with_aws_creds(self):
-        custom_region = "my-custom-region"
+        custom_region = "us-west-2"
         key = "key"
         secret = "secret"
         session = "session"

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -34,7 +34,7 @@ TIMEOUT = 300
 class TestSamPythonHelloWorldIntegration(InvokeIntegBase):
     def assert_is_account_id_valid(self, account_id: str):
         try:
-            self.assertTrue(int(account_id))
+            int(account_id)
         except ValueError:
             self.fail(f"Account ID '{account_id}' is not a valid number")
 

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -12,7 +12,7 @@ import pytest
 import docker
 
 from tests.integration.local.invoke.layer_utils import LayerUtils
-from .invoke_integ_base import InvokeIntegBase
+from tests.integration.local.invoke.invoke_integ_base import IntegrationIntegBase, InvokeIntegBase
 from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY, run_command
 
 # Layers tests require credentials and Appveyor will only add credentials to the env if the PR is from the same repo.
@@ -31,16 +31,7 @@ TIMEOUT = 300
         (Path("nested-templates/template-parent.yaml"),),
     ],
 )
-class TestSamPythonHelloWorldIntegration(InvokeIntegBase):
-    def assert_is_account_id_valid(self, account_id: str):
-        try:
-            int(account_id)
-        except ValueError:
-            self.fail(f"Account ID '{account_id}' is not a valid number")
-
-        # AWS account IDs have length of 12
-        self.assertEqual(len(account_id), 12)
-
+class TestSamPythonHelloWorldIntegration(IntegrationIntegBase):
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returncode_is_zero(self):
         command_list = InvokeIntegBase.get_command_list(

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -12,7 +12,7 @@ import pytest
 import docker
 
 from tests.integration.local.invoke.layer_utils import LayerUtils
-from tests.integration.local.invoke.invoke_integ_base import IntegrationIntegBase, InvokeIntegBase
+from tests.integration.local.invoke.invoke_integ_base import IntegrationCliIntegBase, InvokeIntegBase
 from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY, run_command
 
 # Layers tests require credentials and Appveyor will only add credentials to the env if the PR is from the same repo.
@@ -31,7 +31,7 @@ TIMEOUT = 300
         (Path("nested-templates/template-parent.yaml"),),
     ],
 )
-class TestSamPythonHelloWorldIntegration(IntegrationIntegBase):
+class TestSamPythonHelloWorldIntegration(IntegrationCliIntegBase):
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returncode_is_zero(self):
         command_list = InvokeIntegBase.get_command_list(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None

#### Why is this change necessary?
A recent change made to the local command behaviour causes some of the integration tests to fail. This is due to the local integration tests never expecting there to be an actual valid account ID, however this is no longer the case.

#### How does it address the issue?
Checks if the account ID looks and smells like an account ID, instead of checking for an exact value.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
