### PR TITLE
chore: Remove py313 install steps from the Windows Al2023 based AppVeyor project

### DIFF
--- a/appveyor-windows-al2023.yml
+++ b/appveyor-windows-al2023.yml
@@ -54,20 +54,10 @@ install:
   # Make sure the temp directory exists for Python to use.
   - ps: "mkdir -Force C:\\tmp"
   - "python --version"
-  # Temporarily install python3.13 from the embedded zip file. Once AppVeyor installs it in the image, the below code can be removed.
-  - ps: 'Invoke-WebRequest -Uri https://www.python.org/ftp/python/3.13.0/python-3.13.0-embed-amd64.zip -OutFile python313.zip'
-  - ps: "Expand-Archive -Path python313.zip -DestinationPath C:\\Python313-x64"
-  - 'set PATH=%PYTHON_HOME%;C:\Ruby33-x64\bin;C:\Ruby32-x64\bin;%PATH%;C:\Python39-x64;C:\Python310-x64;C:\Python311-x64;C:\Python312-x64;C:\Python313-x64;C:\Python313-x64\Scripts;'
-  - ps: | 
-      $pth_file = "C:\Python313-x64\python313._pth"
-      (Get-Content -Path $pth_file) -replace '#import site', 'import site' | Set-Content -Path $pth_file
-  - ps: |
-      if (!(Test-Path -Path "C:\Python313-x64\Scripts\pip.exe")) {
-          Invoke-WebRequest -Uri https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
-          & "C:\Python313-x64\python.exe" get-pip.py
-      }
+  - 'set PATH=C:\Python313-x64;%PYTHON_HOME%;C:\Ruby33-x64\bin;C:\Ruby32-x64\bin;%PATH%;C:\Python39-x64;C:\Python310-x64;C:\Python311-x64;C:\Python312-x64;C:\Python313-x64;C:\Python313-x64\Scripts;'
   - "python --version"
   - ps: pip --version
+  - "node --version"
   - "echo %PYTHON_HOME%"
   - "echo %PATH%"
   - "python --version"

--- a/appveyor-windows-al2023.yml
+++ b/appveyor-windows-al2023.yml
@@ -54,9 +54,7 @@ install:
   # Make sure the temp directory exists for Python to use.
   - ps: "mkdir -Force C:\\tmp"
   - "python --version"
-  - 'set PATH=C:\Python313-x64;%PYTHON_HOME%;C:\Ruby33-x64\bin;C:\Ruby32-x64\bin;%PATH%;C:\Python39-x64;C:\Python310-x64;C:\Python311-x64;C:\Python312-x64;C:\Python313-x64;C:\Python313-x64\Scripts;'
-  - "python --version"
-  - ps: pip --version
+  - 'set PATH=%PYTHON_HOME%;C:\Ruby33-x64\bin;C:\Ruby32-x64\bin;%PATH%;C:\Python39-x64;C:\Python310-x64;C:\Python311-x64;C:\Python312-x64;C:\Python313-x64'
   - "node --version"
   - "echo %PYTHON_HOME%"
   - "echo %PATH%"


### PR DESCRIPTION
#### Why is this change necessary?

`Python3.13` and `nodejs22` are installed in the AppVeyor image for Al2023 Windows based project.

#### How does it address the issue?

Don't need to install python3.13 from the embedded zip file

```
python --version
Python 3.12.3
set PATH=C:\Python313-x64;%PYTHON_HOME%;C:\Ruby33-x64\bin;C:\Ruby32-x64\bin;%PATH%;C:\Python39-x64;C:\Python310-x64;C:\Python311-x64;C:\Python312-x64;C:\Python313-x64;C:\Python313-x64\Scripts;
python --version
Python 3.13.0
pip --version
pip 24.3.1 from C:\Python312\Lib\site-packages\pip (python 3.12)
node --version
v22.6.0
```

#### What side effects does this change have?

no side effects

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
