### PR TITLE
chore(test): optimize integ test maven gradle setup

### DIFF
--- a/tests/install-maven-gradle.sh
+++ b/tests/install-maven-gradle.sh
@@ -1,55 +1,20 @@
 #!/bin/bash
-# Install Maven 3.9.13 and Gradle 9.3.1 for SAM CLI integration tests.
-# Supports both Linux and Windows (Git Bash on GitHub Actions).
+# Install latest stable Maven and Gradle for SAM CLI integration tests.
 set -euo pipefail
 
-MAVEN_VERSION="3.9.13"
-GRADLE_VERSION="9.3.1"
-
-# Check if correct versions are already installed
-MAVEN_INSTALLED=$(mvn --version 2>/dev/null | head -1 | grep -o "${MAVEN_VERSION}" || true)
-GRADLE_INSTALLED=$(gradle --version 2>/dev/null | grep "Gradle ${GRADLE_VERSION}" || true)
-
-if [[ -n "$MAVEN_INSTALLED" && -n "$GRADLE_INSTALLED" ]]; then
-  echo "Maven ${MAVEN_VERSION} and Gradle ${GRADLE_VERSION} are already installed, skipping."
-  mvn --version
-  gradle --version
-  exit 0
-fi
+echo "=== Before install ==="
+mvn --version 2>&1 || echo "Maven: not installed"
+gradle --version 2>&1 || echo "Gradle: not installed"
 
 if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
-  echo "=== Installing Maven ${MAVEN_VERSION} and Gradle ${GRADLE_VERSION} on Windows via choco ==="
-  [[ -z "$MAVEN_INSTALLED" ]] && choco install maven --version="${MAVEN_VERSION}" -y --allow-downgrade
-  [[ -z "$GRADLE_INSTALLED" ]] && choco install gradle --version="${GRADLE_VERSION}" -y --allow-downgrade
-
-  # Chocolatey updates the system PATH in the registry but the current bash session
-  # doesn't see it. Explicitly add the known install paths so mvn/gradle are available
-  # in this session and in subsequent workflow steps.
-  CHOCO_MAVEN_BIN="C:/ProgramData/chocolatey/lib/maven/apache-maven-${MAVEN_VERSION}/bin"
-  CHOCO_GRADLE_BIN="C:/ProgramData/chocolatey/lib/gradle/gradle-${GRADLE_VERSION}/bin"
-  export PATH="${CHOCO_MAVEN_BIN}:${CHOCO_GRADLE_BIN}:${PATH}"
-  echo "${CHOCO_MAVEN_BIN}" >> "$GITHUB_PATH"
-  echo "${CHOCO_GRADLE_BIN}" >> "$GITHUB_PATH"
+  choco install maven gradle -y
+  # Refresh PATH for current session
+  eval "$(powershell.exe -Command '[Environment]::GetEnvironmentVariable("Path","Machine")' | tr ';' '\n' | sed 's|\\|/|g' | while read -r p; do echo "export PATH=\"$p:\$PATH\""; done)"
 else
-  echo "=== Installing Maven ${MAVEN_VERSION} and Gradle ${GRADLE_VERSION} on Linux ==="
-  sudo apt-get remove -y maven || true
-
-  wget -q "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.zip" -P /tmp
-  sudo unzip -o -q /tmp/apache-maven-*.zip -d /opt/mvn
-
-  wget -q "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -P /tmp
-  sudo unzip -o -q /tmp/gradle-*.zip -d /opt/gradle
-
-  sudo ln -sf "/opt/mvn/apache-maven-${MAVEN_VERSION}/bin/mvn" /usr/local/bin/mvn
-  sudo ln -sf "/opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle" /usr/local/bin/gradle
-
-  echo "/opt/mvn/apache-maven-${MAVEN_VERSION}/bin" >> "$GITHUB_PATH"
-  echo "/opt/gradle/gradle-${GRADLE_VERSION}/bin" >> "$GITHUB_PATH"
-  echo "MAVEN_HOME=/opt/mvn/apache-maven-${MAVEN_VERSION}" >> "$GITHUB_ENV"
-
-  export PATH="/opt/mvn/apache-maven-${MAVEN_VERSION}/bin:/opt/gradle/gradle-${GRADLE_VERSION}/bin:$PATH"
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq maven gradle
 fi
 
-mvn --version || echo "WARNING: mvn --version failed"
-gradle --version || echo "WARNING: gradle --version failed"
-echo "=== Maven and Gradle installation complete ==="
+echo "=== After install ==="
+mvn --version 2>&1 || echo "Maven: not installed"
+gradle --version 2>&1 || echo "Gradle: not installed"

--- a/tests/install-maven-gradle.sh
+++ b/tests/install-maven-gradle.sh
@@ -1,20 +1,70 @@
 #!/bin/bash
-# Install latest stable Maven and Gradle for SAM CLI integration tests.
+# Install latest stable Maven 3.x and Gradle for SAM CLI integration tests.
+# Auto-detects latest versions from official APIs.
+# Skips install if pre-installed versions meet minimums.
 set -euo pipefail
 
-echo "=== Before install ==="
-mvn --version 2>&1 || echo "Maven: not installed"
-gradle --version 2>&1 || echo "Gradle: not installed"
+MIN_MAVEN="3.9.12"
+MIN_GRADLE="9.2.0"
 
-if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
-  choco install maven gradle -y
-  # Refresh PATH for current session
-  eval "$(powershell.exe -Command '[Environment]::GetEnvironmentVariable("Path","Machine")' | tr ';' '\n' | sed 's|\\|/|g' | while read -r p; do echo "export PATH=\"$p:\$PATH\""; done)"
-else
-  sudo apt-get update -qq
-  sudo apt-get install -y -qq maven gradle
+version_gte() { printf '%s\n%s' "$2" "$1" | sort -V -C; }
+get_maven_ver() { mvn --version 2>/dev/null | head -1 | grep -oP '[\d.]+' | head -1 || true; }
+get_gradle_ver() { gradle --version 2>/dev/null | grep -oP 'Gradle \K[\d.]+' || true; }
+
+MVN_VER=$(get_maven_ver)
+GRADLE_VER=$(get_gradle_ver)
+echo "=== Current: Maven=${MVN_VER:-none} Gradle=${GRADLE_VER:-none} ==="
+
+NEED_MAVEN=true; NEED_GRADLE=true
+[[ -n "$MVN_VER" ]] && version_gte "$MVN_VER" "$MIN_MAVEN" && NEED_MAVEN=false
+[[ -n "$GRADLE_VER" ]] && version_gte "$GRADLE_VER" "$MIN_GRADLE" && NEED_GRADLE=false
+
+if ! $NEED_MAVEN && ! $NEED_GRADLE; then
+  echo "Versions sufficient, skipping install."
+  exit 0
 fi
 
-echo "=== After install ==="
-mvn --version 2>&1 || echo "Maven: not installed"
-gradle --version 2>&1 || echo "Gradle: not installed"
+# Resolve latest stable versions from official sources
+resolve_maven_version() {
+  # Maven metadata XML lists all 3.9.x versions
+  curl -sfL "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml" \
+    | grep -oP '<version>3\.9\.\K[0-9]+' | sort -n | tail -1 | xargs -I{} echo "3.9.{}"
+}
+
+resolve_gradle_version() {
+  # Gradle API returns the latest release version
+  curl -sfL "https://services.gradle.org/versions/current" | grep -oP '"version"\s*:\s*"\K[^"]+'
+}
+
+if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+  # Chocolatey always installs latest by default
+  $NEED_MAVEN && choco install maven -y
+  $NEED_GRADLE && choco install gradle -y
+  # Refresh PATH from registry for current session
+  CHOCO_BASE="C:/ProgramData/chocolatey/lib"
+  MVN_BIN=$(find "$CHOCO_BASE/maven" -name "mvn.cmd" -print -quit 2>/dev/null | xargs dirname || true)
+  GRADLE_BIN=$(find "$CHOCO_BASE/gradle" -name "gradle.bat" -print -quit 2>/dev/null | xargs dirname || true)
+  [[ -n "$MVN_BIN" ]] && { export PATH="$MVN_BIN:$PATH"; echo "$MVN_BIN" >> "$GITHUB_PATH"; }
+  [[ -n "$GRADLE_BIN" ]] && { export PATH="$GRADLE_BIN:$PATH"; echo "$GRADLE_BIN" >> "$GITHUB_PATH"; }
+else
+  sudo apt-get remove -y maven 2>/dev/null || true
+
+  if $NEED_MAVEN; then
+    MAVEN_VERSION=$(resolve_maven_version)
+    echo "Installing Maven ${MAVEN_VERSION}..."
+    wget -q "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" -O /tmp/maven.tar.gz
+    sudo tar -xzf /tmp/maven.tar.gz -C /opt
+    sudo ln -sf "/opt/apache-maven-${MAVEN_VERSION}/bin/mvn" /usr/local/bin/mvn
+    echo "MAVEN_HOME=/opt/apache-maven-${MAVEN_VERSION}" >> "$GITHUB_ENV"
+  fi
+
+  if $NEED_GRADLE; then
+    GRADLE_VERSION=$(resolve_gradle_version)
+    echo "Installing Gradle ${GRADLE_VERSION}..."
+    wget -q "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -O /tmp/gradle.zip
+    sudo unzip -o -q /tmp/gradle.zip -d /opt
+    sudo ln -sf "/opt/gradle-${GRADLE_VERSION}/bin/gradle" /usr/local/bin/gradle
+  fi
+fi
+
+echo "=== Installed: Maven=$(get_maven_ver) Gradle=$(get_gradle_ver) ==="

--- a/tests/install-maven-gradle.sh
+++ b/tests/install-maven-gradle.sh
@@ -8,8 +8,8 @@ MIN_MAVEN="3.9.12"
 MIN_GRADLE="9.2.0"
 
 version_gte() { printf '%s\n%s' "$2" "$1" | sort -V -C; }
-get_maven_ver() { mvn --version 2>/dev/null | head -1 | grep -oP '[\d.]+' | head -1 || true; }
-get_gradle_ver() { gradle --version 2>/dev/null | grep -oP 'Gradle \K[\d.]+' || true; }
+get_maven_ver() { mvn --version 2>/dev/null | head -1 | sed -n 's/.*Maven \([0-9.]*\).*/\1/p' || true; }
+get_gradle_ver() { gradle --version 2>/dev/null | sed -n 's/.*Gradle \([0-9.]*\).*/\1/p' || true; }
 
 MVN_VER=$(get_maven_ver)
 GRADLE_VER=$(get_gradle_ver)
@@ -24,23 +24,18 @@ if ! $NEED_MAVEN && ! $NEED_GRADLE; then
   exit 0
 fi
 
-# Resolve latest stable versions from official sources
 resolve_maven_version() {
-  # Maven metadata XML lists all 3.9.x versions
   curl -sfL "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml" \
-    | grep -oP '<version>3\.9\.\K[0-9]+' | sort -n | tail -1 | xargs -I{} echo "3.9.{}"
+    | sed -n 's/.*<version>3\.9\.\([0-9]*\)<.*/\1/p' | sort -n | tail -1 | xargs -I{} echo "3.9.{}"
 }
 
 resolve_gradle_version() {
-  # Gradle API returns the latest release version
-  curl -sfL "https://services.gradle.org/versions/current" | grep -oP '"version"\s*:\s*"\K[^"]+'
+  curl -sfL "https://services.gradle.org/versions/current" | sed -n 's/.*"version"\s*:\s*"\([^"]*\)".*/\1/p'
 }
 
 if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
-  # Chocolatey always installs latest by default
   $NEED_MAVEN && choco install maven -y
   $NEED_GRADLE && choco install gradle -y
-  # Refresh PATH from registry for current session
   CHOCO_BASE="C:/ProgramData/chocolatey/lib"
   MVN_BIN=$(find "$CHOCO_BASE/maven" -name "mvn.cmd" -print -quit 2>/dev/null | xargs dirname || true)
   GRADLE_BIN=$(find "$CHOCO_BASE/gradle" -name "gradle.bat" -print -quit 2>/dev/null | xargs dirname || true)


### PR DESCRIPTION
#### Which issue(s) does this change fix?

Maven updated to 3.9.14 breaking our attempt to download 3.9.13. In this new approach, we will skip maven & gradle install if already provided by setup java - If install, check latest version first

#### Why is this change necessary?


#### How does it address the issue?
expected output
```
=== Current: Maven=3.9.12 Gradle=9.3.1
9.3.1 ===
Versions sufficient, skipping install.
```
#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
