### PR TITLE
Update dependabot.yml to use correct boto3 group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,11 +26,12 @@ updates:
     groups:
       boto:
         patterns:
-        - "boto3"
+        - "boto3[crt]"
         - "boto3-stubs*"
-        - "botocore"
+        - "botocore[crt]"
         - "botocore-stubs"
         - "mypy-boto3-*"
+        - "types-awscrt"
       types:
         patterns:
         - "types-*"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
boto3 group not functioning correctly after we changed from boto3 -> boto3[crt], botocore -> botocore[crt], now these dependency updates are creating seperate PRs. This change can make sure the boto3 group updates will be included in a single Depbot PR

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
