### PR TITLE
fix: update esbuild build-in-source tests to nodejs24.x and CI to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
           ruby-version: "3.3"
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - uses: actions/setup-java@v5
         with:
           distribution: 'corretto'

--- a/tests/integration/buildcmd/test_build_in_source.py
+++ b/tests/integration/buildcmd/test_build_in_source.py
@@ -77,7 +77,7 @@ class TestBuildCommand_BuildInSource_Esbuild(BuildIntegEsbuildBase):
 
         self._test_with_default_package_json(
             build_in_source=build_in_source,
-            runtime="nodejs18.x",
+            runtime="nodejs24.x",
             code_uri=codeuri,
             handler="main.lambdaHandler",
             architecture="x86_64",
@@ -91,7 +91,7 @@ class TestBuildCommand_BuildInSource_Esbuild(BuildIntegEsbuildBase):
     @pytest.mark.flaky(reruns=3)
     def test_builds_successfully_with_local_dependency(self):
         codeuri = os.path.join(self.working_dir, "NodeWithLocalDependency")
-        runtime = "nodejs18.x"
+        runtime = "nodejs24.x"
         architecture = "x86_64"
 
         self._test_with_default_package_json(
@@ -142,7 +142,7 @@ class TestBuildCommand_BuildInSource_Nodejs(BuildIntegNodeBase):
         self.codeuri_path = Path(self.working_dir, "Node")
 
         overrides = self.get_override(
-            runtime="nodejs18.x", code_uri=self.codeuri_path, architecture="x86_64", handler="main.lambdaHandler"
+            runtime="nodejs24.x", code_uri=self.codeuri_path, architecture="x86_64", handler="main.lambdaHandler"
         )
         command_list = self.get_command_list(build_in_source=build_in_source, parameter_overrides=overrides, debug=True)
 
@@ -154,7 +154,7 @@ class TestBuildCommand_BuildInSource_Nodejs(BuildIntegNodeBase):
         self.codeuri_path = Path(self.working_dir, "NodeWithLocalDependency")
 
         overrides = self.get_override(
-            runtime="nodejs18.x", code_uri=self.codeuri_path, architecture="x86_64", handler="main.lambdaHandler"
+            runtime="nodejs24.x", code_uri=self.codeuri_path, architecture="x86_64", handler="main.lambdaHandler"
         )
         command_list = self.get_command_list(build_in_source=True, parameter_overrides=overrides)
 


### PR DESCRIPTION
nodejs18.x is EOL and the npm registry returns 403 for esbuild when running on Node 18, causing `TestBuildCommand_BuildInSource_Esbuild` tests to fail.

### Changes
- Update `setup-node` in `build.yml` from Node 22 to Node 24
- Update esbuild build-in-source integration tests from `nodejs18.x` to `nodejs24.x`