### PR TITLE
ci: update SAM PR Reviewer to latest version

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
-      - uses: roger-zhangg/sam-pr-reviewer@793976165e969a6ccb6ace13d35811c02471f471 # v1
+      - uses: roger-zhangg/sam-pr-reviewer@742fd2b1a8574050bcdeb41ffe0b762a11ba24d5 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           kiro_api_key: ${{ secrets.KIRO_API_KEY }}


### PR DESCRIPTION
Updates the pinned SHA for `roger-zhangg/sam-pr-reviewer` to the latest version (`742fd2b`).

Changes since the initial merge:
- Use `git ls-files` for project tree (works reliably across all project types)
- Fix empty response handling for GitHub DELETE API calls
- Mark superseded reviews with strikethrough when dismiss fails
- Auto-dismiss previous review comments before posting new review
- Remove dead code