### PR TITLE
fix: Resolve symlinks on local invoke only

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -61,6 +61,7 @@ from samcli.lib.utils.resources import (
     AWS_SERVERLESS_LAYERVERSION,
 )
 from samcli.lib.utils.stream_writer import StreamWriter
+from samcli.local.docker.container import ContainerContext
 from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 from samcli.local.docker.manager import ContainerManager, DockerImagePullFailedException
 from samcli.local.docker.utils import get_docker_platform, is_docker_reachable
@@ -968,7 +969,7 @@ class ApplicationBuilder:
 
         try:
             try:
-                self._container_manager.run(container)
+                self._container_manager.run(container, context=ContainerContext.BUILD)
             except docker.errors.APIError as ex:
                 if "executable file not found in $PATH" in str(ex):
                     raise UnsupportedBuilderLibraryVersionError(

--- a/samcli/local/docker/manager.py
+++ b/samcli/local/docker/manager.py
@@ -12,7 +12,7 @@ import docker
 from samcli.lib.constants import DOCKER_MIN_API_VERSION
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.docker import utils
-from samcli.local.docker.container import Container
+from samcli.local.docker.container import Container, ContainerContext
 from samcli.local.docker.lambda_image import LambdaImage
 
 LOG = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class ContainerManager:
         """
         return utils.is_docker_reachable(self.docker_client)
 
-    def create(self, container):
+    def create(self, container, context):
         """
         Create a container based on the given configuration.
 
@@ -63,6 +63,8 @@ class ContainerManager:
         ----------
         container samcli.local.docker.container.Container:
             Container to be created
+        context: samcli.local.docker.container.ContainerContext
+            Context for the container management to run. (build, invoke)
 
         Raises
         ------
@@ -93,9 +95,9 @@ class ContainerManager:
                 LOG.info("Failed to download a new %s image. Invoking with the already downloaded image.", image_name)
 
         container.network_id = self.docker_network_id
-        container.create()
+        container.create(context)
 
-    def run(self, container, input_data=None):
+    def run(self, container, context: ContainerContext, input_data=None):
         """
         Run a Docker container based on the given configuration.
         If the container is not created, it will call Create method to create.
@@ -104,6 +106,8 @@ class ContainerManager:
         ----------
         container: samcli.local.docker.container.Container
             Container to create and run
+        context: samcli.local.docker.container.ContainerContext
+            Context for the container management to run. (build, invoke)
         input_data: str, optional
             Input data sent to the container through container's stdin.
 
@@ -113,8 +117,7 @@ class ContainerManager:
             If the Docker image was not available in the server
         """
         if not container.is_created():
-            self.create(container)
-
+            self.create(container, context)
         container.start(input_data=input_data)
 
     def stop(self, container: Container) -> None:

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -14,7 +14,7 @@ from typing import Dict, Optional, Union
 from samcli.lib.telemetry.metric import capture_parameter
 from samcli.lib.utils.file_observer import LambdaFunctionObserver
 from samcli.lib.utils.packagetype import ZIP
-from samcli.local.docker.container import Container
+from samcli.local.docker.container import Container, ContainerContext
 from samcli.local.docker.container_analyzer import ContainerAnalyzer
 from samcli.local.docker.exceptions import ContainerFailureError, DockerContainerCreationFailedException
 from samcli.local.docker.lambda_container import LambdaContainer
@@ -113,7 +113,7 @@ class LambdaRuntime:
         )
         try:
             # create the container.
-            self._container_manager.create(container)
+            self._container_manager.create(container, ContainerContext.INVOKE)
             return container
 
         except DockerContainerCreationFailedException:
@@ -174,7 +174,7 @@ class LambdaRuntime:
 
         try:
             # start the container.
-            self._container_manager.run(container)
+            self._container_manager.run(container, ContainerContext.INVOKE)
             return container
 
         except KeyboardInterrupt:

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -32,6 +32,7 @@ from samcli.lib.utils.architecture import X86_64, ARM64
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.docker.manager import DockerImagePullFailedException
+from samcli.local.docker.container import ContainerContext
 from tests.unit.lib.build_module.test_build_graph import generate_function
 
 
@@ -2940,7 +2941,7 @@ class TestApplicationBuilder_build_function_on_container(TestCase):
             build_dir="/build/dir",
         )
 
-        self.container_manager.run.assert_called_with(container_mock)
+        self.container_manager.run.assert_called_with(container_mock, context=ContainerContext.BUILD)
         self.builder._parse_builder_response.assert_called_once_with(stdout_data, container_mock.image)
         container_mock.copy.assert_called_with(response["result"]["artifacts_dir"] + "/.", "artifacts_dir")
         self.container_manager.stop.assert_called_with(container_mock)

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -16,6 +16,7 @@ from samcli.lib.utils.packagetype import IMAGE
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.docker.container import (
     Container,
+    ContainerContext,
     ContainerResponseException,
     ContainerConnectionTimeoutException,
     PortAlreadyInUse,
@@ -76,6 +77,7 @@ class TestContainer_create(TestCase):
         self.additional_volumes = {"/somepath": {"blah": "blah value"}}
         self.container_host = "localhost"
         self.container_host_interface = "127.0.0.1"
+        self.container_context = ContainerContext.BUILD
 
         self.mock_docker_client = Mock()
         self.mock_docker_client.containers = Mock()
@@ -104,7 +106,7 @@ class TestContainer_create(TestCase):
             exposed_ports=self.exposed_ports,
         )
 
-        container_id = container.create()
+        container_id = container.create(ContainerContext.INVOKE)
         self.assertEqual(container_id, generated_id)
         self.assertEqual(container.id, generated_id)
 
@@ -121,6 +123,7 @@ class TestContainer_create(TestCase):
             use_config_proxy=True,
         )
         self.mock_docker_client.networks.get.assert_not_called()
+        mock_resolve_symlinks.assert_called_with()  # When context is INVOKE
 
     @patch("samcli.local.docker.container.Container._create_mapped_symlink_files")
     def test_must_create_container_including_all_optional_values(self, mock_resolve_symlinks):
@@ -155,7 +158,7 @@ class TestContainer_create(TestCase):
             container_host_interface=self.container_host_interface,
         )
 
-        container_id = container.create()
+        container_id = container.create(ContainerContext.BUILD)
         self.assertEqual(container_id, generated_id)
         self.assertEqual(container.id, generated_id)
 
@@ -176,6 +179,7 @@ class TestContainer_create(TestCase):
             container="opts",
         )
         self.mock_docker_client.networks.get.assert_not_called()
+        mock_resolve_symlinks.assert_not_called()  # When context is BUILD
 
     @patch("samcli.local.docker.utils.os")
     @patch("samcli.local.docker.container.Container._create_mapped_symlink_files")
@@ -216,7 +220,7 @@ class TestContainer_create(TestCase):
             additional_volumes=additional_volumes,
         )
 
-        container_id = container.create()
+        container_id = container.create(self.container_context)
         self.assertEqual(container_id, generated_id)
         self.assertEqual(container.id, generated_id)
 
@@ -261,7 +265,7 @@ class TestContainer_create(TestCase):
 
         container.network_id = network_id
 
-        container_id = container.create()
+        container_id = container.create(self.container_context)
         self.assertEqual(container_id, generated_id)
 
         self.mock_docker_client.containers.create.assert_called_with(
@@ -300,7 +304,7 @@ class TestContainer_create(TestCase):
 
         container.network_id = network_id
 
-        container_id = container.create()
+        container_id = container.create(self.container_context)
         self.assertEqual(container_id, generated_id)
 
         self.mock_docker_client.containers.create.assert_called_with(
@@ -324,7 +328,7 @@ class TestContainer_create(TestCase):
         container.is_created.return_value = True
 
         with self.assertRaises(RuntimeError):
-            container.create()
+            container.create(self.container_context)
 
 
 class TestContainer_stop(TestCase):

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -11,6 +11,7 @@ from samcli.lib.providers.provider import LayerVersion
 from samcli.local.lambdafn.env_vars import EnvironmentVariables
 from samcli.local.lambdafn.runtime import LambdaRuntime, _unzip_file, WarmLambdaRuntime, _require_container_reloading
 from samcli.local.lambdafn.config import FunctionConfig
+from samcli.local.docker.container import ContainerContext
 
 
 class LambdaRuntime_create(TestCase):
@@ -95,7 +96,7 @@ class LambdaRuntime_create(TestCase):
             function_full_path=self.full_path,
         )
         # Run the container and get results
-        self.manager_mock.create.assert_called_with(container)
+        self.manager_mock.create.assert_called_with(container, ContainerContext.INVOKE)
 
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_keyboard_interrupt_must_raise(self, LambdaContainerMock):
@@ -166,7 +167,7 @@ class LambdaRuntime_create(TestCase):
             function_full_path=self.full_path,
         )
         # Run the container and get results
-        self.manager_mock.create.assert_called_with(container)
+        self.manager_mock.create.assert_called_with(container, ContainerContext.INVOKE)
 
 
 class LambdaRuntime_run(TestCase):
@@ -212,7 +213,7 @@ class LambdaRuntime_run(TestCase):
         self.runtime = LambdaRuntime(self.manager_mock, lambda_image_mock)
 
         self.runtime.run(container, self.func_config, debug_context=debug_options)
-        self.manager_mock.run.assert_called_with(container)
+        self.manager_mock.run.assert_called_with(container, ContainerContext.INVOKE)
 
     def test_must_create_container_first_if_passed_container_is_none(self):
         container = Mock()
@@ -233,7 +234,7 @@ class LambdaRuntime_run(TestCase):
             container_host_interface=None,
             extra_hosts=None,
         )
-        self.manager_mock.run.assert_called_with(container)
+        self.manager_mock.run.assert_called_with(container, ContainerContext.INVOKE)
 
     def test_must_skip_run_running_container(self):
         container = Mock()
@@ -352,7 +353,7 @@ class LambdaRuntime_invoke(TestCase):
         )
 
         # Run the container and get results
-        self.manager_mock.run.assert_called_with(container)
+        self.manager_mock.run.assert_called_with(container, ContainerContext.INVOKE)
         self.runtime._configure_interrupt.assert_called_with(self.full_path, self.DEFAULT_TIMEOUT, container, True)
         container.wait_for_result.assert_called_with(
             event=event, full_path=self.full_path, stdout=stdout, stderr=stderr, start_timer=start_timer
@@ -392,7 +393,7 @@ class LambdaRuntime_invoke(TestCase):
             self.runtime.invoke(self.func_config, event, debug_context=None, stdout=stdout, stderr=stderr)
 
         # Run the container and get results
-        self.manager_mock.run.assert_called_with(container)
+        self.manager_mock.run.assert_called_with(container, ContainerContext.INVOKE)
 
         self.runtime._configure_interrupt.assert_not_called()
 
@@ -430,7 +431,7 @@ class LambdaRuntime_invoke(TestCase):
             self.runtime.invoke(self.func_config, event, debug_context=debug_options, stdout=stdout, stderr=stderr)
 
         # Run the container and get results
-        self.manager_mock.run.assert_called_with(container)
+        self.manager_mock.run.assert_called_with(container, ContainerContext.INVOKE)
 
         self.runtime._configure_interrupt.assert_called_with(self.full_path, self.DEFAULT_TIMEOUT, container, True)
 
@@ -464,7 +465,7 @@ class LambdaRuntime_invoke(TestCase):
         self.runtime.invoke(self.func_config, event, stdout=stdout, stderr=stderr)
 
         # Run the container and get results
-        self.manager_mock.run.assert_called_with(container)
+        self.manager_mock.run.assert_called_with(container, ContainerContext.INVOKE)
 
         self.runtime._configure_interrupt.assert_not_called()
 
@@ -713,7 +714,7 @@ class TestWarmLambdaRuntime_invoke(TestCase):
         )
 
         # Run the container and get results
-        self.manager_mock.run.assert_called_with(container)
+        self.manager_mock.run.assert_called_with(container, ContainerContext.INVOKE)
         self.runtime._configure_interrupt.assert_called_with(self.full_path, self.DEFAULT_TIMEOUT, container, True)
         container.wait_for_result.assert_called_with(
             event=event, full_path=self.full_path, stdout=stdout, stderr=stderr, start_timer=start_timer
@@ -814,7 +815,7 @@ class TestWarmLambdaRuntime_create(TestCase):
             function_full_path=self.full_path,
         )
 
-        self.manager_mock.create.assert_called_with(container)
+        self.manager_mock.create.assert_called_with(container, ContainerContext.INVOKE)
         # validate that the created container got cached
         self.assertEqual(self.runtime._containers[self.full_path], container)
         lambda_function_observer_mock.watch.assert_called_with(self.func_config)
@@ -881,7 +882,9 @@ class TestWarmLambdaRuntime_create(TestCase):
             ]
         )
 
-        self.manager_mock.create.assert_has_calls([call(container), call(container2)])
+        self.manager_mock.create.assert_has_calls(
+            [call(container, ContainerContext.INVOKE), call(container2, ContainerContext.INVOKE)]
+        )
         self.manager_mock.stop.assert_called_with(container)
         # validate that the created container got cached
         self.assertEqual(self.runtime._containers[self.full_path], container2)
@@ -907,7 +910,7 @@ class TestWarmLambdaRuntime_create(TestCase):
         result = self.runtime.create(self.func_config, debug_context=debug_options)
 
         # validate that the manager.create method got called only one time
-        self.manager_mock.create.assert_called_once_with(container)
+        self.manager_mock.create.assert_called_once_with(container, ContainerContext.INVOKE)
         self.assertEqual(result, container)
 
     @patch("samcli.local.lambdafn.runtime.LambdaFunctionObserver")
@@ -950,7 +953,7 @@ class TestWarmLambdaRuntime_create(TestCase):
             extra_hosts=None,
             function_full_path=self.full_path,
         )
-        self.manager_mock.create.assert_called_with(container)
+        self.manager_mock.create.assert_called_with(container, ContainerContext.INVOKE)
         # validate that the created container got cached
         self.assertEqual(self.runtime._containers[self.full_path], container)
 


### PR DESCRIPTION
SAM CLI shouldn't be mounting symlinks by default when building in a container

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Symbolic links are used in SAM CLI to achieve faster build times with `build-in-source`. The build process creates symlinks for dependencies, that then can be used when running `sam local invoke`. These symlinks don't need to be mounted during `sam build`.

#### How does it address the issue?
We add a new context property for the container to make a different decision depending on the context.

#### What side effects does this change have?
If SAM CLI users were relying on this behavior during builds, their workflow might get broken. Please create an issue if you're affected by this change, and we'll prioritize to add a new property to allow mounting symlinks in any case.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
