### PR TITLE
test: fix dotnet10 integ tests

### DIFF
--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -71,9 +71,11 @@ install:
   - sh: "PATH=/opt/gradle/gradle-9.0.0/bin:$PATH"
   - sh: "gradle --version"
 
-  # Install dotnet8 SDK
+  # Install dotnet10 SDK (backwards compatible so it works to build all previous versions)
+  # https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet10&pivots=os-linux-ubuntu-2204
+  - sh: "sudo add-apt-repository ppa:dotnet/backports"
   - sh: "sudo apt-get update"
-  - sh: "sudo apt-get install -y dotnet-sdk-8.0"
+  - sh: "sudo apt-get install -y dotnet-sdk-10.0"
 
   # Install AWS CLI
   - sh: "virtualenv aws_cli"

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -244,9 +244,11 @@ install:
   - sh: "PATH=/opt/gradle/gradle-9.2.0/bin:$PATH"
   - sh: "gradle --version"
 
-  # Install dotnet8 SDK
+  # Install dotnet10 SDK (backwards compatible so it works to build all previous versions)
+  # https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install?tabs=dotnet10&pivots=os-linux-ubuntu-2204
+  - sh: "sudo add-apt-repository ppa:dotnet/backports"
   - sh: "sudo apt-get update"
-  - sh: "sudo apt-get install -y dotnet-sdk-8.0"
+  - sh: "sudo apt-get install -y dotnet-sdk-10.0"
 
   # Install AWS CLI
   - sh: "virtualenv aws_cli"

--- a/tests/integration/testdata/buildcmd/Dotnet10/HelloWorld.csproj
+++ b/tests/integration/testdata/buildcmd/Dotnet10/HelloWorld.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 


### PR DESCRIPTION
Files for dotnet10 runtime were still using dotnet8 as a target framework. Also, the version installed in the Linux integration tests was still dotnet8

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
