### PR TITLE
fix: preserve Fn::FindInMap with unresolved Ref keys in PARTIAL mode

### DIFF
--- a/samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py
@@ -95,12 +95,18 @@ class FnFindInMapResolver(IntrinsicFunctionResolver):
             top_key = top_key_arg
             second_key = second_key_arg
 
-        # Validate resolved keys are strings
-        if not isinstance(map_name, str):
-            raise InvalidTemplateException("Fn::FindInMap layout is incorrect")
-        if not isinstance(top_key, str):
-            raise InvalidTemplateException("Fn::FindInMap layout is incorrect")
-        if not isinstance(second_key, str):
+        # In PARTIAL mode an unresolved nested intrinsic (e.g. {"Ref": "ENV"})
+        # arrives here as a dict — preserve the Fn::FindInMap expression so
+        # CloudFormation can resolve it at deploy time. Non-dict, non-string keys
+        # (e.g. an int literal) remain a layout error in either mode.
+        if not isinstance(map_name, str) or not isinstance(top_key, str) or not isinstance(second_key, str):
+            from samcli.lib.cfn_language_extensions.models import ResolutionMode
+
+            has_unresolved_intrinsic = (
+                isinstance(map_name, dict) or isinstance(top_key, dict) or isinstance(second_key, dict)
+            )
+            if has_unresolved_intrinsic and self.context.resolution_mode == ResolutionMode.PARTIAL:
+                return value
             raise InvalidTemplateException("Fn::FindInMap layout is incorrect")
 
         # Check for DefaultValue option (4th argument)

--- a/tests/unit/lib/cfn_language_extensions/compatibility/test_kotlin_compatibility.py
+++ b/tests/unit/lib/cfn_language_extensions/compatibility/test_kotlin_compatibility.py
@@ -32,7 +32,10 @@ from typing import Any, Dict, Optional, Tuple, List
 
 from samcli.lib.cfn_language_extensions.api import process_template
 from samcli.lib.cfn_language_extensions.models import ResolutionMode, PseudoParameterValues
-from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
+from samcli.lib.cfn_language_extensions.exceptions import (
+    InvalidTemplateException,
+    UnresolvableReferenceError,
+)
 
 # Path to test templates
 KOTLIN_TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -189,6 +192,13 @@ ERROR_TEMPLATES_PASSING = [
     "fnFindInMapWithDefaultValueWithMapTopKeyNotResolveToString",
     "fnFindInMapWithMapNameNotResolveToString",
     "fnFindInMapWithReferenceToIncorrectParameterType",
+]
+
+# Templates that the Kotlin reference treats as errors, but whose error in
+# Python depends on resolution mode: PARTIAL preserves unresolvable resource
+# references inside Fn::FindInMap so the expression survives to CloudFormation;
+# FULL keeps Kotlin parity and treats them as layout errors.
+ERROR_TEMPLATES_FULL_MODE_ONLY = [
     "fnFindInMapWithUnsupportedFunctionFnGetAtt",
     "fnFindInMapWithUnsupportedFunctionFnRef",
     "fnFindInMapWithUnsupportedFunctionInMapName",
@@ -215,6 +225,24 @@ def test_error_templates_passing(template_name: str):
     input_template = load_json_template(input_path)
     with pytest.raises(InvalidTemplateException):
         process_template(input_template)
+
+
+@pytest.mark.parametrize("template_name", ERROR_TEMPLATES_FULL_MODE_ONLY)
+def test_error_templates_passing_in_full_mode(template_name: str):
+    """Templates that match Kotlin's strict error behavior only in FULL mode.
+
+    PARTIAL mode preserves these intentionally; FULL mode keeps Kotlin parity
+    for callers that need strict resolution.
+    """
+    input_path = KOTLIN_TEMPLATES_DIR / f"{template_name}.json"
+    if not input_path.exists():
+        pytest.skip(f"Template {template_name} not available")
+    input_template = load_json_template(input_path)
+    # Depending on which resolver fires first, FULL mode raises either
+    # InvalidTemplateException (FindInMap layout error) or
+    # UnresolvableReferenceError (Ref to a resource).
+    with pytest.raises((InvalidTemplateException, UnresolvableReferenceError)):
+        process_template(input_template, resolution_mode=ResolutionMode.FULL)
 
 
 @pytest.mark.parametrize("template_name", ERROR_TEMPLATES_WITH_PLACEHOLDER)

--- a/tests/unit/lib/cfn_language_extensions/test_fn_find_in_map.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_find_in_map.py
@@ -38,6 +38,7 @@ from samcli.lib.cfn_language_extensions.resolvers.base import (
     IntrinsicResolver,
 )
 from samcli.lib.cfn_language_extensions.resolvers.fn_find_in_map import FnFindInMapResolver
+from samcli.lib.cfn_language_extensions.resolvers.fn_ref import FnRefResolver
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
 
 # =============================================================================
@@ -710,6 +711,55 @@ class TestFnFindInMapResolverPartialMode:
             "ami": "ami-12345678",
             "preserved": {"Fn::GetAtt": ["MyBucket", "Arn"]},
         }
+
+    @pytest.fixture
+    def partial_orchestrator_with_ref(self, partial_context: TemplateProcessingContext) -> IntrinsicResolver:
+        """Orchestrator in partial mode with both FnFindInMap and FnRef registered."""
+        orchestrator = IntrinsicResolver(partial_context)
+        orchestrator.register_resolver(FnFindInMapResolver)
+        orchestrator.register_resolver(FnRefResolver)
+        return orchestrator
+
+    def test_fn_find_in_map_preserves_expression_when_top_key_unresolved_in_partial_mode(
+        self, partial_orchestrator_with_ref: IntrinsicResolver
+    ):
+        """Unresolved Ref in the top-level key position is preserved in partial mode."""
+        value = {"Fn::FindInMap": ["RegionMap", {"Ref": "ENV"}, "AMI"]}
+        result = partial_orchestrator_with_ref.resolve_value(value)
+
+        assert result == {"Fn::FindInMap": ["RegionMap", {"Ref": "ENV"}, "AMI"]}
+
+    def test_fn_find_in_map_preserves_expression_when_map_name_unresolved_in_partial_mode(
+        self, partial_orchestrator_with_ref: IntrinsicResolver
+    ):
+        """Unresolved Ref in the map-name position is also preserved in partial mode."""
+        value = {"Fn::FindInMap": [{"Ref": "ENV"}, "us-east-1", "AMI"]}
+        result = partial_orchestrator_with_ref.resolve_value(value)
+
+        assert result == {"Fn::FindInMap": [{"Ref": "ENV"}, "us-east-1", "AMI"]}
+
+    def test_fn_find_in_map_preserves_expression_when_second_key_unresolved_in_partial_mode(
+        self, partial_orchestrator_with_ref: IntrinsicResolver
+    ):
+        """Unresolved Ref in the second-level key position is also preserved in partial mode."""
+        value = {"Fn::FindInMap": ["RegionMap", "us-east-1", {"Ref": "ENV"}]}
+        result = partial_orchestrator_with_ref.resolve_value(value)
+
+        assert result == {"Fn::FindInMap": ["RegionMap", "us-east-1", {"Ref": "ENV"}]}
+
+    def test_fn_find_in_map_still_raises_for_non_string_key_in_full_mode(self, mappings: Dict[str, Any]):
+        """FULL mode keeps raising InvalidTemplateException for a non-string key."""
+        full_context = TemplateProcessingContext(
+            fragment={"Resources": {}, "Mappings": mappings},
+            resolution_mode=ResolutionMode.FULL,
+        )
+        full_context.parsed_template = ParsedTemplate(resources={}, mappings=mappings)
+        resolver = FnFindInMapResolver(full_context)
+
+        value = {"Fn::FindInMap": ["RegionMap", {"Ref": "ENV"}, "AMI"]}
+        with pytest.raises(InvalidTemplateException) as exc_info:
+            resolver.resolve(value)
+        assert "Fn::FindInMap layout is incorrect" in str(exc_info.value)
 
 
 # =============================================================================


### PR DESCRIPTION
#### Which issue(s) does this change fix?

#9004

#### Why is this change necessary?

`sam build` (1.160.0) fails with `Fn::FindInMap layout is incorrect` for any `AWS::LanguageExtensions` template that uses `Fn::FindInMap` with a `!Ref Param` as one of the keys, when no value is supplied for that parameter at build time (no `--parameter-overrides`, no `Default`). The same template built successfully with 1.159.1 — this is a regression introduced together with the new `cfn_language_extensions` module.

Root cause: `FnRefResolver` correctly preserves an unresolved `{"Ref": "ENV"}` dict in `ResolutionMode.PARTIAL` (the default for SAM CLI integration), but `FnFindInMapResolver` then validated the resolved keys with `isinstance(..., str)` and raised `InvalidTemplateException` unconditionally, regardless of resolution mode.

#### How does it address the issue?

In `samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py`, mirror the `FnRefResolver` PARTIAL-mode pattern: when any resolved FindInMap key arrives as a `dict` (an unresolved nested intrinsic) and `resolution_mode == PARTIAL`, return the original `Fn::FindInMap` expression so CloudFormation can resolve it at deploy time. Non-`dict`, non-`str` keys (e.g. an `int` literal) remain a layout error in either mode, preserving existing behavior for genuine template mistakes.

#### What side effects does this change have?

- 3 Kotlin-compatibility tests in `test_kotlin_compatibility.py` previously asserted that `Fn::FindInMap` with `Ref`/`GetAtt` to a resource raises in default (PARTIAL) mode. That assertion captured the Kotlin reference's strict semantics, which conflict with SAM CLI's documented PARTIAL intent ("preserve unresolvable references in the output"). Those templates were moved to a new `ERROR_TEMPLATES_FULL_MODE_ONLY` list and are now asserted under `ResolutionMode.FULL`, keeping Kotlin parity for the strict callers while letting PARTIAL mode pass the expression through to CloudFormation. The remaining `fnFindInMapWithUnsupportedFunctionFnSub` template is unaffected (it already errored via a different code path).
- No public API changes. No changes to `FULL` mode behavior.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] \`make pr\` passes
- [ ] \`make update-reproducible-reqs\` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).