### PR TITLE
fix: set mock credentials for durable emulator boto client

### DIFF
--- a/samcli/lib/clients/lambda_client.py
+++ b/samcli/lib/clients/lambda_client.py
@@ -53,11 +53,15 @@ class DurableFunctionsClient:
             # Create a fresh botocore session
             session = botocore.session.Session()
 
-            # Create the boto3 client with custom service model using the fresh session
+            # Create the boto3 client using the fresh session
             client = session.create_client(
                 "lambda",
                 endpoint_url=endpoint_url,
                 region_name=region,
+                # the emulator doesnt access any AWS resources,
+                # but we need _some_ credentials to create a boto client
+                aws_access_key_id="foo",
+                aws_secret_access_key="bar",
             )
 
             return cls(client)

--- a/tests/unit/lib/clients/test_lambda_client.py
+++ b/tests/unit/lib/clients/test_lambda_client.py
@@ -44,7 +44,11 @@ class TestDurableFunctionsClient(unittest.TestCase):
         self.assertEqual(client.client, mock_client)
         mock_session_class.assert_called_once()
         mock_session.create_client.assert_called_once_with(
-            "lambda", endpoint_url="http://localhost:5000", region_name="us-west-2"
+            "lambda",
+            endpoint_url="http://localhost:5000",
+            region_name="us-west-2",
+            aws_access_key_id="foo",
+            aws_secret_access_key="bar",
         )
 
     @patch("samcli.lib.clients.lambda_client.botocore.session.Session")
@@ -69,6 +73,8 @@ class TestDurableFunctionsClient(unittest.TestCase):
             "lambda",
             endpoint_url=f"http://{custom_host}:{custom_port}",
             region_name=custom_region,
+            aws_access_key_id="foo",
+            aws_secret_access_key="bar",
         )
 
     @patch("samcli.lib.clients.lambda_client.botocore.session.Session")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
We create an instance of a botocore lambda client to interact between the CLI commands and the durable executions emulator. However, if a customer doesn't have _any_ AWS credentials set through any credential provider, API calls using the boto client will fail with `Unable to locate credentials`.

#### How does it address the issue?
Adding a set of mock credentials passed to the `.create()` classmethod. This is only used by the emulator when it creates a lambda client.

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
