### PR TITLE
fix: handle FunctionNotFound for ECR-based image functions in sam sync

### DIFF
--- a/samcli/lib/sync/watch_manager.py
+++ b/samcli/lib/sync/watch_manager.py
@@ -22,7 +22,7 @@ from samcli.lib.utils.code_trigger_factory import CodeTriggerFactory
 from samcli.lib.utils.colors import Colored, Colors
 from samcli.lib.utils.path_observer import HandlerObserver
 from samcli.lib.utils.resource_trigger import OnChangeCallback, TemplateTrigger
-from samcli.local.lambdafn.exceptions import ResourceNotFound
+from samcli.local.lambdafn.exceptions import FunctionNotFound, ResourceNotFound
 
 if TYPE_CHECKING:  # pragma: no cover
     from samcli.commands.build.build_context import BuildContext
@@ -152,10 +152,10 @@ class WatchManager:
                     extra=dict(markup=True),
                 )
                 continue
-            except ResourceNotFound:
+            except (ResourceNotFound, FunctionNotFound):
                 LOG.warning(
                     self._color.color_log(
-                        msg="CodeTrigger not created as %s is not found or is with a S3 Location.",
+                        msg="CodeTrigger not created as %s is not found or is with a remote location (S3/ECR).",
                         color=Colors.WARNING,
                     ),
                     str(resource_id),


### PR DESCRIPTION
## Issue

Fixes #8381

## Description

`sam sync --watch` fails with `FunctionNotFound` when a nested stack contains a Lambda function with `PackageType: Image` that uses an ECR URI for `ImageUri` without `DockerContext` metadata.

## Root Cause

1. `_add_code_triggers()` iterates over all resource IDs from the template
2. For image functions, it creates a `LambdaImageCodeTrigger`, which calls `SamFunctionProvider.get()`
3. However, `SamFunctionProvider._extract_functions()` intentionally skips image functions with ECR URIs but no `DockerContext` metadata (since they can't be built locally)
4. This causes `SamFunctionProvider.get()` to return `None`, raising `FunctionNotFound`

## Solution

Catch `FunctionNotFound` alongside `ResourceNotFound` in `_add_code_triggers()`, allowing `sam sync` to gracefully skip these functions with a warning instead of crashing. This is consistent with how S3-based functions are already handled.

## Changes

- `samcli/lib/sync/watch_manager.py`: Added `FunctionNotFound` to exception handling
- `tests/unit/lib/sync/test_watch_manager.py`: Added test for `FunctionNotFound` handling

## Testing

- Added unit test `test_add_code_triggers_function_not_found`
