### PR TITLE
chore(dep): ignore watchdog in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -110,6 +110,9 @@ updates:
       # Ignored intentionally since we have a GHA that updates to more
       # completely
       - dependency-name: "aws_lambda_builders"
+      # Ignored intentionally since watchdog v5+ breaks sync watch
+      # file change detection; pinned to 4.0.2
+      - dependency-name: "watchdog"
       # The dependencies are intentionally pinned to certain
       # version ranges for specific Python versions
       - dependency-name: "flake8"


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
https://github.com/aws/aws-sam-cli/pull/7611
Watchdog > 4.0.2 has breaking changes and will break `sam sync --watch` 
Disabling depbot update and will manual update when required.

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
