### PR TITLE
chore: remove python3.8 from validate tests

### DIFF
--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -180,7 +180,6 @@ class TestValidate(TestCase):
             "provided",
             "provided.al2",
             "provided.al2023",
-            "python3.8",
             "python3.9",
             "python3.10",
             "python3.11",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A


#### Why is this change necessary?
`python3.8` is going to be deprecated soon, for that reason `sam validate` tests are failing.

#### How does it address the issue?
By removing `python3.8` runtime from validate tests.


#### What side effects does this change have?
N/A


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
