### PR TITLE
test: Increase start-api tests timeouts

### DIFF
--- a/tests/integration/local/start_api/lambda_authorizers/test_cfn_authorizer_definitions.py
+++ b/tests/integration/local/start_api/lambda_authorizers/test_cfn_authorizer_definitions.py
@@ -184,7 +184,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Authorizer 'RequestAuthorizer' with type 'notvalid' is currently not supported. "
@@ -219,7 +219,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Error: Lambda Authorizer 'RequestAuthorizerV2Simple' contains an "
@@ -254,7 +254,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Error: 'EnableSimpleResponses' is only supported for '2.0' "
@@ -289,7 +289,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Authorizer 'RequestAuthorizerV2Simple' with type 'unsupportedtype' is currently "
@@ -323,7 +323,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Error: Lambda Authorizer RequestAuthorizerV2Simple does not contain valid identity sources.",

--- a/tests/integration/local/start_api/lambda_authorizers/test_sfn_props_lambda_authorizers.py
+++ b/tests/integration/local/start_api/lambda_authorizers/test_sfn_props_lambda_authorizers.py
@@ -159,7 +159,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "EnableSimpleResponses must be used with the 2.0 payload "
@@ -210,7 +210,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Error: Lambda Authorizer 'RequestAuthorizerV2' must contain "
@@ -261,7 +261,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Unable to parse the Lambda ARN for Authorizer 'RequestAuthorizerV2', skipping",

--- a/tests/integration/local/start_api/lambda_authorizers/test_swagger_authorizer_definitions.py
+++ b/tests/integration/local/start_api/lambda_authorizers/test_swagger_authorizer_definitions.py
@@ -182,7 +182,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Lambda authorizer 'Authorizer' type 'bad type' is unsupported, skipping",
@@ -223,7 +223,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Simple responses are only available on HTTP APIs with "
@@ -264,7 +264,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Error: Authorizer 'Authorizer' contains an invalid payload version",
@@ -304,7 +304,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Error: Identity source 'a.b.c.d.e' for Lambda Authorizer "
@@ -345,7 +345,7 @@ Resources:
 """
 
     @pytest.mark.flaky(reruns=3)
-    @pytest.mark.timeout(timeout=10, method="thread")
+    @pytest.mark.timeout(timeout=100, method="thread")
     def test_invalid_template(self):
         self.assertIn(
             "Type 'token' for Lambda Authorizer 'Authorizer' is unsupported",


### PR DESCRIPTION
The start-api tests take longer on Windows, so we increase the timeout so they don't fail.

#### Which issue(s) does this change fix?
Failure on integration tests. 


#### Why is this change necessary?
Tests were failing just because of a timeout and not because of real problems in the tests. This were all "invalid template" tests, that had a very small timeout, but it depends on the machine where these tests are run.

#### How does it address the issue?
Increasing the timeout

#### What side effects does this change have?
If the test were to get stuck forever, it will take longer for the overall test infrastructure to stop this particular test.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
