### PR TITLE
fix: avoid TypeError on CommaDelimitedList parameter / logical ID collision

### DIFF
--- a/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
+++ b/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
@@ -271,7 +271,12 @@ class IntrinsicResolver:
         """
         processed_dict = OrderedDict()
         for key, val in cloud_formation_property.items():
-            processed_key = self._symbol_resolver.get_translation(key) or key
+            translated_key = self._symbol_resolver.get_translation(key)
+            # Only use the translated key when it is a string. get_translation()
+            # can return a list when a CommaDelimitedList parameter shares its
+            # name with a Resource/Output logical ID; using that list as a dict
+            # key would raise TypeError: unhashable type: 'list'.
+            processed_key = translated_key if isinstance(translated_key, str) else key
             try:
                 processed_resource = self.intrinsic_property_resolver(val, ignore_errors, parent_function=processed_key)
                 processed_dict[processed_key] = processed_resource

--- a/tests/unit/lib/intrinsic_resolver/test_intrinsic_resolver.py
+++ b/tests/unit/lib/intrinsic_resolver/test_intrinsic_resolver.py
@@ -1099,9 +1099,7 @@ class TestResolveTemplate(TestCase):
         # values into logical_id_translator. Mirror that here so
         # get_translation() actually returns the list form that triggers the
         # crash on the unfixed code path.
-        symbol_resolver = IntrinsicsSymbolTable(
-            template=template, logical_id_translator={"AppName": "hello, world"}
-        )
+        symbol_resolver = IntrinsicsSymbolTable(template=template, logical_id_translator={"AppName": "hello, world"})
         resolver = IntrinsicResolver(template=template, symbol_resolver=symbol_resolver)
         processed_template = resolver.resolve_template()
 

--- a/tests/unit/lib/intrinsic_resolver/test_intrinsic_resolver.py
+++ b/tests/unit/lib/intrinsic_resolver/test_intrinsic_resolver.py
@@ -1077,6 +1077,77 @@ class TestResolveTemplate(TestCase):
         resolver = IntrinsicResolver(template=template, symbol_resolver=symbol_resolver)
         self.assertEqual(resolver.resolve_template(), expected_template)
 
+    def test_output_name_collides_with_comma_delimited_list_parameter(self):
+        # Regression test for https://github.com/aws/aws-sam-cli/issues/8627
+        # When an Output's logical name matches the name of a CommaDelimitedList
+        # parameter, get_translation() returns a list for that name. Previously
+        # this list was used as a dict key in resolve_attribute() and raised
+        # TypeError: unhashable type: 'list'. The processed template must
+        # preserve the original Output key.
+        template = {
+            "Parameters": {"AppName": {"Type": "CommaDelimitedList", "Default": "hello, world"}},
+            "Resources": {
+                "MyFunction": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {"Runtime": "python3.12", "Handler": "index.handler"},
+                }
+            },
+            "Outputs": {"AppName": {"Value": {"Ref": "AppName"}}},
+        }
+
+        # Real call sites (e.g. SamBaseProvider) pass resolved parameter
+        # values into logical_id_translator. Mirror that here so
+        # get_translation() actually returns the list form that triggers the
+        # crash on the unfixed code path.
+        symbol_resolver = IntrinsicsSymbolTable(
+            template=template, logical_id_translator={"AppName": "hello, world"}
+        )
+        resolver = IntrinsicResolver(template=template, symbol_resolver=symbol_resolver)
+        processed_template = resolver.resolve_template()
+
+        self.assertIn("AppName", processed_template["Outputs"])
+        self.assertEqual(processed_template["Outputs"]["AppName"], {"Value": ["hello", "world"]})
+
+    def test_resource_name_collides_with_comma_delimited_list_parameter(self):
+        # Same root cause as the Output collision above, but exercised against
+        # the Resources branch of resolve_attribute to ensure both call sites
+        # are protected from the unhashable-key crash.
+        template = {
+            "Parameters": {"VpcSubnetIds": {"Type": "CommaDelimitedList", "Default": "subnet-a, subnet-b"}},
+            "Resources": {
+                "VpcSubnetIds": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {"Type": "StringList", "Value": {"Ref": "VpcSubnetIds"}},
+                }
+            },
+        }
+
+        symbol_resolver = IntrinsicsSymbolTable(
+            template=template, logical_id_translator={"VpcSubnetIds": "subnet-a, subnet-b"}
+        )
+        resolver = IntrinsicResolver(template=template, symbol_resolver=symbol_resolver)
+        processed_template = resolver.resolve_template()
+
+        self.assertIn("VpcSubnetIds", processed_template["Resources"])
+
+    def test_resource_logical_id_renaming_still_works(self):
+        # Guard against regressing the legitimate logical-ID renaming that
+        # resolve_attribute relies on. When logical_id_translator maps a
+        # resource key to a string, that string should still become the new
+        # key in the processed template.
+        template = {
+            "Resources": {
+                "OldName": {"Type": "AWS::ApiGateway::RestApi", "Properties": {"Name": "api"}},
+            }
+        }
+
+        symbol_resolver = IntrinsicsSymbolTable(template=template, logical_id_translator={"OldName": "NewName"})
+        resolver = IntrinsicResolver(template=template, symbol_resolver=symbol_resolver)
+        processed_template = resolver.resolve_template()
+
+        self.assertIn("NewName", processed_template["Resources"])
+        self.assertNotIn("OldName", processed_template["Resources"])
+
     def load_test_data(self, template_path):
         integration_path = str(Path(__file__).resolve().parents[0].joinpath("test_data", template_path))
         with open(integration_path) as f:


### PR DESCRIPTION
#### Which issue(s) does this change fix?
Fixes #8627

#### Why is this change necessary?
`sam deploy --guided` (and any other command path that resolves a template) crashes with `TypeError: unhashable type: 'list'` when a CloudFormation template contains a `CommaDelimitedList` parameter whose name collides with a Resource or Output logical ID of the same name.

Minimal repro template (from the issue thread):

```yaml
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31

Parameters:
  AppName:
    Type: CommaDelimitedList
    Default: "hello, world"

Resources:
  MyFunction:
    Type: AWS::Serverless::Function
    Properties:
      Runtime: python3.12
      Handler: index.handler
      InlineCode: |
        def handler(event, context):
            return "hi"

Outputs:
  AppName:
    Value: !Ref AppName
```

#### How does it address the issue?
In `samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py`, `resolve_attribute()` was using `get_translation(key) or key` to derive the processed key for `Resources`/`Outputs`. For a `CommaDelimitedList` parameter, `IntrinsicsSymbolTable.get_translation()` deliberately returns a Python `list` (e.g. `["hello", "world"]`). That list was then assigned as a dictionary key on the next line, which is what raised `TypeError: unhashable type: 'list'`.

The fix narrows the use of the translated key to the case it was actually designed for — string renames (e.g. `RestApi.Deployment` → `RestApi` via `logical_id_translator`) — and falls back to the original key when the translation is anything other than a string:

```python
translated_key = self._symbol_resolver.get_translation(key)
processed_key = translated_key if isinstance(translated_key, str) else key
```

Refs from the existing test suite (`TestIntrinsicAttribteResolution`) verify the logical-ID renaming path still works, since those translations resolve to strings.

#### What side effects does this change have?
- No behavior change for templates without a name collision.
- No behavior change for legitimate logical-ID renaming via `logical_id_translator`, which always returns a string for that path.
- Templates that previously crashed now resolve normally: the Output/Resource key is preserved as-is, and `!Ref <CommaDelimitedListParam>` values continue to expand into a list as expected.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods (no new functions added)
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document)) — not needed for a bug fix
- [x] Write/update unit tests
- [ ] Write/update integration tests — bug is fully reproducible at the unit level
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed — no dependency changes
- [ ] Write documentation — no user-facing API change

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).