### PR TITLE
test: Fix Terraform tests

### DIFF
--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/expected.template.yaml
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/expected.template.yaml
@@ -135,7 +135,6 @@ Resources:
       LayerName: my_layer
       CompatibleRuntimes:
       - python3.9
-      - python3.9
       Content: aws-sam-cli/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/my_layer_code
     Metadata:
       SamResourceId: aws_lambda_layer_version.from_local


### PR DESCRIPTION
Remove double "python3.9"

#### Which issue(s) does this change fix?
Integration tests with Terraform were failing with an error when removing python3.8

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
