### PR TITLE
chore: update dependabot to scan pyproject.toml at root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     open-pull-requests-limit: 10
 
   - package-ecosystem: "pip"
-    directory: "/requirements"
+    directory: "/"
     schedule:
       interval: "daily"
     target-branch: "develop"


### PR DESCRIPTION
## Summary

Update the dependabot pip ecosystem directory from `/requirements` to `/` so it picks up `pyproject.toml` for version update PRs.

This is a follow-up to #8747 which migrated all dependency declarations from `requirements/base.txt` and `requirements/dev.txt` into `pyproject.toml`.

## Changes

- `.github/dependabot.yml`: Change pip ecosystem directory from `/requirements` to `/`

Dependabot only scans recognized manifest files (`pyproject.toml`, `setup.py`, `requirements*.txt`) in the specified directory — it does not recursively scan subdirectories, so test data files under `tests/` are not affected.