### PR TITLE
test: install latest versions of python/java in linux-binary tests

### DIFF
--- a/appveyor-linux-binary.yml
+++ b/appveyor-linux-binary.yml
@@ -35,8 +35,8 @@ install:
   # install coretto 21
   - sh: wget -O - https://apt.corretto.aws/corretto.key | sudo gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg
   - sh: echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | sudo tee /etc/apt/sources.list.d/corretto.list
-  - sh: sudo apt-get update; sudo apt-get install -y java-21-amazon-corretto-jdk
-  - sh: JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto
+  - sh: sudo apt-get update; sudo apt-get install -y java-25-amazon-corretto-jdk
+  - sh: JAVA_HOME=/usr/lib/jvm/java-25-amazon-corretto
   - sh: PATH=$JAVA_HOME/bin:$PATH
   - sh: java --version
   - sh: javac --version
@@ -81,6 +81,15 @@ install:
   - sh: "virtualenv aws_cli"
   - sh: "./aws_cli/bin/python -m pip install awscli"
   - sh: "PATH=$(echo $PWD'/aws_cli/bin'):$PATH"
+
+  # install python 3.14
+  - sh: |
+      DEST="$HOME/venv3.14"
+      URL="https://github.com/astral-sh/python-build-standalone/releases/download/20251031/cpython-3.14.0+20251031-x86_64-unknown-linux-gnu-install_only.tar.gz"
+      curl -L "$URL" | tar -xz
+      mv python $DEST
+      $HOME/venv3.14/bin/python --version
+      $HOME/venv3.14/bin/pip --version
 
   - sh: "PATH=$PATH:$HOME/venv3.9/bin:$HOME/venv3.10/bin:$HOME/venv3.11/bin:$HOME/venv3.12/bin:$HOME/venv3.13/bin:$HOME/venv3.14/bin"
 

--- a/appveyor-ubuntu.yml
+++ b/appveyor-ubuntu.yml
@@ -264,7 +264,7 @@ install:
       $HOME/venv3.14/bin/python --version
       $HOME/venv3.14/bin/pip --version
 
-  - sh: "PATH=$PATH:$HOME/venv3.7/bin:$HOME/venv3.8/bin:$HOME/venv3.9/bin:$HOME/venv3.10/bin:$HOME/venv3.11/bin:$HOME/venv3.12/bin:$HOME/venv3.13/bin:$HOME/venv3.14/bin"
+  - sh: "PATH=$PATH:$HOME/venv3.9/bin:$HOME/venv3.10/bin:$HOME/venv3.11/bin:$HOME/venv3.12/bin:$HOME/venv3.13/bin:$HOME/venv3.14/bin"
 
   # update ca-certificates which causes failures with newest golang library
   - sh: "sudo apt-get install --reinstall ca-certificates"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
In linux-binary integration tests, we were not installing Python 3.14 or java 25. 

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
