### PR TITLE
fix(test): Create seperate env for smoke test

### DIFF
--- a/tests/smoke/test_all_commands.py
+++ b/tests/smoke/test_all_commands.py
@@ -51,8 +51,18 @@ class TestAllCommands(TestCase):
         sam_cmd = "samdev" if os.getenv("SAM_CLI_DEV", 0) else "sam"
         # if a previous smoke test run have been killed, re-running them will fail. so run them in a temp folder
         with tempfile.TemporaryDirectory() as temp:
+            # Create isolated config directory for each test to prevent metadata.json conflicts
+            env = os.environ.copy()
+            # Use a unique subdirectory for SAM CLI config to avoid concurrent access issues
+            config_dir = os.path.join(temp, ".aws-sam")
+            env["__SAM_CLI_APP_DIR"] = config_dir
+
             process = subprocess.Popen(
-                [sam_cmd, cmd_name] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=temp
+                [sam_cmd, cmd_name] + args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=temp,
+                env=env,  # Use modified environment with isolated config dir
             )
             stdout, stderr = process.communicate()
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/actions/runs/17596078472/job/49988516171?pr=8206


#### Why is this change necessary?
Fix the metadata flaky error in smoketest:
```
2025-09-09 21:24:54 Error when loading global config file: /home/runner/.aws-sam/metadata.json
Traceback (most recent call last):
  File "/home/runner/work/aws-sam-cli/aws-sam-cli/samcli/cli/global_config.py", line 308, in _load_config
    json_body = json.loads(body)
                ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

#### How does it address the issue?
Create a temp dir/env for each test case

#### What side effects does this change have?
No, git action is one time use.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
