### PR TITLE
Add slackbot to PR label workflow

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,8 +1,6 @@
 name: Slack Notifications
 
 on:
-  pull_request:
-    types: [labeled]
   issues:
     types: [opened]
 
@@ -12,20 +10,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Wait for label to be applied
-        run: sleep 10s
-        shell: bash
-      - name: Send External PR Notification
-        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr/external')
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_TITLE: 'PR Created: ${{ github.event.pull_request.title }} by ${{ github.event.pull_request.user.login }}'
-          SLACK_FOOTER: ''
-          MSG_MINIMAL: true
-          SLACK_MESSAGE: '${{ github.event.pull_request.html_url }}'
       - name: Send New Issue Notification
-        if: github.event_name == 'issue'
+        if: github.event_name == 'issues'
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -19,7 +19,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - name: Apply internal/external label
+        id: label_step
+        uses: actions/github-script@v8
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -29,19 +31,30 @@ jobs:
               'Vandita2020', 'roger-zhangg',
               'vicheey', 'bnusunny', 'tobixlea', 
               'reedham-aws', 'licjun', 'dependabot[bot]'
-            ]
+            ];
             if (maintainers.includes(context.payload.sender.login)) {
-              github.rest.issues.addLabels({
+              await github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 labels: ['pr/internal']
-              })
+              });
+              core.setOutput("external", "false");
             } else {
-              github.rest.issues.addLabels({
+              await github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 labels: ['pr/external', 'stage/needs-triage']
-              })
+              });
+              core.setOutput("external", "true");
             }
+      - name: Send Slack Notification for External PR
+        if: steps.label_step.outputs.external == 'true'
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_TITLE: 'PR Created: ${{ github.event.pull_request.title }} by ${{ github.event.pull_request.user.login }}'
+          SLACK_FOOTER: ''
+          MSG_MINIMAL: true
+          SLACK_MESSAGE: '${{ github.event.pull_request.html_url }}'


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
The previous slackbot wasn't triggering because it seems there is a github limitation where events triggered inside a workflow do not create new workflow runs https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
