### PR TITLE
fix: remove unnecessary hidden import for pkg_resources

### DIFF
--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -25,9 +25,6 @@ SAM_CLI_HIDDEN_IMPORTS = list(samcli_modules) + [
     "cookiecutter.extensions",
     "text_unidecode",
     "samtranslator",
-    # default hidden import 'pkg_resources.py2_warn' is added
-    # since pyInstaller 4.0.
-    "pkg_resources.py2_warn",
     "aws_lambda_builders.workflows",
     "configparser",
     "dateparser",


### PR DESCRIPTION
#### Why is this change necessary?
I'm seeing unit tests fail locally when running `make pr`:
```
samcli.cli.import_module_proxy.MissingDynamicImportError: Dynamic import not allowed for name: jaraco.text package: None
```

I looked into the issue and it's due to a hidden import that gets brought in by recent versions of `setuptools` for `jaraco.text`. This is only happening on the test when running `pkg_resources.py2_warn` - which gets included in the test parameterization since it was added to this list of hidden imports to test.

I looked into it further and found that PyInstaller removed support for pkg_resources.py2_warn in version 5.3 (July 2022) in [issue #6952](https://github.com/pyinstaller/pyinstaller/issues/6952). We depend on PyInstaller 6.15.0, so this dependency isn't being brought in transitively anymore anyway, and doesn't exist in the current python environments.


#### How does it address the issue?
This removes the unnecessary hidden import from the list. No functional changes made -- PyInstaller already is ignoring the import, this is just for a unit test.


#### What side effects does this change have?
None


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [N/A] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [N/A] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [N/A] Write/update integration tests
- [N/A] Write/update functional tests if needed
- [X] `make pr` passes
- [N/A] `make update-reproducible-reqs` if dependencies were changed
- [N/A] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
