### PR TITLE
chore(deps): update Maven to 3.9.12 in integ tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -149,8 +149,8 @@ jobs:
           # Remove system Maven if it exists
           sudo apt-get remove -y maven || true
           
-          # Install Maven 3.9.11
-          wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip -P /tmp
+          # Install Maven 3.9.12
+          wget https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.zip -P /tmp
           sudo unzip -d /opt/mvn /tmp/apache-maven-*.zip
           
           # Install Gradle 9.2.0
@@ -158,18 +158,18 @@ jobs:
           sudo unzip -d /opt/gradle /tmp/gradle-*.zip
           
           # Create symlinks to ensure our Maven is used
-          sudo ln -sf /opt/mvn/apache-maven-3.9.11/bin/mvn /usr/local/bin/mvn
+          sudo ln -sf /opt/mvn/apache-maven-3.9.12/bin/mvn /usr/local/bin/mvn
           sudo ln -sf /opt/gradle/gradle-9.2.0/bin/gradle /usr/local/bin/gradle
           
           # Add to PATH (prepend to ensure our versions are used first)
-          echo "/opt/mvn/apache-maven-3.9.11/bin" >> $GITHUB_PATH
+          echo "/opt/mvn/apache-maven-3.9.12/bin" >> $GITHUB_PATH
           echo "/opt/gradle/gradle-9.2.0/bin" >> $GITHUB_PATH
           
           # Set MAVEN_HOME
-          echo "MAVEN_HOME=/opt/mvn/apache-maven-3.9.11" >> $GITHUB_ENV
+          echo "MAVEN_HOME=/opt/mvn/apache-maven-3.9.12" >> $GITHUB_ENV
           
           # Verify versions
-          export PATH="/opt/mvn/apache-maven-3.9.11/bin:/opt/gradle/gradle-9.2.0/bin:$PATH"
+          export PATH="/opt/mvn/apache-maven-3.9.12/bin:/opt/gradle/gradle-9.2.0/bin:$PATH"
           mvn --version
           gradle --version
 

--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -46,9 +46,9 @@ install:
   - sh: "ls /usr/"
   # install latest maven which is compatible with jdk17
   - sh: "sudo apt-get -y remove maven"
-  - sh: "wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip -P /tmp"
+  - sh: "wget https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.zip -P /tmp"
   - sh: "sudo unzip -d /opt/mvn /tmp/apache-maven-*.zip"
-  - sh: "PATH=/opt/mvn/apache-maven-3.9.11/bin:$PATH"
+  - sh: "PATH=/opt/mvn/apache-maven-3.9.12/bin:$PATH"
   - sh: "mvn --version"
 
   - sh: "source ${HOME}/venv${PYTHON_VERSION}/bin/activate"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -58,9 +58,9 @@ install:
   - sh: "ls /usr/"
   # install latest maven which is compatible with jdk17
   - sh: "sudo apt-get -y remove maven"
-  - sh: "wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip -P /tmp"
+  - sh: "wget https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.zip -P /tmp"
   - sh: "sudo unzip -d /opt/mvn /tmp/apache-maven-*.zip"
-  - sh: "PATH=/opt/mvn/apache-maven-3.9.11/bin:$PATH"
+  - sh: "PATH=/opt/mvn/apache-maven-3.9.12/bin:$PATH"
   - sh: "mvn --version"
 
   # Finch Runtime Setup (Steps 1-7)


### PR DESCRIPTION
We should probably have this in a variable or something, but just updating this directly for now

#### Which issue(s) does this change fix?
Integration tests failing because of Maven version update https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux/build/job/4r630vrgf73daxs0

(apparently Maven now quickly removes old version from being able to be downloaded directly) 


#### Why is this change necessary?
Failure when trying to download the previous version 3.9.11

#### How does it address the issue?
Update the version

#### What side effects does this change have?
It uses the new version of Maven. 

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
