### PR TITLE
fix: Fix a canary failure due to an updated error messages from boto lib

### DIFF
--- a/tests/integration/pipeline/test_bootstrap_command.py
+++ b/tests/integration/pipeline/test_bootstrap_command.py
@@ -412,8 +412,8 @@ class TestBootstrap(BootstrapIntegBase):
         # Assert non SSl requests are denied
         with self.assertRaises(ClientError) as error:
             s3_non_ssl_client.get_object(Bucket=bucket_name, Key=bucket_key)
-        self.assertEqual(
-            str(error.exception), "An error occurred (AccessDenied) when calling the GetObject operation: Access Denied"
+        self.assertTrue(
+            str(error.exception).startswith("An error occurred (AccessDenied) when calling the GetObject operation:")
         )
 
     def test_bootstrapped_artifacts_bucket_has_server_access_log_enabled(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Error message changed from boto3 and we need to adapt the integ tests accordingly.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
