### PR TITLE
fix: handle StopDurableExecution payload deserialization correctly

### DIFF
--- a/samcli/lib/clients/lambda_client.py
+++ b/samcli/lib/clients/lambda_client.py
@@ -232,18 +232,19 @@ class DurableFunctionsClient:
         # Prepare the request parameters
         params: Dict[str, Any] = {"DurableExecutionArn": durable_execution_arn}
 
-        # Add error object if any error fields are provided
-        if error_message or error_type or error_data or stack_trace:
-            error_object: Dict[str, Any] = {}
-            if error_message:
-                error_object["ErrorMessage"] = error_message
-            if error_type:
-                error_object["ErrorType"] = error_type
-            if error_data:
-                error_object["ErrorData"] = error_data
-            if stack_trace:
-                error_object["StackTrace"] = stack_trace
-            params["Error"] = error_object
+        # Build Error dict if any error fields are provided
+        error_dict: Dict[str, Any] = {}
+        if error_message:
+            error_dict["ErrorMessage"] = error_message
+        if error_type:
+            error_dict["ErrorType"] = error_type
+        if error_data:
+            error_dict["ErrorData"] = error_data
+        if stack_trace:
+            error_dict["StackTrace"] = stack_trace
+
+        if error_dict:
+            params["Error"] = error_dict
 
         try:
             # Call the StopDurableExecution API

--- a/samcli/local/lambda_service/local_lambda_http_service.py
+++ b/samcli/local/lambda_service/local_lambda_http_service.py
@@ -398,12 +398,39 @@ class LocalLambdaHttpService(BaseLocalService):
 
         try:
             # Parse request body for error details - handle empty payloads gracefully
-            request_data = request.get_json(silent=True) or {}
+            request_data = request.get_json(silent=True)
+            if request_data is None:
+                request_data = {}
+            if not isinstance(request_data, dict):
+                LOG.debug("Request body is not a JSON object")
+                return LambdaErrorResponses.invalid_request_content("Request body must be a JSON object")
+
+            error_value = request_data.get("Error")
+            if error_value is not None and not isinstance(error_value, dict):
+                LOG.debug("Error field in request body is not a JSON object")
+                return LambdaErrorResponses.invalid_request_content("Error must be a JSON object")
+            error_dict = error_value or {}
+
+            # Validate leaf value types so a client mistake is a 400, not a botocore 500
+            stack_trace = error_dict.get("StackTrace")
+            if stack_trace is not None and not (
+                isinstance(stack_trace, list) and all(isinstance(entry, str) for entry in stack_trace)
+            ):
+                LOG.debug("Error.StackTrace in request body is not an array of strings")
+                return LambdaErrorResponses.invalid_request_content("Error.StackTrace must be an array of strings")
+            for field in ("ErrorMessage", "ErrorType", "ErrorData"):
+                value = error_dict.get(field)
+                if value is not None and not isinstance(value, str):
+                    LOG.debug("Error.%s in request body is not a string", field)
+                    return LambdaErrorResponses.invalid_request_content(f"Error.{field} must be a string")
 
             with DurableContext() as context:
                 response = context.client.stop_durable_execution(
                     durable_execution_arn=decoded_arn,
-                    error=request_data.get("Error"),
+                    error_message=error_dict.get("ErrorMessage"),
+                    error_type=error_dict.get("ErrorType"),
+                    error_data=error_dict.get("ErrorData"),
+                    stack_trace=error_dict.get("StackTrace"),
                 )
             return self.service_response(
                 json.dumps(response, cls=DateTimeEncoder), {"Content-Type": "application/json"}, 200

--- a/tests/integration/local/start_lambda/test_start_lambda_durable.py
+++ b/tests/integration/local/start_lambda/test_start_lambda_durable.py
@@ -351,3 +351,50 @@ class TestStartLambdaDurable(DurableIntegBase, StartLambdaIntegBaseClass):
             DurableExecutionArn=execution_arn, IncludeExecutionData=True
         )
         self.assert_execution_history(history_response, DurableFunctionExamples.WAIT_FOR_CALLBACK)
+
+    @parameterized.expand(
+        [
+            (
+                "all_parameters",
+                {
+                    "Error": {
+                        "ErrorMessage": "Test error message",
+                        "ErrorType": "TestError",
+                        "ErrorData": '{"detail": "test error"}',
+                        "StackTrace": ["line1", "line2"],
+                    }
+                },
+            ),
+            ("minimal_parameters", {}),
+            ("error_message_only", {"Error": {"ErrorMessage": "Simple error message"}}),
+        ]
+    )
+    @pytest.mark.timeout(timeout=300, method="thread")
+    def test_local_start_lambda_stop_durable_execution_http(self, name, error_params):
+        """Test stop_durable_execution via HTTP API with various error parameters."""
+        # Start a long-running execution
+        event_payload = json.dumps({"timeout_seconds": 60, "heartbeat_timeout_seconds": 30})
+        execution_arn, callback_id = self.invoke_and_wait_for_callback(payload=event_payload)
+
+        # Stop the execution with error parameters
+        self.lambda_client.stop_durable_execution(DurableExecutionArn=execution_arn, **error_params)
+
+        # Verify execution is stopped
+        execution_response = self.wait_for_execution_status(execution_arn, "STOPPED")
+        self.assertEqual(execution_response.get("Status"), "STOPPED")
+
+        # Verify execution history contains stop event
+        history_response = self.lambda_client.get_durable_execution_history(
+            DurableExecutionArn=execution_arn, IncludeExecutionData=True
+        )
+        execution_stopped = self.get_event_from_history(history_response.get("Events", []), "ExecutionStopped")
+        self.assertIsNotNone(execution_stopped, "Expected ExecutionStopped event in history")
+
+        # Verify the submitted error fields round-tripped through the HTTP -> client hop.
+        # Shape confirmed in samcli/lib/utils/durable_formatters.py: ExecutionStoppedDetails.Error.Payload.
+        sent_error = error_params.get("Error", {})
+        error_payload = execution_stopped.get("ExecutionStoppedDetails", {}).get("Error", {}).get("Payload", {})
+        if "ErrorMessage" in sent_error:
+            self.assertEqual(error_payload.get("ErrorMessage"), sent_error["ErrorMessage"])
+        if "ErrorType" in sent_error:
+            self.assertEqual(error_payload.get("ErrorType"), sent_error["ErrorType"])

--- a/tests/unit/local/lambda_service/test_local_lambda_http_service.py
+++ b/tests/unit/local/lambda_service/test_local_lambda_http_service.py
@@ -979,7 +979,14 @@ class TestDurableExecutionHandlers(TestCase):
         service_response_mock.return_value = "success response"
 
         request_mock = Mock()
-        request_mock.get_json.return_value = {"Error": "test error"}
+        request_mock.get_json.return_value = {
+            "Error": {
+                "ErrorMessage": "test error message",
+                "ErrorType": "TestError",
+                "ErrorData": "test data",
+                "StackTrace": ["line1", "line2"],
+            }
+        }
         local_lambda_http_service.request = request_mock
 
         lambda_runner_mock = Mock()
@@ -991,7 +998,10 @@ class TestDurableExecutionHandlers(TestCase):
         context_class_mock.assert_called_once()
         client_mock.stop_durable_execution.assert_called_once_with(
             durable_execution_arn="test-arn",
-            error="test error",
+            error_message="test error message",
+            error_type="TestError",
+            error_data="test data",
+            stack_trace=["line1", "line2"],
         )
 
     @patch("samcli.local.lambda_service.local_lambda_http_service.DurableContext")
@@ -1041,8 +1051,148 @@ class TestDurableExecutionHandlers(TestCase):
         context_class_mock.assert_called_once()
         client_mock.stop_durable_execution.assert_called_once_with(
             durable_execution_arn="test-arn",
-            error=None,  # Should be None when no payload
+            error_message=None,
+            error_type=None,
+            error_data=None,
+            stack_trace=None,
         )
+
+    @parameterized.expand(
+        [
+            ("string_error", "some error string"),
+            ("list_error", ["a", "b"]),
+            ("empty_string", ""),
+            ("empty_list", []),
+            ("false_error", False),
+        ]
+    )
+    @patch("samcli.local.lambda_service.local_lambda_http_service.DurableContext")
+    @patch("samcli.local.lambda_service.local_lambda_http_service.LambdaErrorResponses")
+    def test_stop_durable_execution_handler_malformed_error(
+        self, name, error_value, error_responses_mock, context_class_mock
+    ):
+        # Any non-object "Error" (string, list, "", [], False) must be rejected with a 400, not silently
+        # accepted or turned into a 500. Only an absent/null Error means "no error" (tested separately).
+        context_mock = Mock()
+        client_mock = Mock()
+        context_class_mock.return_value.__enter__.return_value = context_mock
+        context_mock.client = client_mock
+        error_responses_mock.invalid_request_content.return_value = "invalid request response"
+
+        request_mock = Mock()
+        request_mock.get_json.return_value = {"Error": error_value}
+        local_lambda_http_service.request = request_mock
+
+        lambda_runner_mock = Mock()
+        service = LocalLambdaHttpService(lambda_runner=lambda_runner_mock, port=3000, host="localhost")
+
+        response = service._stop_durable_execution_handler("test-arn")
+
+        self.assertEqual(response, "invalid request response")
+        error_responses_mock.invalid_request_content.assert_called_once_with("Error must be a JSON object")
+        client_mock.stop_durable_execution.assert_not_called()
+
+    @patch("samcli.local.lambda_service.local_lambda_http_service.DurableContext")
+    @patch("samcli.local.lambda_service.local_lambda_http_service.LocalLambdaHttpService.service_response")
+    def test_stop_durable_execution_handler_null_error_treated_as_no_error(
+        self, service_response_mock, context_class_mock
+    ):
+        # A null "Error" means no error: the execution stops with all fields None
+        context_mock = Mock()
+        client_mock = Mock()
+        context_class_mock.return_value.__enter__.return_value = context_mock
+        context_mock.client = client_mock
+        client_mock.stop_durable_execution.return_value = {"StopDate": "2025-11-04T17:56:00Z"}
+        service_response_mock.return_value = "success response"
+
+        request_mock = Mock()
+        request_mock.get_json.return_value = {"Error": None}
+        local_lambda_http_service.request = request_mock
+
+        lambda_runner_mock = Mock()
+        service = LocalLambdaHttpService(lambda_runner=lambda_runner_mock, port=3000, host="localhost")
+
+        response = service._stop_durable_execution_handler("test-arn")
+
+        self.assertEqual(response, "success response")
+        client_mock.stop_durable_execution.assert_called_once_with(
+            durable_execution_arn="test-arn",
+            error_message=None,
+            error_type=None,
+            error_data=None,
+            stack_trace=None,
+        )
+
+    @parameterized.expand(
+        [
+            ("list_body", [1, 2]),
+            ("string_body", "oops"),
+            ("empty_list_body", []),
+            ("empty_string_body", ""),
+            ("false_body", False),
+            ("zero_body", 0),
+        ]
+    )
+    @patch("samcli.local.lambda_service.local_lambda_http_service.DurableContext")
+    @patch("samcli.local.lambda_service.local_lambda_http_service.LambdaErrorResponses")
+    def test_stop_durable_execution_handler_non_object_body(
+        self, name, body_value, error_responses_mock, context_class_mock
+    ):
+        # A parsed body that is a non-object -- truthy ([1,2], "oops") or falsy ([], "", False, 0) --
+        # must be rejected with a 400, not silently accepted or turned into a 500. Only None (absent/
+        # unparseable body) keeps the graceful empty-payload path (tested elsewhere).
+        context_mock = Mock()
+        client_mock = Mock()
+        context_class_mock.return_value.__enter__.return_value = context_mock
+        context_mock.client = client_mock
+        error_responses_mock.invalid_request_content.return_value = "invalid request response"
+
+        request_mock = Mock()
+        request_mock.get_json.return_value = body_value
+        local_lambda_http_service.request = request_mock
+
+        lambda_runner_mock = Mock()
+        service = LocalLambdaHttpService(lambda_runner=lambda_runner_mock, port=3000, host="localhost")
+
+        response = service._stop_durable_execution_handler("test-arn")
+
+        self.assertEqual(response, "invalid request response")
+        error_responses_mock.invalid_request_content.assert_called_once_with("Request body must be a JSON object")
+        client_mock.stop_durable_execution.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("stacktrace_not_list", {"StackTrace": "not-a-list"}, "Error.StackTrace must be an array of strings"),
+            ("stacktrace_list_of_non_str", {"StackTrace": [1, 2]}, "Error.StackTrace must be an array of strings"),
+            ("message_not_str", {"ErrorMessage": {"a": 1}}, "Error.ErrorMessage must be a string"),
+            ("type_not_str", {"ErrorType": ["x"]}, "Error.ErrorType must be a string"),
+            ("data_not_str", {"ErrorData": 42}, "Error.ErrorData must be a string"),
+        ]
+    )
+    @patch("samcli.local.lambda_service.local_lambda_http_service.DurableContext")
+    @patch("samcli.local.lambda_service.local_lambda_http_service.LambdaErrorResponses")
+    def test_stop_durable_execution_handler_invalid_error_leaf_types(
+        self, name, error_obj, expected_message, error_responses_mock, context_class_mock
+    ):
+        # A well-shaped Error dict with a wrongly-typed leaf must be a 400, not a botocore-driven 500
+        context_mock = Mock()
+        client_mock = Mock()
+        context_class_mock.return_value.__enter__.return_value = context_mock
+        context_mock.client = client_mock
+        error_responses_mock.invalid_request_content.return_value = "invalid request response"
+
+        request_mock = Mock()
+        request_mock.get_json.return_value = {"Error": error_obj}
+        local_lambda_http_service.request = request_mock
+
+        lambda_runner_mock = Mock()
+        service = LocalLambdaHttpService(lambda_runner=lambda_runner_mock, port=3000, host="localhost")
+
+        response = service._stop_durable_execution_handler("test-arn")
+
+        self.assertEqual(response, "invalid request response")
+        error_responses_mock.invalid_request_content.assert_called_once_with(expected_message)
+        client_mock.stop_durable_execution.assert_not_called()
 
     @patch("samcli.local.lambda_service.local_lambda_http_service.DurableContext")
     @patch("samcli.local.lambda_service.local_lambda_http_service.LocalLambdaHttpService.service_response")
@@ -1070,7 +1220,10 @@ class TestDurableExecutionHandlers(TestCase):
         expected_decoded = "arn:aws:lambda:us-west-2:123456789012:function:test"
         client_mock.stop_durable_execution.assert_called_once_with(
             durable_execution_arn=expected_decoded,
-            error=None,
+            error_message=None,
+            error_type=None,
+            error_data=None,
+            stack_trace=None,
         )
         self.assertEqual(response, "success response")
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
A customer reported a bug in the SAM CLI with using the `StopDurableExecution` API over HTTP when passing in the `Error` object.

#### How does it address the issue?
There is a bug where the arguments passed from the HTTP client to the lambda client aren't aligned - specifically the `stop_durable_execution` method needs all expanded arguments for the API, instead of a single argument.

#### What side effects does this change have?
N/A - works as expected now.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
