### PR TITLE
test: Set Python3.9 for AppVeyor tests

### DIFF
--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -16,8 +16,8 @@ configuration:
   - OtherAndEndToEndTesting
 
 environment:
-  PYTHON_HOME: "$HOME/venv3.11/bin"
-  PYTHON_VERSION: '3.11'
+  PYTHON_HOME: "$HOME/venv3.9/bin"
+  PYTHON_VERSION: '3.9'
   AWS_DEFAULT_REGION: us-east-1
   SAM_CLI_DEV: 1
   NODE_VERSION: "18.18.2"

--- a/appveyor-windows-al2023.yml
+++ b/appveyor-windows-al2023.yml
@@ -13,10 +13,10 @@ environment:
   TMPDIR: "%TEMP%"
   TMP: "%TEMP%"
 
-  # MSI Installers use Py3.11. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python311-x64"
-  PYTHON_SCRIPTS: "C:\\Python311-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python311-x64\\python.exe"
+  # MSI Installers use Py3.9. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python39-x64"
+  PYTHON_SCRIPTS: "C:\\Python39-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python39-x64\\python.exe"
   PYTHON_ARCH: "64"
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: "C:"

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -26,10 +26,10 @@ environment:
   TMPDIR: "%TEMP%"
   TMP: "%TEMP%"
 
-  # MSI Installers uses Py3.11. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python311-x64"
-  PYTHON_SCRIPTS: "C:\\Python311-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python311-x64\\python.exe"
+  # MSI Installers uses Py3.9. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python39-x64"
+  PYTHON_SCRIPTS: "C:\\Python39-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python39-x64\\python.exe"
   PYTHON_ARCH: "64"
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: "C:"


### PR DESCRIPTION
Previous jump from Python3.8 to 3.11 might have caused some issues, so we're returning only to Python3.9

Previous change in #7857

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
