### PR TITLE
chore: bump cfn-lint to 1.19.0 to fix sam validate for python3.13

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ regex!=2021.10.8
 tzlocal==5.2
 
 #Adding cfn-lint dependency for SAM validate
-cfn-lint~=1.18.4
+cfn-lint~=1.19.0
 
 # Type checking boto3 objects
 boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray,sqs,kinesis]==1.35.56

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -129,9 +129,9 @@ cffi==1.17.1 \
     --hash=sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87 \
     --hash=sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b
     # via cryptography
-cfn-lint==1.18.4 \
-    --hash=sha256:73dadc33d6a91c69651cb08fe919138ab4e2f6cf1be1e361f7c6dcbccd1527ba \
-    --hash=sha256:76741e76fa26f31bfacc3eb465eddd93ad535838d84fbc6dd092817d8e22d57f
+cfn-lint==1.19.0 \
+    --hash=sha256:63835e083f7831e54c512bce4808754df221b5895aed9a114c71879d1cc4ebff \
+    --hash=sha256:9c43a6b866915df6d2ac5584000ef05e53c67624809808c2cebd3dc6154b7c14
     # via aws-sam-cli (setup.py)
 chardet==5.2.0 \
     --hash=sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7 \

--- a/requirements/reproducible-mac.txt
+++ b/requirements/reproducible-mac.txt
@@ -147,9 +147,9 @@ cffi==1.17.1 \
     --hash=sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87 \
     --hash=sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b
     # via cryptography
-cfn-lint==1.18.4 \
-    --hash=sha256:73dadc33d6a91c69651cb08fe919138ab4e2f6cf1be1e361f7c6dcbccd1527ba \
-    --hash=sha256:76741e76fa26f31bfacc3eb465eddd93ad535838d84fbc6dd092817d8e22d57f
+cfn-lint==1.19.0 \
+    --hash=sha256:63835e083f7831e54c512bce4808754df221b5895aed9a114c71879d1cc4ebff \
+    --hash=sha256:9c43a6b866915df6d2ac5584000ef05e53c67624809808c2cebd3dc6154b7c14
     # via aws-sam-cli (setup.py)
 chardet==5.2.0 \
     --hash=sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7 \

--- a/requirements/reproducible-win.txt
+++ b/requirements/reproducible-win.txt
@@ -129,9 +129,9 @@ cffi==1.17.1 \
     --hash=sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87 \
     --hash=sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b
     # via cryptography
-cfn-lint==1.18.4 \
-    --hash=sha256:73dadc33d6a91c69651cb08fe919138ab4e2f6cf1be1e361f7c6dcbccd1527ba \
-    --hash=sha256:76741e76fa26f31bfacc3eb465eddd93ad535838d84fbc6dd092817d8e22d57f
+cfn-lint==1.19.0 \
+    --hash=sha256:63835e083f7831e54c512bce4808754df221b5895aed9a114c71879d1cc4ebff \
+    --hash=sha256:9c43a6b866915df6d2ac5584000ef05e53c67624809808c2cebd3dc6154b7c14
     # via aws-sam-cli (setup.py)
 chardet==5.2.0 \
     --hash=sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7 \

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -182,6 +182,7 @@ class TestValidate(TestCase):
             "python3.10",
             "python3.11",
             "python3.12",
+            "python3.13",
             "ruby3.2",
             "ruby3.3",
         ]


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

https://github.com/aws/aws-sam-cli/issues/7673

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
