### PR TITLE
fix: update runc to 1.3.4 in Finch CI for symlink bind-mount support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -250,6 +250,15 @@ jobs:
           echo 'deb [signed-by=/usr/share/keyrings/runfinch-finch-archive-keyring.gpg arch=amd64] https://artifact.runfinch.com/deb noble main' | sudo tee /etc/apt/sources.list.d/runfinch-finch.list
           sudo apt update
           sudo apt install -y runfinch-finch
+          
+          # Update runc to 1.3.4 to fix symlink bind-mount issue
+          RUNC_VERSION="1.3.4"
+          echo "Updating runc to v${RUNC_VERSION}..."
+          wget -q "https://github.com/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.amd64" -O /tmp/runc
+          sudo install -m 755 /tmp/runc /usr/sbin/runc
+          sudo install -m 755 /tmp/runc /usr/bin/runc
+          echo "runc updated: $(runc --version)"
+          
           sudo systemctl enable --now finch
           sudo systemctl enable --now finch-buildkit
           sleep 3

--- a/tests/integration/local/invoke/test_invoke_build_in_source.py
+++ b/tests/integration/local/invoke/test_invoke_build_in_source.py
@@ -2,11 +2,10 @@ from pathlib import Path
 import shutil
 import tempfile
 import os
-from unittest import skipIf
 
 from samcli.lib.utils import osutils
 from tests.integration.local.invoke.invoke_integ_base import InvokeIntegBase
-from tests.testing_utils import get_build_command_list, USING_FINCH_RUNTIME
+from tests.testing_utils import get_build_command_list
 
 
 class BuildInSourceInvokeBase(InvokeIntegBase):
@@ -29,12 +28,6 @@ class BuildInSourceInvokeBase(InvokeIntegBase):
             pass
 
 
-# TODO: Remove this skip once Finch fixes symlink mount support.
-# Finch/containerd fails with "not a directory" when bind-mounting over a symlink.
-@skipIf(
-    USING_FINCH_RUNTIME,
-    "Skip test when using Finch runtime: Finch does not support mounting over symlinks (known Finch bug)",
-)
 class TestInvokeBuildInSourceSymlinkedModules(BuildInSourceInvokeBase):
     project_test_folder = "build-in-source"
 


### PR DESCRIPTION
Finch/containerd fails with 'not a directory' when bind-mounting over a symlink due to a bug in the bundled runc. The Finch team confirmed the fix is to update runc to 1.3.4.

Instead of skipping the affected integration tests, this PR updates runc to 1.3.4 in the GitHub Actions CI pipeline after Finch is installed, which resolves the underlying issue.

### Changes
- Install runc 1.3.4 in the Finch setup step of `integration-tests.yml`, replacing the binaries at `/usr/sbin/runc` and `/usr/bin/runc`
- Revert the `@skipIf` test decorator on `TestInvokeBuildInSourceSymlinkedModules` so symlink tests run on all runtimes