### PR TITLE
test: Pin numpy on integ tests to 2.2.6

### DIFF
--- a/tests/integration/testdata/sync/code/after/function/requirements.txt
+++ b/tests/integration/testdata/sync/code/after/function/requirements.txt
@@ -1,2 +1,2 @@
-numpy
+numpy==2.2.6
 requests

--- a/tests/integration/testdata/sync/code/after/python_function_no_deps/requirements.txt
+++ b/tests/integration/testdata/sync/code/after/python_function_no_deps/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==2.2.6

--- a/tests/integration/testdata/sync/code/before/function/requirements.txt
+++ b/tests/integration/testdata/sync/code/before/function/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==2.2.6

--- a/tests/integration/testdata/sync/infra/after/Python/function/requirements.txt
+++ b/tests/integration/testdata/sync/infra/after/Python/function/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==2.2.6

--- a/tests/integration/testdata/sync/infra/before/Python/function/requirements.txt
+++ b/tests/integration/testdata/sync/infra/before/Python/function/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==2.2.6

--- a/tests/integration/testdata/sync/infra/cdk/after/asset.6598609927b272b36fdf01072092f9851ddcd1b41ba294f736ce77091f5cc456/requirements.txt
+++ b/tests/integration/testdata/sync/infra/cdk/after/asset.6598609927b272b36fdf01072092f9851ddcd1b41ba294f736ce77091f5cc456/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==2.2.6

--- a/tests/integration/testdata/sync/infra/cdk/after/asset.b998895901bf33127f2c9dce715854f8b35aa73fb7eb5245ba9721580bbe5837/requirements.txt
+++ b/tests/integration/testdata/sync/infra/cdk/after/asset.b998895901bf33127f2c9dce715854f8b35aa73fb7eb5245ba9721580bbe5837/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==2.2.6

--- a/tests/integration/testdata/sync/infra/cdk/before/asset.6598609927b272b36fdf01072092f9851ddcd1b41ba294f736ce77091f5cc456/requirements.txt
+++ b/tests/integration/testdata/sync/infra/cdk/before/asset.6598609927b272b36fdf01072092f9851ddcd1b41ba294f736ce77091f5cc456/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==2.2.6

--- a/tests/integration/testdata/sync/infra/cdk/before/asset.b998895901bf33127f2c9dce715854f8b35aa73fb7eb5245ba9721580bbe5837/requirements.txt
+++ b/tests/integration/testdata/sync/infra/cdk/before/asset.b998895901bf33127f2c9dce715854f8b35aa73fb7eb5245ba9721580bbe5837/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy==2.2.6

--- a/tests/integration/testdata/sync/nested_intrinsics/before/child_stack/child_function/function/requirements.txt
+++ b/tests/integration/testdata/sync/nested_intrinsics/before/child_stack/child_function/function/requirements.txt
@@ -1,2 +1,2 @@
-numpy
+numpy==2.2.6
 requests


### PR DESCRIPTION
The new version of numpy (2.3.0) is not building correctly in SAM CLI integration tests environment. So let's pin to 2.2.6 for now

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->

Integration test failures

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
