### PR TITLE
test: fix validate tests and test-events tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ schema:
 	python -m schema.make_schema
 
 # Verifications to run before sending a pull request
-pr: init dev schema black-check
+pr: init schema black-check dev
 
 # lucashuy: Linux and MacOS are on the same Python version,
 # however we should follow up in a different change

--- a/tests/integration/remote/test_event/test_remote_test_event.py
+++ b/tests/integration/remote/test_event/test_remote_test_event.py
@@ -32,7 +32,7 @@ class TestRemoteTestEvent(RemoteTestEventIntegBase):
             self.stack_name,
             function_name,
             expected_output="",
-            expected_error="Error: No events found for function HelloWorldFunction1",
+            expected_error="No events found for function HelloWorldFunction1",
         )
         self.get_event_and_check(
             self.stack_name,

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import tempfile
+from datetime import datetime
 from enum import Enum, auto
 from pathlib import Path
 from typing import List, Optional
@@ -20,6 +21,31 @@ from tests.testing_utils import (
     run_command,
     get_sam_command,
 )
+
+from cfnlint.helpers import load_resource
+from cfnlint.data import AdditionalSpecs
+
+
+# cfn-lint has a dynamic validation for deprecated runtimes depending on the date, and the error will change according to that
+# some of the logic from cfn-lint):
+# https://github.com/aws-cloudformation/cfn-lint/blob/baa4f017592fc56f7f11f10d22c8044ff36c3f6a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py#L32
+def get_runtime_deprecation_values(runtime):
+    current_date = datetime.today()
+    # Runtime deprecation dates: https://github.com/aws-cloudformation/cfn-lint/blob/main/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+    deprecated_runtimes = load_resource(AdditionalSpecs, "LmbdRuntimeLifecycle.json")
+    runtime_data = deprecated_runtimes.get(runtime)
+    # Not deprecated
+    if not runtime_data or current_date < datetime.strptime(runtime_data["deprecated"], "%Y-%m-%d"):
+        return None
+    # Deprecated but not create-blocked yet
+    if current_date < datetime.strptime(runtime_data["create-block"], "%Y-%m-%d"):
+        return {"code": "W2531", "msg": "Check if EOL Lambda Function Runtimes are used"}
+    # Create-blocked but not update-blocked
+    if current_date < datetime.strptime(runtime_data["update-block"], "%Y-%m-%d"):
+        return {"code": "E2531", "msg": "Validate if lambda runtime is deprecated"}
+    # Fully deprecated including update-blocked
+    return {"code": "E2533", "msg": "Check if Lambda Function Runtimes are updatable"}
+
 
 # Validate tests require credentials and CI/CD will only add credentials to the env if the PR is from the same repo.
 # This is to restrict package tests to run outside of CI/CD, when the branch is not master or tests are not run by Canary
@@ -127,11 +153,18 @@ class TestValidate(TestCase):
 
     @parameterized.expand(
         [
+            ("nodejs",),
+            ("python3.7",),
             ("nodejs16.x",),
             ("nodejs18.x",),
         ]
     )
     def test_lint_deprecated_runtimes(self, runtime):
+
+        # The message for deprecated runtimes can change according to the current date
+        deprecation_values = get_runtime_deprecation_values(runtime)
+        if not deprecation_values:
+            self.fail(f"Runtime {runtime} is not marked as deprecated. This shouldn't happen in this test.")
         template = {
             "AWSTemplateFormatVersion": "2010-09-09",
             "Transform": "AWS::Serverless-2016-10-31",
@@ -156,10 +189,9 @@ class TestValidate(TestCase):
 
             output = command_result.stdout.decode("utf-8")
             self.assertEqual(command_result.process.returncode, 1)
-            self.assertRegex(
+            self.assertIn(
+                f"[[{deprecation_values['code']}: {deprecation_values['msg']}] (Runtime '{runtime}' was deprecated on ",
                 output,
-                f"\\[\\[W2531: Check if EOL Lambda Function Runtimes are used] "
-                f"\\(Runtime '{runtime}' was deprecated on.*",
             )
 
     def test_lint_supported_runtimes(self):


### PR DESCRIPTION
- cfn-lint can send different errors/warning for Lambda deprecated runtimes, so we make an extra check to make sure that the error that we check is the right one.
- `sam remote test-event list` doesn't fail anymore when there are no events.

#### Which issue(s) does this change fix?
Tests failures: https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux/build/job/fheq10brhbfi6r3w


I also change the order of the commands in `make pr`, so the linting happens before running the tests (so you don't have to wait for all the tests to run to realize `black` doesn't like your files format)

#### Why is this change necessary?
To prevent tests from failing.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
