### PR TITLE
fix: Fix copying symlink files for Windows

### DIFF
--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -184,7 +184,7 @@ def copytree(source, destination, ignore=None):
             except OSError as e:
                 if e.errno != errno.EINVAL:
                     raise e
-                
+
                 # Symlinks do not get copied for Windows using shutil.copy2, which is why
                 # they are handled separately here.
                 create_symlink_or_copy(new_source, new_destination)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
https://github.com/aws/aws-sam-cli/issues/6943

Note: Adding an integration test seemed like an overkill for a small change. I've added unit tests to cover these, but lmk if you feel adding one is necessary.

#### Why is this change necessary?

When the shared (within same code_uri) node_module dependencies were copied over to the other Function, the symlink files were not being copied over. However, as mentioned in the [docs](https://docs.python.org/3/library/shutil.html#shutil.copy2), copy2 does not copy symlinks on all the platforms (Windows being 1 of them). This causes OsError to be thrown crashing the command.


#### How does it address the issue?

Catches the exception and handles it by calling `create_symlink_or_copy` function to either create a symlink or copy the target file directly.


#### What side effects does this change have?

No side effects.


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
