### PR TITLE
fix: sam sync ruby tests

### DIFF
--- a/tests/integration/testdata/sync/infra/after/Ruby/function/app.rb
+++ b/tests/integration/testdata/sync/infra/after/Ruby/function/app.rb
@@ -1,11 +1,11 @@
-require 'statistics'
+require 'ruby-statistics/distribution/normal'
 require 'json'
 require 'layer'
 
 def lambda_handler(event:, context:)
   # Sample pure Lambda function that returns a message and a location
 
-  normal = Statistics::Distribution::Normal.new(2,3)
+  normal = RubyStatistics::Distribution::Normal.new(2,3)
 
   {
     statusCode: 200,

--- a/tests/integration/testdata/sync/infra/before/Ruby/function/app.rb
+++ b/tests/integration/testdata/sync/infra/before/Ruby/function/app.rb
@@ -1,11 +1,11 @@
-require 'statistics'
+require 'ruby-statistics/distribution/normal'
 require 'json'
 require 'layer'
 
 def lambda_handler(event:, context:)
   # Sample pure Lambda function that returns a message and a location
 
-  normal = Statistics::Distribution::Normal.new(2,3)
+  normal = RubyStatistics::Distribution::Normal.new(2,3)
 
   {
     statusCode: 200,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
Dependency used in `sam sync` tests for ruby runtime got updated with backward incompatible changes.

#### How does it address the issue?
Update ruby code to align changes from the library upgrade

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
