### PR TITLE
fix: wait for CloudFormation stack deletion in pipeline bootstrap tearDown

### DIFF
--- a/tests/integration/pipeline/base.py
+++ b/tests/integration/pipeline/base.py
@@ -65,12 +65,31 @@ class BootstrapIntegBase(PipelineBase):
         super().setUp()
         shutil.rmtree(os.path.join(os.getcwd(), ".aws-sam", "pipeline"), ignore_errors=True)
 
+    # Max time in seconds to wait for each stack deletion to complete
+    STACK_DELETE_TIMEOUT_SECONDS = 180
+
     def tearDown(self):
         for stack_name in self.stack_names:
             self._cleanup_s3_buckets(stack_name)
             self.cf_client.delete_stack(StackName=stack_name)
+        self._wait_for_stack_deletions()
         shutil.rmtree(os.path.join(os.getcwd(), ".aws-sam", "pipeline"), ignore_errors=True)
         super().tearDown()
+
+    def _wait_for_stack_deletions(self):
+        """Wait for all stack deletions to complete so subsequent runs don't collide."""
+        waiter = self.cf_client.get_waiter("stack_delete_complete")
+        for stack_name in self.stack_names:
+            try:
+                waiter.wait(
+                    StackName=stack_name,
+                    WaiterConfig={
+                        "Delay": 10,
+                        "MaxAttempts": self.STACK_DELETE_TIMEOUT_SECONDS // 10,
+                    },
+                )
+            except botocore.exceptions.WaiterError:
+                logging.warning("Timed out waiting for stack %s to delete", stack_name)
 
     def _cleanup_s3_buckets(self, stack_name):
         try:


### PR DESCRIPTION
## Problem

The `test_interactive_pipeline_user_only_created_once` integration test was flaky in CI ([run #268](https://github.com/aws/aws-sam-cli/actions/runs/22748153276/job/65976464565)).

`tearDown` calls `delete_stack` but doesn't wait for the deletion to complete. On reruns (via `--reruns`) or back-to-back test executions, the stack can still be in `DELETE_IN_PROGRESS`, causing `CreateChangeSet` to fail:

```
Error: Failed to create managed resources: An error occurred (ValidationError) when calling the
CreateChangeSet operation: Stack [...] already exists and cannot be created again with the
changeSet [InitialCreation].
```

## Fix

Add a CloudFormation waiter in `tearDown` that polls every 10s (up to 180s) for each stack deletion to complete before moving on. Timeouts log a warning without failing teardown.

## Testing

- Existing integration tests cover the affected code path
- The waiter is a standard boto3 CloudFormation waiter with bounded timeout