### PR TITLE
chore(test): move invoke/start-api/start-lambda durable function test to unit test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,9 @@ jobs:
           #- "delete"
           #- "deploy"
           - name: "integ-all-other"
-            params: "-n 2 --reruns 3 tests/integration/init tests/integration/local tests/integration/pipeline tests/integration/root tests/integration/scripts tests/integration/telemetry tests/integration/docs"
+            params: "-n 2 --reruns 3 tests/integration/init tests/integration/local tests/integration/pipeline tests/integration/root tests/integration/scripts tests/integration/telemetry tests/integration/docs --ignore=tests/integration/local/invoke/test_invoke_durable.py --ignore=tests/integration/local/start_api/test_start_api_durable.py --ignore=tests/integration/local/start_lambda/test_start_lambda_durable.py"
+          - name: "durable-functions"
+            params: "--reruns 3 tests/integration/local/invoke/test_invoke_durable.py tests/integration/local/start_api/test_start_api_durable.py tests/integration/local/start_lambda/test_start_lambda_durable.py"
           #- "list"
           #- "logs"
           #- "package"
@@ -138,6 +140,10 @@ jobs:
           #- "sync"
           #- "traces"
           #- "validate"
+        exclude:
+          - os: windows-latest
+            tests_config:
+              name: "durable-functions"
     steps:
       - uses: actions/checkout@v6
       - name: Set TEMP to D:/Temp
@@ -197,6 +203,8 @@ jobs:
         run: uv pip install --system --python python3.12 --upgrade pip setuptools
       - name: Run integration tests for ${{ matrix.tests_config.name }}
         run: pytest -vv ${{ matrix.tests_config.params }}
+        env:
+          FORCE_RUN_DOCKER_TEST: ${{ matrix.tests_config.name == 'durable-functions' && '1' || '' }}
 
   smoke-and-functional-tests:
     name: ${{ matrix.tests_config.name }} / ${{ matrix.tests_config.os }} / ${{ matrix.python }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,6 @@ jobs:
           - local-invoke
           - local-start1
           - local-start2
-          - durable-functions
           - other-and-e2e
         exclude:
           # no-container mode only applies to build-integ test suites
@@ -67,8 +66,6 @@ jobs:
             test_suite: local-start1
           - container_runtime: no-container
             test_suite: local-start2
-          - container_runtime: no-container
-            test_suite: durable-functions
           - container_runtime: no-container
             test_suite: other-and-e2e
 
@@ -402,10 +399,7 @@ jobs:
               pytest -vv --reruns 3 tests/integration/local/start_api --ignore tests/integration/local/start_api/test_start_api_with_terraform_application.py --ignore tests/integration/local/start_api/test_start_api_durable.py --json-report --json-report-file=TEST_REPORT-integration-local-start1-${{ matrix.container_runtime }}.json
               ;;
             "local-start2")
-              pytest -vv --reruns 3 tests/integration/local/start_lambda tests/integration/local/start_api/test_start_api_with_terraform_application.py --ignore tests/integration/local/start_lambda/test_start_lambda_durable.py --json-report --json-report-file=TEST_REPORT-integration-local-start2-${{ matrix.container_runtime }}.json
-              ;;
-            "durable-functions")
-              pytest -vv --reruns 3 tests/integration/local/invoke/test_invoke_durable.py tests/integration/local/start_api/test_start_api_durable.py tests/integration/local/start_lambda/test_start_lambda_durable.py tests/integration/local/callback/test_callback.py tests/integration/local/execution/test_execution.py --json-report --json-report-file=TEST_REPORT-integration-durable-functions-${{ matrix.container_runtime }}.json
+              pytest -vv --reruns 3 tests/integration/local/start_lambda tests/integration/local/start_api/test_start_api_with_terraform_application.py tests/integration/local/callback/test_callback.py tests/integration/local/execution/test_execution.py --ignore tests/integration/local/start_lambda/test_start_lambda_durable.py --json-report --json-report-file=TEST_REPORT-integration-local-start2-${{ matrix.container_runtime }}.json
               ;;
             "other-and-e2e")
               pytest -vv -n 4 --reruns 3 --dist loadgroup tests/integration tests/end_to_end tests/regression --ignore=tests/integration/buildcmd --ignore=tests/integration/delete --ignore=tests/integration/deploy --ignore=tests/integration/package --ignore=tests/integration/sync --ignore=tests/integration/local --json-report --json-report-file=TEST_REPORT-integration-others-${{ matrix.container_runtime }}.json

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -38,7 +38,8 @@ RUN_BY_CANARY = os.environ.get("BY_CANARY", False)
 USING_FINCH_RUNTIME = os.environ.get("CONTAINER_RUNTIME") == "finch"
 
 # Tests require docker suffers from Docker Hub request limit
-SKIP_DOCKER_TESTS = RUNNING_ON_CI and not RUN_BY_CANARY
+FORCE_RUN_DOCKER_TEST = os.environ.get("FORCE_RUN_DOCKER_TEST", False)
+SKIP_DOCKER_TESTS = RUNNING_ON_CI and not RUN_BY_CANARY and not FORCE_RUN_DOCKER_TEST
 
 
 # SKIP LMI unless test resource is deployed in the test accounts


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
There's no Durable function test coverage in unit test, causing
#8608 #8590 unknowingly broke Durable function.

#### How does it address the issue?
Move few DAR test from integ test to unit test.

#### What side effects does this change have?
N/A as we still have other DAR test coverage in integ test

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
