### PR TITLE
fix: install maven in windows tests

### DIFF
--- a/appveyor-windows-al2023.yml
+++ b/appveyor-windows-al2023.yml
@@ -47,7 +47,7 @@ install:
   - 'set PATH=%JAVA_HOME%\bin;%PATH%'
   - java --version
   - javac --version
-  - choco install maven
+  - choco install maven --version=3.9.12
   - choco upgrade gradle --version=9.0.0
   - choco install ruby --version=3.2.7.1
   - choco install ruby --version=3.3.7.1

--- a/appveyor-windows-binary.yml
+++ b/appveyor-windows-binary.yml
@@ -60,7 +60,7 @@ install:
   - 'set PATH=%JAVA_HOME%\bin;%PATH%'
   - java --version
   - javac --version
-  - choco install maven
+  - choco install maven --version=3.9.12
   - choco upgrade gradle --version=9.0.0
   - "gradle -v"
   - "mvn --version"

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -59,7 +59,7 @@ install:
   - 'set PATH=%JAVA_HOME%\bin;%PATH%'
   - java --version
   - javac --version
-  - choco install maven
+  - choco install maven --version=3.9.12
   - choco upgrade gradle --version=9.0.0
   - choco install ruby --version=3.2.7.1
   - choco install ruby --version=3.3.7.1


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Error in windows integ tests
```
mvn --version
'mvn' is not recognized as an internal or external command,
operable program or batch file.
Command exited with code 1
```

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
