### PR TITLE
fix: Integration test using OS line endings

### DIFF
--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -228,7 +228,7 @@ class TestValidate(TestCase):
         output = command_result.stderr.decode("utf-8")
 
         error_message = (
-            f"Error: AWS Region was not found. Please configure your region through the --region option.\n"
+            f"Error: AWS Region was not found. Please configure your region through the --region option.{os.linesep}"
             f"Regions ['us-north-5'] are unsupported. Supported regions are"
         )
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Use OS-specific line endings to fix integration test on Windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
