### PR TITLE
Replace Python 3.9 with 3.10 in build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.9"
+          - "3.10"
           - "3.11"
     steps:
     # This allows temp file creation on drive D, which won't trigger windows defender scan and leads to faster IO
@@ -116,7 +116,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.9"
+          - "3.10"
           - "3.11"
         # folders that is commented below requires credentials, no need to spare time to run them
         tests_config:
@@ -213,7 +213,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.9"
+          - "3.10"
           - "3.11"
         tests_config:
           - name: "Smoke & Functional Tests - All"


### PR DESCRIPTION
## Problem
Python 3.9 is EOL and actions/setup-python installs an outdated patch version (3.9.13) on macOS and Windows, causing test failures.

## Fix
Replace "3.9" with "3.10" in all three matrix configurations (make-pr, 
integration-tests.yml
, smoke-and-functional-tests). Python 3.10 is actively maintained and actions/setup-python provides up-to-date versions across all platforms.