### PR TITLE
Fix: sam sync defintion validator handling file opened event

### DIFF
--- a/samcli/lib/utils/definition_validator.py
+++ b/samcli/lib/utils/definition_validator.py
@@ -4,9 +4,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from watchdog.events import EVENT_TYPE_OPENED, FileSystemEvent, FileOpenedEvent
-
 import yaml
+from watchdog.events import FileOpenedEvent, FileSystemEvent
 
 from samcli.yamlhelper import parse_yaml_file
 

--- a/samcli/lib/utils/definition_validator.py
+++ b/samcli/lib/utils/definition_validator.py
@@ -4,6 +4,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from watchdog.events import EVENT_TYPE_OPENED, FileSystemEvent, FileOpenedEvent
+
 import yaml
 
 from samcli.yamlhelper import parse_yaml_file
@@ -39,7 +41,7 @@ class DefinitionValidator:
         if initialize_data:
             self.validate_change()
 
-    def validate_change(self) -> bool:
+    def validate_change(self, event: Optional[FileSystemEvent] = None) -> bool:
         """Validate change on json or yaml file.
 
         Returns
@@ -49,6 +51,8 @@ class DefinitionValidator:
             If detect_change is set, False will also be returned if there is
             no change compared to the previous validation.
         """
+        if event and isinstance(event, FileOpenedEvent):
+            return False
         old_data = self._data
 
         if not self.validate_file():

--- a/samcli/lib/utils/definition_validator.py
+++ b/samcli/lib/utils/definition_validator.py
@@ -53,6 +53,7 @@ class DefinitionValidator:
         """
         if event and isinstance(event, FileOpenedEvent):
             return False
+
         old_data = self._data
 
         if not self.validate_file():

--- a/samcli/lib/utils/resource_trigger.py
+++ b/samcli/lib/utils/resource_trigger.py
@@ -395,7 +395,7 @@ class DefinitionCodeTrigger(CodeResourceTrigger):
         ----------
         event : Optional[FileSystemEvent], optional
         """
-        if self._validator.validate_change():
+        if self._validator.validate_change(event):
             self._on_code_change(event)
 
     def get_path_handlers(self) -> List[PathHandler]:

--- a/tests/unit/lib/utils/test_definition_validator.py
+++ b/tests/unit/lib/utils/test_definition_validator.py
@@ -1,6 +1,7 @@
 from parameterized import parameterized
 from unittest.case import TestCase
 from unittest.mock import MagicMock, patch, ANY
+from watchdog.events import FileOpenedEvent
 from samcli.lib.utils.definition_validator import DefinitionValidator
 
 
@@ -61,3 +62,11 @@ class TestDefinitionValidator(TestCase):
         self.assertFalse(validator.validate_change())
         self.assertFalse(validator.validate_change())
         self.assertTrue(validator.validate_change())
+
+    @patch("samcli.lib.utils.definition_validator.parse_yaml_file")
+    def test_detect_change_for_file_opened_event(self, parse_yaml_file_mock):
+        parse_yaml_file_mock.side_effect = [{"A": 1}, {"B": 1}]
+        validator = DefinitionValidator(self.path, detect_change=True, initialize_data=True)
+        event = FileOpenedEvent("src_path")
+        self.assertFalse(validator.validate_change(event))
+        

--- a/tests/unit/lib/utils/test_definition_validator.py
+++ b/tests/unit/lib/utils/test_definition_validator.py
@@ -69,4 +69,3 @@ class TestDefinitionValidator(TestCase):
         validator = DefinitionValidator(self.path, detect_change=True, initialize_data=True)
         event = FileOpenedEvent("src_path")
         self.assertFalse(validator.validate_change(event))
-        


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
N/A

#### Why is this change necessary?
For definition files (e.g. APIGW, SFN), a validation step is done for each FS event caught by watchdog. The validation step compares the file changes and determines if it's a valid change to sync. However, the validation step checks the file as of current but not the time when the event happened. As a result, we saw "changes" occurred and validated for a "File Opened Event", which is then ignored, and thus did not result in any sync. 

#### How does it address the issue?
Explicitly skip File Opened Event in the validation step.


#### What side effects does this change have?
Definition files are not validated for a File Opened Event. However, this should be fine since we do not create sync flow from File Opened Event anyway.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
