### PR TITLE
feat: Dynamically determine latest init runtime

### DIFF
--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -152,3 +152,10 @@ class LinterRuleMatchedException(UserException):
     """
     The linter matched a rule meaning that the template linting failed
     """
+
+
+class PopularRuntimeNotFoundException(Exception):
+    """
+    Exception thrown when we were not able to parse the SUPPORTED_RUNTIMES
+    constant correctly for the latest runtime
+    """

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -12,7 +12,7 @@ import click
 from botocore.exceptions import ClientError, WaiterError
 
 from samcli.commands._utils.options import generate_next_command_recommendation
-from samcli.commands.exceptions import InvalidInitOptionException, SchemasApiException
+from samcli.commands.exceptions import InvalidInitOptionException, PopularRuntimeNotFoundException, SchemasApiException
 from samcli.commands.init.init_flow_helpers import (
     _get_image_from_runtime,
     _get_runtime_from_image,
@@ -335,10 +335,8 @@ def _get_latest_python_runtime() -> str:
     str:
         The name of the latest Python runtime (ex. "python3.12")
     """
-
-    # set python3.9 as fallback
-    latest_major = 3
-    latest_minor = 9
+    latest_major = 0
+    latest_minor = 0
 
     compiled_regex = re.compile(r"python(.*?)\.(.*)")
 
@@ -367,6 +365,12 @@ def _get_latest_python_runtime() -> str:
             latest_minor = version_minor
         elif version_major == latest_major:
             latest_minor = version_minor if version_minor > latest_minor else latest_minor
+
+    if not latest_major:
+        # major version is still 0, assume that something went wrong
+        # this in theory should not happen as long as Python is
+        # listed in the SUPPORTED_RUNTIMES constant
+        raise PopularRuntimeNotFoundException("Was unable to search for the latest supported runtime")
 
     selected_version = f"python{latest_major}.{latest_minor}"
 

--- a/samcli/commands/init/interactive_init_flow.py
+++ b/samcli/commands/init/interactive_init_flow.py
@@ -362,10 +362,17 @@ def _get_latest_python_runtime() -> str:
             LOG.debug(f"Failed to parse version while checking {runtime}")
             continue
 
-        latest_major = version_major if version_major > latest_major else latest_major
-        latest_minor = version_minor if version_minor > latest_minor else latest_minor
+        if version_major > latest_major:
+            latest_major = version_major
+            latest_minor = version_minor
+        elif version_major == latest_major:
+            latest_minor = version_minor if version_minor > latest_minor else latest_minor
 
-    return f"python{latest_major}.{latest_minor}"
+    selected_version = f"python{latest_major}.{latest_minor}"
+
+    LOG.debug(f"Using {selected_version} as the latest runtime version")
+
+    return selected_version
 
 
 def _generate_default_hello_world_application(

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -3223,3 +3223,18 @@ test-project
             result = _get_latest_python_runtime()
 
         self.assertEqual(result, "python3.9")
+
+    @parameterized.expand(
+        [
+            ({"python7.8": Any, "python9.1": Any}, "python9.1"),
+            ({"python6.1": Any, "python4.7": Any}, "python6.1"),
+        ]
+    )
+    def test_latest_python_fetcher_major_minor_difference(self, versions, expected):
+        with mock.patch(
+            "samcli.commands.init.interactive_init_flow.SUPPORTED_RUNTIMES",
+            versions,
+        ):
+            result = _get_latest_python_runtime()
+
+        self.assertEqual(result, expected)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
None

#### Why is this change necessary?
The current "most popular" runtime is hard coded to Python 3.9.

#### How does it address the issue?
Dynamically checks the (Python) runtimes we support, and returns the latest one.

```
Choose an AWS Quick Start application template
        1 - Hello World Example
        2 - Data processing
.
.
<truncated>
.
.
Template: 1

Use the most popular runtime and package type? (python3.12 and zip) [y/N]: y

Would you like to enable X-Ray tracing on the function(s) in your application?  [y/N]: 

Would you like to enable monitoring using CloudWatch Application Insights?
For more info, please view https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-application-insights.html [y/N]: 

Would you like to set Structured Logging in JSON format on your Lambda functions?  [y/N]: 

Project name [sam-app]: sam2

    -----------------------
    Generating application:
    -----------------------
    Name: sam2
    Runtime: python3.12
    Architectures: x86_64
    Dependency Manager: pip
    Application Template: hello-world
    Output Directory: .
    Configuration file: sam2/samconfig.toml
    
    Next steps can be found in the README file at sam2/README.md

$ cat sam2/template.yaml | grep Runtime
      Runtime: python3.12
```

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
