### PR TITLE
Declare that Python 3.14 is not supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
     license="Apache License 2.0",
     packages=find_packages(exclude=["tests.*", "tests", "installer.*", "installer", "schema.*", "schema"]),
     keywords="AWS SAM CLI",
-    # Support Python 3.9 or greater
-    python_requires=">=3.9, <=4.0, !=4.0",
+    # Support Python 3.9 through 3.13
+    python_requires=">=3.9, <3.14",
     entry_points={"console_scripts": ["{}=samcli.cli.main:cli".format(cmd_name)]},
     install_requires=read_requirements("base.txt"),
     extras_require={"pre-dev": read_requirements("pre-dev.txt"), "dev": read_requirements("dev.txt")},


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Until https://github.com/aws/serverless-application-model/issues/3831 gets resolved, this PR declares that `aws-sam-cli` doesn't support Python 3.14.

#### Why is this change necessary?
This change helps tools avoid trying to run `aws-sam-cli` using Python 3.14.

#### How does it address the issue?
For example when running `uvx --from aws-sam-cli sam local --help`, uv will read this metadata to determine the best version of Python to use. This PR will help uv understand to not try 3.14.

#### What side effects does this change have?
N/A

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
