### PR TITLE
fix: build durable emulator image and copy binary to it

### DIFF
--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -26,7 +26,12 @@ from samcli.lib.utils.packagetype import IMAGE, ZIP
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.lib.utils.tar import create_tarball
 from samcli.local.common.file_lock import FileLock, cleanup_stale_locks
-from samcli.local.docker.utils import get_docker_platform, get_rapid_name, get_validated_container_client
+from samcli.local.docker.utils import (
+    get_docker_platform,
+    get_rapid_name,
+    get_tar_filter_for_windows,
+    get_validated_container_client,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -409,15 +414,8 @@ class LambdaImage:
             for layer in layers:
                 tar_paths[layer.codeuri] = "/" + layer.name
 
-            # Set permission for all the files in the tarball to 500(Read and Execute Only)
-            # This is need for systems without unix like permission bits(Windows) while creating a unix image
-            # Without setting this explicitly, tar will default the permission to 666 which gives no execute permission
-            def set_item_permission(tar_info):
-                tar_info.mode = 0o500
-                return tar_info
-
-            # Set only on Windows, unix systems will preserve the host permission into the tarball
-            tar_filter = set_item_permission if platform.system().lower() == "windows" else None
+            # Use shared tar filter for Windows compatibility
+            tar_filter = get_tar_filter_for_windows()
 
             with create_tarball(tar_paths, tar_filter=tar_filter, dereference=True) as tarballfile:
                 try:

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -5,6 +5,7 @@ Helper methods that aid interactions within docker containers.
 import logging
 import os
 import pathlib
+import platform
 import posixpath
 import random
 import re
@@ -136,6 +137,27 @@ def get_validated_container_client():
     Get validated container client using strategy pattern.
     """
     return ContainerClientFactory.create_client()
+
+
+def get_tar_filter_for_windows():
+    """
+    Get tar filter function for Windows compatibility.
+
+    Sets permission for all files in the tarball to 500 (Read and Execute Only).
+    This is needed for systems without unix-like permission bits (Windows) while creating a unix image.
+    Without setting this explicitly, tar will default the permission to 666 which gives no execute permission.
+
+    Returns
+    -------
+    callable or None
+        Filter function for Windows, None for Unix systems
+    """
+
+    def set_item_permission(tar_info):
+        tar_info.mode = 0o500
+        return tar_info
+
+    return set_item_permission if platform.system().lower() == "windows" else None
 
 
 def is_image_current(docker_client: docker.DockerClient, image_name: str) -> bool:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
We found a bug in the latest release of SAM CLI in the emulator creation process. It seems to be only affecting the Mac installer; we were able to test executions on Linux and Windows successfully.

The issue manifests like this:
```
Error: 400 Client Error for http+docker://localhost/v1.35/containers/0c3bf73e11a1f171988bfed82e8842bb4682cc07fe729fd2cc379cd8867ee0f8/start: Bad Request ("failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/usr/local/bin/aws-durable-execution-emulator-arm64": stat /usr/local/bin/aws-durable-execution-emulator-arm64: no such file or directory: unknown")
```

The underlying issue is that while the binary itself exists in the artifacts for the release, they don't get copied into the container image properly.

#### How does it address the issue?
We need to create a new image from the base image (Ubuntu), and copy the emulator binaries into it, and then set the executable permissions on the emulator binary. This is the correct approach to the container image creation, and follows the pattern that the lambda container uses when generating the runtime images to run the function code.

I validated it by running the pyinstaller script manually and symlinked the build output artifacts to run an execution:
```
sudo mkdir -p /usr/local/aws-sam-cli
sudo cp -r pyinstaller-output/dist/* /usr/local/aws-sam-cli/
sudo ln -sf /usr/local/aws-sam-cli/sam /usr/local/bin/sam

✗ sam --version
SAM CLI, version 1.151.0

✗ sam local execution get asdf
Error: An error occurred (404) when calling the GetDurableExecution operation: Execution asdf not found

✗ sam local invoke HelloWorld --container-host-interface 0.0.0.0
No current session found, using default AWS::AccountId
Invoking hello-world.handler (nodejs22.x)
Local image was not found.
Removing rapid images for repo public.ecr.aws/sam/emulation-nodejs22.x
Building image............
Using local image: public.ecr.aws/lambda/nodejs:22-rapid-x86_64.

START RequestId: 362138ee-0799-43ac-80e7-99c9b735de9b Version: $LATEST
2025-12-03T06:45:52.408Z	c96df452-41be-4c95-aff1-5cf13429a6b6	INFO	Hello world from a durable function!
END RequestId: c96df452-41be-4c95-aff1-5cf13429a6b6
REPORT RequestId: c96df452-41be-4c95-aff1-5cf13429a6b6	Init Duration: 0.74 ms	Duration: 1804.98 ms	Billed Duration: 1805 ms	Memory Size: 128 MB	Max Memory Used: 128 MB

Execution Summary:
=========================
ARN:      041f8d1e-e762-414c-8bce-ed0339a2320c
Name:     N/A
Duration: 1.92s
Status:   SUCCEEDED ✅
Input:    {}
Result:   "Hello World!"

Commands you can use next
=========================
[*] Get execution details: sam local execution get 041f8d1e-e762-414c-8bce-ed0339a2320c
[*] View execution history: sam local execution history 041f8d1e-e762-414c-8bce-ed0339a2320c
```

#### What side effects does this change have?
None.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
