### PR TITLE
fix: clear build cache in sync build-in-source test tearDown for reliable reruns

### DIFF
--- a/tests/integration/sync/test_sync_build_in_source.py
+++ b/tests/integration/sync/test_sync_build_in_source.py
@@ -33,6 +33,9 @@ class TestSyncInfra_BuildInSource_Makefile(SyncIntegBase):
             if os.path.isfile(path):
                 os.remove(path)
 
+        # Clear the build cache so reruns re-execute the Makefile and recreate marker files
+        shutil.rmtree(self.test_data_path.joinpath(".aws-sam"), ignore_errors=True)
+
     @parameterized.expand(
         [
             (True, True),  # build in source
@@ -93,6 +96,9 @@ class TestSyncCode_BuildInSource_Makefile(TestSyncCodeBase):
         for path in self.new_files_in_source:
             if os.path.isfile(path):
                 os.remove(path)
+
+        # Clear the build cache so reruns re-execute the Makefile and recreate marker files
+        shutil.rmtree(Path(self.test_data_path, ".aws-sam"), ignore_errors=True)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

The `TestSyncInfra_BuildInSource_Makefile::test_sync_builds_and_deploys_successfully_0` integration test fails on pytest reruns due to stale SAM build cache.

The `tearDown` deletes the Makefile-created marker files (`file-created-from-makefile-*.txt`) but does not invalidate the SAM build cache inside the temp test data directory. The base class `SyncIntegBase.tearDown` clears `.aws-sam` from `os.getcwd()` (the repo root), but the actual build cache lives at `self.test_data_path/.aws-sam/` (inside the temp directory).

On pytest reruns, SAM finds a "valid cache" and skips re-running the Makefile, so the marker files are never recreated and the file-existence assertion fails with `AssertionError: False != True`.

## Fix

Clear `.aws-sam` inside `self.test_data_path` in `tearDown` for both `TestSyncInfra_BuildInSource_Makefile` and `TestSyncCode_BuildInSource_Makefile`, so the build cache is invalidated and the Makefile re-executes on retries.

## Testing

This fix addresses a flaky test rerun issue observed in CI: https://github.com/aws/aws-sam-cli/actions/runs/22754896467/job/65997092656