### PR TITLE
fix: inconsistent examples of shell commands by adding space after $ symbol

### DIFF
--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -125,7 +125,7 @@ class BaseCommand(click.MultiCommand):
                     ),
                     RowDefinition(
                         name="Get Started:",
-                        text=click.style(f"${ctx.command_path} init"),
+                        text=click.style(f"$ {ctx.command_path} init"),
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                 ],

--- a/samcli/commands/build/core/command.py
+++ b/samcli/commands/build/core/command.py
@@ -25,27 +25,27 @@ class BuildCommand(CoreCommand):
                         text="\n",
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path}"),
+                        name=style(f"$ {ctx.command_path}"),
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path} FUNCTION_LOGICAL_ID"),
+                        name=style(f"$ {ctx.command_path} FUNCTION_LOGICAL_ID"),
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path} --use-container"),
+                        name=style(f"$ {ctx.command_path} --use-container"),
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path} --use-container --container-env-var-file env.json"),
+                        name=style(f"$ {ctx.command_path} --use-container --container-env-var-file env.json"),
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path} && {ctx.parent.command_path} local invoke"),  # type: ignore
+                        name=style(f"$ {ctx.command_path} && {ctx.parent.command_path} local invoke"),  # type: ignore
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path} && {ctx.parent.command_path} deploy"),  # type: ignore
+                        name=style(f"$ {ctx.command_path} && {ctx.parent.command_path} deploy"),  # type: ignore
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                 ],

--- a/samcli/commands/delete/command.py
+++ b/samcli/commands/delete/command.py
@@ -18,11 +18,6 @@ SHORT_HELP = "Delete an AWS SAM application and the artifacts created by sam dep
 
 HELP_TEXT = """The sam delete command deletes the CloudFormation
 stack and all the artifacts which were created using sam deploy.
-
-\b
-e.g. sam delete
-
-\b
 """
 
 LOG = logging.getLogger(__name__)

--- a/samcli/commands/init/command.py
+++ b/samcli/commands/init/command.py
@@ -197,7 +197,7 @@ def non_interactive_validation(func):
 @click.option(
     "--app-template",
     help="Identifier of the managed application template to be used. "
-    "Alternatively, run '$sam init' without options for an interactive workflow.",
+    "Alternatively, run '$ sam init' without options for an interactive workflow.",
     cls=ClickMutex,
     incompatible_params=["location"],
     incompatible_params_hint=INCOMPATIBLE_PARAMS_HINT,

--- a/samcli/commands/local/generate_event/core/command.py
+++ b/samcli/commands/local/generate_event/core/command.py
@@ -26,7 +26,7 @@ class CoreGenerateEventCommand(CoreCommand, GenerateEventCommand):
                             text="\n",
                         ),
                         RowDefinition(
-                            name=style(f"${ctx.command_path} s3 [put/delete]"),
+                            name=style(f"$ {ctx.command_path} s3 [put/delete]"),
                             extra_row_modifiers=[ShowcaseRowModifier()],
                         ),
                     ]
@@ -38,11 +38,11 @@ class CoreGenerateEventCommand(CoreCommand, GenerateEventCommand):
                             text="\n",
                         ),
                         RowDefinition(
-                            name=style(f"${ctx.command_path} s3 [put/delete] --help"),
+                            name=style(f"$ {ctx.command_path} s3 [put/delete] --help"),
                             extra_row_modifiers=[ShowcaseRowModifier()],
                         ),
                         RowDefinition(
-                            name=style(f"${ctx.command_path} s3 [put/delete] --bucket <bucket> --key <key>"),
+                            name=style(f"$ {ctx.command_path} s3 [put/delete] --bucket <bucket> --key <key>"),
                             extra_row_modifiers=[ShowcaseRowModifier()],
                         ),
                     ]
@@ -57,7 +57,7 @@ class CoreGenerateEventCommand(CoreCommand, GenerateEventCommand):
                         ),
                         RowDefinition(
                             name=style(
-                                f"${ctx.command_path} s3 [put/delete] --bucket <bucket> --key <key> | "
+                                f"$ {ctx.command_path} s3 [put/delete] --bucket <bucket> --key <key> | "
                                 f"{getattr(ctx.parent, 'command_path')} invoke -e -"
                             ),
                             extra_row_modifiers=[ShowcaseRowModifier()],

--- a/samcli/commands/local/invoke/core/command.py
+++ b/samcli/commands/local/invoke/core/command.py
@@ -28,7 +28,7 @@ class InvokeCommand(CoreCommand):
                             text="\n",
                         ),
                         RowDefinition(
-                            name=style(f"${ctx.command_path}"),
+                            name=style(f"$ {ctx.command_path}"),
                             extra_row_modifiers=[ShowcaseRowModifier()],
                         ),
                     ]
@@ -40,7 +40,7 @@ class InvokeCommand(CoreCommand):
                             text="\n",
                         ),
                         RowDefinition(
-                            name=style(f"${ctx.command_path} HelloWorldFunction"),
+                            name=style(f"$ {ctx.command_path} HelloWorldFunction"),
                             extra_row_modifiers=[ShowcaseRowModifier()],
                         ),
                     ]
@@ -52,7 +52,7 @@ class InvokeCommand(CoreCommand):
                             text="\n",
                         ),
                         RowDefinition(
-                            name=style(f"${ctx.command_path} HelloWorldFunction -e event.json"),
+                            name=style(f"$ {ctx.command_path} HelloWorldFunction -e event.json"),
                             extra_row_modifiers=[ShowcaseRowModifier()],
                         ),
                     ]

--- a/samcli/commands/local/start_api/core/command.py
+++ b/samcli/commands/local/start_api/core/command.py
@@ -25,7 +25,7 @@ class InvokeAPICommand(CoreCommand):
                         text="\n",
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path}"),
+                        name=style(f"$ {ctx.command_path}"),
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                 ]

--- a/samcli/commands/local/start_lambda/core/command.py
+++ b/samcli/commands/local/start_lambda/core/command.py
@@ -40,7 +40,7 @@ class InvokeLambdaCommand(CoreCommand):
                             name="Start the local lambda endpoint.",
                         ),
                         RowDefinition(
-                            name=style(f"${ctx.command_path}"),
+                            name=style(f"$ {ctx.command_path}"),
                             extra_row_modifiers=[ShowcaseRowModifier()],
                         ),
                     ]

--- a/samcli/commands/remote/invoke/core/command.py
+++ b/samcli/commands/remote/invoke/core/command.py
@@ -28,7 +28,7 @@ class RemoteInvokeCommand(CoreCommand):
                     formatter.write_rd(
                         [
                             RowDefinition(
-                                name=style(f"${ctx.command_path} --stack-name hello-world"),
+                                name=style(f"$ {ctx.command_path} --stack-name hello-world"),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
                             ),
                         ]
@@ -40,7 +40,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} --stack-name hello-world -e"
+                                    f"$ {ctx.command_path} --stack-name hello-world -e"
                                     f" '{json.dumps({'message':'hello!'})}'"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -54,7 +54,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} --stack-name "
+                                    f"$ {ctx.command_path} --stack-name "
                                     f"hello-world HelloWorldFunction --event-file event.json"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -80,7 +80,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} arn:aws:lambda:us-west-2:123456789012:function:my-function"
+                                    f"$ {ctx.command_path} arn:aws:lambda:us-west-2:123456789012:function:my-function"
                                     f" -e <> --output json"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -94,7 +94,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} HelloWorldFunction -e <> "
+                                    f"$ {ctx.command_path} HelloWorldFunction -e <> "
                                     f"--parameter InvocationType=Event --parameter Qualifier=MyQualifier"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -109,7 +109,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} HelloWorldFunction -e <> --output json "
+                                    f"$ {ctx.command_path} HelloWorldFunction -e <> --output json "
                                     f"--parameter InvocationType=DryRun"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -125,7 +125,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} --stack-name mock-stack StockTradingStateMachine"
+                                    f"$ {ctx.command_path} --stack-name mock-stack StockTradingStateMachine"
                                     f" -e '{json.dumps({'message':'hello!'})}'"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -140,7 +140,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} arn:aws:states:us-east-1:123456789012:stateMachine:MySFN"
+                                    f"$ {ctx.command_path} arn:aws:states:us-east-1:123456789012:stateMachine:MySFN"
                                     f" -e <> --parameter name=mock-execution-name"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -155,7 +155,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} --stack-name mock-stack StockTradingStateMachine"
+                                    f"$ {ctx.command_path} --stack-name mock-stack StockTradingStateMachine"
                                     f" --event-file event.json --output json"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -171,7 +171,7 @@ class RemoteInvokeCommand(CoreCommand):
                             RowDefinition(
                                 name=style(
                                     f"$ echo '{json.dumps({'message':'hello!'})}' | "
-                                    f"${ctx.command_path} --stack-name mock-stack StockTradingStateMachine"
+                                    f"{ctx.command_path} --stack-name mock-stack StockTradingStateMachine"
                                     f" --parameter traceHeader=<>"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -186,7 +186,7 @@ class RemoteInvokeCommand(CoreCommand):
                     formatter.write_rd(
                         [
                             RowDefinition(
-                                name=style(f"${ctx.command_path} --stack-name mock-stack MySQSQueue -e hello-world"),
+                                name=style(f"$ {ctx.command_path} --stack-name mock-stack MySQSQueue -e hello-world"),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
                             ),
                         ]
@@ -199,7 +199,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} https://sqs.us-east-1.amazonaws.com/12345678910/QueueName"
+                                    f"$ {ctx.command_path} https://sqs.us-east-1.amazonaws.com/12345678910/QueueName"
                                     f" --event-file event.json"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -214,7 +214,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} arn:aws:sqs:region:account_id:queue_name -e hello-world"
+                                    f"$ {ctx.command_path} arn:aws:sqs:region:account_id:queue_name -e hello-world"
                                     f" --parameter DelaySeconds=10"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -229,7 +229,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} --stack-name mock-stack MySQSQueue -e hello-world"
+                                    f"$ {ctx.command_path} --stack-name mock-stack MySQSQueue -e hello-world"
                                     f" --output json --parameter MessageAttributes="
                                     f"'{json.dumps({'City': {'DataType': 'String', 'StringValue': 'City'}})}'"
                                 ),
@@ -246,7 +246,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} --stack-name mock-stack MySQSQueue -e hello-world"
+                                    f"$ {ctx.command_path} --stack-name mock-stack MySQSQueue -e hello-world"
                                     f" --parameter MessageGroupId=mock-message-group"
                                     f" --parameter MessageDeduplicationId=mock-dedup-id"
                                 ),
@@ -263,7 +263,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} --stack-name mock-stack MyKinesisStream -e"
+                                    f"$ {ctx.command_path} --stack-name mock-stack MyKinesisStream -e"
                                     f" '{json.dumps({'message':'hello!'})}'"
                                 ),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
@@ -277,7 +277,7 @@ class RemoteInvokeCommand(CoreCommand):
                     formatter.write_rd(
                         [
                             RowDefinition(
-                                name=style(f"${ctx.command_path} MyKinesisStreamName" f" --event-file event.json"),
+                                name=style(f"$ {ctx.command_path} MyKinesisStreamName" f" --event-file event.json"),
                                 extra_row_modifiers=[ShowcaseRowModifier()],
                             ),
                         ]
@@ -290,7 +290,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path}"
+                                    f"$ {ctx.command_path}"
                                     f" arn:aws:kinesis:us-east-2:123456789012:stream/mystream"
                                     f" --event-file event.json --parameter ExplicitHashKey=<>"
                                 ),
@@ -306,7 +306,7 @@ class RemoteInvokeCommand(CoreCommand):
                         [
                             RowDefinition(
                                 name=style(
-                                    f"${ctx.command_path} MyKinesisStreamName"
+                                    f"$ {ctx.command_path} MyKinesisStreamName"
                                     f" --event hello-world --parameter SequenceNumberForOrdering=<>"
                                     f" --parameter PartitionKey=<>"
                                 ),

--- a/samcli/commands/sync/command.py
+++ b/samcli/commands/sync/command.py
@@ -77,7 +77,7 @@ HELP_TEXT = """
 """
 
 DESCRIPTION = """
-  By default, `$sam sync` runs a full AWS Cloudformation stack update.
+  By default, `$ sam sync` runs a full AWS Cloudformation stack update.
 
   Running `sam sync --watch` with `--code` will provide a way to run just code
   synchronization, speeding up start time skipping template changes.
@@ -85,7 +85,7 @@ DESCRIPTION = """
   Remember to update the deployed stack by running
   without --code for infrastructure changes.
 
-  `$sam sync` also supports nested stacks and nested stack resources.
+  `$ sam sync` also supports nested stacks and nested stack resources.
 """
 
 

--- a/samcli/commands/sync/core/command.py
+++ b/samcli/commands/sync/core/command.py
@@ -25,16 +25,16 @@ class SyncCommand(CoreCommand):
                         text="\n",
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path} " f"--watch --stack-name {{stack}}"),
+                        name=style(f"$ {ctx.command_path} " f"--watch --stack-name {{stack}}"),
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                     RowDefinition(
-                        name=style(f"${ctx.command_path} " f"--code --watch --stack-name {{stack}}"),
+                        name=style(f"$ {ctx.command_path} " f"--code --watch --stack-name {{stack}}"),
                         extra_row_modifiers=[ShowcaseRowModifier()],
                     ),
                     RowDefinition(
                         name=style(
-                            f"${ctx.command_path} "
+                            f"$ {ctx.command_path} "
                             f"--code --stack-name {{stack}} --resource-id {{ChildStack}}/{{ResourceId}}"
                         ),
                         extra_row_modifiers=[ShowcaseRowModifier()],

--- a/samcli/commands/validate/core/command.py
+++ b/samcli/commands/validate/core/command.py
@@ -26,7 +26,7 @@ class ValidateCommand(CoreCommand):
                             text="\n",
                         ),
                         RowDefinition(
-                            name=style(f"${ctx.command_path} --lint"),
+                            name=style(f"$ {ctx.command_path} --lint"),
                             extra_row_modifiers=[ShowcaseRowModifier()],
                         ),
                     ]

--- a/tests/unit/commands/buildcmd/core/test_command.py
+++ b/tests/unit/commands/buildcmd/core/test_command.py
@@ -52,12 +52,12 @@ class TestBuildCommand(unittest.TestCase):
             "Description": [(cmd.description + cmd.description_addendum, "")],
             "Examples": [
                 ("", ""),
-                ("$sam build\x1b[0m", ""),
-                ("$sam build FUNCTION_LOGICAL_ID\x1b[0m", ""),
-                ("$sam build --use-container\x1b[0m", ""),
-                ("$sam build --use-container --container-env-var-file env.json\x1b[0m", ""),
-                ("$sam build && sam local invoke\x1b[0m", ""),
-                ("$sam build && sam deploy\x1b[0m", ""),
+                ("$ sam build\x1b[0m", ""),
+                ("$ sam build FUNCTION_LOGICAL_ID\x1b[0m", ""),
+                ("$ sam build --use-container\x1b[0m", ""),
+                ("$ sam build --use-container --container-env-var-file env.json\x1b[0m", ""),
+                ("$ sam build && sam local invoke\x1b[0m", ""),
+                ("$ sam build && sam deploy\x1b[0m", ""),
             ],
         }
 

--- a/tests/unit/commands/local/generate_event/core/test_command.py
+++ b/tests/unit/commands/local/generate_event/core/test_command.py
@@ -55,19 +55,19 @@ class TestLocalGenerateEventCommand(unittest.TestCase):
             ],
             "Customize event by adding parameter flags.": [
                 ("", ""),
-                ("$sam local generate-event s3 " "[put/delete] --help\x1b[0m", ""),
-                ("$sam local generate-event s3 " "[put/delete] --bucket " "<bucket> --key <key>\x1b[0m", ""),
+                ("$ sam local generate-event s3 " "[put/delete] --help\x1b[0m", ""),
+                ("$ sam local generate-event s3 " "[put/delete] --bucket " "<bucket> --key <key>\x1b[0m", ""),
             ],
             "Description": [(cmd.description + cmd.description_addendum, "")],
             "Examples": [],
             "Generate event S3 sends to local Lambda function": [
                 ("", ""),
-                ("$sam local " "generate-event s3 " "[put/delete]\x1b[0m", ""),
+                ("$ sam local " "generate-event s3 " "[put/delete]\x1b[0m", ""),
             ],
             "Test generated event with serverless function locally!": [
                 ("", ""),
                 (
-                    "$sam local "
+                    "$ sam local "
                     "generate-event "
                     "s3 [put/delete] "
                     "--bucket "

--- a/tests/unit/commands/local/invoke/core/test_command.py
+++ b/tests/unit/commands/local/invoke/core/test_command.py
@@ -46,18 +46,18 @@ class TestLocalInvokeCommand(unittest.TestCase):
             "Extension Options": [("", ""), ("--hook_name", ""), ("", "")],
             "Terraform Hook Options": [("", ""), ("--terraform-plan-file", ""), ("", "")],
             "Beta Options": [("", ""), ("--beta-features", ""), ("", "")],
-            "Invoke default lambda function with no event": [("", ""), ("$sam local invoke\x1b[0m", "")],
+            "Invoke default lambda function with no event": [("", ""), ("$ sam local invoke\x1b[0m", "")],
             "Invoke lambda function with stdin input": [
                 ("", ""),
                 ('$ echo {"message": "hello!"} | ' "sam local invoke " "HelloWorldFunction -e -\x1b[0m", ""),
             ],
             "Invoke named lambda function with an event file": [
                 ("", ""),
-                ("$sam local invoke " "HelloWorldFunction -e " "event.json\x1b[0m", ""),
+                ("$ sam local invoke " "HelloWorldFunction -e " "event.json\x1b[0m", ""),
             ],
             "Invoke named lambda function with no event": [
                 ("", ""),
-                ("$sam local invoke " "HelloWorldFunction\x1b[0m", ""),
+                ("$ sam local invoke " "HelloWorldFunction\x1b[0m", ""),
             ],
             "Other Options": [("", ""), ("--debug", ""), ("", "")],
             "Required Options": [("", ""), ("--template-file", ""), ("", "")],

--- a/tests/unit/commands/local/start_api/core/test_command.py
+++ b/tests/unit/commands/local/start_api/core/test_command.py
@@ -42,7 +42,7 @@ class TestLocalStartAPICommand(unittest.TestCase):
             "Configuration Options": [("", ""), ("--config-file", ""), ("", "")],
             "Container Options": [("", ""), ("--host", ""), ("", "")],
             "Description": [(cmd.description + cmd.description_addendum, "")],
-            "Examples": [("", ""), ("$sam local start-api\x1b[0m", "")],
+            "Examples": [("", ""), ("$ sam local start-api\x1b[0m", "")],
             "Extension Options": [("", ""), ("--hook_name", ""), ("", "")],
             "Terraform Hook Options": [("", ""), ("--terraform-plan-file", ""), ("", "")],
             "Other Options": [("", ""), ("--debug", ""), ("", "")],

--- a/tests/unit/commands/local/start_lambda/core/test_command.py
+++ b/tests/unit/commands/local/start_lambda/core/test_command.py
@@ -44,7 +44,7 @@ class TestLocalStartLambdaCommand(unittest.TestCase):
             "Description": [(cmd.description + cmd.description_addendum, "")],
             "Examples": [],
             "Terraform Hook Options": [("", ""), ("--terraform-plan-file", ""), ("", "")],
-            "Setup": [("", ""), ("Start the local lambda endpoint.", ""), ("$sam local start-lambda\x1b[0m", "")],
+            "Setup": [("", ""), ("Start the local lambda endpoint.", ""), ("$ sam local start-lambda\x1b[0m", "")],
             "Template Options": [("", ""), ("--parameter-overrides", ""), ("", "")],
             "Using AWS CLI": [
                 ("", ""),

--- a/tests/unit/commands/remote/invoke/core/test_command.py
+++ b/tests/unit/commands/remote/invoke/core/test_command.py
@@ -38,104 +38,104 @@ class TestRemoteInvokeCommand(unittest.TestCase):
             "Examples": [],
             "Lambda Functions": [],
             "Invoke default lambda function with empty event": [
-                ("$sam remote invoke --stack-name hello-world\x1b[0m", ""),
+                ("$ sam remote invoke --stack-name hello-world\x1b[0m", ""),
             ],
             "Invoke default lambda function with event passed as text input": [
-                ('$sam remote invoke --stack-name hello-world -e \'{"message": "hello!"}\'\x1b[0m', ""),
+                ('$ sam remote invoke --stack-name hello-world -e \'{"message": "hello!"}\'\x1b[0m', ""),
             ],
             "Invoke named lambda function with an event file": [
-                ("$sam remote invoke --stack-name hello-world HelloWorldFunction --event-file event.json\x1b[0m", ""),
+                ("$ sam remote invoke --stack-name hello-world HelloWorldFunction --event-file event.json\x1b[0m", ""),
             ],
             "Invoke function with event as stdin input": [
                 ('$ echo \'{"message": "hello!"}\' | sam remote invoke HelloWorldFunction --event-file -\x1b[0m', ""),
             ],
             "Invoke function using lambda ARN and get the full AWS API response": [
                 (
-                    "$sam remote invoke arn:aws:lambda:us-west-2:123456789012:function:my-function -e <> --output json\x1b[0m",
+                    "$ sam remote invoke arn:aws:lambda:us-west-2:123456789012:function:my-function -e <> --output json\x1b[0m",
                     "",
                 ),
             ],
             "Asynchronously invoke function with additional boto parameters": [
                 (
-                    "$sam remote invoke HelloWorldFunction -e <> --parameter InvocationType=Event --parameter Qualifier=MyQualifier\x1b[0m",
+                    "$ sam remote invoke HelloWorldFunction -e <> --parameter InvocationType=Event --parameter Qualifier=MyQualifier\x1b[0m",
                     "",
                 ),
             ],
             "Dry invoke a function to validate parameter values and user/role permissions": [
                 (
-                    "$sam remote invoke HelloWorldFunction -e <> --output json --parameter InvocationType=DryRun\x1b[0m",
+                    "$ sam remote invoke HelloWorldFunction -e <> --output json --parameter InvocationType=DryRun\x1b[0m",
                     "",
                 ),
             ],
             "Step Functions": [],
             "Start execution with event passed as text input": [
                 (
-                    '$sam remote invoke --stack-name mock-stack StockTradingStateMachine -e \'{"message": "hello!"}\'\x1b[0m',
+                    '$ sam remote invoke --stack-name mock-stack StockTradingStateMachine -e \'{"message": "hello!"}\'\x1b[0m',
                     "",
                 ),
             ],
             "Start execution using its physical-id or ARN with an execution name parameter": [
                 (
-                    "$sam remote invoke arn:aws:states:us-east-1:123456789012:stateMachine:MySFN -e <> --parameter name=mock-execution-name\x1b[0m",
+                    "$ sam remote invoke arn:aws:states:us-east-1:123456789012:stateMachine:MySFN -e <> --parameter name=mock-execution-name\x1b[0m",
                     "",
                 ),
             ],
             "Start execution with an event file and get the full AWS API response": [
                 (
-                    "$sam remote invoke --stack-name mock-stack StockTradingStateMachine --event-file event.json --output json\x1b[0m",
+                    "$ sam remote invoke --stack-name mock-stack StockTradingStateMachine --event-file event.json --output json\x1b[0m",
                     "",
                 ),
             ],
             "Start execution with event as stdin input and pass the X-ray trace header to the execution": [
                 (
-                    '$ echo \'{"message": "hello!"}\' | $sam remote invoke --stack-name mock-stack StockTradingStateMachine --parameter traceHeader=<>\x1b[0m',
+                    '$ echo \'{"message": "hello!"}\' | sam remote invoke --stack-name mock-stack StockTradingStateMachine --parameter traceHeader=<>\x1b[0m',
                     "",
                 ),
             ],
             "SQS Queue": [],
             "Send a message with the MessageBody passed as event": [
-                ("$sam remote invoke --stack-name mock-stack MySQSQueue -e hello-world\x1b[0m", ""),
+                ("$ sam remote invoke --stack-name mock-stack MySQSQueue -e hello-world\x1b[0m", ""),
             ],
             "Send a message using its physical-id and pass event using --event-file": [
                 (
-                    "$sam remote invoke https://sqs.us-east-1.amazonaws.com/12345678910/QueueName --event-file event.json\x1b[0m",
+                    "$ sam remote invoke https://sqs.us-east-1.amazonaws.com/12345678910/QueueName --event-file event.json\x1b[0m",
                     "",
                 ),
             ],
             "Send a message using its ARN and delay the specified message": [
                 (
-                    "$sam remote invoke arn:aws:sqs:region:account_id:queue_name -e hello-world --parameter DelaySeconds=10\x1b[0m",
+                    "$ sam remote invoke arn:aws:sqs:region:account_id:queue_name -e hello-world --parameter DelaySeconds=10\x1b[0m",
                     "",
                 ),
             ],
             "Send a message along with message attributes and get the full AWS API response": [
                 (
-                    '$sam remote invoke --stack-name mock-stack MySQSQueue -e hello-world --output json --parameter MessageAttributes=\'{"City": {"DataType": "String", "StringValue": "City"}}\'\x1b[0m',
+                    '$ sam remote invoke --stack-name mock-stack MySQSQueue -e hello-world --output json --parameter MessageAttributes=\'{"City": {"DataType": "String", "StringValue": "City"}}\'\x1b[0m',
                     "",
                 ),
             ],
             "Send a message to a FIFO SQS Queue": [
                 (
-                    "$sam remote invoke --stack-name mock-stack MySQSQueue -e hello-world --parameter MessageGroupId=mock-message-group --parameter MessageDeduplicationId=mock-dedup-id\x1b[0m",
+                    "$ sam remote invoke --stack-name mock-stack MySQSQueue -e hello-world --parameter MessageGroupId=mock-message-group --parameter MessageDeduplicationId=mock-dedup-id\x1b[0m",
                     "",
                 ),
             ],
             "Kinesis Data Stream": [],
             "Put a record using the data provided as event": [
-                ('$sam remote invoke --stack-name mock-stack MyKinesisStream -e \'{"message": "hello!"}\'\x1b[0m', ""),
+                ('$ sam remote invoke --stack-name mock-stack MyKinesisStream -e \'{"message": "hello!"}\'\x1b[0m', ""),
             ],
             "Put a record using its physical-id and pass event using --event-file": [
-                ("$sam remote invoke MyKinesisStreamName --event-file event.json\x1b[0m", ""),
+                ("$ sam remote invoke MyKinesisStreamName --event-file event.json\x1b[0m", ""),
             ],
             "Put a record using its ARN and override the key hash": [
                 (
-                    "$sam remote invoke arn:aws:kinesis:us-east-2:123456789012:stream/mystream --event-file event.json --parameter ExplicitHashKey=<>\x1b[0m",
+                    "$ sam remote invoke arn:aws:kinesis:us-east-2:123456789012:stream/mystream --event-file event.json --parameter ExplicitHashKey=<>\x1b[0m",
                     "",
                 ),
             ],
             "Put a record with a sequence number for ordering with a PartitionKey": [
                 (
-                    "$sam remote invoke MyKinesisStreamName --event hello-world --parameter SequenceNumberForOrdering=<> --parameter PartitionKey=<>\x1b[0m",
+                    "$ sam remote invoke MyKinesisStreamName --event hello-world --parameter SequenceNumberForOrdering=<> --parameter PartitionKey=<>\x1b[0m",
                     "",
                 ),
             ],

--- a/tests/unit/commands/sync/core/test_command.py
+++ b/tests/unit/commands/sync/core/test_command.py
@@ -41,9 +41,9 @@ class TestSyncCommand(unittest.TestCase):
             "Description": [(cmd.description + cmd.description_addendum, "")],
             "Examples": [
                 ("", ""),
-                ("$sam sync --watch --stack-name {stack}\x1b[0m", ""),
-                ("$sam sync --code --watch --stack-name {stack}\x1b[0m", ""),
-                ("$sam sync --code --stack-name {stack} --resource-id " "{ChildStack}/{ResourceId}\x1b[0m", ""),
+                ("$ sam sync --watch --stack-name {stack}\x1b[0m", ""),
+                ("$ sam sync --code --watch --stack-name {stack}\x1b[0m", ""),
+                ("$ sam sync --code --stack-name {stack} --resource-id " "{ChildStack}/{ResourceId}\x1b[0m", ""),
             ],
             "Infrastructure Options": [("", ""), ("--s3-bucket", ""), ("", "")],
             "Other Options": [("", ""), ("--debug", ""), ("", "")],

--- a/tests/unit/commands/validate/core/test_command.py
+++ b/tests/unit/commands/validate/core/test_command.py
@@ -41,7 +41,7 @@ class TestValidateCommand(unittest.TestCase):
             "Beta Options": [("", ""), ("--beta-features", ""), ("", "")],
             "Description": [(cmd.description + cmd.description_addendum, "")],
             "Examples": [],
-            "Validate and Lint": [("", ""), ("$sam validate --lint\x1b[0m", "")],
+            "Validate and Lint": [("", ""), ("$ sam validate --lint\x1b[0m", "")],
         }
 
         cmd.format_options(ctx, formatter)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#7780


#### Why is this change necessary?
Pretty simple change that improves UX.

#### How does it address the issue?
Makes commands copy pastable.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
