### PR TITLE
fix: make pr failure for python 3.12+

### DIFF
--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -1,4 +1,3 @@
-# This avoids the type incompatibility issue
 import shutil
 import os
 from unittest import skipIf

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -1,10 +1,10 @@
-from distutils.dir_util import copy_tree
+# Use shutil.copytree directly instead of distutils.dir_util.copy_tree
+# This avoids the type incompatibility issue
+import shutil
+import os
 from unittest import skipIf
-
 import json
 from pathlib import Path
-
-import os
 from parameterized import parameterized_class
 
 from tests.end_to_end.end_to_end_base import EndToEndBase
@@ -181,7 +181,7 @@ class TestEsbuildDatadogLayerIntegration(EndToEndBase):
         with EndToEndTestContext(self.app_name) as e2e_context:
             project_path = str(self.e2e_test_data_path / "esbuild-datadog-integration")
             os.mkdir(e2e_context.project_directory)
-            copy_tree(project_path, e2e_context.project_directory)
+            shutil.copytree(project_path, e2e_context.project_directory, dirs_exist_ok=True)
             self.template_path = e2e_context.template_path
             build_command_list = self.get_command_list()
             deploy_command_list = self._get_deploy_command(stack_name)

--- a/tests/end_to_end/test_runtimes_e2e.py
+++ b/tests/end_to_end/test_runtimes_e2e.py
@@ -1,4 +1,3 @@
-# Use shutil.copytree directly instead of distutils.dir_util.copy_tree
 # This avoids the type incompatibility issue
 import shutil
 import os


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Make failure with following error when using python 3.12+
```
tests/end_to_end/test_runtimes_e2e.py:1: error: Cannot find implementation or library stub for module named "distutils.dir_util"  [import-not-found]
tests/end_to_end/test_runtimes_e2e.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

#### Why is this change necessary?
Make pr failure.

The distutils module was deprecated in Python 3.10 and removed in Python 3.12. Therefore, distutils.dir_util is no longer available in Python 3.12 or later versions.
The recommended replacement for distutils.dir_util is the shutil module, which provides similar functionality and is still actively maintained in Python.

#### How does it address the issue?
 The error was in the `tests/end_to_end/test_runtimes_e2e.py` file. The `mypy` type checker was failing because it couldn't find the implementation or library stub for the `distutils.dir_util` module.

Changes made:
   • Removed the import of `copy_tree` from `distutils.dir_util`
   • Added an import for `shutil` instead
   • Modified the function call to use `shutil.copytree` with the `dirs_exist_ok=True` parameter to ensure it works correctly

#### What side effects does this change have?
No. Update the test file. 

Verified success with python 3.11.11 and 3.13.0

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
