### PR TITLE
fix: set maven path in al2023 tests

### DIFF
--- a/appveyor-windows-al2023.yml
+++ b/appveyor-windows-al2023.yml
@@ -48,6 +48,8 @@ install:
   - java --version
   - javac --version
   - choco install maven --version=3.9.12
+  - 'set MAVEN_HOME=C:\ProgramData\chocolatey\lib\maven\apache-maven-3.9.12'
+  - 'set PATH=%MAVEN_HOME%\bin;%PATH%'
   - choco upgrade gradle --version=9.0.0
   - choco install ruby --version=3.2.7.1
   - choco install ruby --version=3.3.7.1


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
in windows al2023 integ tests, mvn is still not being found because maven has not been set in PATH

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
