### PR TITLE
fix: Remove str type constrain in Fn:FindInMap to avoid the issue of …

### DIFF
--- a/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
+++ b/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
@@ -492,7 +492,7 @@ class IntrinsicResolver:
         )
 
         second_level_value = top_level_value.get(second_level_key)
-        verify_intrinsic_type_str(
+        verify_non_null(
             second_level_value,
             IntrinsicResolver.FN_FIND_IN_MAP,
             message="The SecondLevelKey is missing in the Mappings dictionary in Fn::FindInMap  "

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -26,6 +26,11 @@ Parameters:
     Type: String
     Default: "2"
 
+Mappings:
+  common:
+    LambdaFunction:
+      Timeout: 5
+
 Resources:
   HelloWorldServerlessFunction:
     Type: AWS::Serverless::Function
@@ -57,6 +62,14 @@ Resources:
       Runtime: python3.9
       CodeUri: .
       Timeout: 5
+
+  TimeoutFunctionUsingLookupValue:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.sleep_handler
+      Runtime: python3.9
+      CodeUri: .
+      Timeout: !FindInMap [common, LambdaFunction, Timeout]    
 
   HelloWorldSleepFunction:
     Type: AWS::Serverless::Function

--- a/tests/unit/lib/intrinsic_resolver/test_intrinsic_resolver.py
+++ b/tests/unit/lib/intrinsic_resolver/test_intrinsic_resolver.py
@@ -209,6 +209,7 @@ class TestIntrinsicFnFindInMapResolver(TestCase):
                 "Basic": {"Test": {"key": "value"}},
                 "value": {"anotherkey": {"key": "result"}},
                 "result": {"value": {"key": "final"}},
+                "NonStrValue": {"Test": {"key": 0}},
             }
         }
         self.resolver = IntrinsicResolver(symbol_resolver=IntrinsicsSymbolTable(), template=template)
@@ -217,6 +218,11 @@ class TestIntrinsicFnFindInMapResolver(TestCase):
         intrinsic = {"Fn::FindInMap": ["Basic", "Test", "key"]}
         result = self.resolver.intrinsic_property_resolver(intrinsic, True)
         self.assertEqual(result, "value")
+
+    def test_basic_find_in_map_with_non_string_value(self):
+        intrinsic = {"Fn::FindInMap": ["NonStrValue", "Test", "key"]}
+        result = self.resolver.intrinsic_property_resolver(intrinsic, True)
+        self.assertEqual(result, 0)
 
     def test_nested_find_in_map(self):
         intrinsic_base_1 = {"Fn::FindInMap": ["Basic", "Test", "key"]}


### PR DESCRIPTION
Remove the restriction on `str` type when `Fn:FindInMap` is called.

#### Which issue(s) does this change fix?
#6975 


#### Why is this change necessary?
To allow customer to start lambda locally.

#### How does it address the issue?
Customer cannot start lambda locally if the yaml template include a function `Fn:FindInMap` inside a `timeout` property.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
