### PR TITLE
chore(runtime): move ruby3.3 out of test runtime

### DIFF
--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
 
 RAPID_IMAGE_TAG_PREFIX = "rapid"
 
-TEST_RUNTIMES = []
+TEST_RUNTIMES = ["N/A"]
 
 
 class Runtime(Enum):

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
 
 RAPID_IMAGE_TAG_PREFIX = "rapid"
 
-TEST_RUNTIMES = ["ruby3.3"]
+TEST_RUNTIMES = []
 
 
 class Runtime(Enum):

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
 
 RAPID_IMAGE_TAG_PREFIX = "rapid"
 
-TEST_RUNTIMES = ["N/A"]
+TEST_RUNTIMES: list[str] = []
 
 
 class Runtime(Enum):


### PR DESCRIPTION
ruby 3.3 is officially supported

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#7839

#### Why is this change necessary?
The latest public.ecr.aws/lambda/ruby:3.3 is upgraded to 3.3.5 but sam local invoke still uses public.ecr.aws/lambda/ruby:3.3-preview and the version is 3.3.0 this version has some bug cause sam local invoke cannot work correctly.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
