### PR TITLE
Address ruff PLW1508

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -39,7 +39,7 @@ from samcli.local.docker.utils import NoFreePortsError, find_free_port, to_posix
 
 LOG = logging.getLogger(__name__)
 
-CONTAINER_CONNECTION_TIMEOUT = float(os.environ.get("SAM_CLI_CONTAINER_CONNECTION_TIMEOUT", 20))
+CONTAINER_CONNECTION_TIMEOUT = float(os.environ.get("SAM_CLI_CONTAINER_CONNECTION_TIMEOUT", "20"))
 DEFAULT_CONTAINER_HOST_INTERFACE = "127.0.0.1"
 
 # Keep a lock instance to access the locks for individual containers (see dict below)

--- a/samcli/local/lambdafn/remote_files.py
+++ b/samcli/local/lambdafn/remote_files.py
@@ -30,7 +30,7 @@ def unzip_from_uri(uri, layer_zip_path, unzip_output_dir, progressbar_label):
         Label to use in the Progressbar
     """
     try:
-        get_request = requests.get(uri, stream=True, verify=os.environ.get("AWS_CA_BUNDLE", True))
+        get_request = requests.get(uri, stream=True, verify=os.environ.get("AWS_CA_BUNDLE", "True"))
 
         with open(layer_zip_path, "wb") as local_layer_file:
             file_length = int(get_request.headers["Content-length"])

--- a/tests/unit/local/lambdafn/test_remote_files.py
+++ b/tests/unit/local/lambdafn/test_remote_files.py
@@ -36,7 +36,7 @@ class TestUnzipFromUri(TestCase):
         path_patch.assert_called_with("layer_zip_path")
         path_mock.unlink.assert_called()
         unzip_patch.assert_called_with("layer_zip_path", "output_zip_dir", permission=0o700)
-        os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", True)
+        os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", "True")
 
     @patch("samcli.local.lambdafn.remote_files.unzip")
     @patch("samcli.local.lambdafn.remote_files.Path")
@@ -69,7 +69,7 @@ class TestUnzipFromUri(TestCase):
         path_patch.assert_called_with("layer_zip_path")
         path_mock.unlink.assert_not_called()
         unzip_patch.assert_called_with("layer_zip_path", "output_zip_dir", permission=0o700)
-        os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", True)
+        os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", "True")
 
     @patch("samcli.local.lambdafn.remote_files.unzip")
     @patch("samcli.local.lambdafn.remote_files.Path")
@@ -102,4 +102,4 @@ class TestUnzipFromUri(TestCase):
         path_patch.assert_called_with("layer_zip_path")
         path_mock.unlink.assert_called()
         unzip_patch.assert_called_with("layer_zip_path", "output_zip_dir", permission=0o700)
-        os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", True)
+        os_patch.environ.get.assert_called_with("AWS_CA_BUNDLE", "True")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Address [PLW1508](https://docs.astral.sh/ruff/rules/invalid-envvar-default/). This is needed to merge https://github.com/aws/aws-sam-cli/pull/7947. Currently, some checks are failing on the PR.

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
