### PR TITLE
Update sync action to overwrite develop in mirror

### DIFF
--- a/.github/workflows/sync-to-mirror-repo.yml
+++ b/.github/workflows/sync-to-mirror-repo.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Push to mirror repo
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-          git push origin develop:develop --force-with-lease
+          git push origin develop:develop --force


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
--force-with-lease fails because the action does not fetch the mirror every time. We could do this, but since we want to overwrite the dev branch of the mirror repo every time, we can just use --force since no actual updates should be pushed to the dev branch of the mirror repo, only to other branches.

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
