### PR TITLE
Revert "Uncomment cryptography dependency in Python build test fixtur…

### DIFF
--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -747,7 +747,7 @@ class BuildIntegPythonBase(BuildIntegBase):
         "__init__.py",
         "main.py",
         "numpy",
-        "cryptography",
+        # 'cryptography',
     }
 
     FUNCTION_LOGICAL_ID = "Function"

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -398,7 +398,7 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
         "__init__.py",
         "main.py",
         "numpy",
-        "cryptography",
+        # 'cryptography',
         "requirements.txt",
     }
 
@@ -1753,7 +1753,7 @@ class TestBuildWithNestedStacksImage(NestedBuildIntegBase):
         "__init__.py",
         "main.py",
         "numpy",
-        "cryptography",
+        # 'cryptography',
         "requirements.txt",
     }
 
@@ -1927,7 +1927,7 @@ class TestBuildWithS3FunctionsOrLayers(NestedBuildIntegBase):
         "__init__.py",
         "main.py",
         "numpy",
-        "cryptography",
+        # 'cryptography',
         "requirements.txt",
     }
 

--- a/tests/integration/testdata/buildcmd/PyLayer/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PyLayer/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version < '3.10'
 numpy==1.26.4; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/PyLayerMake/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PyLayerMake/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version < '3.10'
 numpy==1.26.4; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/Python/main.py
+++ b/tests/integration/testdata/buildcmd/Python/main.py
@@ -1,11 +1,12 @@
 import numpy
 
-from cryptography.fernet import Fernet
+
+# from cryptography.fernet import Fernet
 
 
 def handler(event, context):
     # Try using some of the modules to make sure they work & don't crash the process
-    print(Fernet.generate_key())
+    # print(Fernet.generate_key())
 
     return {"pi": "{0:.2f}".format(numpy.pi)}
 

--- a/tests/integration/testdata/buildcmd/Python/requirements.txt
+++ b/tests/integration/testdata/buildcmd/Python/requirements.txt
@@ -4,4 +4,6 @@
 numpy<1.20.3; python_version <= '3.9'
 numpy==2.1.3; python_version >= '3.10' and python_version < '3.14'
 numpy==2.3.4; python_version >= '3.14'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/PythonContainerEnvVars/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PythonContainerEnvVars/requirements.txt
@@ -1,7 +1,0 @@
-# These are some hard packages to build. Using them here helps us verify that building works on various platforms
-
-# NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
-numpy<1.20.3; python_version <= '3.9'
-numpy==2.1.3; python_version >= '3.10' and python_version < '3.14'
-numpy==2.3.4; python_version >= '3.14'
-cryptography~=42.0

--- a/tests/integration/testdata/buildcmd/PythonImage/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PythonImage/requirements.txt
@@ -4,4 +4,6 @@
 numpy<1.20.3; python_version < '3.10'
 numpy==2.1.3; python_version >= '3.10' and python_version < '3.14'
 numpy==2.3.4; python_version >= '3.14'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/PythonImagesWithSharedCode/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PythonImagesWithSharedCode/requirements.txt
@@ -4,4 +4,6 @@
 numpy<1.20.3; python_version < '3.10'
 numpy==2.1.3; python_version >= '3.10' and python_version < '3.14'
 numpy==2.3.4; python_version >= '3.14'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/PythonPEP600/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PythonPEP600/requirements.txt
@@ -7,4 +7,3 @@ numpy==2.3.4; python_version >= '3.14'
 greenlet==3.1.1; python_version < '3.14'
 greenlet==3.2.4; python_version >= '3.14'
 sqlalchemy==2.0.36
-cryptography~=42.0

--- a/tests/integration/testdata/buildcmd/PythonParentPackages/src/fnone/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PythonParentPackages/src/fnone/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version <= '3.9'
 numpy==2.1.3; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/PythonParentPackages/src/fntwo/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PythonParentPackages/src/fntwo/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version <= '3.9'
 numpy==2.1.3; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/PythonPyProject/main.py
+++ b/tests/integration/testdata/buildcmd/PythonPyProject/main.py
@@ -1,11 +1,12 @@
 import numpy
 
-from cryptography.fernet import Fernet
+
+# from cryptography.fernet import Fernet
 
 
 def handler(event, context):
     # Try using some of the modules to make sure they work & don't crash the process
-    print(Fernet.generate_key())
+    # print(Fernet.generate_key())
 
     return {"pi": "{0:.2f}".format(numpy.pi)}
 

--- a/tests/integration/testdata/buildcmd/PythonPyProject/pyproject.toml
+++ b/tests/integration/testdata/buildcmd/PythonPyProject/pyproject.toml
@@ -5,5 +5,7 @@ dependencies = [
   "numpy==2.0.0; python_version <= '3.9'",
   "numpy==2.1.3; python_version >= '3.10' and python_version < '3.14'",
   "numpy==2.3.4; python_version >= '3.14'",
-  "cryptography~=42.0",
+  # `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+  # Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+  # "cryptography~=2.4"
 ]

--- a/tests/integration/testdata/buildcmd/PythonWithLayer/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PythonWithLayer/requirements.txt
@@ -1,3 +1,5 @@
 # These are some hard packages to build. Using them here helps us verify that building works on various platforms
 
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/my_layer_code/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend/my_layer_code/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version < '3.10'
 numpy==1.26.4; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_container_windows/my_layer_code/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_container_windows/my_layer_code/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version < '3.10'
 numpy==1.26.4; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_windows/my_layer_code/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_local_backend_windows/my_layer_code/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version < '3.10'
 numpy==1.26.4; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/my_layer_code/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend/my_layer_code/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version < '3.10'
 numpy==1.26.4; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend_container_windows/my_layer_code/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend_container_windows/my_layer_code/requirements.txt
@@ -2,4 +2,6 @@
 
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend_windows/my_layer_code/requirements.txt
+++ b/tests/integration/testdata/buildcmd/terraform/zip_based_lambda_functions_s3_backend_windows/my_layer_code/requirements.txt
@@ -3,4 +3,6 @@
 # NOTE: Fixing to <1.20.3 as numpy1.20.3 started to use a new wheel naming convention (PEP 600)
 numpy<1.20.3; python_version < '3.10'
 numpy==1.26.4; python_version >= '3.10'
-cryptography~=42.0
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4


### PR DESCRIPTION
…es (#8667)"

This reverts commit 8792a044697b3742b1baf3fa1ac227525590f905.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
