### PR TITLE
test(canary): Call Lambda function to reset test account instead of making StepFunctions api call

### DIFF
--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -46,9 +46,9 @@ install:
   - sh: "ls /usr/"
   # install latest maven which is compatible with jdk17
   - sh: "sudo apt-get -y remove maven"
-  - sh: "wget https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip -P /tmp"
+  - sh: "wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip -P /tmp"
   - sh: "sudo unzip -d /opt/mvn /tmp/apache-maven-*.zip"
-  - sh: "PATH=/opt/mvn/apache-maven-3.9.10/bin:$PATH"
+  - sh: "PATH=/opt/mvn/apache-maven-3.9.11/bin:$PATH"
   - sh: "mvn --version"
 
   - sh: "source ${HOME}/venv${PYTHON_VERSION}/bin/activate"
@@ -171,7 +171,10 @@ on_finish:
   - sh: 'export AWS_SECRET_ACCESS_KEY=$CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY'
   - sh: 'export AWS_SESSION_TOKEN=$CI_ACCESS_ROLE_AWS_SESSION_TOKEN'
 
-  - sh: 'aws stepfunctions send-task-success --task-token "$TASK_TOKEN" --task-output "{}" --region us-west-2'
+    # When we update to AWS CLI v2, we need to add the `--cli-binary-format raw-in-base64-out` option to pass the payload as a JSON string
+  - sh: >
+      aws lambda invoke --function-name "$ACCOUNT_RESET_LAMBDA_ARN" --payload "{\"taskToken\": \"$TASK_TOKEN\", \"output\": \"{}\"}" ./lambda-output.txt --region us-west-2
+  - sh: 'cat ./lambda-output.txt'
 
 for:
   # Integ testing build

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -47,9 +47,9 @@ install:
   - sh: "ls /usr/"
   # install latest maven which is compatible with jdk17
   - sh: "sudo apt-get -y remove maven"
-  - sh: "wget https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip -P /tmp"
+  - sh: "wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip -P /tmp"
   - sh: "sudo unzip -d /opt/mvn /tmp/apache-maven-*.zip"
-  - sh: "PATH=/opt/mvn/apache-maven-3.9.10/bin:$PATH"
+  - sh: "PATH=/opt/mvn/apache-maven-3.9.11/bin:$PATH"
   - sh: "mvn --version"
 
   - sh: "source ${HOME}/venv${PYTHON_VERSION}/bin/activate"
@@ -157,7 +157,10 @@ on_finish:
   - sh: 'export AWS_SECRET_ACCESS_KEY=$CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY'
   - sh: 'export AWS_SESSION_TOKEN=$CI_ACCESS_ROLE_AWS_SESSION_TOKEN'
 
-  - sh: 'aws stepfunctions send-task-success --task-token "$TASK_TOKEN" --task-output "{}" --region us-west-2'
+    # When we update to AWS CLI v2, we need to add the `--cli-binary-format raw-in-base64-out` option to pass the payload as a JSON string
+  - sh: >
+      aws lambda invoke --function-name "$ACCOUNT_RESET_LAMBDA_ARN" --payload "{\"taskToken\": \"$TASK_TOKEN\", \"output\": \"{}\"}" ./lambda-output.txt --region us-west-2
+  - sh: 'cat ./lambda-output.txt'
 
 for:
   # Integ testing build

--- a/appveyor-windows-al2023.yml
+++ b/appveyor-windows-al2023.yml
@@ -137,22 +137,23 @@ install:
 on_finish:
   # Upload test reports as artifacts
   - ps: Get-ChildItem .\TEST_REPORT-*.json | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-  - ps: '
-  If (Test-Path env:BY_CANARY){
-    $env:AWS_ACCESS_KEY_ID = $env:TEST_REPORT_S3_BUCKET_ACCESS_KEY_ID;
-    $env:AWS_SECRET_ACCESS_KEY = $env:TEST_REPORT_S3_BUCKET_SECRET_ACCESS_KEY;
-    $env:AWS_SESSION_TOKEN = $env:TEST_REPORT_S3_BUCKET_SESSION_TOKEN;
-    aws s3 cp ".\" "s3://$env:TEST_REPORT_S3_BUCKET_NAME/appveyor/$env:APPVEYOR_PROJECT_SLUG/$env:APPVEYOR_BUILD_ID/$env:APPVEYOR_JOB_ID/" --recursive --exclude "*" --include "TEST_REPORT-*.json" --region us-west-2
-  }'
+  - ps: |
+      If (Test-Path env:BY_CANARY){
+        $env:AWS_ACCESS_KEY_ID = $env:TEST_REPORT_S3_BUCKET_ACCESS_KEY_ID;
+        $env:AWS_SECRET_ACCESS_KEY = $env:TEST_REPORT_S3_BUCKET_SECRET_ACCESS_KEY;
+        $env:AWS_SESSION_TOKEN = $env:TEST_REPORT_S3_BUCKET_SESSION_TOKEN;
+        aws s3 cp ".\" "s3://$env:TEST_REPORT_S3_BUCKET_NAME/appveyor/$env:APPVEYOR_PROJECT_SLUG/$env:APPVEYOR_BUILD_ID/$env:APPVEYOR_JOB_ID/" --recursive --exclude "*" --include "TEST_REPORT-*.json" --region us-west-2
+      }
 
   # notify success
-  - ps: "
-  If (Test-Path env:BY_CANARY){
-    $env:AWS_ACCESS_KEY_ID = $env:CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID;
-    $env:AWS_SECRET_ACCESS_KEY = $env:CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY;
-    $env:AWS_SESSION_TOKEN = $env:CI_ACCESS_ROLE_AWS_SESSION_TOKEN;
-    aws stepfunctions send-task-success --task-token \"$env:TASK_TOKEN\" --task-output \"{}\" --region us-west-2;
-  }"
+  - ps: |
+      If (Test-Path env:BY_CANARY){
+        $env:AWS_ACCESS_KEY_ID = $env:CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID;
+        $env:AWS_SECRET_ACCESS_KEY = $env:CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY;
+        $env:AWS_SESSION_TOKEN = $env:CI_ACCESS_ROLE_AWS_SESSION_TOKEN;
+        aws lambda invoke --function-name "$env:ACCOUNT_RESET_LAMBDA_ARN" --payload "{\`"taskToken\`": \`"$env:TASK_TOKEN\`", \`"output\`": \`"{}\`"}" lambda-output.txt --region us-west-2;
+        cat lambda-output.txt
+      }
 
 build_script:
   # install Rust in build_script to not override the default "install" actions

--- a/appveyor-windows-binary.yml
+++ b/appveyor-windows-binary.yml
@@ -180,7 +180,8 @@ on_finish:
         $env:AWS_ACCESS_KEY_ID = $env:CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID;
         $env:AWS_SECRET_ACCESS_KEY = $env:CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY;
         $env:AWS_SESSION_TOKEN = $env:CI_ACCESS_ROLE_AWS_SESSION_TOKEN;
-        aws stepfunctions send-task-success --task-token "$env:TASK_TOKEN" --task-output "{}" --region us-west-2;
+        aws lambda invoke --function-name "$env:ACCOUNT_RESET_LAMBDA_ARN" --payload "{\`"taskToken\`": \`"$env:TASK_TOKEN\`", \`"output\`": \`"{}\`"}" lambda-output.txt --region us-west-2;
+        cat lambda-output.txt
       }
 
 

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -145,22 +145,23 @@ install:
 on_finish:
   # Upload test reports as artifacts
   - ps: Get-ChildItem .\TEST_REPORT-*.json | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-  - ps: '
-  If (Test-Path env:BY_CANARY){
-    $env:AWS_ACCESS_KEY_ID = $env:TEST_REPORT_S3_BUCKET_ACCESS_KEY_ID;
-    $env:AWS_SECRET_ACCESS_KEY = $env:TEST_REPORT_S3_BUCKET_SECRET_ACCESS_KEY;
-    $env:AWS_SESSION_TOKEN = $env:TEST_REPORT_S3_BUCKET_SESSION_TOKEN;
-    aws s3 cp ".\" "s3://$env:TEST_REPORT_S3_BUCKET_NAME/appveyor/$env:APPVEYOR_PROJECT_SLUG/$env:APPVEYOR_BUILD_ID/$env:APPVEYOR_JOB_ID/" --recursive --exclude "*" --include "TEST_REPORT-*.json" --region us-west-2
-  }'
+  - ps: |
+      If (Test-Path env:BY_CANARY){
+        $env:AWS_ACCESS_KEY_ID = $env:TEST_REPORT_S3_BUCKET_ACCESS_KEY_ID;
+        $env:AWS_SECRET_ACCESS_KEY = $env:TEST_REPORT_S3_BUCKET_SECRET_ACCESS_KEY;
+        $env:AWS_SESSION_TOKEN = $env:TEST_REPORT_S3_BUCKET_SESSION_TOKEN;
+        aws s3 cp ".\" "s3://$env:TEST_REPORT_S3_BUCKET_NAME/appveyor/$env:APPVEYOR_PROJECT_SLUG/$env:APPVEYOR_BUILD_ID/$env:APPVEYOR_JOB_ID/" --recursive --exclude "*" --include "TEST_REPORT-*.json" --region us-west-2;
+      }
 
   # notify success
-  - ps: "
-  If (Test-Path env:BY_CANARY){
-    $env:AWS_ACCESS_KEY_ID = $env:CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID;
-    $env:AWS_SECRET_ACCESS_KEY = $env:CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY;
-    $env:AWS_SESSION_TOKEN = $env:CI_ACCESS_ROLE_AWS_SESSION_TOKEN;
-    aws stepfunctions send-task-success --task-token \"$env:TASK_TOKEN\" --task-output \"{}\" --region us-west-2;
-  }"
+  - ps: |
+      If (Test-Path env:BY_CANARY){
+        $env:AWS_ACCESS_KEY_ID = $env:CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID;
+        $env:AWS_SECRET_ACCESS_KEY = $env:CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY;
+        $env:AWS_SESSION_TOKEN = $env:CI_ACCESS_ROLE_AWS_SESSION_TOKEN;
+        aws lambda invoke --function-name "$env:ACCOUNT_RESET_LAMBDA_ARN" --payload "{\`"taskToken\`": \`"$env:TASK_TOKEN\`", \`"output\`": \`"{}\`"}" lambda-output.txt --region us-west-2;
+        cat lambda-output.txt
+      }
 
 
 for:


### PR DESCRIPTION
Modify the end of the canary to call Lambda function instead of sending a task action directly to Step Functions

Also update Maven to 3.9.11 (Maven 3.9.10 is not available in that location anymore)

Updated some indentation in some Windows files.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
- As part of a canary infrastructure update, the new credentials used to run the canary can no longer make a call to StepFunctions directly, so we added a new Lambda function to wrap the account reset action. This Lambda function calls Step Functions internally so the outcome is the same.

#### How does it address the issue?
- Changing a direct Step Functions call with a Lambda function call.

#### What side effects does this change have?
- The output of the function is put into a file, and then we print that file (that's how Lambda gives you the result of a function call)

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
