### PR TITLE
fix: update durable execution stop test for new emulator behavior

### DIFF
--- a/tests/integration/local/execution/test_execution.py
+++ b/tests/integration/local/execution/test_execution.py
@@ -63,12 +63,8 @@ class TestLocalExecution(DurableIntegBase, InvokeIntegBase):
         # Try to stop already completed execution
         stop_command = [self.cmd, "local", "execution", "stop", execution_arn]
         result = run_command(stop_command)
-        stderr_str = result.stderr.decode("utf-8") if isinstance(result.stderr, bytes) else result.stderr
-        stderr_str = stderr_str.replace("\r\n", "\n")
 
-        self.assertNotEqual(result.process.returncode, 0)
-        expected_message = f"Error: An error occurred (409) when calling the StopDurableExecution operation: Execution {execution_arn} is already completed\n"
-        self.assertEqual(stderr_str, expected_message)
+        self.assertEqual(result.process.returncode, 0)
 
     @pytest.mark.tier1_extra
     def test_tier1_execution(self):


### PR DESCRIPTION
#### Why is this change necessary?
The durable execution emulator has been updated to have idempotent responses for `StopDurableExecution` (https://github.com/aws/aws-durable-execution-sdk-python-testing/pull/195). Previously, our integration tests had been assuming that the responses were not idempotent and testing against that, causing the tests to fail.

#### How does it address the issue?
Update the test so that the expected error code matches what is returned in the idempotent case.\


#### What side effects does this change have?
Slightly less rigorous testing on the message returned from `StopDurableExecution`. I think this is fine because it allows us decouple from what the emulator returns for a string, in case that changes.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
