### PR TITLE
chore(workflow): fix pip, pip-tools version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,13 @@ pr: init dev schema black-check
 # to consider combining these files again
 update-reproducible-linux-reqs:
 	python3.11 -m venv venv-update-reproducible-linux
-	venv-update-reproducible-linux/bin/pip install --upgrade pip-tools pip
+	venv-update-reproducible-linux/bin/pip install pip==24.0 pip-tools==7.4.1
 	venv-update-reproducible-linux/bin/pip install -r requirements/base.txt
 	venv-update-reproducible-linux/bin/pip-compile --generate-hashes --allow-unsafe -o requirements/reproducible-linux.txt
 
 update-reproducible-mac-reqs:
 	python3.11 -m venv venv-update-reproducible-mac
-	venv-update-reproducible-mac/bin/pip install --upgrade pip-tools pip
+	venv-update-reproducible-mac/bin/pip install pip==24.0 pip-tools==7.4.1
 	venv-update-reproducible-mac/bin/pip install -r requirements/base.txt
 	venv-update-reproducible-mac/bin/pip-compile --generate-hashes --allow-unsafe -o requirements/reproducible-mac.txt
 
@@ -77,7 +77,7 @@ update-reproducible-mac-reqs:
 update-reproducible-win-reqs:
 	python -m venv venv-update-reproducible-win
 	.\venv-update-reproducible-win\Scripts\activate
-	python.exe -m pip install --upgrade pip-tools pip
+	python.exe -m pip install pip==24.0 pip-tools==7.4.1
 	pip install -r requirements\base.txt
 	pip-compile --generate-hashes --allow-unsafe -o requirements\reproducible-win.txt
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Reproducible workflow failing since pip auto upgraded to 25.1, forcing it to use 24.0 until pip tools supported pip 25.1

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
