### PR TITLE
chore: Bump checkout version

### DIFF
--- a/.github/workflows/validate_pyinstaller.yml
+++ b/.github/workflows/validate_pyinstaller.yml
@@ -12,26 +12,27 @@ jobs:
   build-for-linux:
     name: build-pyinstaller-linux
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64:latest
     if: github.repository_owner == 'aws'
     strategy:
       fail-fast: false
     steps:
-      # we need to keep checkout as v3 otherwise it doesn't work with manylinux image above
-      # due to glibc requirement from github actions 
-      # see example failure: https://github.com/aws/aws-sam-cli/actions/runs/6102715182/job/16561754862?pr=5887
-      - uses: actions/checkout@v3
-      - name: Build PyInstaller
+      - uses: actions/checkout@v4
+      - name: Make installer script executable
+        run: chmod +x ./installer/pyinstaller/build-linux.sh
+      - name: Build PyInstaller in manylinux container
         run: |
-          chmod +x ./installer/pyinstaller/build-linux.sh
-          ./installer/pyinstaller/build-linux.sh aws-sam-cli-linux-x86_64.zip
+          docker run --rm -v .:/samcli -w /samcli -e CI_OVERRIDE='1' \
+          quay.io/pypa/manylinux2014_x86_64:latest /samcli/installer/pyinstaller/build-linux.sh aws-sam-cli-linux-x86_64.zip
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
       - name: Basic tests for PyInstaller
         run: |
           unzip .build/output/aws-sam-cli-linux-x86_64.zip -d sam-installation
-          ./sam-installation/install
+          sudo ./sam-installation/install
           sam-beta --version
           ./tests/sanity-check.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pyinstaller-linux-zip
           path: .build/output/aws-sam-cli-linux-x86_64.zip

--- a/installer/pyinstaller/Instruction.md
+++ b/installer/pyinstaller/Instruction.md
@@ -4,3 +4,15 @@ docker run --mount type=bind,src="{Absolute path to AWS SAM CLI source}",dst="/a
 cd aws-sam-cli
 ./installer/pyinstaller/build-linux.sh aws-sam-cli-linux-x86_64.zip
 ```
+
+### Linux Builds
+The Linux builds require using a [manylinux image](https://github.com/pypa/manylinux) to build an artifact usable on a breadth of Linux machines. The currently used image is
+`quay.io/pypa/manylinux2014_x86_64:latest` which uses glibc version `2.17`. This version of glibc is outdated and requires updating
+to support newer software such as Node.js 20 used by GitHub actions. In the meantime, the Linux pyinstaller action is run inside
+of a nested container to get around this issue. In the future, we need to move to using a newer image with a newer version of glibc
+configured. 
+
+A good candidate for this is `quay.io/pypa/manylinux_2_28_x86_64` which is an image that uses glibc version `2.28`. However,
+the current Amazon Linux 2 image uses glibc version `2.26`, meaning that upgrading now will render customer on that OS incapable of using
+newer versions of AWS SAM CLI. When that image hits its [end-of-life date](https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#distro-compatibility), we can update the installer to use the newer image.
+


### PR DESCRIPTION
Since GitHub updated the internals of their actions to use Node.js 20, the Linux pyinstaller test started failing since the version of glibc used in the manylinux image is outdated. We will build the pyinstaller artifact in a nested container instead of directly on the runner.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
