### PR TITLE
test: Fix Terraform Docker container

### DIFF
--- a/tests/integration/testdata/buildcmd/terraform/build_image_docker/Dockerfile
+++ b/tests/integration/testdata/buildcmd/terraform/build_image_docker/Dockerfile
@@ -1,9 +1,7 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 RUN yum -y update \
-    && yum install -y unzip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
-    less libcurl-devel openssl openssl-devel readline-devel xz-devel \
-    zlib-devel glibc-static libcxx libcxx-devel llvm-toolset-7 zlib-static \
+    && yum install -y unzip tar gzip ed less \
     && rm -rf /var/cache/yum
 
 RUN yum -y install make \
@@ -15,11 +13,9 @@ RUN yum install -y yum-utils \
     && terraform --version
 
 # AWS Lambda Builders
-RUN amazon-linux-extras enable python3.9
-RUN yum clean metadata && yum -y install python3.9
+# AL2023 uses Python3.9 by default. This might fail in the future if that changes. We just need the proper version
 RUN curl -L get-pip.io | python3.9
 RUN pip3 install aws-lambda-builders
-RUN ln -s /usr/bin/python3.9 /usr/bin/python3
 RUN python3 --version
 
 VOLUME /project


### PR DESCRIPTION
Terraform Docker container was trying to use python3.9 on AL2, which doesn't exist. Migrate to AL2023, which already has python3.9 installed (so we don't even need to install it)

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
