### PR TITLE
chore: action to sync to mirror repo

### DIFF
--- a/.github/workflows/sync-to-mirror-repo.yml
+++ b/.github/workflows/sync-to-mirror-repo.yml
@@ -18,7 +18,7 @@ jobs:
           ref: develop
           fetch-depth: 0
 
-      - name: Push to private repo
+      - name: Push to mirror repo
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           git push origin develop:develop --force-with-lease


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Action for mirror repo to pull periodically from public repo’s develop branch to keep the mirror in sync with public. The action runs twice daily and can be triggered manually. Action is not run on public repo (it’s skipped)

Tested with 
```
act workflow_dispatch --job sync-from-public --dryrun
act workflow_dispatch --job sync-from-public --dryrun -env GITHUB_REPOSITORY=aws/aws-sam-cli
```

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
