### PR TITLE
test: fix validate error message

### DIFF
--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -157,8 +157,8 @@ class TestValidate(TestCase):
             self.assertEqual(command_result.process.returncode, 1)
             self.assertRegex(
                 output,
-                f"\\[\\[E2531: Validate if lambda runtime is deprecated\\] "
-                f"\\(Runtime '{runtime}' was deprecated on.*",
+                f"\\[\\[W2531: Check if EOL Lambda Function Runtimes are used] "
+                f"\\(Runtime \\'{runtime}'\\ was deprecated on.*",
             )
 
     def test_lint_supported_runtimes(self):
@@ -243,9 +243,9 @@ class TestValidate(TestCase):
 
         warning_message = (
             "[[E0000: Parsing error found when parsing the template] "
-            '(Duplicate found "HelloWorldFunction" (line 5)) matched 5, '
+            "(Duplicate found 'HelloWorldFunction' (line 5)) matched 5, "
             "[E0000: Parsing error found when parsing the template] "
-            '(Duplicate found "HelloWorldFunction" (line 12)) matched 12]\n'
+            "(Duplicate found 'HelloWorldFunction' (line 12)) matched 12]\n"
         )
 
         self.assertIn(warning_message, output)

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -158,7 +158,7 @@ class TestValidate(TestCase):
             self.assertRegex(
                 output,
                 f"\\[\\[W2531: Check if EOL Lambda Function Runtimes are used] "
-                f"\\(Runtime \\'{runtime}'\\ was deprecated on.*",
+                f"\\(Runtime '{runtime}' was deprecated on.*",
             )
 
     def test_lint_supported_runtimes(self):


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

`cfn-lint` changed their message (again) when a Lambda runtime is deprecated.

From `Validate if lambda runtime is deprecated`
Back to `Check if EOL Lambda Function Runtimes are used`

This PR reverts https://github.com/aws/aws-sam-cli/pull/7920


#### Why is this change necessary?
This 

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
