### PR TITLE
Add clean parameter sections to samconfig.toml

### DIFF
--- a/samcli/lib/config/parameter_loaders.py
+++ b/samcli/lib/config/parameter_loaders.py
@@ -26,12 +26,12 @@ class ParameterFileLoader:
     def is_file_url(parameter_value: Optional[str]) -> bool:
         """
         Check if a parameter value is a file:// URL.
-        
+
         Parameters
         ----------
         parameter_value : str, optional
             Parameter value to check
-            
+
         Returns
         -------
         bool
@@ -45,17 +45,17 @@ class ParameterFileLoader:
     def parse_file_url(file_url: str) -> str:
         """
         Parse file:// URL and return the file path with environment variable expansion.
-        
+
         Parameters
         ----------
         file_url : str
             File URL in format file://path/to/file.ext
-            
+
         Returns
         -------
         str
             Expanded file path
-            
+
         Raises
         ------
         ValueError
@@ -63,18 +63,18 @@ class ParameterFileLoader:
         """
         if not ParameterFileLoader.is_file_url(file_url):
             raise ValueError(f"Invalid file URL format: {file_url}")
-        
+
         # Extract path by removing file:// prefix
         # Don't use urlparse because it doesn't handle env vars and relative paths correctly
         file_path = file_url[7:]  # Remove 'file://' prefix
-        
+
         # Handle Windows paths (file:///C:/path/to/file)
-        if os.name == 'nt' and file_path.startswith('/') and ':' in file_path[1:3]:
+        if os.name == "nt" and file_path.startswith("/") and ":" in file_path[1:3]:
             file_path = file_path[1:]
-            
+
         # Expand environment variables before returning
         expanded_path = os.path.expandvars(file_path)
-        
+
         LOG.debug(f"Parsed file URL '{file_url}' to path '{expanded_path}'")
         return expanded_path
 
@@ -82,22 +82,22 @@ class ParameterFileLoader:
     def load_from_file(file_path: str) -> Dict:
         """
         Load parameters from a file based on its extension.
-        
+
         Supported formats:
         - .json: JSON format
-        - .yaml/.yml: YAML format  
+        - .yaml/.yml: YAML format
         - .env: Environment variable format
-        
+
         Parameters
         ----------
         file_path : str
             Path to the parameter file
-            
+
         Returns
         -------
         Dict
             Dictionary of loaded parameters
-            
+
         Raises
         ------
         FileNotFoundError
@@ -106,26 +106,25 @@ class ParameterFileLoader:
             If file format is invalid or unsupported
         """
         path_obj = Path(file_path)
-        
+
         if not path_obj.exists():
             raise FileNotFoundError(f"Parameter file not found: {file_path}")
-            
+
         if not path_obj.is_file():
             raise FileParseException(f"Parameter path is not a file: {file_path}")
-            
+
         extension = path_obj.suffix.lower()
-        
+
         try:
-            if extension == '.json':
+            if extension == ".json":
                 return ParameterFileLoader._load_json_file(path_obj)
-            elif extension in ['.yaml', '.yml']:
+            elif extension in [".yaml", ".yml"]:
                 return ParameterFileLoader._load_yaml_file(path_obj)
-            elif extension == '.env':
+            elif extension == ".env":
                 return ParameterFileLoader._load_env_file(path_obj)
             else:
                 raise FileParseException(
-                    f"Unsupported parameter file format: {extension}. "
-                    f"Supported formats: .json, .yaml, .yml, .env"
+                    f"Unsupported parameter file format: {extension}. " f"Supported formats: .json, .yaml, .yml, .env"
                 )
         except Exception as e:
             if isinstance(e, (FileParseException, FileNotFoundError)):
@@ -136,27 +135,27 @@ class ParameterFileLoader:
     def _load_json_file(file_path: Path) -> Dict:
         """
         Load parameters from JSON file.
-        
+
         Parameters
         ----------
         file_path : Path
             Path to JSON file
-            
+
         Returns
         -------
         Dict
             Dictionary of parameters
         """
         try:
-            content = file_path.read_text(encoding='utf-8')
+            content = file_path.read_text(encoding="utf-8")
             params = json.loads(content)
-            
+
             if not isinstance(params, dict):
                 raise FileParseException(f"JSON parameter file must contain an object, got {type(params)}")
-                
+
             LOG.debug(f"Loaded {len(params)} parameters from JSON file: {file_path}")
             return params
-            
+
         except json.JSONDecodeError as e:
             raise FileParseException(f"Invalid JSON in parameter file '{file_path}': {str(e)}") from e
 
@@ -164,32 +163,32 @@ class ParameterFileLoader:
     def _load_yaml_file(file_path: Path) -> Dict:
         """
         Load parameters from YAML file.
-        
+
         Parameters
         ----------
         file_path : Path
             Path to YAML file
-            
+
         Returns
         -------
         Dict
             Dictionary of parameters
         """
-        yaml = YAML(typ='safe', pure=True)
-        
+        yaml = YAML(typ="safe", pure=True)
+
         try:
-            content = file_path.read_text(encoding='utf-8')
+            content = file_path.read_text(encoding="utf-8")
             params = yaml.load(content)
-            
+
             if params is None:
                 return {}
-                
+
             if not isinstance(params, dict):
                 raise FileParseException(f"YAML parameter file must contain a mapping, got {type(params)}")
-                
+
             LOG.debug(f"Loaded {len(params)} parameters from YAML file: {file_path}")
             return params
-            
+
         except YAMLError as e:
             raise FileParseException(f"Invalid YAML in parameter file '{file_path}': {str(e)}") from e
 
@@ -197,7 +196,7 @@ class ParameterFileLoader:
     def _load_env_file(file_path: Path) -> Dict:
         """
         Load parameters from environment variable file.
-        
+
         Format:
         KEY1=value1
         KEY2=value2
@@ -205,57 +204,57 @@ class ParameterFileLoader:
         MULTILINE_KEY="line1
         line2
         line3"
-        
+
         Parameters
         ----------
         file_path : Path
             Path to ENV file
-            
+
         Returns
         -------
         Dict
             Dictionary of parameters
         """
         params: Dict[str, str] = {}
-        
+
         try:
-            content = file_path.read_text(encoding='utf-8')
+            content = file_path.read_text(encoding="utf-8")
             lines = content.splitlines()
-            
+
             current_key: Optional[str] = None
             current_value: List[str] = []
             in_multiline = False
-            
+
             for line_num, raw_line in enumerate(lines, 1):
                 line = raw_line.rstrip()
-                
+
                 # Skip empty lines and comments
-                if not line or line.startswith('#'):
+                if not line or line.startswith("#"):
                     continue
-                    
+
                 # Handle multiline values
                 if in_multiline:
                     if line.endswith('"') and not line.endswith('\\"'):
                         # End of multiline value
                         current_value.append(line[:-1])  # Remove closing quote
                         if current_key is not None:
-                            params[current_key] = '\n'.join(current_value)
+                            params[current_key] = "\n".join(current_value)
                         current_key = None
                         current_value = []
                         in_multiline = False
                     else:
                         current_value.append(line)
                     continue
-                
+
                 # Parse key=value pairs
-                if '=' not in line:
+                if "=" not in line:
                     LOG.warning(f"Skipping invalid line {line_num} in {file_path}: {line}")
                     continue
-                    
-                key, value = line.split('=', 1)
+
+                key, value = line.split("=", 1)
                 key = key.strip()
                 value = value.strip()
-                
+
                 # Handle quoted values
                 if value.startswith('"'):
                     if value.endswith('"') and len(value) > 1 and not value.endswith('\\"'):
@@ -268,13 +267,13 @@ class ParameterFileLoader:
                         in_multiline = True
                 else:
                     params[key] = value
-                    
+
             if in_multiline:
                 raise FileParseException(f"Unterminated quoted value for key '{current_key}' in {file_path}")
-                
+
             LOG.debug(f"Loaded {len(params)} parameters from ENV file: {file_path}")
             return params
-            
+
         except Exception as e:
             if isinstance(e, FileParseException):
                 raise
@@ -284,12 +283,12 @@ class ParameterFileLoader:
     def resolve_parameter_files(parameter_overrides: Optional[str]) -> Tuple[Dict, Dict]:
         """
         Resolve parameter overrides that may contain file:// URLs.
-        
+
         Parameters
         ----------
         parameter_overrides : str, optional
             Parameter overrides string that may contain file:// URLs
-            
+
         Returns
         -------
         Tuple[Dict, Dict]
@@ -299,18 +298,19 @@ class ParameterFileLoader:
         """
         if not parameter_overrides:
             return {}, {}
-            
+
         direct_params = {}
         file_params = {}
-        
+
         # Split parameter overrides by spaces, handling quoted values
         import shlex
+
         try:
             parts = shlex.split(parameter_overrides)
         except ValueError:
             # Fall back to simple split if shlex fails
             parts = parameter_overrides.split()
-            
+
         for part in parts:
             if ParameterFileLoader.is_file_url(part):
                 # Load parameters from file
@@ -322,38 +322,38 @@ class ParameterFileLoader:
                 except Exception as e:
                     LOG.error(f"Failed to load parameters from {part}: {str(e)}")
                     raise
-            elif '=' in part:
+            elif "=" in part:
                 # Direct parameter specification
-                key, value = part.split('=', 1)
+                key, value = part.split("=", 1)
                 direct_params[key.strip()] = value.strip()
             else:
                 LOG.warning(f"Skipping invalid parameter format: {part}")
-                
+
         return direct_params, file_params
 
     @staticmethod
     def expand_environment_variables(params: Dict) -> Dict:
         """
         Expand environment variables in parameter values.
-        
+
         Supports ${VAR_NAME} and $VAR_NAME syntax.
-        
+
         Parameters
         ----------
         params : Dict
             Dictionary of parameters
-            
+
         Returns
         -------
         Dict
             Dictionary with expanded environment variables
         """
         expanded = {}
-        
+
         for key, value in params.items():
             if isinstance(value, str):
                 expanded[key] = os.path.expandvars(value)
             else:
                 expanded[key] = value
-                
+
         return expanded

--- a/samcli/lib/config/parameter_merger.py
+++ b/samcli/lib/config/parameter_merger.py
@@ -22,12 +22,12 @@ class ParameterMerger:
     ) -> Dict:
         """
         Merge parameters with precedence rules.
-        
+
         Precedence (highest to lowest):
         1. CLI parameters (--parameter-overrides)
         2. File parameters (--parameter-overrides file://params.json)
         3. Config parameters ([env.command.parameters.template_parameters])
-        
+
         Parameters
         ----------
         config_params : Dict, optional
@@ -36,29 +36,29 @@ class ParameterMerger:
             Parameters from CLI --parameter-overrides
         file_params : Dict, optional
             Parameters loaded from external files
-            
+
         Returns
         -------
         Dict
             Merged parameter dictionary with CLI taking precedence
         """
         merged = {}
-        
+
         # Start with config parameters (lowest precedence)
         if config_params:
             merged.update(config_params)
             LOG.debug(f"Added config parameters: {list(config_params.keys())}")
-        
+
         # Add file parameters (medium precedence)
         if file_params:
             merged.update(file_params)
             LOG.debug(f"Added file parameters: {list(file_params.keys())}")
-            
-        # Add CLI parameters (highest precedence)  
+
+        # Add CLI parameters (highest precedence)
         if cli_params:
             merged.update(cli_params)
             LOG.debug(f"Added CLI parameters: {list(cli_params.keys())}")
-            
+
         LOG.debug(f"Final merged parameters: {list(merged.keys())}")
         return merged
 
@@ -70,12 +70,12 @@ class ParameterMerger:
     ) -> Dict:
         """
         Merge tags with same precedence rules as parameters.
-        
+
         Precedence (highest to lowest):
         1. CLI tags (--tags)
         2. File tags (--tags file://tags.json)
         3. Config tags ([env.command.parameters.template_tags])
-        
+
         Parameters
         ----------
         config_tags : Dict, optional
@@ -84,29 +84,29 @@ class ParameterMerger:
             Tags from CLI --tags
         file_tags : Dict, optional
             Tags loaded from external files
-            
+
         Returns
         -------
         Dict
             Merged tag dictionary with CLI taking precedence
         """
         merged = {}
-        
+
         # Start with config tags (lowest precedence)
         if config_tags:
             merged.update(config_tags)
             LOG.debug(f"Added config tags: {list(config_tags.keys())}")
-        
+
         # Add file tags (medium precedence)
         if file_tags:
             merged.update(file_tags)
             LOG.debug(f"Added file tags: {list(file_tags.keys())}")
-            
+
         # Add CLI tags (highest precedence)
         if cli_tags:
             merged.update(cli_tags)
             LOG.debug(f"Added CLI tags: {list(cli_tags.keys())}")
-            
+
         LOG.debug(f"Final merged tags: {list(merged.keys())}")
         return merged
 
@@ -115,12 +115,12 @@ class ParameterMerger:
         """
         Format merged parameters for CloudFormation deployment.
         Converts our merged dict to the format expected by CloudFormation.
-        
+
         Parameters
         ----------
         parameters : Dict
             Merged parameters dictionary
-            
+
         Returns
         -------
         Dict
@@ -128,7 +128,7 @@ class ParameterMerger:
         """
         if not parameters:
             return {}
-            
+
         # Convert to CloudFormation parameter format
         formatted = {}
         for key, value in parameters.items():
@@ -136,25 +136,26 @@ class ParameterMerger:
             if isinstance(value, (dict, list)):
                 # Convert complex types to JSON strings
                 import json
+
                 formatted[key] = json.dumps(value)
             elif value is None:
                 formatted[key] = ""
             else:
                 formatted[key] = str(value)
-                
+
         return formatted
 
-    @staticmethod  
+    @staticmethod
     def parse_legacy_parameter_string(parameter_string: str) -> Dict:
         """
         Parse legacy parameter_overrides string format.
         Handles space-separated key=value pairs with proper quoting support.
-        
+
         Parameters
         ----------
         parameter_string : str
             String in format "Key1=Value1 Key2=Value2"
-            
+
         Returns
         -------
         Dict
@@ -165,7 +166,7 @@ class ParameterMerger:
 
         params = {}
         import shlex
-        
+
         try:
             # Use shlex to properly handle quoted values
             pairs = shlex.split(parameter_string)
@@ -190,14 +191,14 @@ class ParameterMerger:
     def validate_parameters(parameters: Dict, template_parameters: Optional[Dict] = None) -> Dict:
         """
         Validate merged parameters against template parameter definitions.
-        
+
         Parameters
         ----------
         parameters : Dict
             Merged parameters to validate
         template_parameters : Dict, optional
             Template parameter definitions from CloudFormation template
-            
+
         Returns
         -------
         Dict
@@ -205,13 +206,13 @@ class ParameterMerger:
         """
         if not template_parameters:
             return parameters
-            
+
         validated = {}
-        
+
         for key, value in parameters.items():
             if key in template_parameters:
                 validated[key] = value
             else:
                 LOG.warning(f"Parameter '{key}' not found in template parameters. Skipping.")
-                
+
         return validated

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -305,7 +305,7 @@ class SamConfig:
             Dictionary of template parameters. Empty dict if none found.
         """
         env = env or DEFAULT_ENV
-        
+
         try:
             # Try new format first
             template_params = self.get_all(cmd_names, TEMPLATE_PARAMETERS_SECTION, env)
@@ -343,7 +343,7 @@ class SamConfig:
             Dictionary of template tags. Empty dict if none found.
         """
         env = env or DEFAULT_ENV
-        
+
         try:
             # Try new format first
             template_tags = self.get_all(cmd_names, TEMPLATE_TAGS_SECTION, env)
@@ -419,6 +419,7 @@ class SamConfig:
         params = {}
         # Split by spaces, but handle quoted values
         import shlex
+
         try:
             pairs = shlex.split(parameter_overrides_str)
             for pair in pairs:

--- a/tests/unit/lib/samconfig/test_new_schema_integration.py
+++ b/tests/unit/lib/samconfig/test_new_schema_integration.py
@@ -7,12 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from samcli.lib.config.samconfig import (
-    SamConfig,
-    DEFAULT_ENV,
-    TEMPLATE_PARAMETERS_SECTION,
-    TEMPLATE_TAGS_SECTION
-)
+from samcli.lib.config.samconfig import SamConfig, DEFAULT_ENV, TEMPLATE_PARAMETERS_SECTION, TEMPLATE_TAGS_SECTION
 
 
 class TestSamConfigNewSchema(unittest.TestCase):
@@ -28,6 +23,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
         if self.samconfig.exists():
             os.remove(self.samconfig.path())
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_put_get_template_parameter(self):
@@ -61,11 +57,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_get_template_parameters_multiple(self):
         """Test retrieving multiple template parameters"""
         cmd_names = ["deploy"]
-        params = {
-            "Param1": "Value1",
-            "Param2": "Value2",
-            "Param3": 123
-        }
+        params = {"Param1": "Value1", "Param2": "Value2", "Param3": 123}
 
         # Store multiple parameters
         for key, value in params.items():
@@ -79,11 +71,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_get_template_tags_multiple(self):
         """Test retrieving multiple template tags"""
         cmd_names = ["deploy"]
-        tags = {
-            "Environment": "prod",
-            "Project": "MyApp",
-            "CostCenter": "Engineering"
-        }
+        tags = {"Environment": "prod", "Project": "MyApp", "CostCenter": "Engineering"}
 
         # Store multiple tags
         for key, value in tags.items():
@@ -97,7 +85,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_get_template_parameters_different_environments(self):
         """Test template parameters in different environments"""
         cmd_names = ["deploy"]
-        
+
         # Store parameters in different environments
         self.samconfig.put_template_parameter(cmd_names, "Param1", "DefaultValue", DEFAULT_ENV)
         self.samconfig.put_template_parameter(cmd_names, "Param1", "StagingValue", "staging")
@@ -141,7 +129,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_get_template_parameters_new_format_preferred(self):
         """Test that new format takes precedence over legacy"""
         cmd_names = ["deploy"]
-        
+
         # Store in both formats
         self.samconfig.put(cmd_names, "parameters", "parameter_overrides", "LegacyParam=LegacyValue")
         self.samconfig.put_template_parameter(cmd_names, "NewParam", "NewValue")
@@ -155,21 +143,21 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_get_template_parameters_empty_when_none_found(self):
         """Test that empty dict is returned when no parameters found"""
         cmd_names = ["deploy"]
-        
+
         params = self.samconfig.get_template_parameters(cmd_names)
         self.assertEqual(params, {})
 
     def test_get_template_tags_empty_when_none_found(self):
         """Test that empty dict is returned when no tags found"""
         cmd_names = ["deploy"]
-        
+
         tags = self.samconfig.get_template_tags(cmd_names)
         self.assertEqual(tags, {})
 
     def test_parse_parameter_overrides_simple(self):
         """Test parsing simple parameter overrides string"""
         param_string = "Key1=Value1 Key2=Value2"
-        
+
         result = SamConfig._parse_parameter_overrides(param_string)
         expected = {"Key1": "Value1", "Key2": "Value2"}
         self.assertEqual(result, expected)
@@ -177,7 +165,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_parse_parameter_overrides_quoted(self):
         """Test parsing quoted parameter overrides string"""
         param_string = 'Key1="Value with spaces" Key2=SimpleValue'
-        
+
         result = SamConfig._parse_parameter_overrides(param_string)
         expected = {"Key1": "Value with spaces", "Key2": "SimpleValue"}
         self.assertEqual(result, expected)
@@ -191,7 +179,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_parse_parameter_overrides_malformed(self):
         """Test parsing malformed parameter overrides string"""
         param_string = "ValidKey=ValidValue InvalidFormat"
-        
+
         result = SamConfig._parse_parameter_overrides(param_string)
         # Should only parse valid key=value pairs
         expected = {"ValidKey": "ValidValue"}
@@ -200,7 +188,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_template_parameters_with_complex_values(self):
         """Test template parameters with complex values"""
         cmd_names = ["deploy"]
-        
+
         # Test different value types
         self.samconfig.put_template_parameter(cmd_names, "StringParam", "string_value")
         self.samconfig.put_template_parameter(cmd_names, "NumberParam", 42)
@@ -210,7 +198,7 @@ class TestSamConfigNewSchema(unittest.TestCase):
         self.samconfig.flush()
 
         params = self.samconfig.get_template_parameters(cmd_names)
-        
+
         self.assertEqual(params["StringParam"], "string_value")
         self.assertEqual(params["NumberParam"], 42)
         self.assertEqual(params["BooleanParam"], True)
@@ -220,11 +208,11 @@ class TestSamConfigNewSchema(unittest.TestCase):
     def test_template_parameters_multiline_values(self):
         """Test template parameters with multiline values"""
         cmd_names = ["deploy"]
-        
+
         multiline_value = """line1
 line2
 line3"""
-        
+
         self.samconfig.put_template_parameter(cmd_names, "MultilineParam", multiline_value)
         self.samconfig.flush()
 
@@ -234,28 +222,28 @@ line3"""
     def test_backward_compatibility_mixed_usage(self):
         """Test backward compatibility with mixed old and new formats"""
         cmd_names = ["deploy"]
-        
+
         # Store some parameters in legacy format
         self.samconfig.put(cmd_names, "parameters", "parameter_overrides", "LegacyParam=LegacyValue")
         self.samconfig.put(cmd_names, "parameters", "tags", "LegacyTag=LegacyTagValue")
-        
+
         # Store some parameters in new format
         self.samconfig.put_template_parameter(cmd_names, "NewParam", "NewValue")
         self.samconfig.put_template_tag(cmd_names, "NewTag", "NewTagValue")
-        
+
         # Store other legacy parameters
         self.samconfig.put(cmd_names, "parameters", "stack_name", "my-stack")
         self.samconfig.put(cmd_names, "parameters", "s3_bucket", "my-bucket")
-        
+
         self.samconfig.flush()
 
         # New format should be preferred for template_parameters and template_tags
         params = self.samconfig.get_template_parameters(cmd_names)
         tags = self.samconfig.get_template_tags(cmd_names)
-        
+
         self.assertEqual(params, {"NewParam": "NewValue"})
         self.assertEqual(tags, {"NewTag": "NewTagValue"})
-        
+
         # Legacy parameters should still be accessible via get_all
         legacy_params = self.samconfig.get_all(cmd_names, "parameters")
         self.assertEqual(legacy_params["stack_name"], "my-stack")
@@ -264,9 +252,9 @@ line3"""
     def test_global_parameters_inheritance(self):
         """Test that global parameters are inherited in new format"""
         from samcli.lib.config.samconfig import DEFAULT_GLOBAL_CMDNAME
-        
+
         cmd_names = ["deploy"]
-        
+
         # Store global template parameter
         self.samconfig.put_template_parameter([DEFAULT_GLOBAL_CMDNAME], "GlobalParam", "GlobalValue")
         # Store command-specific template parameter
@@ -275,12 +263,12 @@ line3"""
 
         # Should get both global and command-specific parameters
         params = self.samconfig.get_template_parameters(cmd_names)
-        
+
         # Note: The current get_template_parameters doesn't implement global inheritance
         # This test documents the expected behavior for future enhancement
         self.assertEqual(params["CommandParam"], "CommandValue")
         # Global inheritance would need to be implemented in get_template_parameters
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/lib/samconfig/test_parameter_loaders.py
+++ b/tests/unit/lib/samconfig/test_parameter_loaders.py
@@ -24,6 +24,7 @@ class TestParameterFileLoader(unittest.TestCase):
     def tearDown(self):
         """Clean up test fixtures"""
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_is_file_url_valid(self):
@@ -54,7 +55,7 @@ class TestParameterFileLoader(unittest.TestCase):
 
     def test_parse_file_url_with_env_vars(self):
         """Test parsing file URLs with environment variables"""
-        with patch.dict(os.environ, {'TEST_VAR': 'test_value'}, clear=False):
+        with patch.dict(os.environ, {"TEST_VAR": "test_value"}, clear=False):
             url = "file://$TEST_VAR/file.json"
             result = ParameterFileLoader.parse_file_url(url)
             self.assertEqual(result, "test_value/file.json")
@@ -102,12 +103,7 @@ nested:
         yaml_file.write_text(yaml_content)
 
         result = ParameterFileLoader.load_from_file(str(yaml_file))
-        expected = {
-            "param1": "value1",
-            "param2": "value2", 
-            "param3": 123,
-            "nested": {"key": "nested_value"}
-        }
+        expected = {"param1": "value1", "param2": "value2", "param3": 123, "nested": {"key": "nested_value"}}
         self.assertEqual(result, expected)
 
     def test_load_yaml_file_empty(self):
@@ -143,31 +139,27 @@ PARAM3=123
 
     def test_load_env_file_quoted_values(self):
         """Test loading ENV file with quoted values"""
-        env_content = '''
+        env_content = """
 SIMPLE=value
 QUOTED="quoted value with spaces"
 MULTILINE="line1
 line2
 line3"
-'''
+"""
         env_file = self.temp_path / "params.env"
         env_file.write_text(env_content)
 
         result = ParameterFileLoader.load_from_file(str(env_file))
-        expected = {
-            "SIMPLE": "value",
-            "QUOTED": "quoted value with spaces",
-            "MULTILINE": "line1\nline2\nline3"
-        }
+        expected = {"SIMPLE": "value", "QUOTED": "quoted value with spaces", "MULTILINE": "line1\nline2\nline3"}
         self.assertEqual(result, expected)
 
     def test_load_env_file_malformed_multiline(self):
         """Test loading ENV file with malformed multiline value"""
-        env_content = '''
+        env_content = """
 PARAM1=value1
 UNTERMINATED="unclosed quote
 PARAM2=value2
-'''
+"""
         env_file = self.temp_path / "params.env"
         env_file.write_text(env_content)
 
@@ -253,13 +245,13 @@ PARAM2=value2
 
     def test_expand_environment_variables(self):
         """Test expanding environment variables in parameter values"""
-        with patch.dict(os.environ, {'TEST_VAR': 'expanded'}, clear=False):
+        with patch.dict(os.environ, {"TEST_VAR": "expanded"}, clear=False):
             params = {
                 "NoVar": "simple_value",
                 "WithVar": "$TEST_VAR",
                 "WithBraces": "${TEST_VAR}_suffix",
                 "NonExistent": "$NON_EXISTENT_VAR",
-                "NumericValue": 123
+                "NumericValue": 123,
             }
 
             result = ParameterFileLoader.expand_environment_variables(params)
@@ -269,11 +261,11 @@ PARAM2=value2
                 "WithVar": "expanded",
                 "WithBraces": "expanded_suffix",
                 "NonExistent": "$NON_EXISTENT_VAR",  # Unexpanded if var doesn't exist
-                "NumericValue": 123  # Non-string values unchanged
+                "NumericValue": 123,  # Non-string values unchanged
             }
             self.assertEqual(result, expected)
 
-    @patch('samcli.lib.config.parameter_loaders.LOG')
+    @patch("samcli.lib.config.parameter_loaders.LOG")
     def test_resolve_parameter_files_logs_info(self, mock_log):
         """Test that file parameter loading logs info messages"""
         json_data = {"param": "value"}
@@ -286,7 +278,7 @@ PARAM2=value2
         mock_log.info.assert_called_once()
         self.assertIn("Loaded 1 parameters from file", mock_log.info.call_args[0][0])
 
-    @patch('samcli.lib.config.parameter_loaders.LOG')
+    @patch("samcli.lib.config.parameter_loaders.LOG")
     def test_resolve_parameter_files_logs_warning_invalid_format(self, mock_log):
         """Test that invalid parameter formats log warnings"""
         param_string = "ValidParam=Value InvalidFormat"
@@ -299,5 +291,5 @@ PARAM2=value2
         mock_log.warning.assert_called_once_with("Skipping invalid parameter format: InvalidFormat")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/lib/samconfig/test_parameter_merger.py
+++ b/tests/unit/lib/samconfig/test_parameter_merger.py
@@ -14,27 +14,27 @@ class TestParameterMerger(unittest.TestCase):
     def test_merge_parameters_config_only(self):
         """Test merging with only config parameters"""
         config_params = {"Param1": "ConfigValue1", "Param2": "ConfigValue2"}
-        
+
         result = ParameterMerger.merge_parameters(config_params=config_params)
-        
+
         expected = {"Param1": "ConfigValue1", "Param2": "ConfigValue2"}
         self.assertEqual(result, expected)
 
     def test_merge_parameters_cli_only(self):
         """Test merging with only CLI parameters"""
         cli_params = {"Param1": "CLIValue1", "Param2": "CLIValue2"}
-        
+
         result = ParameterMerger.merge_parameters(cli_params=cli_params)
-        
+
         expected = {"Param1": "CLIValue1", "Param2": "CLIValue2"}
         self.assertEqual(result, expected)
 
     def test_merge_parameters_file_only(self):
         """Test merging with only file parameters"""
         file_params = {"Param1": "FileValue1", "Param2": "FileValue2"}
-        
+
         result = ParameterMerger.merge_parameters(file_params=file_params)
-        
+
         expected = {"Param1": "FileValue1", "Param2": "FileValue2"}
         self.assertEqual(result, expected)
 
@@ -43,17 +43,15 @@ class TestParameterMerger(unittest.TestCase):
         config_params = {"Param1": "ConfigValue", "Param2": "ConfigValue", "Param3": "ConfigValue"}
         file_params = {"Param2": "FileValue", "Param3": "FileValue"}
         cli_params = {"Param3": "CLIValue"}
-        
+
         result = ParameterMerger.merge_parameters(
-            config_params=config_params,
-            cli_params=cli_params,
-            file_params=file_params
+            config_params=config_params, cli_params=cli_params, file_params=file_params
         )
-        
+
         expected = {
             "Param1": "ConfigValue",  # Only in config
-            "Param2": "FileValue",    # File overrides config
-            "Param3": "CLIValue"      # CLI overrides both
+            "Param2": "FileValue",  # File overrides config
+            "Param3": "CLIValue",  # CLI overrides both
         }
         self.assertEqual(result, expected)
 
@@ -61,16 +59,16 @@ class TestParameterMerger(unittest.TestCase):
         """Test merging with empty/None inputs"""
         result = ParameterMerger.merge_parameters()
         self.assertEqual(result, {})
-        
+
         result = ParameterMerger.merge_parameters(config_params={}, cli_params=None, file_params={})
         self.assertEqual(result, {})
 
     def test_merge_tags_config_only(self):
         """Test merging with only config tags"""
         config_tags = {"Environment": "prod", "Project": "MyApp"}
-        
+
         result = ParameterMerger.merge_tags(config_tags=config_tags)
-        
+
         expected = {"Environment": "prod", "Project": "MyApp"}
         self.assertEqual(result, expected)
 
@@ -79,17 +77,13 @@ class TestParameterMerger(unittest.TestCase):
         config_tags = {"Environment": "config", "Project": "config", "CostCenter": "config"}
         file_tags = {"Project": "file", "CostCenter": "file"}
         cli_tags = {"CostCenter": "cli"}
-        
-        result = ParameterMerger.merge_tags(
-            config_tags=config_tags,
-            cli_tags=cli_tags,
-            file_tags=file_tags
-        )
-        
+
+        result = ParameterMerger.merge_tags(config_tags=config_tags, cli_tags=cli_tags, file_tags=file_tags)
+
         expected = {
             "Environment": "config",  # Only in config
-            "Project": "file",        # File overrides config
-            "CostCenter": "cli"       # CLI overrides both
+            "Project": "file",  # File overrides config
+            "CostCenter": "cli",  # CLI overrides both
         }
         self.assertEqual(result, expected)
 
@@ -101,18 +95,18 @@ class TestParameterMerger(unittest.TestCase):
             "BooleanParam": True,
             "NullParam": None,
             "DictParam": {"key": "value"},
-            "ListParam": [1, 2, 3]
+            "ListParam": [1, 2, 3],
         }
-        
+
         result = ParameterMerger.format_for_cloudformation(parameters)
-        
+
         expected = {
             "StringParam": "value",
             "NumberParam": "42",
             "BooleanParam": "True",
             "NullParam": "",
             "DictParam": '{"key": "value"}',
-            "ListParam": "[1, 2, 3]"
+            "ListParam": "[1, 2, 3]",
         }
         self.assertEqual(result, expected)
 
@@ -120,39 +114,39 @@ class TestParameterMerger(unittest.TestCase):
         """Test formatting empty parameters"""
         result = ParameterMerger.format_for_cloudformation({})
         self.assertEqual(result, {})
-        
+
         result = ParameterMerger.format_for_cloudformation(None)
         self.assertEqual(result, {})
 
     def test_parse_legacy_parameter_string_simple(self):
         """Test parsing simple parameter strings"""
         param_string = "Key1=Value1 Key2=Value2"
-        
+
         result = ParameterMerger.parse_legacy_parameter_string(param_string)
-        
+
         expected = {"Key1": "Value1", "Key2": "Value2"}
         self.assertEqual(result, expected)
 
     def test_parse_legacy_parameter_string_quoted(self):
         """Test parsing parameter strings with quoted values"""
         param_string = 'Key1="Value with spaces" Key2=SimpleValue'
-        
+
         result = ParameterMerger.parse_legacy_parameter_string(param_string)
-        
+
         expected = {"Key1": "Value with spaces", "Key2": "SimpleValue"}
         self.assertEqual(result, expected)
 
     def test_parse_legacy_parameter_string_complex(self):
         """Test parsing complex parameter strings"""
         param_string = 'DBHost=localhost DBPort=5432 DBName="my database" ConnectionString="host=localhost;port=5432"'
-        
+
         result = ParameterMerger.parse_legacy_parameter_string(param_string)
-        
+
         expected = {
             "DBHost": "localhost",
-            "DBPort": "5432", 
+            "DBPort": "5432",
             "DBName": "my database",
-            "ConnectionString": "host=localhost;port=5432"
+            "ConnectionString": "host=localhost;port=5432",
         }
         self.assertEqual(result, expected)
 
@@ -162,55 +156,46 @@ class TestParameterMerger(unittest.TestCase):
         self.assertEqual(ParameterMerger.parse_legacy_parameter_string(None), {})
         self.assertEqual(ParameterMerger.parse_legacy_parameter_string("   "), {})
 
-    @patch('samcli.lib.config.parameter_merger.LOG')
+    @patch("samcli.lib.config.parameter_merger.LOG")
     def test_parse_legacy_parameter_string_invalid_format(self, mock_log):
         """Test parsing parameter strings with invalid format"""
         param_string = "ValidKey=ValidValue InvalidEntry AnotherKey=AnotherValue"
-        
+
         result = ParameterMerger.parse_legacy_parameter_string(param_string)
-        
+
         expected = {"ValidKey": "ValidValue", "AnotherKey": "AnotherValue"}
         self.assertEqual(result, expected)
         mock_log.warning.assert_called_once()
 
     def test_validate_parameters_with_template(self):
         """Test parameter validation against template parameters"""
-        parameters = {
-            "ValidParam1": "value1",
-            "ValidParam2": "value2", 
-            "InvalidParam": "invalid"
-        }
-        template_parameters = {
-            "ValidParam1": {"Type": "String"},
-            "ValidParam2": {"Type": "String"}
-        }
-        
+        parameters = {"ValidParam1": "value1", "ValidParam2": "value2", "InvalidParam": "invalid"}
+        template_parameters = {"ValidParam1": {"Type": "String"}, "ValidParam2": {"Type": "String"}}
+
         result = ParameterMerger.validate_parameters(parameters, template_parameters)
-        
+
         expected = {"ValidParam1": "value1", "ValidParam2": "value2"}
         self.assertEqual(result, expected)
 
     def test_validate_parameters_without_template(self):
         """Test parameter validation without template parameters"""
         parameters = {"Param1": "value1", "Param2": "value2"}
-        
+
         result = ParameterMerger.validate_parameters(parameters, None)
-        
+
         self.assertEqual(result, parameters)
 
-    @patch('samcli.lib.config.parameter_merger.LOG')
+    @patch("samcli.lib.config.parameter_merger.LOG")
     def test_validate_parameters_logs_warnings(self, mock_log):
         """Test parameter validation logs warnings for invalid parameters"""
         parameters = {"InvalidParam": "value"}
         template_parameters = {"ValidParam": {"Type": "String"}}
-        
+
         result = ParameterMerger.validate_parameters(parameters, template_parameters)
-        
+
         self.assertEqual(result, {})
-        mock_log.warning.assert_called_once_with(
-            "Parameter 'InvalidParam' not found in template parameters. Skipping."
-        )
+        mock_log.warning.assert_called_once_with("Parameter 'InvalidParam' not found in template parameters. Skipping.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The current samconfig.toml parameter format is hard to work with:
- Single-line strings get very long and unreadable
- CLI parameters replace config completely (no merging)  
- Complex escaping needed for arrays and special characters
- No multiline support for certificates or JSON configs

## Solution

Added clean parameter sections to samconfig.toml:

New format:
- [env.command.parameters.template_parameters] for clean key-value pairs
- [env.command.parameters.template_tags] for tags  
- Parameter merging: CLI adds to config instead of replacing
- File loading: load parameters from JSON/YAML/ENV files
- Multiline value support with TOML literal strings

## Features

- Parameter merging (CLI parameters add to config parameters)
- External parameter files: file://params.json, file://params.yaml, file://params.env  
- Multiline values for certificates, JSON configs, SQL queries
- Tag improvements with same clean format
- 100% backward compatible - old format still works

## Implementation

Extended existing SamConfig class with new methods. Added ParameterMerger for smart merging and ParameterFileLoader for external files. All existing functionality preserved.

61 new tests added, all existing tests pass.

Closes #2253