### PR TITLE
chore(tests): Fix Switch-DockerLinux in Windows Appveyor

### DIFF
--- a/appveyor-windows-binary.yml
+++ b/appveyor-windows-binary.yml
@@ -74,7 +74,7 @@ install:
   - "python --version"
   - ps: "Restart-Service docker"
   # Switch to Docker Linux containers
-  - ps: Switch-DockerLinux
+  - ps: '& $Env:ProgramFiles\Docker\Docker\DockerCli.exe -SwitchLinuxEngine'
   - "docker info"
   - "docker version"
 

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -71,7 +71,7 @@ install:
   - "python --version"
   - ps: "Restart-Service docker"
   # Switch to Docker Linux containers
-  - ps: Switch-DockerLinux
+  - ps: '& $Env:ProgramFiles\Docker\Docker\DockerCli.exe -SwitchLinuxEngine'
   - "docker info"
   - "docker version"
 


### PR DESCRIPTION
#### Why is this change necessary?
While running the canaries, the switch in Docker environment is necessary from Windows container to Linux container before running the integration tests as the tests for SAM-CLI need to use Linux containers. That switch to linux was failing in Windows AppVeyor canary with the error, 
```
Switch-DockerLinux : The term 'Switch-DockerLinux' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct 
and try again.
```
It was failing for `windows-binary` and `windows` build, but things were working properly for `windows-al2023`. We realized that the `windows-al2023` was using different command, so this PR changes the command used to change the container in Docker. 

#### How does it address the issue?
Used the correct way of switching the Docker container to Linux

#### What side effects does this change have?
Nothing

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
