### PR TITLE
correcting runtime versions in integ test

### DIFF
--- a/tests/install-rust.sh
+++ b/tests/install-rust.sh
@@ -31,6 +31,13 @@ rustup default stable
 if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   # On Windows, add Windows-native targets
   rustup target add x86_64-pc-windows-msvc --toolchain stable || true
+  # Also pre-install the Linux cross-compile targets used by cargo-lambda.
+  # If cargo-lambda has to install these on demand during parallel test runs
+  # (pytest -n 2), concurrent rustup invocations can produce a partial/corrupt
+  # target install (e.g., "can't find crate for `adler2`"). Pre-installing here
+  # avoids that race.
+  rustup target add x86_64-unknown-linux-gnu --toolchain stable
+  rustup target add aarch64-unknown-linux-gnu --toolchain stable
 else
   rustup target add x86_64-unknown-linux-gnu --toolchain stable
   rustup target add aarch64-unknown-linux-gnu --toolchain stable

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory/modules/lambda_function/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory/modules/lambda_function/main.tf
@@ -34,7 +34,7 @@ EOF
 resource "aws_lambda_function" "this" {
     filename = var.source_code
     handler = "app.lambda_handler"
-    runtime = "python3.9"
+    runtime = "python3.12"
     function_name = var.function_name
     role = aws_iam_role.iam_for_lambda.arn
     layers = var.layers

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory/modules/lambda_layer/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory/modules/lambda_layer/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_layer_version" "layer" {
   filename   = var.source_code
   layer_name = var.name
 
-  compatible_runtimes = ["python3.9"]
+  compatible_runtimes = ["python3.12"]
 }
 
 output "arn" {

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory/root_module/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory/root_module/main.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_layer_version" "layer1" {
   count               = 1
   filename            = "${local.building_path}/${local.layer1_artifact_file_name}"
   layer_name          = "lambda_layer1"
-  compatible_runtimes = ["python3.9"]
+  compatible_runtimes = ["python3.12"]
   depends_on = [
     null_resource.build_layer1_version
   ]
@@ -96,7 +96,7 @@ resource "null_resource" "sam_metadata_aws_lambda_function1" {
 resource "aws_lambda_function" "function1" {
   filename      = "${local.building_path}/${local.hello_world_artifact_file_name}"
   handler       = "app.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = "python3.12"
   function_name = "function1"
   timeout       = 300
   role          = aws_iam_role.iam_for_lambda.arn
@@ -174,8 +174,8 @@ module "layer7" {
   version             = "4.6.0"
   create_layer        = true
   layer_name          = "lambda_layer7"
-  compatible_runtimes = ["python3.9"]
-  runtime             = "python3.9"
+  compatible_runtimes = ["python3.12"]
+  runtime             = "python3.12"
   source_path = {
     path             = local.layer1_src_path
     prefix_in_zip    = "python"
@@ -190,6 +190,6 @@ module "function7" {
   source_path   = local.hello_world_function_src_path
   function_name = "function7"
   handler       = "app.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = "python3.12"
   layers        = [module.layer7.lambda_layer_arn]
 }

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows/modules/lambda_function/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows/modules/lambda_function/main.tf
@@ -34,7 +34,7 @@ EOF
 resource "aws_lambda_function" "this" {
     filename = var.source_code
     handler = "app.lambda_handler"
-    runtime = "python3.9"
+    runtime = "python3.12"
     function_name = var.function_name
     role = aws_iam_role.iam_for_lambda.arn
     layers = var.layers

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows/modules/lambda_layer/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows/modules/lambda_layer/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_layer_version" "layer" {
   filename   = var.source_code
   layer_name = var.name
 
-  compatible_runtimes = ["python3.9"]
+  compatible_runtimes = ["python3.12"]
 }
 
 output "arn" {

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows/root_module/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows/root_module/main.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_layer_version" "layer1" {
   count               = 1
   filename            = "${local.building_path}/${local.layer1_artifact_file_name}"
   layer_name          = "lambda_layer1"
-  compatible_runtimes = ["python3.9"]
+  compatible_runtimes = ["python3.12"]
   depends_on = [
     null_resource.build_layer1_version
   ]
@@ -96,7 +96,7 @@ resource "null_resource" "sam_metadata_aws_lambda_function1" {
 resource "aws_lambda_function" "function1" {
   filename      = "${local.building_path}/${local.hello_world_artifact_file_name}"
   handler       = "app.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = "python3.12"
   function_name = "function1"
   timeout       = 300
   role          = aws_iam_role.iam_for_lambda.arn

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows_container/modules/lambda_function/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows_container/modules/lambda_function/main.tf
@@ -34,7 +34,7 @@ EOF
 resource "aws_lambda_function" "this" {
     filename = var.source_code
     handler = "app.lambda_handler"
-    runtime = "python3.9"
+    runtime = "python3.12"
     function_name = var.function_name
     role = aws_iam_role.iam_for_lambda.arn
     layers = var.layers

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows_container/modules/lambda_layer/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows_container/modules/lambda_layer/main.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_layer_version" "layer" {
   filename   = var.source_code
   layer_name = var.name
 
-  compatible_runtimes = ["python3.9"]
+  compatible_runtimes = ["python3.12"]
 }
 
 output "arn" {

--- a/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows_container/root_module/main.tf
+++ b/tests/integration/testdata/buildcmd/terraform/application_outside_root_directory_windows_container/root_module/main.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_layer_version" "layer1" {
   count               = 1
   filename            = "${local.building_path}/${local.layer1_artifact_file_name}"
   layer_name          = "lambda_layer1"
-  compatible_runtimes = ["python3.9"]
+  compatible_runtimes = ["python3.12"]
   depends_on = [
     null_resource.build_layer1_version
   ]
@@ -96,7 +96,7 @@ resource "null_resource" "sam_metadata_aws_lambda_function1" {
 resource "aws_lambda_function" "function1" {
   filename      = "${local.building_path}/${local.hello_world_artifact_file_name}"
   handler       = "app.lambda_handler"
-  runtime       = "python3.9"
+  runtime       = "python3.12"
   function_name = "function1"
   timeout       = 300
   role          = aws_iam_role.iam_for_lambda.arn

--- a/tests/integration/testdata/validate/multiple_files/template.json
+++ b/tests/integration/testdata/validate/multiple_files/template.json
@@ -8,7 +8,7 @@
       "Properties": {
         "CodeUri": "hello-world/",
         "Handler": "app.lambdaHandler",
-        "Runtime": "nodejs20.x"
+        "Runtime": "nodejs22.x"
       }
     }
   }

--- a/tests/integration/testdata/validate/with_build/.aws-sam/build/template.yaml
+++ b/tests/integration/testdata/validate/with_build/.aws-sam/build/template.yaml
@@ -7,4 +7,4 @@ Resources:
     Properties:
       CodeUri: HelloWorldFunction
       Handler: app.lambdaHandler
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x

--- a/tests/integration/testdata/validate/with_build/template.json
+++ b/tests/integration/testdata/validate/with_build/template.json
@@ -8,7 +8,7 @@
       "Properties": {
         "CodeUri": "hello-world/",
         "Handler": "app.lambdaHandler",
-        "Runtime": "nodejs20.x"
+        "Runtime": "nodejs22.x"
       }
     }
   }

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -160,6 +160,7 @@ class TestValidate(TestCase):
             ("nodejs18.x",),
             ("ruby3.2",),
             ("dotnet6",),
+            ("nodejs20.x"),
         ]
     )
     def test_lint_deprecated_runtimes(self, runtime):
@@ -211,7 +212,6 @@ class TestValidate(TestCase):
             "java17",
             "java11",
             "java8.al2",
-            "nodejs20.x",
             "nodejs22.x",
             "nodejs24.x",
             "provided.al2",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
NA

#### Why is this change necessary?
Fixes the integration test failure:
[terraform-build](https://github.com/aws/aws-sam-cli/actions/runs/25369209822/job/74387987011)
[other-and-e2e](https://github.com/aws/aws-sam-cli/actions/runs/25369209822/job/74387987002)
[tier1-windows-build-2](https://github.com/aws/aws-sam-cli/actions/runs/25369209822/job/74387987046)


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
