### PR TITLE
ci: add push trigger on master for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,9 @@
 name: Integration Tests
 
 on:
+  push:
+    branches:
+      - master
   schedule:
     # Run at 7pm PST (3am UTC next day) Monday-Friday
     # This translates to Tuesday-Saturday 3am UTC


### PR DESCRIPTION
## Changes

Adds a `push` trigger on the `master` branch to the integration tests workflow. This ensures integration tests run automatically when changes are pushed to master (e.g., after a merge).

## What changed

- Added `push: branches: [master]` trigger to `.github/workflows/integration-tests.yml`

## Why

Currently integration tests only run on schedule, release, and manual dispatch. Adding a push trigger on master provides immediate feedback when code lands on the main branch.