### PR TITLE
fix: add mount-with write for java25 tests

### DIFF
--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -664,7 +664,7 @@ class BuildIntegJavaBase(BuildIntegBase):
         overrides = self.get_override(runtime, code_path, architecture, "aws.example.Hello::myHandler")
         mount_with = (
             MountMode.WRITE
-            if use_container and str(runtime).lower() == "java25" and code_path != self.USING_MAVEN_PATH
+            if use_container and str(runtime).lower() == "java25" and self.USING_MAVEN_PATH not in code_path
             else None
         )
         cmdlist = self.get_command_list(


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
#### Why is this change necessary?
Gradle 9 (which Java25 uses) requires the addition of the --mount-with WRITE flag.

#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
