### PR TITLE
fix: handle docker network host

### DIFF
--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -307,7 +307,7 @@ class TestContainer_create(TestCase):
             self.image,
             command=self.cmd,
             working_dir=self.working_dir,
-            ports=self.always_exposed_ports,
+            network_mode="host",
             tty=False,
             use_config_proxy=True,
             volumes=expected_volumes,


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Fixes #4236.

#### Why is this change necessary?

PR #669 allowed usage of the host network for Docker containers, but that feature was removed in PR #5279.

#### How does it address the issue?

This change reintroduces setting `network_mode` to `host` when `docker_network` is `host`, and adds some additional debug logging to ease debugging.

#### What side effects does this change have?

None AFAIK.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
