### PR TITLE
fix: close event loops for async tasks

### DIFF
--- a/samcli/lib/utils/async_utils.py
+++ b/samcli/lib/utils/async_utils.py
@@ -131,7 +131,11 @@ class AsyncContext:
         List of result of the executions in order
         """
         event_loop = new_event_loop()
-        if not default_executor:
-            with ThreadPoolExecutor() as self.executor:
-                return run_given_tasks_async(self._async_tasks, event_loop, self.executor)
-        return run_given_tasks_async(self._async_tasks, event_loop)
+        try:
+            if not default_executor:
+                with ThreadPoolExecutor() as self.executor:
+                    return run_given_tasks_async(self._async_tasks, event_loop, self.executor)
+            return run_given_tasks_async(self._async_tasks, event_loop)
+        finally:
+            # Close the event loop to prevent memory leaks
+            event_loop.close()


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Not sure if there was an issue for this.


#### Why is this change necessary?
Something I noticed while running the tests.

<img width="1026" alt="Screenshot 2025-05-09 at 3 02 24 PM" src="https://github.com/user-attachments/assets/ee2a85e6-5d0a-4069-9d45-35b6137423e1" />


#### How does it address the issue?
<img width="1019" alt="Screenshot 2025-05-09 at 3 04 59 PM" src="https://github.com/user-attachments/assets/5d04c247-5464-46eb-9f17-2c91121eaaa8" />

The event loops closed and I don't see the warning anymore on running the unit tests.



#### What side effects does this change have?
There should'nt be any.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
