### PR TITLE
fix: catch ResourceNotFound error when adding code trigger in sam sync

### DIFF
--- a/samcli/lib/sync/watch_manager.py
+++ b/samcli/lib/sync/watch_manager.py
@@ -22,6 +22,7 @@ from samcli.lib.utils.code_trigger_factory import CodeTriggerFactory
 from samcli.lib.utils.colors import Colored, Colors
 from samcli.lib.utils.path_observer import HandlerObserver
 from samcli.lib.utils.resource_trigger import OnChangeCallback, TemplateTrigger
+from samcli.local.lambdafn.exceptions import ResourceNotFound
 
 if TYPE_CHECKING:  # pragma: no cover
     from samcli.commands.build.build_context import BuildContext
@@ -145,6 +146,16 @@ class WatchManager:
                 LOG.warning(
                     self._color.color_log(
                         msg="CodeTrigger not created as CodeUri or DefinitionUri is missing for %s.",
+                        color=Colors.WARNING,
+                    ),
+                    str(resource_id),
+                    extra=dict(markup=True),
+                )
+                continue
+            except ResourceNotFound:
+                LOG.warning(
+                    self._color.color_log(
+                        msg="CodeTrigger not created as %s is not found or is with a S3 Location.",
                         color=Colors.WARNING,
                     ),
                     str(resource_id),

--- a/tests/unit/lib/sync/test_watch_manager.py
+++ b/tests/unit/lib/sync/test_watch_manager.py
@@ -7,6 +7,8 @@ from samcli.lib.providers.exceptions import MissingCodeUri, MissingLocalDefiniti
 from samcli.lib.sync.exceptions import MissingPhysicalResourceError, SyncFlowException
 from parameterized import parameterized
 
+from samcli.local.lambdafn.exceptions import ResourceNotFound
+
 
 class TestWatchManager(TestCase):
     def setUp(self) -> None:
@@ -84,6 +86,7 @@ class TestWatchManager(TestCase):
             MissingCodeUri(),
             trigger_2,
             MissingLocalDefinition(MagicMock(), MagicMock()),
+            ResourceNotFound(),
         ]
         self.watch_manager._stacks = [MagicMock()]
         self.watch_manager._trigger_factory = trigger_factory


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#6873 

#### Why is this change necessary?
If a Layer is set with a S3 Location, `sam sync` throws an error and stack trace when trying to add a code trigger for that layer. (Same for Lambda Function as well). This is due to the Layer/Function with a S3 Location is considered as `ResourceNotFound` from the `create_trigger`'s perspective.

#### How does it address the issue?
In the caller (`_add_code_triggers` of `WatchManager`), catch `ResourceNotFound` and issue a warning.

example:

```
2024-07-12 09:09:07,876 | The resource AWS::Serverless::LayerVersion 'MyLayer' has specified S3 location for ContentUri. It will not be built and SAM CLI does not support invoking it locally.                                                                                                                                                  
2024-07-12 09:09:07,877 | CodeTrigger not created as MyLayer is not found or is with a S3 Location.  
``` 


#### What side effects does this change have?
No

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
