### PR TITLE
fix: Race conditions with multiple downloads on the same layer

### DIFF
--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -3,7 +3,7 @@ Downloads Layers locally
 """
 
 import logging
-import threading
+import uuid
 from pathlib import Path
 from typing import List
 
@@ -107,8 +107,7 @@ class LayerDownloader:
             LOG.info("%s is already cached. Skipping download", layer.arn)
             return layer
 
-        current_thread_id = str(threading.get_ident())
-        layer_zip_path = f"{layer.codeuri}_{current_thread_id}.zip"
+        layer_zip_path = f"{layer.codeuri}_{uuid.uuid4().hex}.zip"
         layer_zip_uri = self._fetch_layer_uri(layer)
         unzip_from_uri(
             layer_zip_uri,

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -108,7 +108,7 @@ class LayerDownloader:
             return layer
 
         current_thread_id = str(threading.get_ident())
-        layer_zip_path = f'{layer.codeuri}_{current_thread_id}.zip'
+        layer_zip_path = f"{layer.codeuri}_{current_thread_id}.zip"
         layer_zip_uri = self._fetch_layer_uri(layer)
         unzip_from_uri(
             layer_zip_uri,

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -3,11 +3,11 @@ Downloads Layers locally
 """
 
 import logging
+import threading
 from pathlib import Path
 from typing import List
 
 import boto3
-import threading
 from botocore.exceptions import ClientError, NoCredentialsError
 
 from samcli.commands.local.cli_common.user_exceptions import CredentialsRequired, ResourceNotFound

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List
 
 import boto3
+import threading
 from botocore.exceptions import ClientError, NoCredentialsError
 
 from samcli.commands.local.cli_common.user_exceptions import CredentialsRequired, ResourceNotFound
@@ -106,7 +107,8 @@ class LayerDownloader:
             LOG.info("%s is already cached. Skipping download", layer.arn)
             return layer
 
-        layer_zip_path = layer.codeuri + ".zip"
+        current_thread_id = str(threading.get_ident())
+        layer_zip_path = f'{layer.codeuri}_{current_thread_id}.zip'
         layer_zip_uri = self._fetch_layer_uri(layer)
         unzip_from_uri(
             layer_zip_uri,

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -3219,6 +3219,18 @@ class TestWarmContainersRemoteLayersLazyInvoke(WarmContainersWithRemoteLayersBas
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), '"Layer1"')
 
+class TestWarmContainersMultipleRemoteLayersInvoke(WarmContainersWithRemoteLayersBase):
+    template_path = "/testdata/start_api/template-warm-containers-multi-layers.yaml"
+    container_mode = ContainersInitializationMode.EAGER.value
+    mode_env_variable = str(uuid.uuid4())
+    parameter_overrides = {"ModeEnvVariable": mode_env_variable}
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_can_invoke_lambda_layer_successfully(self):
+        response = requests.get(self.url + "/", timeout=300)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode("utf-8"), '"Layer1"')
 
 class TestDisableAuthorizer(StartApiIntegBaseClass):
     # integration test for scenario: 'sam local start-api --disable-authorizer'

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -3219,6 +3219,7 @@ class TestWarmContainersRemoteLayersLazyInvoke(WarmContainersWithRemoteLayersBas
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), '"Layer1"')
 
+
 class TestWarmContainersMultipleRemoteLayersInvoke(WarmContainersWithRemoteLayersBase):
     template_path = "/testdata/start_api/template-warm-containers-multi-layers.yaml"
     container_mode = ContainersInitializationMode.EAGER.value
@@ -3231,6 +3232,7 @@ class TestWarmContainersMultipleRemoteLayersInvoke(WarmContainersWithRemoteLayer
         response = requests.get(self.url + "/", timeout=300)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), '"Layer1"')
+
 
 class TestDisableAuthorizer(StartApiIntegBaseClass):
     # integration test for scenario: 'sam local start-api --disable-authorizer'

--- a/tests/integration/testdata/start_api/template-warm-containers-multi-layers.yaml
+++ b/tests/integration/testdata/start_api/template-warm-containers-multi-layers.yaml
@@ -1,0 +1,88 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  ModeEnvVariable:
+    Type: String
+  LayerArn:
+    Default: arn:aws:lambda:us-west-2:111111111111:layer:layer:1
+    Type: String
+
+Resources:
+  ApiGatewayApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      CacheClusterEnabled: true
+      CacheClusterSize: '0.5'
+      MethodSettings:
+        - ResourcePath: /
+          HttpMethod: GET
+          CachingEnabled: true
+          CacheTtlInSeconds: 300
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main-layers.custom_layer_handler
+      Runtime: python3.9
+      FunctionName: customname
+      CodeUri: .
+      Timeout: 600
+      Environment:
+        Variables:
+          MODE: !Ref ModeEnvVariable
+      Layers:
+        # Test remote layers with warm containers.
+        - Ref: LayerArn
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+            RestApiId:
+              Ref: ApiGatewayApi
+  HelloWorldFunction2:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main-layers.custom_layer_handler
+      Runtime: python3.9
+      FunctionName: customname
+      CodeUri: .
+      Timeout: 600
+      Environment:
+        Variables:
+          MODE: !Ref ModeEnvVariable
+      Layers:
+        # Test remote layers with warm containers.
+        - Ref: LayerArn
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+            RestApiId:
+              Ref: ApiGatewayApi   
+  HelloWorldFunction3:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main-layers.custom_layer_handler
+      Runtime: python3.9
+      FunctionName: customname
+      CodeUri: .
+      Timeout: 600
+      Environment:
+        Variables:
+          MODE: !Ref ModeEnvVariable
+      Layers:
+        # Test remote layers with warm containers.
+        - Ref: LayerArn
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+            RestApiId:
+              Ref: ApiGatewayApi                          

--- a/tests/unit/local/layers/test_download_layers.py
+++ b/tests/unit/local/layers/test_download_layers.py
@@ -1,5 +1,4 @@
 import os
-import threading
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -99,6 +98,10 @@ class TestDownloadLayers(TestCase):
     def test_download_layer(
         self, is_layer_cached_patch, create_cache_patch, fetch_layer_uri_patch, unzip_from_uri_patch
     ):
+        class AnyStringWith(str):
+            def __eq__(self, other):
+                return self in other
+
         is_layer_cached_patch.return_value = False
 
         download_layers = LayerDownloader("/home", ".", Mock())
@@ -117,10 +120,9 @@ class TestDownloadLayers(TestCase):
 
         create_cache_patch.assert_called_once_with("/home")
         fetch_layer_uri_patch.assert_called_once_with(layer_mock)
-        current_thread_id = str(threading.get_ident())
         unzip_from_uri_patch.assert_called_once_with(
             "layer/uri",
-            str(Path("/home/layer1_" + current_thread_id + ".zip").resolve()),
+            AnyStringWith(str(Path("/home/layer1_"))),
             unzip_output_dir=str(Path("/home/layer1").resolve()),
             progressbar_label="Downloading arn:layer:layer1",
         )

--- a/tests/unit/local/layers/test_download_layers.py
+++ b/tests/unit/local/layers/test_download_layers.py
@@ -1,4 +1,5 @@
 import os
+import threading
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -116,9 +117,10 @@ class TestDownloadLayers(TestCase):
 
         create_cache_patch.assert_called_once_with("/home")
         fetch_layer_uri_patch.assert_called_once_with(layer_mock)
+        current_thread_id = str(threading.get_ident())
         unzip_from_uri_patch.assert_called_once_with(
             "layer/uri",
-            str(Path("/home/layer1.zip").resolve()),
+            str(Path("/home/layer1_" + current_thread_id + ".zip").resolve()),
             unzip_output_dir=str(Path("/home/layer1").resolve()),
             progressbar_label="Downloading arn:layer:layer1",
         )


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Customer reports that when the SAM template contains multiple functions, some shared the same lambda layer, `local start-api` throw the exception

```
2024-08-27 09:43:43,083 | Lambda functions containers initialization failed because of [Errno 2] No such file or directory: '/Users/aguro/.aws-sam/layers-pkg/NFTUserLayer-3-ff9c237555.zip'
```

This is because there was a race condition when multiple layer_downloaders were running to build multiple functions concurrently. Some could finish downloading the file first and remove the .zip file, causing the other one failed to unzip.

#### How does it address the issue?
The fix is to ask each downloader to download into separate zip file (by adding the thread id to the file name), but the extracted folder remains the same.

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [X] Write/update integration tests
- [X] Write/update functional tests if needed
- [X] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
