### PR TITLE
fix: catch error in _relevant_cdk_files_are_present

### DIFF
--- a/samcli/lib/iac/cdk/utils.py
+++ b/samcli/lib/iac/cdk/utils.py
@@ -2,9 +2,11 @@
 Utils for CDK-based projects
 """
 
+import logging
 import os
 from typing import Dict
 
+LOG = logging.getLogger(__name__)
 CDK_METADATA_TYPE_VALUE = "AWS::CDK::Metadata"
 CDK_PATH_METADATA_KEY = "aws:cdk:path"
 
@@ -70,5 +72,9 @@ def _relevant_cdk_files_are_present() -> bool:
     relevant_cdk_files = ["manifest.json", "tree.json", "cdk.json"]
     # In case a customer runs `cdk synth --no-staging > template.yaml` the template
     # will be in the project root and it's entirely possible to find the cdk.json there
-    project_files = os.listdir(os.getcwd())
-    return any(cdk_file in project_files for cdk_file in relevant_cdk_files)
+    try:
+        project_files = os.listdir(os.getcwd())
+        return any(cdk_file in project_files for cdk_file in relevant_cdk_files)
+    except FileNotFoundError as e:
+        LOG.debug("Error listing CWD: %s", e)
+        return False

--- a/tests/unit/lib/iac/cdk/test_cdk_utils.py
+++ b/tests/unit/lib/iac/cdk/test_cdk_utils.py
@@ -25,16 +25,20 @@ class TestIsCDKProject(TestCase):
 
     @parameterized.expand(
         [
-            (True, ["lib", "app.py", "requirements.txt", "cdk.json"]),
-            (True, ["Stack.template.json", "manifest.json", "asset"]),
-            (True, ["Stack.template.json", "tree.json", "asset"]),
-            (True, ["Stack.template.json", "manifest.json", "tree.json"]),
-            (False, ["lib", "app.py", "requirements.txt"]),
-            (False, []),
+            (True, ["lib", "app.py", "requirements.txt", "cdk.json"], None),
+            (True, ["Stack.template.json", "manifest.json", "asset"], None),
+            (True, ["Stack.template.json", "tree.json", "asset"], None),
+            (True, ["Stack.template.json", "manifest.json", "tree.json"], None),
+            (False, ["lib", "app.py", "requirements.txt"], None),
+            (False, [], None),
+            (False, [], FileNotFoundError),
         ]
     )
-    def test_cdk_project_files(self, expected_is_cdk, project_files):
+    def test_cdk_project_files(self, expected_is_cdk, project_files, side_effect):
         with patch("samcli.lib.iac.cdk.utils.os") as mock_os:
-            mock_os.listdir.return_value = project_files
+            if side_effect:
+                mock_os.listdir.side_effect = side_effect
+            else:
+                mock_os.listdir.return_value = project_files
             is_cdk = is_cdk_project({})
             self.assertEqual(is_cdk, expected_is_cdk)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#6756 


#### Why is this change necessary?
To prevent unlikely error from `os.listdir(os.getcwd())` to break telemetry

#### How does it address the issue?
In `_relevant_cdk_files_are_present`, catch the `FileNotFoundError` and return `False`


#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
