### PR TITLE
fix: bump timeout for waiting for restapi sync in sam sync integ test

### DIFF
--- a/tests/integration/sync/test_sync_watch.py
+++ b/tests/integration/sync/test_sync_watch.py
@@ -264,7 +264,7 @@ class TestSyncWatchCode(TestSyncWatchBase):
             self.test_data_path.joinpath("code", "after", "apigateway", "definition.json"),
             self.test_data_path.joinpath("code", "before", "apigateway", "definition.json"),
         )
-        read_until_string(self.watch_process, "Finished syncing RestApi HelloWorldApi.\x1b[0m\n", timeout=20)
+        read_until_string(self.watch_process, "Finished syncing RestApi HelloWorldApi.\x1b[0m\n", timeout=40)
         time.sleep(API_SLEEP)
         rest_api = self.stack_resources.get(AWS_APIGATEWAY_RESTAPI)[0]
         self.assertEqual(self._get_api_message(rest_api), '{"message": "hello 2"}')


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
`sam sync` Integration Test often timed-out at the `RestApi` validation step


#### How does it address the issue?
Bump the timeout for `RestApi` validation from 20s to 40s

#### What side effects does this change have?
Test run might take longer

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
