### PR TITLE
test: fix error message in 'validate'

### DIFF
--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -157,8 +157,8 @@ class TestValidate(TestCase):
             self.assertEqual(command_result.process.returncode, 1)
             self.assertRegex(
                 output,
-                f"\\[\\[W2531: Check if EOL Lambda Function Runtimes are used] "
-                f"\\(Runtime \\'{runtime}'\\ was deprecated on.*",
+                f"\\[\\[E2531: Validate if lambda runtime is deprecated\\] "
+                f"\\(Runtime '{runtime}' was deprecated on.*",
             )
 
     def test_lint_supported_runtimes(self):


### PR DESCRIPTION
`cfn-lint` changed their message when a Lambda runtime is deprecated [1]

From `Check if EOL Lambda Function Runtimes are used`
To `Validate if lambda runtime is deprecated`

And also using nodejs16.x changed from a warning (W2531) to an error (E2531)

Also, removed some extra escape characters that were not required.

[1]: https://github.com/aws-cloudformation/cfn-lint/commit/31783cadb0b1faaa7d8ec4dc1389dfe5fc2f4fd7#diff-3e96ba21727bba3d7bfb0c5c235a0cbc45eca97819429104d7ff9fbec8aa05b2

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
