### PR TITLE
chore: remove go1.x & provided from validate tests

### DIFF
--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -170,7 +170,6 @@ class TestValidate(TestCase):
         supported_runtimes = [
             "dotnet8",
             "dotnet6",
-            "go1.x",
             "java21",
             "java17",
             "java11",

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -176,7 +176,6 @@ class TestValidate(TestCase):
             "java8.al2",
             "nodejs18.x",
             "nodejs20.x",
-            "provided",
             "provided.al2",
             "provided.al2023",
             "python3.9",


### PR DESCRIPTION
Removing `go1.x` and `provided` from list of runtimes we test for `sam validate`

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
