### PR TITLE
FunctionBuildDefinition: Fix docstring error

### DIFF
--- a/samcli/lib/build/build_graph.py
+++ b/samcli/lib/build/build_graph.py
@@ -578,7 +578,7 @@ class LayerBuildDefinition(AbstractBuildDefinition):
 
 class FunctionBuildDefinition(AbstractBuildDefinition):
     """
-    LayerBuildDefinition holds information about each unique function build
+    FunctionBuildDefinition holds information about each unique function build
     """
 
     def __init__(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
No open issue

#### Why is this change necessary?
The docstring incorrectly references LayerBuildDefinition in the FunctionBuildDefinition class.

#### How does it address the issue?
Replaces the incorrect class name.

#### What side effects does this change have?
Improves docs.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
