### PR TITLE
fix: pin ruby action to specific version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.19'
-      - uses: ruby/setup-ruby@v1
+      # Pin to specific version until Lambda Builders support bundler 4.0.0
+      - uses: ruby/setup-ruby@v1.268.0
         with:
           ruby-version: "3.3"
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Pin Ruby action to specific version until Lambda Buidlers support `bundler` 4.0.0

#### Which issue(s) does this change fix?

SAM CLI integration tests use a ruby GitHub action to set up ruby to check that building ruby works correctly. However, Lambda Builders doesn't support `bundler` 4.0.0 yet. So the tests are failing when trying to use the latest version. 


#### Why is this change necessary?
Integ tests are failing without this

#### How does it address the issue?
Pins the version of ruby GitHtub action, to before they updated to use bundler 4.0.0
diff: https://github.com/ruby/setup-ruby/compare/v1.268.0...v1.269.0

#### What side effects does this change have?
None

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
