### PR TITLE
fix(ci): add retry and debug logging for Windows InvalidSignatureException

### DIFF
--- a/tests/get_testing_resources.py
+++ b/tests/get_testing_resources.py
@@ -50,6 +50,11 @@ def get_testing_credentials(skip_role_deletion=False):
             read_timeout=LAMBDA_TIME_OUT + 60,
         ),
         region_name="us-west-2",
+        # Explicitly pass credentials stripped of whitespace to avoid Windows \r\n corruption
+        # from GITHUB_ENV that can cause InvalidSignatureException
+        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "").strip(),
+        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "").strip(),
+        aws_session_token=os.environ.get("AWS_SESSION_TOKEN", "").strip() or None,
     )
 
     # Prepare payload if skip_role_deletion is True

--- a/tests/setup_testing_resources.py
+++ b/tests/setup_testing_resources.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import time
 
+from datetime import datetime, timezone
 from get_testing_resources import get_testing_credentials, get_managed_test_resource_outputs  # type: ignore[import-not-found]  # noqa: E402
 
 from boto3.session import Session
@@ -103,12 +104,28 @@ def setup_credentials():
             mask_value(value)
             write_env(f"CI_ACCESS_ROLE_{env_key}", value)
 
-    # Get test credentials
-    try:
-        env_vars = get_testing_credentials(skip_role_deletion=True)
-    except Exception:
-        print("First attempt with skip_role_deletion failed, trying without parameter...")
-        env_vars = get_testing_credentials(skip_role_deletion=False)
+    # Log system clock for debugging InvalidSignatureException on Windows
+    print(f"[DEBUG] System clock UTC: {datetime.now(timezone.utc).isoformat()}")
+
+    # Get test credentials with retry for transient OIDC propagation issues
+    max_retries = 3
+    for attempt in range(1, max_retries + 1):
+        try:
+            try:
+                env_vars = get_testing_credentials(skip_role_deletion=True)
+            except Exception:
+                print("First attempt with skip_role_deletion failed, trying without parameter...")
+                env_vars = get_testing_credentials(skip_role_deletion=False)
+            break
+        except Exception as e:
+            if attempt < max_retries:
+                print(f"Credential fetch attempt {attempt}/{max_retries} failed: {e}", file=sys.stderr)
+                print(f"[DEBUG] System clock UTC: {datetime.now(timezone.utc).isoformat()}")
+                print(f"Retrying in 5s...")
+                time.sleep(5)
+            else:
+                print(f"FATAL: Failed to get credentials after {max_retries} attempts.", file=sys.stderr)
+                raise
 
     # Get managed test resources
     test_session = Session(


### PR DESCRIPTION
## Problem

The `setup_testing_resources.py` step intermittently fails (~10% of the time) on Windows GitHub runners with `InvalidSignatureException` when invoking the credential distribution Lambda. This never happens on Linux runners.
Example: https://github.com/aws/aws-sam-cli/actions/runs/23665127474/job/68945043702

## Changes

- **tests/get_testing_resources.py**: Explicitly `.strip()` AWS credentials before passing to boto3 client to guard against any trailing whitespace/`\r` on Windows
- **tests/setup_testing_resources.py**: Added retry loop (3 attempts, 5s delay) around credential fetch, and added UTC clock logging on each attempt to help diagnose whether clock skew is the root cause