### PR TITLE
fix: support nested stacks when normalizing function name

### DIFF
--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -23,7 +23,7 @@ from samcli.lib.providers.sam_function_provider import SamFunctionProvider
 from samcli.lib.utils.architecture import validate_architecture_runtime
 from samcli.lib.utils.codeuri import resolve_code_path
 from samcli.lib.utils.colors import Colored
-from samcli.lib.utils.name_utils import normalize_lambda_function_name
+from samcli.lib.utils.name_utils import normalize_sam_function_identifier
 from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.docker.container import ContainerConnectionTimeoutException, ContainerResponseException
@@ -129,7 +129,7 @@ class LocalLambdaRunner:
         """
 
         # Normalize function identifier from ARN if provided
-        normalized_function_identifier = normalize_lambda_function_name(function_identifier)
+        normalized_function_identifier = normalize_sam_function_identifier(function_identifier)
 
         # Generate the correct configuration based on given inputs
         function = self.provider.get(normalized_function_identifier)

--- a/samcli/lib/utils/name_utils.py
+++ b/samcli/lib/utils/name_utils.py
@@ -22,6 +22,25 @@ class InvalidFunctionNameException(Exception):
     pass
 
 
+def normalize_sam_function_identifier(function_identifier: str) -> str:
+    """
+    Normalize a SAM CLI function identifier, handling nested stack paths.
+
+    Examples:
+    - "MyFunction" -> normalize("MyFunction")
+    - "Stack/MyFunction" -> "Stack/" + normalize("MyFunction")
+    - "Stack1/Stack2/MyFunction" -> "Stack1/Stack2/" + normalize("MyFunction")
+    - "Stack/arn:aws:lambda:..." -> "Stack/" + normalize("arn:aws:lambda:...")
+    """
+    if "/" in function_identifier:
+        # Split on last / to separate stack path from function identifier
+        stack_path, func_identifier = function_identifier.rsplit("/", 1)
+        normalized_func = normalize_lambda_function_name(func_identifier)
+        return f"{stack_path}/{normalized_func}"
+
+    return normalize_lambda_function_name(function_identifier)
+
+
 def normalize_lambda_function_name(function_identifier: str) -> str:
     """
     Normalize a Lambda function identifier by extracting the function name from various formats.

--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -8,7 +8,7 @@ from flask import Flask, request
 from werkzeug.routing import BaseConverter
 
 from samcli.commands.local.lib.exceptions import UnsupportedInlineCodeError
-from samcli.lib.utils.name_utils import InvalidFunctionNameException, normalize_lambda_function_name
+from samcli.lib.utils.name_utils import InvalidFunctionNameException, normalize_sam_function_identifier
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.docker.exceptions import DockerContainerCreationFailedException
 from samcli.local.lambdafn.exceptions import FunctionNotFound
@@ -169,7 +169,7 @@ class LocalLambdaInvokeService(BaseLocalService):
 
         # Normalize function name from ARN if provided
         try:
-            normalized_function_name = normalize_lambda_function_name(function_name)
+            normalized_function_name = normalize_sam_function_identifier(function_name)
         except InvalidFunctionNameException as e:
             LOG.error("Invalid function name: %s", str(e))
             return LambdaErrorResponses.validation_exception(str(e))

--- a/tests/unit/lib/utils/test_name_utils.py
+++ b/tests/unit/lib/utils/test_name_utils.py
@@ -6,17 +6,23 @@ from unittest import TestCase
 
 from parameterized import parameterized
 
-from samcli.lib.utils.name_utils import normalize_lambda_function_name, InvalidFunctionNameException
+from samcli.lib.utils.name_utils import (
+    normalize_lambda_function_name,
+    normalize_sam_function_identifier,
+    InvalidFunctionNameException,
+)
 
 
-class TestNormalizeLambdaFunctionName(TestCase):
-    """Test cases for normalize_lambda_function_name function"""
+class TestNormalizeSamFunctionIdentifier(TestCase):
+    """Test cases for normalize_sam_function_identifier function"""
 
     @parameterized.expand(
         [
             # Simple function names (pass-through)
             ("my-function", "my-function"),
             ("function-with_mixed-chars123", "function-with_mixed-chars123"),
+            ("my-function:v1", "my-function"),
+            ("my-function:$LATEST", "my-function"),
             # Full ARNs with versions/aliases
             ("arn:aws:lambda:us-east-1:123456789012:function:my-function", "my-function"),
             ("arn:aws:lambda:us-east-1:123456789012:function:my-function:$LATEST", "my-function"),
@@ -25,21 +31,34 @@ class TestNormalizeLambdaFunctionName(TestCase):
             # Partial ARNs
             ("123456789012:function:my-function", "my-function"),
             ("123456789012:function:my-function:$LATEST", "my-function"),
-            # Function names with versions/aliases
-            ("my-function:$LATEST", "my-function"),
-            ("my-function:v1", "my-function"),
             # Invalid partial ARN format (should pass through)
             ("123456789012:invalid:my-function", "123456789012:invalid:my-function"),
+            # Nested stack paths with simple function names
+            ("NestedStack/my-function", "NestedStack/my-function"),
+            ("NestedStack/my-function:v1", "NestedStack/my-function"),
+            ("LocalNestedStack/Function1", "LocalNestedStack/Function1"),
+            ("LocalNestedStack/Function2", "LocalNestedStack/Function2"),
+            # Deep nested stack paths
+            ("Stack1/Stack2/my-function", "Stack1/Stack2/my-function"),
+            ("ChildStackX/ChildStackY/FunctionA", "ChildStackX/ChildStackY/FunctionA"),
+            ("Stack1/Stack2/Stack3/my-function", "Stack1/Stack2/Stack3/my-function"),
+            # Nested stack paths with ARNs
+            ("NestedStack/arn:aws:lambda:us-east-1:123456789012:function:my-function", "NestedStack/my-function"),
+            (
+                "Stack1/Stack2/arn:aws:lambda:us-east-1:123456789012:function:my-function:$LATEST",
+                "Stack1/Stack2/my-function",
+            ),
+            # Nested stack paths with partial ARNs
+            ("NestedStack/123456789012:function:my-function", "NestedStack/my-function"),
         ]
     )
-    def test_normalize_lambda_function_name(self, input_name, expected_output):
-        """Test normalize_lambda_function_name with various inputs"""
-        result = normalize_lambda_function_name(input_name)
+    def test_normalize_sam_function_identifier(self, input_name, expected_output):
+        """Test normalize_sam_function_identifier with various inputs"""
+        result = normalize_sam_function_identifier(input_name)
         self.assertEqual(result, expected_output)
 
     @parameterized.expand(
         [
-            ("arn:aws:s3:::my-bucket/my-key",),
             ("arn:aws:lambda",),
             (":HelloWorld",),
             ("HelloWorld:",),
@@ -47,14 +66,15 @@ class TestNormalizeLambdaFunctionName(TestCase):
             (":",),
             ("function-with-invalid-chars!",),
             ("123456789012:function:",),
+            ("Stack1/Stack2/function-with-invalid-chars!",),
+            ("NestedStack/",),
         ]
     )
     def test_raises_exception_for_invalid_function_names(self, invalid_name):
         """Test that invalid function names raise InvalidFunctionNameException"""
         with self.assertRaises(InvalidFunctionNameException) as exc_info:
-            normalize_lambda_function_name(invalid_name)
+            normalize_sam_function_identifier(invalid_name)
 
         # Check that the error message matches AWS Lambda's format
         self.assertIn("1 validation error detected", str(exc_info.exception))
-        self.assertIn(f"Value '{invalid_name}' at 'functionName'", str(exc_info.exception))
         self.assertIn("failed to satisfy constraint", str(exc_info.exception))


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#8289

#### Why is this change necessary?
Canaries are failing after merging https://github.com/aws/aws-sam-cli/pull/8295, due to SAM supporting nested stacks but the change not handling nested stacks properly. There weren't unit tests covering nested stacks being passed as the function identifier.

#### How does it address the issue?
I've updated how we normalize the SAM resource to support nested stacks and added unit tests. Now, we parse the last component of the identifier to normalize as the function name. So if you have a nested stack (e.g. `NestedStack/MyFunction`), we'll only try normalizing `MyFunction`.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [X] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [X] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [X] Write/update unit tests
- [N/A] Write/update integration tests
- [N/A] Write/update functional tests if needed
- [X] `make pr` passes
- [N/A] `make update-reproducible-reqs` if dependencies were changed
- [X] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
