### PR TITLE
Experimental flag to boost 'package' command performance

### DIFF
--- a/samcli/commands/_utils/experimental.py
+++ b/samcli/commands/_utils/experimental.py
@@ -46,6 +46,9 @@ class ExperimentalFlag:
     BuildPerformance = ExperimentalEntry(
         "experimentalBuildPerformance", EXPERIMENTAL_ENV_VAR_PREFIX + "BUILD_PERFORMANCE"
     )
+    PackagePerformance = ExperimentalEntry(
+        "experimentalPackagePerformance", EXPERIMENTAL_ENV_VAR_PREFIX + "PACKAGE_PERFORMANCE"
+    )
     IaCsSupport = {
         "terraform": ExperimentalEntry(
             "experimentalTerraformSupport", EXPERIMENTAL_ENV_VAR_PREFIX + "TERRAFORM_SUPPORT"

--- a/samcli/lib/package/packageable_resources.py
+++ b/samcli/lib/package/packageable_resources.py
@@ -67,9 +67,10 @@ class Resource:
     EXPORT_DESTINATION: Destination
     ARTIFACT_TYPE: Optional[str] = None
 
-    def __init__(self, uploaders: Uploaders, code_signer):
+    def __init__(self, uploaders: Uploaders, code_signer, cache: Optional[Dict] = None):
         self.uploaders = uploaders
         self.code_signer = code_signer
+        self.cache = cache
 
     @property
     def uploader(self) -> Union[S3Uploader, ECRUploader]:
@@ -167,6 +168,7 @@ class ResourceZip(Resource):
             uploader,
             artifact_extension,
             local_path,
+            self.cache,
         )
         if should_sign_package:
             uploaded_url = self.code_signer.sign_package(

--- a/tests/unit/commands/_utils/test_experimental.py
+++ b/tests/unit/commands/_utils/test_experimental.py
@@ -57,16 +57,16 @@ class TestExperimental(TestCase):
         self.gc_mock.return_value.set_value.assert_called_once_with(config_entry, False, is_flag=True, flush=False)
 
     def test_get_all_experimental(self):
-        self.assertEqual(len(get_all_experimental()), 4)
+        self.assertEqual(len(get_all_experimental()), 5)
 
     def test_get_all_experimental_statues(self):
-        self.assertEqual(len(get_all_experimental_statues()), 4)
+        self.assertEqual(len(get_all_experimental_statues()), 5)
 
     def test_get_all_experimental_env_vars(self):
-        self.assertEqual(len(get_all_experimental_env_vars()), 4)
+        self.assertEqual(len(get_all_experimental_env_vars()), 5)
 
     def test_get_enabled_experimental_flags(self):
-        self.assertEqual(len(get_enabled_experimental_flags()), 4)
+        self.assertEqual(len(get_enabled_experimental_flags()), 5)
 
     @patch("samcli.commands._utils.experimental.set_experimental")
     @patch("samcli.commands._utils.experimental.get_all_experimental")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#4053


#### Why is this change necessary?
`sam package` (and `deploy`) can take an extremely long time.

This happens because the command zips every lambda resource in a template, even if all the lambdas point to the same local path. For instance, with NodeJS lambdas, there are many files involved due to the nature of npm/node, and that puts a serious dent on the disk (especially so in CI environments where SSD is not guarenteed).

#### How does it address the issue?

Normally, `sam build` will create a separate directory for each lambda resource in the template. However, there is an experimental flag -- `SAM_CLI_BETA_BUILD_PERFORMANCE` -- which creates only one shared directory for all the lambdas. This boosts `sam build` performance tremendously, and it works because in most cases, all lambdas in a project share the same code (just a different handler endpoint).

This PR adds a new flag -- `SAM_CLI_BETA_PACKAGE_PERFORMANCE` -- that is aimed to work in conjunction with the build performance flag.

All that it does is add a cache that is currently only used by `ResourceZip` + `S3Uploader`. The uploader checks if the local path was previously uploaded, and if so, it simply returns the cached upload url.

#### What side effects does this change have?

Should have no effect as the changes are only enabled when using the new flag.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
