### PR TITLE
chore: bump python pysintaller versions

### DIFF
--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -12,7 +12,7 @@ if [ "$python_library_zip_filename" = "" ]; then
 fi
 
 if [ "$python_version" = "" ]; then
-    python_version="3.11.8";
+    python_version="3.11.10";
 fi
 
 if [ "$openssl_version" = "" ]; then

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -34,7 +34,7 @@ if [ "$openssl_version" = "" ]; then
 fi
 
 if [ "$python_version" = "" ]; then
-    python_version="3.8.13";
+    python_version="3.8.20";
 fi
 
 if ! [ "$build_binary_name" = "" ]; then


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Because of CVE from https://www.cve.org/CVERecord?id=CVE-2024-45490, we need to bump python versions of pyinstaller to latest version


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
