### PR TITLE
chore: remove SBT from dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
       prefix: chore
       include: scope
     reviewers:
-      - aws/serverless-application-experience-sbt
       - aws/aws-lambda-tooling
     open-pull-requests-limit: 10
 
@@ -22,7 +21,6 @@ updates:
       prefix: chore
       include: scope
     reviewers:
-      -  aws/serverless-application-experience-sbt
       -  aws/aws-lambda-tooling
     open-pull-requests-limit: 10
     groups:


### PR DESCRIPTION
#### Which issue(s) does this change fix?

`aws/serverless-application-experience-sbt` are still being added as reviewers to dependabot PRs.

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
