### PR TITLE
test: Update Python version to 3.11 for Terraform Build Docker Image

### DIFF
--- a/tests/integration/testdata/buildcmd/terraform/build_image_docker/Dockerfile
+++ b/tests/integration/testdata/buildcmd/terraform/build_image_docker/Dockerfile
@@ -15,11 +15,11 @@ RUN yum install -y yum-utils \
     && terraform --version
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.9
-RUN yum clean metadata && yum -y install python3.9
-RUN curl -L get-pip.io | python3.9
+RUN amazon-linux-extras enable python3.11
+RUN yum clean metadata && yum -y install python3.11
+RUN curl -L get-pip.io | python3.11
 RUN pip3 install aws-lambda-builders
-RUN ln -s /usr/bin/python3.9 /usr/bin/python3
+RUN ln -s /usr/bin/python3.11 /usr/bin/python3
 RUN python3 --version
 
 VOLUME /project


### PR DESCRIPTION
#### Which issue(s) does this change fix?
This would fix the  AllTerraformBuildTesting integration test failure in the main canary.

#### Why is this change necessary?
 This [#7854](https://github.com/aws/aws-sam-cli/pull/7854) update AppVeyor to Python 11 and [t #7862](https://github.com/aws/aws-sam-cli/pull/7862/files) only update to Python 3.9. 

```log
INFO     tests.integration.buildcmd.test_build_terraform_applications:test_build_terraform_applications.py:57 {'stream': '\x1b[91mTopic python3.9 is not found.\n\x1b[0m'}
INFO     tests.integration.buildcmd.test_build_terraform_applications:test_build_terraform_applications.py:57 {'errorDetail': {'code': 4, 'message': "The command '/bin/sh -c amazon-linux-extras enable python3.9' returned a non-zero code: 4"}, 'error': "The command '/bin/sh -c amazon-linux-extras enable python3.9' returned a non-zero code: 4"}
------------------------------ Captured log call ------------------------------
INFO     tests.testing_utils:testing_utils.py:68 Running command: samdev build function9 --use-container --build-image sam-terraform-python-build:v1 --hook-name terraform
INFO     tests.testing_utils:testing_utils.py:72 Stdout: 
Build Failed

....

Starting Build inside a container
Building layer 'module.layer9.aws_lambda_layer_version.this[0]'
For container layer build, first compatible runtime is chosen as build target for container.
Error: Could not find sam-terraform-python-build:v1 image locally and failed to pull it from docker.
------------------------------ Captured log call ------------------------------
INFO     tests.testing_utils:testing_utils.py:68 Running command: samdev build function9 --use-container --build-image sam-terraform-python-build:v1 --hook-name terraform
INFO     tests.testing_utils:testing_utils.py:72 Stdout: 
Build Failed
```

#### How does it address the issue?
This match the Python version needed by docker for Terraform test to use the Python 11 available on AppVeyor. 

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
