### PR TITLE
fix: Avoid crashing on invalid function name

### DIFF
--- a/samcli/lib/providers/exceptions.py
+++ b/samcli/lib/providers/exceptions.py
@@ -83,3 +83,12 @@ class MissingLocalDefinition(Exception):
     @property
     def property_name(self) -> str:
         return self._property_name
+
+
+class MissingFunctionNameException(Exception):
+    """
+    Exception when a resource does not have function name specified
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Unable to get Lambda function because the function identifier is not defined.")

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -11,7 +11,7 @@ from samtranslator.policy_template_processor.exceptions import TemplateNotFoundE
 from samcli.commands._utils.template import TemplateFailedParsingException
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
 from samcli.lib.build.exceptions import MissingFunctionHandlerException
-from samcli.lib.providers.exceptions import InvalidLayerReference
+from samcli.lib.providers.exceptions import InvalidLayerReference, MissingFunctionNameException
 from samcli.lib.utils.colors import Colored, Colors
 from samcli.lib.utils.file_observer import FileObserver
 from samcli.lib.utils.packagetype import IMAGE, ZIP
@@ -119,7 +119,8 @@ class SamFunctionProvider(SamBaseProvider):
         """
 
         if not name:
-            raise ValueError("Function name is required")
+            LOG.debug("Function name is not defined, unable to fetch Lambda function.")
+            raise MissingFunctionNameException()
 
         resolved_function = None
 

--- a/samcli/local/apigw/exceptions.py
+++ b/samcli/local/apigw/exceptions.py
@@ -51,9 +51,3 @@ class AuthorizerUnauthorizedRequest(UserException):
     """
     An exception raised when the request is not authorized by the authorizer
     """
-
-
-class InvocationFailureException(UserException):
-    """
-    An exception raised when an invocation fails
-    """

--- a/samcli/local/apigw/exceptions.py
+++ b/samcli/local/apigw/exceptions.py
@@ -51,3 +51,9 @@ class AuthorizerUnauthorizedRequest(UserException):
     """
     An exception raised when the request is not authorized by the authorizer
     """
+
+
+class InvocationFailureException(UserException):
+    """
+    An exception raised when an invocation fails
+    """

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -15,6 +15,7 @@ from werkzeug.serving import WSGIRequestHandler
 
 from samcli.commands.local.lib.exceptions import UnsupportedInlineCodeError
 from samcli.commands.local.lib.local_lambda import LocalLambdaRunner
+from samcli.lib.providers.exceptions import MissingFunctionNameException
 from samcli.lib.providers.provider import Api, Cors
 from samcli.lib.telemetry.event import EventName, EventTracker, UsedFeature
 from samcli.lib.utils.stream_writer import StreamWriter
@@ -733,6 +734,10 @@ class LocalApigwService(BaseLocalService):
             endpoint_service_error = ServiceErrorResponses.lambda_body_failure_response()
         except DockerContainerCreationFailedException as ex:
             endpoint_service_error = ServiceErrorResponses.container_creation_failed(ex.message)
+        except MissingFunctionNameException as ex:
+            endpoint_service_error = ServiceErrorResponses.lambda_failure_response(
+                f"Failed to execute endpoint. Got an invalid function name ({str(ex)})",
+            )
 
         if endpoint_service_error:
             return endpoint_service_error

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -11,7 +11,7 @@ from samcli.lib.utils.architecture import X86_64, ARM64
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
 from samcli.lib.providers.provider import Function, LayerVersion, Stack, FunctionBuildInfo
 from samcli.lib.providers.sam_function_provider import SamFunctionProvider, RefreshableSamFunctionProvider
-from samcli.lib.providers.exceptions import InvalidLayerReference
+from samcli.lib.providers.exceptions import InvalidLayerReference, MissingFunctionNameException
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 
 
@@ -1908,7 +1908,7 @@ class TestSamFunctionProvider_get(TestCase):
     def test_raise_on_invalid_name(self):
         provider = SamFunctionProvider([])
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(MissingFunctionNameException):
             provider.get(None)
 
     def test_must_return_function_value(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
https://github.com/aws/aws-sam-cli/issues/7236

#### Why is this change necessary?
Avoid SAM CLI hard-crashing when it is unable to invoke a Lambda function due to an invalid function name.

#### How does it address the issue?
Uses a custom-exception and handle it during function invocation.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
