### PR TITLE
chore(test): move ruby3.2 to deprecated runtime

### DIFF
--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -156,9 +156,10 @@ class TestValidate(TestCase):
     @parameterized.expand(
         [
             ("nodejs",),
-            ("python3.7",),
-            ("nodejs16.x",),
+            ("python3.9",),
             ("nodejs18.x",),
+            ("ruby3.2",),
+            ("dotnet6",),
         ]
     )
     def test_lint_deprecated_runtimes(self, runtime):
@@ -205,19 +206,21 @@ class TestValidate(TestCase):
         supported_runtimes = [
             "dotnet10",
             "dotnet8",
+            "java25",
             "java21",
             "java17",
             "java11",
             "java8.al2",
             "nodejs20.x",
             "nodejs22.x",
+            "nodejs24.x",
             "provided.al2",
             "provided.al2023",
             "python3.10",
             "python3.11",
             "python3.12",
             "python3.13",
-            "ruby3.2",
+            "python3.14",
             "ruby3.3",
             "ruby3.4",
         ]


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
https://github.com/aws/aws-sam-cli/actions/runs/23779760611/job/69289522254

#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
