### PR TITLE
chore(action): pin action versions

### DIFF
--- a/.github/workflows/automated-updates-to-sam-cli.yml
+++ b/.github/workflows/automated-updates-to-sam-cli.yml
@@ -97,7 +97,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Update aws-sam-translator & commit
         run: |
@@ -166,7 +166,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Upgrade aws_lambda_builders & commit
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV  
       if: ${{ matrix.os == 'windows-latest' }}
     - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         python-version: ${{ matrix.python }}
         cache-python: false
@@ -79,12 +79,11 @@ jobs:
     name: Validate JSON schema
     if: github.repository_owner == 'aws'
     permissions:
-      pull-requests: write
-      contents: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.11"
           cache-python: false
@@ -157,7 +156,7 @@ jobs:
           mkdir "D:\\Temp"
           echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV  
         if: ${{ matrix.os == 'windows-latest' }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: ${{ matrix.python }}
           cache-python: false
@@ -166,7 +165,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.19'
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@4dc28cf14d77b0afa6832d9765ac422dbf0dfedd # v1
         with:
           ruby-version: "3.3"
       - uses: actions/setup-node@v6
@@ -238,7 +237,7 @@ jobs:
           mkdir "D:\\Temp"
           echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV  
         if: ${{ matrix.os == 'windows-latest' }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: ${{ matrix.python }}
           cache-python: false
@@ -270,7 +269,7 @@ jobs:
           mkdir "D:\\Temp"
           echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV  
         if: ${{ matrix.os == 'windows-latest' }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.10"
           cache-python: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -130,7 +130,7 @@ jobs:
         run: bash tests/setup-wsl.sh
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.11"
           cache-python: false
@@ -178,19 +178,19 @@ jobs:
 
       - name: Set up Ruby 3.3.7
         if: contains(fromJSON('["build-x86-1", "build-x86-2", "build-arm64", "other-and-e2e", "cloud-based-tests"]'), matrix.test_suite)
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@4dc28cf14d77b0afa6832d9765ac422dbf0dfedd # v1
         with:
           ruby-version: '3.3.7'
 
       - name: Set up Ruby 3.2.7
         if: contains(fromJSON('["build-x86-1", "build-x86-2", "build-arm64", "other-and-e2e", "cloud-based-tests"]'), matrix.test_suite)
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@4dc28cf14d77b0afa6832d9765ac422dbf0dfedd # v1
         with:
           ruby-version: '3.2.7'
 
       - name: Set up Ruby 3.4.7
         if: contains(fromJSON('["build-x86-1", "build-x86-2", "build-arm64", "sync-code", "sync-watch", "other-and-e2e", "cloud-based-tests", "tier1-finch", "tier1-windows-build-1", "tier1-windows-build-2", "tier1-windows-build-3", "tier1-windows-other"]'), matrix.test_suite)
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@4dc28cf14d77b0afa6832d9765ac422dbf0dfedd # v1
         with:
           ruby-version: '3.4.7'
           windows-toolchain: none

--- a/.github/workflows/update-reproducibles.yml
+++ b/.github/workflows/update-reproducibles.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - name: Update all reproducible requirements
         run: make update-reproducible-reqs-uv
       - name: Push changes
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - name: Check reproducible requirements are up to date
         run: make update-reproducible-reqs-uv
       - name: Fail if requirements are out of date


### PR DESCRIPTION
Pin third-party GitHub Actions to commit SHAs and tighten permissions.

## Actions pinned

| Action | Tag | SHA |
|--------|-----|-----|
| astral-sh/setup-uv | v7 | 37802adc94f370d6bfd71619e3f0bf239e1f3b78 |
| ruby/setup-ruby | v1 | 4dc28cf14d77b0afa6832d9765ac422dbf0dfedd |

## Permissions tightened

| Workflow | Job | Before | After |
|----------|-----|--------|-------|
| build.yml | validate-schema | contents:write, pull-requests:write | contents:read |

The validate-schema job only generates and diffs a schema — it never writes to the repo or creates PRs.