### PR TITLE
fix: Update to OpenSSL 3.3.1 to avoid the issue with subprocess.check…

### DIFF
--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -16,7 +16,7 @@ if [ "$python_version" = "" ]; then
 fi
 
 if [ "$openssl_version" = "" ]; then
-    openssl_version="3.0.15";
+    openssl_version="3.3.1";
 fi
 
 if [ "$zlib_version" = "" ]; then

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -30,7 +30,7 @@ if [ "$python_library_zip_filename" = "" ]; then
 fi
 
 if [ "$openssl_version" = "" ]; then
-    openssl_version="3.0.15";
+    openssl_version="3.3.1";
 fi
 
 if [ "$python_version" = "" ]; then


### PR DESCRIPTION
…_output

#### Which issue(s) does this change fix?
#7408


#### Why is this change necessary?
To address the issue of `git clone` return status 128 with `sam init` running on some Linux distributions.

#### How does it address the issue?
The issue happened because older version of OpenSSL 3 interfered with Python's subprocess PIPE output, causing `git clone` exited with an error.

#### What side effects does this change have?
Newer version of OpenSSL 3 might cause other issues.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
