### PR TITLE
Feat allow dict values in generate event cmd

### DIFF
--- a/samcli/lib/generated_sample_events/event-mapping.json
+++ b/samcli/lib/generated_sample_events/event-mapping.json
@@ -241,6 +241,10 @@
           "type": "string",
           "default": "path/to/resource"
         },
+        "querystringparameters": {
+          "type": "dict",
+          "default": "{\"foo\": \"bar\"}"
+        },
         "account-id": {
           "default": "123456789012"
         },

--- a/samcli/lib/generated_sample_events/events.py
+++ b/samcli/lib/generated_sample_events/events.py
@@ -95,6 +95,9 @@ class Events:
         if hashing is not None:
             transformed = self.hash(hashing, transformed)
 
+        if properties.get("type") == "dict":
+            transformed = json.loads(transformed)
+
         return transformed
 
     @staticmethod
@@ -180,4 +183,19 @@ class Events:
         data = json.dumps(data, indent=2)
 
         # return the substituted file (A string containing the rendered template.)
-        return renderer.render(data, values_to_sub)
+        rendered = renderer.render(data, values_to_sub)
+
+        # Parse the rendered result
+        rendered_json = json.loads(rendered)
+
+        key_map = {k.lower(): k for k in rendered_json.keys()}
+
+        # Update dictionary values in rendered result
+        for key, value in values_to_sub.items():
+            if isinstance(value, dict):
+                original_key = key_map.get(key.lower())
+                if original_key and isinstance(rendered_json[original_key], str):
+                    rendered_json[original_key] = value
+
+        # Return the final JSON with proper dictionary values
+        return json.dumps(rendered_json, indent=2)

--- a/samcli/lib/generated_sample_events/events/apigateway/AwsProxy.json
+++ b/samcli/lib/generated_sample_events/events/apigateway/AwsProxy.json
@@ -4,9 +4,7 @@
   "path": "/{{{path}}}",
   "httpMethod": "{{{method}}}",
   "isBase64Encoded": true,
-  "queryStringParameters": {
-    "foo": "bar"
-  },
+  "queryStringParameters": "{{{querystringparameters}}}",
   "multiValueQueryStringParameters": {
     "foo": [
       "bar"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?

I want to add the ability to override not only string values but also dictionary values in sam local generate-event. Currently, after running the CLI command, you have to manually adjust the file values.

An example is queryStringParameters in API Gateway. This is not supported via the CLI command. When making basic modifications to event-mapping.json and apigateway/AwsProxy.json to support the parameter, a string is returned, whereas queryStringParameters expects a dictionary.

That's why I'm making changes to `generate_event` to check if a value is of type dict. If so, the string value will be replaced with a dictionary.

I'm creating a draft PR to gather feedback and input on this feature and to see if it's considered a viable option (so I just added this for queryStringParams for API GW aws- proxy.

Test:

```sh
samdev local generate-event apigateway aws-proxy --method GET --path document --body "" --querystringparameters '{"documentId": "1044", "versionId": "v_1"}' --account-id '12345'
```

Output:

```json
{
  "body": "",
  "resource": "/{proxy+}",
  "path": "/document",
  "httpMethod": "GET",
  "isBase64Encoded": true,
  "queryStringParameters": {
    "documentId": "1044",
    "versionId": "v_1"
  },
  "multiValueQueryStringParameters": {
    "foo": [
      "bar"
    ]
  },
  "pathParameters": {
    "proxy": "/document"
  },
  "stageVariables": {
    "baz": "qux"
  },
....
}
```


#### How does it address the issue?


#### What side effects does this change have?

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
