### PR TITLE
chore: update aws_lambda_builders to 1.59.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ aws-sam-translator==1.101.0
 docker~=7.1.0
 dateparser~=1.2
 requests~=2.32.5
-aws_lambda_builders==1.58.0
+aws_lambda_builders==1.59.0
 tomlkit==0.13.3
 # NOTE: For supporting watchdog in Python3.8, version is pinned to 4.0.2 as 
 # version 5.0.2 introduced some breaking changes for versions > Python3.8


### PR DESCRIPTION
update aws_lambda_builders to 1.59.0

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
