### PR TITLE
fix: default to empty list for docker build extra params metadata

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -434,7 +434,7 @@ class ApplicationBuilder:
         docker_tag = f"{image_name.lower()}:{tag}"
         docker_build_target = metadata.get("DockerBuildTarget", None)
         docker_build_args = metadata.get("DockerBuildArgs", {})
-        docker_build_extra_params = metadata.get("DockerBuildExtraParams", None)
+        docker_build_extra_params = metadata.get("DockerBuildExtraParams", [])
 
         if not dockerfile or not docker_context:
             raise DockerBuildFailed("Docker file or Docker context metadata are missed.")

--- a/samcli/lib/samlib/resource_metadata_normalizer.py
+++ b/samcli/lib/samlib/resource_metadata_normalizer.py
@@ -191,7 +191,7 @@ class ResourceMetadataNormalizer:
             SAM_METADATA_DOCKERFILE_KEY: str(dockerfile_path.as_posix()),
             SAM_METADATA_DOCKER_CONTEXT_KEY: str(asset_path),
             SAM_METADATA_DOCKER_BUILD_ARGS_KEY: metadata.get(ASSET_DOCKERFILE_BUILD_ARGS_KEY, {}),
-            SAM_METADATA_DOCKER_BUILD_EXTRA_PARAMS_KEY: metadata.get(ASSET_DOCKER_BUILD_EXTRA_PARAMS_KEY, None),
+            SAM_METADATA_DOCKER_BUILD_EXTRA_PARAMS_KEY: metadata.get(ASSET_DOCKER_BUILD_EXTRA_PARAMS_KEY, []),
         }
 
     @staticmethod


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?
Integration tests are failing after: https://github.com/aws/aws-sam-cli/pull/8913.

https://github.com/aws/aws-sam-cli/actions/runs/25045806939/job/73360436775


#### How does it address the issue?
Changes the default from `None` to an empty list to avoid trying to convert `None` to TOML.
```
Error: Unable to convert an object of <class 'NoneType'> to a TOML item
```

#### What side effects does this change have?
An empty list would be carried around, but that's not too different from the build args where there's an empty dictionary.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
