### PR TITLE
test: remove double runtime in compatible layers

### DIFF
--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_container_windows/expected.template.yaml
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_container_windows/expected.template.yaml
@@ -135,7 +135,6 @@ Resources:
       LayerName: my_layer
       CompatibleRuntimes:
       - python3.9
-      - python3.9
       Content: aws-sam-cli/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_container_windows/my_layer_code
     Metadata:
       SamResourceId: aws_lambda_layer_version.from_local

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_windows/expected.template.yaml
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_windows/expected.template.yaml
@@ -135,7 +135,6 @@ Resources:
       LayerName: my_layer
       CompatibleRuntimes:
       - python3.9
-      - python3.9
       Content: aws-sam-cli/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_container_windows/my_layer_code
     Metadata:
       SamResourceId: aws_lambda_layer_version.from_local

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/expected.template.yaml
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/expected.template.yaml
@@ -135,7 +135,6 @@ Resources:
       LayerName: my_layer
       CompatibleRuntimes:
       - python3.9
-      - python3.9
       Content: aws-sam-cli/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/my_layer_code
     Metadata:
       SamResourceId: aws_lambda_layer_version.from_local

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend_container_windows/expected.template.yaml
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend_container_windows/expected.template.yaml
@@ -135,7 +135,6 @@ Resources:
       LayerName: my_layer
       CompatibleRuntimes:
       - python3.9
-      - python3.9
       Content: aws-sam-cli/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_container_windows/my_layer_code
     Metadata:
       SamResourceId: aws_lambda_layer_version.from_local

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend_windows/expected.template.yaml
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend_windows/expected.template.yaml
@@ -135,7 +135,6 @@ Resources:
       LayerName: my_layer
       CompatibleRuntimes:
       - python3.9
-      - python3.9
       Content: aws-sam-cli/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_container_windows/my_layer_code
     Metadata:
       SamResourceId: aws_lambda_layer_version.from_local

--- a/tests/integration/testdata/sync/infra/cdk/cdk_v1_synthesized_template_level3_nested_zip_functions.json
+++ b/tests/integration/testdata/sync/infra/cdk/cdk_v1_synthesized_template_level3_nested_zip_functions.json
@@ -43,7 +43,6 @@
         },
         "CompatibleRuntimes": [
           "python3.9",
-          "python3.9",
           "python3.11",
           "python3.12"
         ]

--- a/tests/integration/testdata/sync/infra/cdk/cdk_v1_synthesized_template_level3_nested_zip_functions_after.json
+++ b/tests/integration/testdata/sync/infra/cdk/cdk_v1_synthesized_template_level3_nested_zip_functions_after.json
@@ -43,7 +43,6 @@
         },
         "CompatibleRuntimes": [
           "python3.9",
-          "python3.9",
           "python3.11",
           "python3.12"
         ]

--- a/tests/integration/testdata/sync/infra/cdk/cdk_v1_synthesized_template_zip_functions.json
+++ b/tests/integration/testdata/sync/infra/cdk/cdk_v1_synthesized_template_zip_functions.json
@@ -43,7 +43,6 @@
         },
         "CompatibleRuntimes": [
           "python3.9",
-          "python3.9",
           "python3.11",
           "python3.12"
         ]

--- a/tests/integration/testdata/sync/infra/cdk/cdk_v1_synthesized_template_zip_functions_after.json
+++ b/tests/integration/testdata/sync/infra/cdk/cdk_v1_synthesized_template_zip_functions_after.json
@@ -43,7 +43,6 @@
         },
         "CompatibleRuntimes": [
           "python3.9",
-          "python3.9",
           "python3.11",
           "python3.12"
         ]


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Misses during the removal of python3.8. This makes some tests fail.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
