### PR TITLE
Update mirror action to force use PAT

### DIFF
--- a/.github/workflows/sync-to-mirror-repo.yml
+++ b/.github/workflows/sync-to-mirror-repo.yml
@@ -19,10 +19,11 @@ jobs:
           repository: aws/aws-sam-cli
           ref: develop
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Push to mirror repo
         run: |
           git config user.name "aws-sam-cli-bot"
           git config user.email "aws-sam-cli-gh-bot@amazon.com"
-          git remote set-url origin https://x-access-token:${{ secrets.SYNC_REPO_PAT }}@github.com/${{ github.repository }}.git
-          git push origin develop:develop --force
+          git config --unset-all http.https://github.com/.extraheader || true
+          git push https://x-access-token:${{ secrets.SYNC_REPO_PAT }}@github.com/${{ github.repository }}.git develop:develop --force


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Due to caching, the action seems to still be using the generic github token (which doesn't have perms to push workflow files). Forcing it use the bot's PAT here

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
