### PR TITLE
test: Update validate tests to show deprecated nodejs18.x

### DIFF
--- a/tests/integration/testdata/validate/default_json/template.json
+++ b/tests/integration/testdata/validate/default_json/template.json
@@ -8,7 +8,7 @@
       "Properties": {
         "CodeUri": "hello-world/",
         "Handler": "app.lambdaHandler",
-        "Runtime": "nodejs20.x"
+        "Runtime": "nodejs22.x"
       }
     }
   }

--- a/tests/integration/testdata/validate/default_yaml/template.yaml
+++ b/tests/integration/testdata/validate/default_yaml/template.yaml
@@ -7,4 +7,4 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: app.lambdaHandler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x

--- a/tests/integration/testdata/validate/default_yaml/templateError.yaml
+++ b/tests/integration/testdata/validate/default_yaml/templateError.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: app.lambdaHandler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
 
   HelloWorldFunction:
     Type: AWS::Serverless::Api

--- a/tests/integration/testdata/validate/multiple_files/template.yaml
+++ b/tests/integration/testdata/validate/multiple_files/template.yaml
@@ -7,4 +7,4 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: app.lambdaHandler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -128,6 +128,7 @@ class TestValidate(TestCase):
     @parameterized.expand(
         [
             ("nodejs16.x",),
+            ("nodejs18.x",),
         ]
     )
     def test_lint_deprecated_runtimes(self, runtime):
@@ -173,7 +174,6 @@ class TestValidate(TestCase):
             "java17",
             "java11",
             "java8.al2",
-            "nodejs18.x",
             "nodejs20.x",
             "nodejs22.x",
             "provided.al2",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
`sam validate` tests were failing because `nodejs18.x` is currently marked as deprecated for linting purposes.


#### Why is this change necessary?


#### How does it address the issue?
- Update from nodejs18.x to nodejs22.x

#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
