### PR TITLE
chore: Make behaviour clear about returning in finally block

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -718,6 +718,11 @@ class LocalApigwService(BaseLocalService):
                 LOG.error("Lambda authorizer failed to invoke successfully: %s", str(lambda_authorizer_exception))
 
             if auth_service_error:
+                # Return the Flask service error if there is one, since these are the only exceptions
+                # we are anticipating from the authorizer, anything else indicates a local issue.
+                #
+                # Note that returning within a finally block will have the effect of swallowing
+                # any reraised exceptions.
                 return auth_service_error
 
         endpoint_service_error = None


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#7599

#### Why is this change necessary?
Returning inside a finally block swallows any previously re-raised exceptions, and might raise up questions about it's usage.

#### How does it address the issue?
Adds a comment that explains it was deliberate.

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
