### PR TITLE
fix: failing DNS integration tests by using long-running functions

### DIFF
--- a/tests/integration/local/invoke/test_invoke_dns.py
+++ b/tests/integration/local/invoke/test_invoke_dns.py
@@ -90,7 +90,7 @@ class TestInvokeWithDNS(InvokeIntegBase):
         and executes successfully
         """
         command_list = self.get_command_list(
-            function_to_invoke="HelloWorldServerlessFunction",
+            function_to_invoke="WriteToStdoutFunction",
             template_path=self.template_path,
             no_event=True,
         )
@@ -104,4 +104,4 @@ class TestInvokeWithDNS(InvokeIntegBase):
         self.assertEqual(return_code, 0, f"Command failed with stderr: {stderr}")
 
         output = stdout.decode("utf-8")
-        self.assertIn("Hello World", output)
+        self.assertIn("wrote to stdout", output)

--- a/tests/integration/local/start_api/test_start_api_dns.py
+++ b/tests/integration/local/start_api/test_start_api_dns.py
@@ -50,9 +50,8 @@ class TestStartApiWithDNS(StartApiIntegBaseClass):
         response_holder = {}
 
         def make_request():
-            response_holder['response'] = requests.get(
-                f"http://127.0.0.1:{self.port}/sleepfortenseconds/function0",
-                timeout=300
+            response_holder["response"] = requests.get(
+                f"http://127.0.0.1:{self.port}/sleepfortenseconds/function0", timeout=300
             )
 
         request_thread = threading.Thread(target=make_request)
@@ -95,4 +94,4 @@ class TestStartApiWithDNS(StartApiIntegBaseClass):
 
         # Wait for request to complete
         request_thread.join()
-        self.assertEqual(response_holder['response'].status_code, 200)
+        self.assertEqual(response_holder["response"].status_code, 200)

--- a/tests/integration/local/start_api/test_start_api_dns.py
+++ b/tests/integration/local/start_api/test_start_api_dns.py
@@ -2,6 +2,8 @@
 Integration tests for DNS option in sam local start-api
 """
 
+import time
+import threading
 import requests
 import pytest
 from tests.integration.local.start_api.start_api_integ_base import StartApiIntegBaseClass
@@ -44,8 +46,20 @@ class TestStartApiWithDNS(StartApiIntegBaseClass):
         Test that DNS servers are actually configured in the Docker container.
         This inspects the container configuration to verify DNS was set correctly.
         """
-        response = requests.get(f"http://127.0.0.1:{self.port}/anyandall", timeout=300)
-        self.assertEqual(response.status_code, 200)
+        # Start async request to keep container alive during inspection
+        response_holder = {}
+
+        def make_request():
+            response_holder['response'] = requests.get(
+                f"http://127.0.0.1:{self.port}/sleepfortenseconds/function0",
+                timeout=300
+            )
+
+        request_thread = threading.Thread(target=make_request)
+        request_thread.start()
+
+        # Wait for container to start and be in sleep phase
+        time.sleep(7)
 
         sam_containers = self.docker_client.containers.list(
             all=False, filters={"label": "sam.cli.container.type=lambda"}
@@ -76,5 +90,9 @@ class TestStartApiWithDNS(StartApiIntegBaseClass):
 
         self.assertTrue(
             dns_verified,
-            f"Could not verify DNS configuration in any container. " f"Checked {len(sam_containers)} containers",
+            f"Could not verify DNS configuration in any container. Checked {len(sam_containers)} containers",
         )
+
+        # Wait for request to complete
+        request_thread.join()
+        self.assertEqual(response_holder['response'].status_code, 200)

--- a/tests/integration/local/start_lambda/test_start_lambda_dns.py
+++ b/tests/integration/local/start_lambda/test_start_lambda_dns.py
@@ -2,6 +2,8 @@
 Integration tests for DNS option in sam local start-lambda
 """
 
+import time
+import threading
 import pytest
 from tests.integration.local.start_lambda.start_lambda_api_integ_base import StartLambdaIntegBaseClass
 
@@ -78,8 +80,20 @@ class TestStartLambdaWithDNS(StartLambdaIntegBaseClass):
         Test that DNS servers are actually configured in the Docker container.
         This inspects the container configuration to verify DNS was set correctly.
         """
-        response = self.lambda_client.invoke(FunctionName="EchoEventFunction", Payload='{"key": "value"}')
-        self.assertEqual(response.get("StatusCode"), 200)
+        # Start async invocation to keep container alive during inspection
+        response_holder = {}
+
+        def invoke_function():
+            response_holder['response'] = self.lambda_client.invoke(
+                FunctionName="HelloWorldSleepFunction",
+                Payload='{}'
+            )
+
+        invoke_thread = threading.Thread(target=invoke_function)
+        invoke_thread.start()
+
+        # Wait for container to start and be in sleep phase
+        time.sleep(5)
 
         sam_containers = self.docker_client.containers.list(
             all=False, filters={"label": "sam.cli.container.type=lambda"}
@@ -113,5 +127,9 @@ class TestStartLambdaWithDNS(StartLambdaIntegBaseClass):
 
         self.assertTrue(
             dns_verified,
-            f"Could not verify DNS configuration in any container. " f"Checked {len(sam_containers)} containers",
+            f"Could not verify DNS configuration in any container. Checked {len(sam_containers)} containers",
         )
+
+        # Wait for invocation to complete
+        invoke_thread.join()
+        self.assertEqual(response_holder['response'].get("StatusCode"), 200)

--- a/tests/integration/local/start_lambda/test_start_lambda_dns.py
+++ b/tests/integration/local/start_lambda/test_start_lambda_dns.py
@@ -84,9 +84,8 @@ class TestStartLambdaWithDNS(StartLambdaIntegBaseClass):
         response_holder = {}
 
         def invoke_function():
-            response_holder['response'] = self.lambda_client.invoke(
-                FunctionName="HelloWorldSleepFunction",
-                Payload='{}'
+            response_holder["response"] = self.lambda_client.invoke(
+                FunctionName="HelloWorldSleepFunction", Payload="{}"
             )
 
         invoke_thread = threading.Thread(target=invoke_function)
@@ -132,4 +131,4 @@ class TestStartLambdaWithDNS(StartLambdaIntegBaseClass):
 
         # Wait for invocation to complete
         invoke_thread.join()
-        self.assertEqual(response_holder['response'].get("StatusCode"), 200)
+        self.assertEqual(response_holder["response"].get("StatusCode"), 200)


### PR DESCRIPTION
The DNS container inspection tests were failing because Lambda containers exit immediately after the handler completes, making inspection impossible.

Changes:
- test_invoke_dns.py: Use WriteToStdoutFunction instead of HelloWorldServerlessFunction to avoid KeyError when no_event=True is passed
- test_start_api_dns.py: Use threading with /sleepfortenseconds endpoint to keep container alive during inspection
- test_start_lambda_dns.py: Use threading with HelloWorldSleepFunction to keep container alive during inspection

All tests now use long-running functions with async threading pattern, allowing enough time to inspect running containers before they exit.

Fixes tests that were failing after #8878 was merged.

#### Which issue(s) does this change fix?
failing integ tests: https://github.com/aws/aws-sam-cli/actions/runs/23933074527/job/69803885740

from merging this PR: https://github.com/aws/aws-sam-cli/pull/8878


#### Why is this change necessary?
to fix the failing integ tests

#### How does it address the issue?
fixes the failing integ tests by using log running functions

#### What side effects does this change have?
none

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).


### Testing

#### `make pr` successful
```
.
.
.
samcli/vendor/serverlessrepo/__init__.py                                            1      0      0      0   100%
samcli/vendor/serverlessrepo/application_metadata.py                               39      0      6      0   100%
samcli/vendor/serverlessrepo/exceptions.py                                         17      0      0      0   100%
samcli/vendor/serverlessrepo/parser.py                                             36      0      6      0   100%
samcli/vendor/serverlessrepo/publish.py                                           105      4     34      3    95%   101-102, 169, 174, 336->344, 339->341
samcli/yamlhelper.py                                                               54      0     12      0   100%
schema/__init__.py                                                                  0      0      0      0   100%
schema/exceptions.py                                                                2      0      0      0   100%
schema/make_schema.py                                                             119      4     42      3    96%   64->66, 215->213, 282-284, 288
---------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                           29574   1309   6922    667    94%
Required test coverage of 94% reached. Total coverage: 94.12%
=========================================== 6976 passed, 25 skipped, 2 subtests passed in 94.99s (0:01:34) ===========================================

ajvalia in aws-sam-cli on 🌱 fix/sam-local-dn [🤷] via 👾 pyenv 3.12.4 on ☁️   iad took 2m6s
✦ ❯ history -1
10743  make pr
```

#### Failing integ tests pass

```
✦ ❯ SAM_CLI_DEV=1 pytest tests/integration/local/invoke/test_invoke_dns.py::TestInvokeWithDNS::test_invoke_accepts_multiple_dns_servers -v
  SAM_CLI_DEV=1 pytest tests/integration/local/start_api/test_start_api_dns.py::TestStartApiWithDNS::test_dns_configured_in_container -v
  SAM_CLI_DEV=1 pytest tests/integration/local/start_lambda/test_start_lambda_dns.py::TestStartLambdaWithDNS::test_dns_configured_in_container -v
================================================================ test session starts =================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /home/ajvalia/.local/share/mise/installs/python/3.12.13/bin/python3.12
cachedir: .pytest_cache
metadata: {'Python': '3.12.13', 'Platform': 'Linux-5.10.251-249.983.amzn2int.x86_64-x86_64-with-glibc2.26', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'timeout': '2.4.0', 'xdist': '3.8.0', 'cov': '7.1.0', 'rerunfailures': '16.1', 'metadata': '3.1.1', 'json-report-wip': '1.5.1', 'forked': '1.6.0'}, 'JAVA_HOME': '/usr/lib/jvm/java-17-amazon-corretto.x86_64'}
rootdir: /local/home/ajvalia/aws-sam-cli
configfile: pytest.ini
plugins: timeout-2.4.0, xdist-3.8.0, cov-7.1.0, rerunfailures-16.1, metadata-3.1.1, json-report-wip-1.5.1, forked-1.6.0
timeout: 1800.0s
timeout method: signal
timeout func_only: False
collected 1 item

tests/integration/local/invoke/test_invoke_dns.py::TestInvokeWithDNS::test_invoke_accepts_multiple_dns_servers PASSED                          [100%]

================================================================= 1 passed in 7.02s ==================================================================
================================================================ test session starts =================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /home/ajvalia/.local/share/mise/installs/python/3.12.13/bin/python3.12
cachedir: .pytest_cache
metadata: {'Python': '3.12.13', 'Platform': 'Linux-5.10.251-249.983.amzn2int.x86_64-x86_64-with-glibc2.26', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'timeout': '2.4.0', 'xdist': '3.8.0', 'cov': '7.1.0', 'rerunfailures': '16.1', 'metadata': '3.1.1', 'json-report-wip': '1.5.1', 'forked': '1.6.0'}, 'JAVA_HOME': '/usr/lib/jvm/java-17-amazon-corretto.x86_64'}
rootdir: /local/home/ajvalia/aws-sam-cli
configfile: pytest.ini
plugins: timeout-2.4.0, xdist-3.8.0, cov-7.1.0, rerunfailures-16.1, metadata-3.1.1, json-report-wip-1.5.1, forked-1.6.0
timeout: 1800.0s
timeout method: signal
timeout func_only: False
collected 1 item

tests/integration/local/start_api/test_start_api_dns.py::TestStartApiWithDNS::test_dns_configured_in_container
------------------------------------------------------------------- live log setup -------------------------------------------------------------------
INFO     tests.integration.local.common_utils:common_utils.py:25 No current session found, using default AWS::AccountId
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting StringStatusCodeFunction at http://127.0.0.1:31545/stringstatuscode [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting OnlySetBodyFunction at http://127.0.0.1:31545/onlysetbody [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting SleepFunction0 at http://127.0.0.1:31545/sleepfortenseconds/function0 [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting HelloWorldCapacityProviderFunction at http://127.0.0.1:31545/capacity-provider/anyandall [DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting EchoEventFunction at http://127.0.0.1:31545/id/{id} [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting OnlySetStatusCodeFunction at http://127.0.0.1:31545/onlysetstatuscode [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting HelloWorldCapacityProviderFunction at http://127.0.0.1:31545/capacity-provider/proxypath/{proxy+} [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting WriteToStderrFunction at http://127.0.0.1:31545/writetostderr [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting WriteToStdoutFunction at http://127.0.0.1:31545/writetostdout [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting MultipleHeadersOverridesHeadersResponseFunction at http://127.0.0.1:31545/multipleheadersoverridesheaders [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting ZippedHelloWorldFunction at http://127.0.0.1:31545/sleepfortensecondszipped [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting ContentTypeSetterFunction at http://127.0.0.1:31545/getcontenttype [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting Base64ResponseFunction at http://127.0.0.1:31545/base64response [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting EchoEventFunction at http://127.0.0.1:31545/echoeventbody [POST, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting InvalidResponseHashFromLambdaFunction at http://127.0.0.1:31545/invalidresponsehash [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting HelloWorldFunction at http://127.0.0.1:31545/proxypath/{proxy+} [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting EchoEventFunction2 at http://127.0.0.1:31545/echoeventbody [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting SleepFunction1 at http://127.0.0.1:31545/sleepfortenseconds/function1 [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting EchoIntegerBodyFunction at http://127.0.0.1:31545/echo_integer_body [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting HelloWorldCapacityProviderFunction at http://127.0.0.1:31545/capacity-provider/id [POST, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting MultipleHeadersResponseFunction at http://127.0.0.1:31545/multipleheaders [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting HelloWorldFunction at http://127.0.0.1:31545/id [POST, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting EchoBase64EventBodyFunction at http://127.0.0.1:31545/echobase64eventbody [POST, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting HelloWorldFunction at http://127.0.0.1:31545/anyandall [DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting InvalidResponseFromLambdaFunction at http://127.0.0.1:31545/invalidresponsereturned [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 Mounting EchoEventFunction at http://127.0.0.1:31545/id/{id}/user/{user} [GET, OPTIONS]
INFO     tests.integration.local.common_utils:common_utils.py:25 You can now browse to the above endpoints to invoke your functions. You do not need to restart/reload SAM CLI while working on your functions, changes will be reflected instantly/automatically. If you used sam build before running local commands, you will need to re-run sam build for the changes to be picked up. You only need to restart SAM CLI if you update your AWS SAM template
INFO     tests.integration.local.common_utils:common_utils.py:25 2026-04-03 16:50:53 WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
INFO     tests.integration.local.common_utils:common_utils.py:25 * Running on http://127.0.0.1:31545
INFO     tests.integration.local.common_utils:common_utils.py:25 2026-04-03 16:50:53 Press CTRL+C to quit
------------------------------------------------------------------- live log call --------------------------------------------------------------------
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'Invoking main.sleep_10_sec_handler (python3.9)\n'
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'Local image is up-to-date\n'
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'Using local image: public.ecr.aws/lambda/python:3.9-rapid-x86_64.\n'
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'Mounting /local/home/ajvalia/aws-sam-cli/tests/integration/testdata/start_api as /var/task:ro,delegated, inside runtime container\n'
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'SAM_CONTAINER_ID: 09dac5b2b0ef95ffaa9ef18e8238b70948c5544bb4e5684ccc03b36c933b45f5\n'
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'START RequestId: 49ab40e1-bcf1-4d99-9b46-8869a1fe25e7 Version: $LATEST\n'
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'END RequestId: 49ab40e1-bcf1-4d99-9b46-8869a1fe25e7\n'
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'REPORT RequestId: 49ab40e1-bcf1-4d99-9b46-8869a1fe25e7\tInit Duration: 0.03 ms\tDuration: 10051.78 ms\tBilled Duration: 10052 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB\t\n'
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b"No Content-Type given. Defaulting to 'application/json'.\n"
INFO     tests.integration.local.start_api.start_api_integ_base:start_api_integ_base.py:137 b'2026-04-03 16:51:04 127.0.0.1 - - [03/Apr/2026 16:51:04] "GET /sleepfortenseconds/function0 HTTP/1.1" 200 -\n'
PASSED                                                                                                                                         [100%]

================================================================= 1 passed in 16.58s =================================================================
================================================================ test session starts =================================================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /home/ajvalia/.local/share/mise/installs/python/3.12.13/bin/python3.12
cachedir: .pytest_cache
metadata: {'Python': '3.12.13', 'Platform': 'Linux-5.10.251-249.983.amzn2int.x86_64-x86_64-with-glibc2.26', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'timeout': '2.4.0', 'xdist': '3.8.0', 'cov': '7.1.0', 'rerunfailures': '16.1', 'metadata': '3.1.1', 'json-report-wip': '1.5.1', 'forked': '1.6.0'}, 'JAVA_HOME': '/usr/lib/jvm/java-17-amazon-corretto.x86_64'}
rootdir: /local/home/ajvalia/aws-sam-cli
configfile: pytest.ini
plugins: timeout-2.4.0, xdist-3.8.0, cov-7.1.0, rerunfailures-16.1, metadata-3.1.1, json-report-wip-1.5.1, forked-1.6.0
timeout: 1800.0s
timeout method: signal
timeout func_only: False
collected 1 item

tests/integration/local/start_lambda/test_start_lambda_dns.py::TestStartLambdaWithDNS::test_dns_configured_in_container
------------------------------------------------------------------- live log setup -------------------------------------------------------------------
INFO     tests.integration.local.common_utils:common_utils.py:25 No current session found, using default AWS::AccountId
INFO     tests.integration.local.common_utils:common_utils.py:25 Starting the Local Lambda Service. You can now invoke your Lambda Functions defined in your template through the endpoint.
INFO     tests.integration.local.common_utils:common_utils.py:25 2026-04-03 16:51:11 WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
INFO     tests.integration.local.common_utils:common_utils.py:25 * Running on http://127.0.0.1:30235
INFO     tests.integration.local.common_utils:common_utils.py:25 2026-04-03 16:51:11 Press CTRL+C to quit
PASSED                                                                                                                                         [100%]

================================================================= 1 passed in 16.80s =================================================================

```