### PR TITLE
fix(cfn-lang-ext): unify packageable resource properties (#9005)

### DIFF
--- a/docs/cfn-language-extensions.md
+++ b/docs/cfn-language-extensions.md
@@ -41,7 +41,37 @@ Running `sam build` expands this into `UsersFunction`, `OrdersFunction`, and `Pr
 
 ### Dynamic artifact properties
 
-When a packageable property (like `CodeUri`, `ContentUri`, `ImageUri`) uses a loop variable (e.g., `./services/${Name}`), SAM CLI generates a CloudFormation `Mappings` section that maps each collection value to its S3 URI. The `Fn::ForEach` body is rewritten to use `Fn::FindInMap` so CloudFormation can resolve the correct artifact at deploy time.
+When a packageable property uses a loop variable (e.g., `./services/${Name}`), SAM CLI generates a CloudFormation `Mappings` section that maps each collection value to its S3 URI. The `Fn::ForEach` body is rewritten to use `Fn::FindInMap` so CloudFormation can resolve the correct artifact at deploy time.
+
+The set of recognized artifact properties is derived from the same canonical list `sam package` already uses (`RESOURCES_WITH_LOCAL_PATHS` and `RESOURCES_WITH_IMAGE_COMPONENT` in `samcli/lib/utils/resources.py`), so every resource type whose artifact property `sam package` would normally rewrite is supported here too. That includes:
+
+| Resource type | Property |
+|---------------|----------|
+| `AWS::Serverless::Function` | `CodeUri`, `ImageUri` |
+| `AWS::Serverless::LayerVersion` | `ContentUri` |
+| `AWS::Serverless::Api` | `DefinitionUri` |
+| `AWS::Serverless::HttpApi` | `DefinitionUri` |
+| `AWS::Serverless::StateMachine` | `DefinitionUri` |
+| `AWS::Serverless::GraphQLApi` | `SchemaUri`, `CodeUri` |
+| `AWS::Serverless::Application` | `Location` |
+| `AWS::Lambda::Function` | `Code`, `Code.ImageUri` |
+| `AWS::Lambda::LayerVersion` | `Content` |
+| `AWS::ApiGateway::RestApi` | `BodyS3Location` |
+| `AWS::ApiGatewayV2::Api` | `BodyS3Location` |
+| `AWS::AppSync::GraphQLSchema` | `DefinitionS3Location` |
+| `AWS::AppSync::Resolver` | `RequestMappingTemplateS3Location`, `ResponseMappingTemplateS3Location`, `CodeS3Location` |
+| `AWS::AppSync::FunctionConfiguration` | `RequestMappingTemplateS3Location`, `ResponseMappingTemplateS3Location`, `CodeS3Location` |
+| `AWS::StepFunctions::StateMachine` | `DefinitionS3Location` |
+| `AWS::ElasticBeanstalk::ApplicationVersion` | `SourceBundle` |
+| `AWS::Glue::Job` | `Command.ScriptLocation` |
+| `AWS::CloudFormation::Stack` | `TemplateURL` |
+| `AWS::CloudFormation::StackSet` | `TemplateURL` |
+| `AWS::CloudFormation::ModuleVersion` | `ModulePackage` |
+| `AWS::CloudFormation::ResourceVersion` | `SchemaHandlerPackage` |
+
+When a property is dotted (e.g. `Command.ScriptLocation` on `AWS::Glue::Job` or `Code.ImageUri` on `AWS::Lambda::Function`), SAM CLI reads and writes the value at the dotted location on the resource — so it lands at `Properties.Command.ScriptLocation` rather than at a literal `Properties["Command.ScriptLocation"]` key — and uses only the leaf segment when it needs to construct an alphanumeric identifier (Mapping name suffix or `Fn::FindInMap` third argument).
+
+When the property is loop-templated, the Mapping name is `SAM<LeafProperty><LoopName>` (e.g., `SAMCodeUriServices`, `SAMScriptLocationJobs`). Customer-authored mappings should not start with these `SAM*` prefixes — they are reserved for SAM CLI (see [Limitations](#limitations) below).
 
 For example, after `sam package`:
 
@@ -66,6 +96,45 @@ Resources:
           Runtime: python3.12
           CodeUri: !FindInMap [SAMCodeUriServices, !Ref Name, CodeUri]
 ```
+
+### Multiple resources per ForEach body
+
+A single `Fn::ForEach` body can emit more than one resource per iteration. Each resource is generated for every collection value:
+
+```yaml
+Resources:
+  Fn::ForEach::Tables:
+    - TableName
+    - [Users, Orders, Products]
+    - ${TableName}Table:
+        Type: AWS::DynamoDB::Table
+        Properties:
+          TableName: !Sub "${AWS::StackName}-${TableName}"
+          # ...
+
+      ${TableName}StreamProcessor:
+        Type: AWS::Serverless::Function
+        Properties:
+          CodeUri: stream-processors/${TableName}/
+          Events:
+            DDBStream:
+              Type: DynamoDB
+              Properties:
+                Stream: !GetAtt
+                  - !Sub "${TableName}Table"
+                  - StreamArn
+```
+
+### Mapping name collision resolution
+
+When two resources in the same `Fn::ForEach` body declare the same dynamic artifact property (for example, both an `Api` and a `StateMachine` use `DefinitionUri`), SAM CLI appends a sanitized suffix derived from the resource logical-ID template to keep Mapping names unique:
+
+| Resource template | Property | Mapping name |
+|-------------------|----------|--------------|
+| `${Svc}Api` | `DefinitionUri` | `SAMDefinitionUriServicesApi` |
+| `${Svc}StateMachine` | `DefinitionUri` | `SAMDefinitionUriServicesStateMachine` |
+
+When there is no collision the base name (e.g., `SAMDefinitionUriServices`) is used.
 
 ### Parameter-based collections
 
@@ -120,6 +189,46 @@ Resources:
                   STAGE: !Ref Env
 ```
 
+### ForEach in Outputs
+
+`Fn::ForEach` blocks are also expanded inside the `Outputs` section, so you can emit one output per collection value:
+
+```yaml
+Outputs:
+  Fn::ForEach::FunctionArns:
+    - Name
+    - [alpha, beta]
+    - ${Name}FunctionArn:
+        Value: !GetAtt
+          - !Sub "${Name}Function"
+          - Arn
+```
+
+### Conditions and DependsOn
+
+Resources emitted by `Fn::ForEach` can carry `Condition` and `DependsOn` like any other resource. The condition or dependency is replicated onto each generated resource:
+
+```yaml
+Conditions:
+  IsProd: !Equals [!Ref Environment, prod]
+
+Resources:
+  SharedTable:
+    Type: AWS::DynamoDB::Table
+    # ...
+
+  Fn::ForEach::Functions:
+    - Name
+    - [api, worker]
+    - ${Name}Function:
+        Type: AWS::Serverless::Function
+        Condition: IsProd
+        DependsOn: SharedTable
+        Properties:
+          Handler: main.handler
+          CodeUri: functions/${Name}/
+```
+
 ### &{identifier} syntax
 
 The `&{identifier}` syntax strips non-alphanumeric characters from the substituted value, useful for generating valid logical IDs from values like IP addresses:
@@ -154,11 +263,26 @@ The following intrinsic functions are resolved locally during expansion:
 
 Functions that require deployed resources (`Fn::GetAtt`, `Fn::ImportValue`, `Fn::GetAZs`) are preserved for CloudFormation to resolve at deploy time.
 
+## Validation errors
+
+The following template issues are caught locally before the SAM transform runs:
+
+| Error | Cause |
+|-------|-------|
+| `Fn::ForEach must have exactly 3 elements` | The `Fn::ForEach` value is not a 3-element list (`[loop_variable, collection, output_template]`). |
+| `Maximum nesting depth of 5 exceeded` | More than 5 levels of `Fn::ForEach` are nested. |
+| `Parameter '<name>' referenced by Fn::ForEach not found` | The `!Ref` in the collection points at a parameter that is not declared in the template. |
+| Empty collection | If the collection resolves to an empty list (e.g., a `CommaDelimitedList` parameter with `Default: ""`), no resources are emitted — the loop is silently skipped. |
+
 ## Limitations
 
 - **Collections must be resolvable at build/package time.** `Fn::ForEach` collections that use `Fn::GetAtt`, `Fn::ImportValue`, or SSM/Secrets Manager dynamic references cannot be expanded locally. Use a parameter with `--parameter-overrides` instead.
 - **Parameter values are fixed at package time.** If you change `--parameter-overrides` at deploy time without re-packaging, the Mappings won't include entries for new values and deployment will fail.
 - **`DeletionPolicy` and `UpdateReplacePolicy`** are validated and resolved during expansion. They support `Ref` to parameters but not other intrinsic functions.
+- **Nesting limit.** Up to 5 levels of `Fn::ForEach` may be nested, matching CloudFormation's server-side limit.
+- **Reserved Mapping names.** Mapping names starting with any of the following are reserved for SAM CLI — do not author your own mappings with these prefixes:
+  - `SAMCodeUri`, `SAMImageUri`, `SAMContentUri`, `SAMDefinitionUri`, `SAMSchemaUri`, `SAMBodyS3Location`, `SAMDefinitionS3Location`, `SAMTemplateURL`, `SAMCode`, `SAMContent` — emitted by `sam package` for dynamic artifact properties (see the table above).
+  - `SAMLayers` — emitted by `sam build` when a `Fn::ForEach`-generated function picks up auto-generated dependency-layer references (Lambda layers SAM CLI builds into a nested stack). This prefix has no corresponding user-authored property; it is added automatically.
 
 ## Telemetry
 

--- a/docs/cfn-language-extensions.md
+++ b/docs/cfn-language-extensions.md
@@ -267,12 +267,12 @@ Functions that require deployed resources (`Fn::GetAtt`, `Fn::ImportValue`, `Fn:
 
 The following template issues are caught locally before the SAM transform runs:
 
-| Error | Cause |
-|-------|-------|
-| `Fn::ForEach must have exactly 3 elements` | The `Fn::ForEach` value is not a 3-element list (`[loop_variable, collection, output_template]`). |
-| `Maximum nesting depth of 5 exceeded` | More than 5 levels of `Fn::ForEach` are nested. |
-| `Parameter '<name>' referenced by Fn::ForEach not found` | The `!Ref` in the collection points at a parameter that is not declared in the template. |
-| Empty collection | If the collection resolves to an empty list (e.g., a `CommaDelimitedList` parameter with `Default: ""`), no resources are emitted — the loop is silently skipped. |
+| Cause | Error message |
+|-------|---------------|
+| The `Fn::ForEach` value is malformed — not a list, doesn't have exactly 3 elements, or has a non-string loop identifier. | `Fn::ForEach::<key> layout is incorrect` (raised as `InvalidTemplateException`; see `samcli/lib/cfn_language_extensions/processors/foreach.py`). |
+| More than 5 levels of `Fn::ForEach` are nested. | `Fn::ForEach nesting depth of <N> exceeds the maximum allowed depth of 5. CloudFormation supports up to 5 nested Fn::ForEach loops.` |
+| The collection resolves to an empty list (e.g., a `CommaDelimitedList` parameter with `Default: ""`). | No error — the loop is silently skipped and no resources are emitted. |
+| The `!Ref` in the collection points at a parameter that is not declared in the template. | No error in the typical `sam build` / `sam package` flow. SAM CLI runs intrinsic resolution in PARTIAL mode and preserves the unresolved `{"Ref": "<name>"}`. CloudFormation will reject the unresolved ref at deploy time. |
 
 ## Limitations
 

--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -33,8 +33,17 @@ from samcli.yamlhelper import yaml_dump, yaml_parse
 # Artifact path property names derived from PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
 # so the two lists cannot drift. Used by _update_sam_mappings_relative_paths to
 # identify which SAM-generated Mapping values are local paths needing adjustment.
+#
+# Includes both the dotted form (e.g. "Command.ScriptLocation") and its leaf
+# (e.g. "ScriptLocation"), because SAM-generated Mapping value-dicts are keyed
+# by the leaf segment so the third argument of Fn::FindInMap stays alphanumeric
+# (see _compute_mapping_name and _generate_artifact_mappings in
+# samcli/lib/package/language_extensions_packaging.py).
 _ARTIFACT_PATH_PROPERTIES = frozenset(
-    prop for props in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES.values() for prop in props
+    name
+    for props in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES.values()
+    for prop in props
+    for name in (prop, prop.rsplit(".", 1)[-1])
 )
 
 

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -553,6 +553,12 @@ class BuildContext:
         """
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
         from samcli.lib.cfn_language_extensions.sam_integration import resolve_collection
+        from samcli.lib.package.language_extensions_packaging import (
+            _get_prop_value,
+            _leaf_prop_name,
+            _resolve_property_paths,
+            _set_prop_value,
+        )
 
         generated_mappings: Dict[str, Dict[str, Dict[str, str]]] = {}
 
@@ -599,10 +605,16 @@ class BuildContext:
             if not isinstance(properties, dict):
                 continue
 
-            for prop_name in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES.get(resource_type, []):
-                prop_value = properties.get(prop_name)
+            candidate_paths = PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES.get(resource_type, [])
+            for prop_name in _resolve_property_paths(candidate_paths, properties):
+                prop_value = _get_prop_value(properties, prop_name)
                 if prop_value is None:
                     continue
+
+                # CloudFormation Mapping names and FindInMap third-args must be alphanumeric,
+                # so dotted property names (e.g. "Command.ScriptLocation") use the leaf segment
+                # for those identifiers while the dotted form is preserved for property addressing.
+                leaf_name = _leaf_prop_name(prop_name)
 
                 if contains_loop_variable(prop_value, loop_variable) and collection_values:
                     # Determine which outer loop variables the property references
@@ -622,7 +634,7 @@ class BuildContext:
                         referenced_outer_vars=referenced_outer_vars,
                     )
                     if mapping_entries:
-                        mapping_name = f"SAM{prop_name}{nesting_path}"
+                        mapping_name = f"SAM{leaf_name}{nesting_path}"
                         if dynamic_props_count.get(prop_name, 0) > 1:
                             suffix = sanitize_resource_key_for_mapping(resource_template_key)
                             mapping_name = f"{mapping_name}{suffix}"
@@ -637,7 +649,7 @@ class BuildContext:
                         else:
                             lookup_key = {"Ref": loop_variable}
 
-                        properties[prop_name] = {"Fn::FindInMap": [mapping_name, lookup_key, prop_name]}
+                        _set_prop_value(properties, prop_name, {"Fn::FindInMap": [mapping_name, lookup_key, leaf_name]})
                 else:
                     expanded_key = self._build_expanded_key(
                         resource_template_key,
@@ -648,7 +660,7 @@ class BuildContext:
                     if expanded_key:
                         artifact_value = self._get_artifact_value(modified_resources, expanded_key, prop_name)
                         if artifact_value is not None:
-                            properties[prop_name] = artifact_value
+                            _set_prop_value(properties, prop_name, artifact_value)
 
             # Propagate auto dependency layer references from expanded functions
             # to the ForEach body. Each expanded function may have Layers entries
@@ -707,6 +719,7 @@ class BuildContext:
         share the same property name (e.g., two resources both with DefinitionUri).
         """
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        from samcli.lib.package.language_extensions_packaging import _get_prop_value, _resolve_property_paths
 
         count: Counter = Counter()
         for rtk, rt in body.items():
@@ -718,8 +731,9 @@ class BuildContext:
             rprops = rt.get("Properties", {})
             if not isinstance(rprops, dict):
                 continue
-            for pname in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES.get(rtype, []):
-                pval = rprops.get(pname)
+            candidate_paths = PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES.get(rtype, [])
+            for pname in _resolve_property_paths(candidate_paths, rprops):
+                pval = _get_prop_value(rprops, pname)
                 if pval is not None and contains_loop_variable(pval, loop_variable) and collection_values:
                     count[pname] += 1
         return count
@@ -759,8 +773,15 @@ class BuildContext:
 
         For nested ForEach, enumerates all outer value combinations to find
         the fully-expanded resource name.
+
+        ``prop_name`` may be a jmespath dotted path; the value-dict key stored
+        in the Mapping uses the leaf segment so it stays alphanumeric and
+        matches the third argument of the generated Fn::FindInMap.
         """
+        from samcli.lib.package.language_extensions_packaging import _leaf_prop_name
+
         mapping_entries: Dict[str, Dict[str, str]] = {}
+        leaf_name = _leaf_prop_name(prop_name)
 
         for coll_value in collection_values:
             if outer_context:
@@ -778,7 +799,7 @@ class BuildContext:
                 expanded_key = substitute_loop_variable(resource_template_key, loop_variable, coll_value)
                 artifact_value = self._get_artifact_value(modified_resources, expanded_key, prop_name)
                 if artifact_value is not None:
-                    mapping_entries[coll_value] = {prop_name: artifact_value}
+                    mapping_entries[coll_value] = {leaf_name: artifact_value}
 
         return mapping_entries
 
@@ -793,9 +814,15 @@ class BuildContext:
         mapping_entries: Dict[str, Dict[str, str]],
         referenced_outer_vars: Optional[List[Tuple[str, List[str]]]] = None,
     ) -> None:
-        """Enumerate outer value combinations to find expanded resource for a nested ForEach."""
+        """Enumerate outer value combinations to find expanded resource for a nested ForEach.
+
+        ``prop_name`` may be a jmespath dotted path; the value-dict key uses the leaf segment.
+        """
         import itertools
 
+        from samcli.lib.package.language_extensions_packaging import _leaf_prop_name
+
+        leaf_name = _leaf_prop_name(prop_name)
         outer_collections = [oc[1] for oc in outer_context]
         outer_vars = [oc[0] for oc in outer_context]
 
@@ -821,7 +848,7 @@ class BuildContext:
                 mapping_key = coll_value
 
             if mapping_key not in mapping_entries:
-                mapping_entries[mapping_key] = {prop_name: artifact_value}
+                mapping_entries[mapping_key] = {leaf_name: artifact_value}
 
     def _collect_foreach_layer_mappings(
         self,
@@ -895,14 +922,19 @@ class BuildContext:
 
     @staticmethod
     def _get_artifact_value(modified_resources: Dict, expanded_key: str, prop_name: str) -> Optional[Any]:
-        """Extract an artifact property value from an expanded resource, or return None."""
+        """Extract an artifact property value from an expanded resource, or return None.
+
+        ``prop_name`` may be a jmespath dotted path (e.g. "Command.ScriptLocation").
+        """
+        from samcli.lib.package.language_extensions_packaging import _get_prop_value
+
         modified_resource = modified_resources.get(expanded_key, {})
         if not isinstance(modified_resource, dict):
             return None
         modified_props = modified_resource.get("Properties", {})
         if not isinstance(modified_props, dict):
             return None
-        return modified_props.get(prop_name)
+        return _get_prop_value(modified_props, prop_name)
 
     def _copy_artifact_paths(self, original_resource: Dict, modified_resource: Dict) -> None:
         """

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -635,7 +635,11 @@ class BuildContext:
                     )
                     if mapping_entries:
                         mapping_name = f"SAM{leaf_name}{nesting_path}"
-                        if dynamic_props_count.get(prop_name, 0) > 1:
+                        # Collision count is keyed on the leaf so dotted paths
+                        # that share a leaf (e.g. "ImageUri" vs "Code.ImageUri")
+                        # get the resource-key suffix and don't overwrite each
+                        # other's Mapping entries.
+                        if dynamic_props_count.get(leaf_name, 0) > 1:
                             suffix = sanitize_resource_key_for_mapping(resource_template_key)
                             mapping_name = f"{mapping_name}{suffix}"
                         generated_mappings[mapping_name] = mapping_entries
@@ -719,7 +723,11 @@ class BuildContext:
         share the same property name (e.g., two resources both with DefinitionUri).
         """
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
-        from samcli.lib.package.language_extensions_packaging import _get_prop_value, _resolve_property_paths
+        from samcli.lib.package.language_extensions_packaging import (
+            _get_prop_value,
+            _leaf_prop_name,
+            _resolve_property_paths,
+        )
 
         count: Counter = Counter()
         for rtk, rt in body.items():
@@ -735,7 +743,9 @@ class BuildContext:
             for pname in _resolve_property_paths(candidate_paths, rprops):
                 pval = _get_prop_value(rprops, pname)
                 if pval is not None and contains_loop_variable(pval, loop_variable) and collection_values:
-                    count[pname] += 1
+                    # Count by leaf so collisions across resource types with
+                    # different dotted paths but the same leaf are detected.
+                    count[_leaf_prop_name(pname)] += 1
         return count
 
     @staticmethod

--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -919,6 +919,7 @@ class BuildContext:
             The modified resource with updated artifact paths
         """
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        from samcli.lib.package.language_extensions_packaging import _get_prop_value, _set_prop_value
 
         original_props = original_resource.get("Properties", {})
         modified_props = modified_resource.get("Properties", {})
@@ -929,8 +930,9 @@ class BuildContext:
             return
 
         for prop_name in prop_names:
-            if prop_name in modified_props:
-                original_props[prop_name] = modified_props[prop_name]
+            value = _get_prop_value(modified_props, prop_name)
+            if value is not None:
+                _set_prop_value(original_props, prop_name, value)
 
     def _gen_success_msg(self, artifacts_dir: str, output_template_path: str, is_default_build_dir: bool) -> str:
         """

--- a/samcli/lib/cfn_language_extensions/models.py
+++ b/samcli/lib/cfn_language_extensions/models.py
@@ -135,22 +135,34 @@ class TemplateProcessingContext:
 
 
 # Packageable resource types and their artifact properties that can be dynamic in Fn::ForEach blocks.
-# These properties reference local files/directories that SAM CLI needs to package.
-# Dynamic values (using loop variables) are supported via Mappings transformation.
-PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES: Dict[str, List[str]] = {
-    "AWS::Serverless::Function": ["CodeUri", "ImageUri"],
-    "AWS::Lambda::Function": ["Code"],
-    "AWS::Serverless::LayerVersion": ["ContentUri"],
-    "AWS::Lambda::LayerVersion": ["Content"],
-    "AWS::Serverless::Api": ["DefinitionUri"],
-    "AWS::Serverless::HttpApi": ["DefinitionUri"],
-    "AWS::Serverless::StateMachine": ["DefinitionUri"],
-    "AWS::Serverless::GraphQLApi": ["SchemaUri", "CodeUri"],
-    "AWS::ApiGateway::RestApi": ["BodyS3Location"],
-    "AWS::ApiGatewayV2::Api": ["BodyS3Location"],
-    "AWS::StepFunctions::StateMachine": ["DefinitionS3Location"],
-    "AWS::CloudFormation::Stack": ["TemplateURL"],
-}
+# Derived from samcli.lib.utils.resources to keep one source of truth: any resource type
+# whose property the artifact exporter packages MUST be merged back into the original
+# (Fn::ForEach-preserving) template. See issue #9005 for the symptom of drift.
+#
+# Property names follow jmespath syntax (e.g., "Command.ScriptLocation" for nested keys),
+# matching the canonical dicts. Consumers must use jmespath-aware get/set when copying.
+def _build_packageable_resource_artifact_properties() -> Dict[str, List[str]]:
+    from samcli.lib.utils.resources import (
+        AWS_ECR_REPOSITORY,
+        RESOURCES_WITH_IMAGE_COMPONENT,
+        RESOURCES_WITH_LOCAL_PATHS,
+    )
+
+    result: Dict[str, List[str]] = {}
+    for resource_type, props in RESOURCES_WITH_LOCAL_PATHS.items():
+        result[resource_type] = list(props)
+    for resource_type, props in RESOURCES_WITH_IMAGE_COMPONENT.items():
+        # ECR::Repository.RepositoryName is not a packaged-artifact path.
+        if resource_type == AWS_ECR_REPOSITORY:
+            continue
+        result.setdefault(resource_type, [])
+        for prop in props:
+            if prop not in result[resource_type]:
+                result[resource_type].append(prop)
+    return result
+
+
+PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES: Dict[str, List[str]] = _build_packageable_resource_artifact_properties()
 
 
 @dataclass(frozen=True)

--- a/samcli/lib/cfn_language_extensions/sam_integration.py
+++ b/samcli/lib/cfn_language_extensions/sam_integration.py
@@ -412,8 +412,10 @@ def detect_foreach_dynamic_properties(
         if not isinstance(properties, dict):
             continue
 
-        for prop_name in artifact_properties:
-            prop_value = properties.get(prop_name)
+        from samcli.lib.package.language_extensions_packaging import _get_prop_value, _resolve_property_paths
+
+        for prop_name in _resolve_property_paths(artifact_properties, properties):
+            prop_value = _get_prop_value(properties, prop_name)
             if prop_value is not None:
                 if contains_loop_variable(prop_value, loop_variable):
                     dynamic_properties.append(

--- a/samcli/lib/cfn_language_extensions/utils.py
+++ b/samcli/lib/cfn_language_extensions/utils.py
@@ -94,25 +94,34 @@ def is_unresolved_param_or_pseudo_ref(value: Any, context: "TemplateProcessingCo
 
 
 # Mapping-name prefixes that SAM CLI emits for dynamic Fn::ForEach handling:
-#   - SAM + <packageable artifact property> + <nesting path> + [resource suffix]
+#   - SAM + <leaf of packageable artifact property> + <nesting path> + [resource suffix]
 #     (see language_extensions_packaging._compute_mapping_name)
 #   - SAMLayers + <nesting path>  (see build_context — auto dependency layer refs)
-# Customer-authored mappings should never start with one of these exact
-# PascalCase prefixes, so exact-prefix matching avoids the false positives
-# a regex like r"^SAM[A-Z]..." would hit on names like SAMPLE / SAMSUNG.
-_SAM_GENERATED_MAPPING_PREFIXES: Tuple[str, ...] = (
-    "SAMCodeUri",
-    "SAMImageUri",
-    "SAMContentUri",
-    "SAMDefinitionUri",
-    "SAMSchemaUri",
-    "SAMBodyS3Location",
-    "SAMDefinitionS3Location",
-    "SAMTemplateURL",
-    "SAMCode",
-    "SAMContent",
-    "SAMLayers",
-)
+# Derived from PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES so the set automatically
+# tracks the canonical packageable-resource list. Customer-authored mappings
+# should never start with one of these exact PascalCase prefixes; exact-prefix
+# matching avoids the false positives a regex like r"^SAM[A-Z]..." would hit on
+# names like SAMPLE / SAMSUNG.
+def _build_sam_generated_mapping_prefixes() -> Tuple[str, ...]:
+    from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
+    seen: set = set()
+    prefixes: list = []
+    for props in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES.values():
+        for prop in props:
+            leaf = prop.rsplit(".", 1)[-1]
+            prefix = f"SAM{leaf}"
+            if prefix not in seen:
+                seen.add(prefix)
+                prefixes.append(prefix)
+    # SAMLayers is emitted by sam build for auto dependency layer references and
+    # has no corresponding artifact property; add it explicitly.
+    if "SAMLayers" not in seen:
+        prefixes.append("SAMLayers")
+    return tuple(prefixes)
+
+
+_SAM_GENERATED_MAPPING_PREFIXES: Tuple[str, ...] = _build_sam_generated_mapping_prefixes()
 
 
 def is_sam_generated_mapping(mapping_name: str) -> bool:

--- a/samcli/lib/package/language_extensions_packaging.py
+++ b/samcli/lib/package/language_extensions_packaging.py
@@ -8,13 +8,13 @@ None of the functions use instance state — they are pure functions.
 
 import copy
 import itertools
-import jmespath
 import logging
 import re
 from collections import Counter
 from typing import Any, Dict, List, Optional, Tuple
 
 import click
+import jmespath
 from botocore.utils import set_value_from_jmespath
 
 from samcli.lib.cfn_language_extensions.models import (
@@ -124,8 +124,6 @@ def _get_prop_value(props: Dict[str, Any], prop_name: str) -> Optional[Any]:
     """Read a property by jmespath path. Supports flat keys ("CodeUri") and
     dotted paths ("Command.ScriptLocation"). Returns None if missing.
     """
-    if not isinstance(props, dict):
-        return None
     return jmespath.search(prop_name, props)
 
 

--- a/samcli/lib/package/language_extensions_packaging.py
+++ b/samcli/lib/package/language_extensions_packaging.py
@@ -134,6 +134,50 @@ def _set_prop_value(props: Dict[str, Any], prop_name: str, value: Any) -> None:
     set_value_from_jmespath(props, prop_name, value)
 
 
+def _leaf_prop_name(prop_name: str) -> str:
+    """Return the last segment of a jmespath property name.
+
+    CloudFormation Mapping names must be alphanumeric, and the third argument of
+    Fn::FindInMap and the keys of Mapping value-dicts must match each other as
+    plain strings. Dotted property names (e.g. "Command.ScriptLocation") are
+    used to *address* the property on a resource, but the *identifier* used in
+    Mapping names and FindInMap lookups must use only the leaf segment so the
+    generated CloudFormation is well-formed.
+    """
+    return prop_name.rsplit(".", 1)[-1]
+
+
+def _resolve_property_paths(prop_names: List[str], properties: Dict[str, Any]) -> List[str]:
+    """Filter ``prop_names`` so a parent path is dropped when a more specific
+    child path is present in ``properties``.
+
+    Some resource types declare multiple alternative artifact paths in
+    ``PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES``. For example,
+    ``AWS::Lambda::Function`` lists ``Code`` (used for ZIP packages) and
+    ``Code.ImageUri`` (used for image packages). A given user template uses
+    only one of these shapes, but ``Code`` is a prefix of ``Code.ImageUri``,
+    so a naive iteration would address both paths and treat the same nested
+    value twice. Returning only the most specific resolved path picks the
+    correct interpretation for the user's actual property shape.
+    """
+    # Sort longest-first so child paths win over their parents.
+    sorted_paths = sorted(prop_names, key=lambda p: -p.count("."))
+    consumed_prefixes: set = set()
+    selected: List[str] = []
+    for path in sorted_paths:
+        if _get_prop_value(properties, path) is None:
+            continue
+        # If a more specific path under this prefix has already been selected, skip.
+        if any(other.startswith(path + ".") for other in consumed_prefixes):
+            continue
+        selected.append(path)
+        consumed_prefixes.add(path)
+    # Preserve original ordering for callers that care.
+    order = {p: i for i, p in enumerate(prop_names)}
+    selected.sort(key=lambda p: order.get(p, 0))
+    return selected
+
+
 # ---------------------------------------------------------------------------
 # Merge helpers
 # ---------------------------------------------------------------------------
@@ -330,7 +374,9 @@ def _compute_mapping_name(
     compatibility.
     """
     npath = _nesting_path(prop)
-    base_name = f"SAM{prop.property_name}{npath}"
+    # Use the leaf segment for the Mapping name so dotted property paths (e.g.
+    # "Command.ScriptLocation") yield well-formed alphanumeric Mapping names.
+    base_name = f"SAM{_leaf_prop_name(prop.property_name)}{npath}"
     key = (npath, prop.property_name)
     if collision_groups.get(key, 0) <= 1:
         return base_name
@@ -363,6 +409,10 @@ def _generate_artifact_mappings(
         _validate_mapping_key_compatibility(prop)
 
         mapping_name = _compute_mapping_name(prop, collision_groups)
+        # The Mapping value-dict key and the third FindInMap argument must use
+        # the leaf segment so dotted property paths produce well-formed
+        # CloudFormation (Mappings can't contain dots in either name or keys).
+        leaf_name = _leaf_prop_name(prop.property_name)
 
         if mapping_name not in mappings:
             mappings[mapping_name] = {}
@@ -394,7 +444,7 @@ def _generate_artifact_mappings(
                 )
 
                 if s3_uri:
-                    mappings[mapping_name][compound_key] = {prop.property_name: s3_uri}
+                    mappings[mapping_name][compound_key] = {leaf_name: s3_uri}
                 else:
                     LOG.warning(
                         "Could not find S3 URI for %s in expanded resource %s",
@@ -421,7 +471,7 @@ def _generate_artifact_mappings(
                 )
 
                 if s3_uri:
-                    mappings[mapping_name][collection_value] = {prop.property_name: s3_uri}
+                    mappings[mapping_name][collection_value] = {leaf_name: s3_uri}
                 else:
                     LOG.warning(
                         "Could not find S3 URI for %s in expanded resource %s",
@@ -465,7 +515,8 @@ def _find_artifact_uri_for_resource(
     Find the artifact URI for a specific resource and property from the exported resources.
 
     Handles all artifact property export formats (string URIs, {S3Bucket, S3Key},
-    {Bucket, Key}, {ImageUri}).
+    {Bucket, Key}, {ImageUri}). ``property_name`` may be a jmespath dotted path
+    (e.g. "Command.ScriptLocation").
     """
     resource = exported_resources.get(resource_key)
     if not isinstance(resource, dict):
@@ -478,7 +529,7 @@ def _find_artifact_uri_for_resource(
     if not isinstance(properties, dict):
         return None
 
-    artifact_uri = properties.get(property_name)
+    artifact_uri = _get_prop_value(properties, property_name)
 
     if isinstance(artifact_uri, str):
         return artifact_uri
@@ -531,7 +582,8 @@ def _replace_dynamic_artifact_with_findmap(
     Replace a dynamic artifact property value with Fn::FindInMap reference.
     """
     if mapping_name is None:
-        mapping_name = f"SAM{prop.property_name}{_nesting_path(prop)}"
+        # Use the leaf segment so dotted paths produce alphanumeric Mapping names.
+        mapping_name = f"SAM{_leaf_prop_name(prop.property_name)}{_nesting_path(prop)}"
 
     current_scope = resources
     if prop.outer_loops:
@@ -581,13 +633,20 @@ def _replace_dynamic_artifact_with_findmap(
     else:
         lookup_key = {"Ref": prop.loop_variable}
 
-    properties[prop.property_name] = {
-        "Fn::FindInMap": [
-            mapping_name,
-            lookup_key,
-            prop.property_name,
-        ]
-    }
+    # Address the property at its dotted location (creating intermediate dicts
+    # if needed) and use the leaf segment as the FindInMap third argument so
+    # the lookup matches the Mapping value-dict key.
+    _set_prop_value(
+        properties,
+        prop.property_name,
+        {
+            "Fn::FindInMap": [
+                mapping_name,
+                lookup_key,
+                _leaf_prop_name(prop.property_name),
+            ]
+        },
+    )
 
     LOG.debug(
         "Replaced %s in %s/%s with Fn::FindInMap reference to %s",

--- a/samcli/lib/package/language_extensions_packaging.py
+++ b/samcli/lib/package/language_extensions_packaging.py
@@ -271,11 +271,12 @@ def _copy_artifact_uris_for_type(
 
     copied = False
     for prop_name in prop_names:
-        if prop_name not in exported_props:
+        exported_value = _get_prop_value(exported_props, prop_name)
+        if exported_value is None:
             continue
         if dynamic_prop_keys and foreach_key and (foreach_key, prop_name) in dynamic_prop_keys:
             continue
-        original_props[prop_name] = exported_props[prop_name]
+        _set_prop_value(original_props, prop_name, exported_value)
         copied = True
 
     return copied

--- a/samcli/lib/package/language_extensions_packaging.py
+++ b/samcli/lib/package/language_extensions_packaging.py
@@ -376,8 +376,13 @@ def _compute_mapping_name(
     npath = _nesting_path(prop)
     # Use the leaf segment for the Mapping name so dotted property paths (e.g.
     # "Command.ScriptLocation") yield well-formed alphanumeric Mapping names.
-    base_name = f"SAM{_leaf_prop_name(prop.property_name)}{npath}"
-    key = (npath, prop.property_name)
+    leaf = _leaf_prop_name(prop.property_name)
+    base_name = f"SAM{leaf}{npath}"
+    # Collision detection must also key on the leaf — two resources with
+    # different dotted paths but the same leaf (e.g. "ImageUri" vs
+    # "Code.ImageUri") would otherwise generate identical Mapping names and
+    # silently overwrite each other.
+    key = (npath, leaf)
     if collision_groups.get(key, 0) <= 1:
         return base_name
     suffix = _sanitize_resource_key_for_mapping(prop.resource_key)
@@ -400,9 +405,11 @@ def _generate_artifact_mappings(
     mappings: Dict[str, Dict[str, Dict[str, str]]] = {}
     property_to_mapping: Dict[Tuple, str] = {}
 
-    # Pre-pass: detect collisions where multiple resources share (nesting_path, property_name)
+    # Pre-pass: detect collisions where multiple resources share (nesting_path, leaf).
+    # Keyed on the leaf so dotted paths that share a leaf (e.g. "ImageUri" vs
+    # "Code.ImageUri") are detected as colliding and get a resource-key suffix.
     collision_groups: Dict[Tuple[str, str], int] = Counter(
-        (_nesting_path(p), p.property_name) for p in dynamic_properties
+        (_nesting_path(p), _leaf_prop_name(p.property_name)) for p in dynamic_properties
     )
 
     for prop in dynamic_properties:

--- a/samcli/lib/package/language_extensions_packaging.py
+++ b/samcli/lib/package/language_extensions_packaging.py
@@ -8,12 +8,14 @@ None of the functions use instance state — they are pure functions.
 
 import copy
 import itertools
+import jmespath
 import logging
 import re
 from collections import Counter
 from typing import Any, Dict, List, Optional, Tuple
 
 import click
+from botocore.utils import set_value_from_jmespath
 
 from samcli.lib.cfn_language_extensions.models import (
     PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES,
@@ -116,6 +118,22 @@ def generate_and_apply_artifact_mappings(
     mappings, property_to_mapping = _generate_artifact_mappings(dynamic_properties, template_dir, exported_resources)
 
     return _apply_artifact_mappings_to_template(template, mappings, dynamic_properties, property_to_mapping)
+
+
+def _get_prop_value(props: Dict[str, Any], prop_name: str) -> Optional[Any]:
+    """Read a property by jmespath path. Supports flat keys ("CodeUri") and
+    dotted paths ("Command.ScriptLocation"). Returns None if missing.
+    """
+    if not isinstance(props, dict):
+        return None
+    return jmespath.search(prop_name, props)
+
+
+def _set_prop_value(props: Dict[str, Any], prop_name: str, value: Any) -> None:
+    """Write a property by jmespath path. Creates intermediate dicts as needed.
+    Supports flat keys and dotted paths.
+    """
+    set_value_from_jmespath(props, prop_name, value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/commands/_utils/test_template.py
+++ b/tests/unit/commands/_utils/test_template.py
@@ -688,6 +688,53 @@ class Test_update_sam_mappings_relative_paths(TestCase):
                 "emulation-python3.9-beta:latest",
             )
 
+    def test_updates_glue_script_location_mapping(self):
+        """Mappings emitted for AWS::Glue::Job (key 'ScriptLocation' from leaf of 'Command.ScriptLocation')
+        must be recognized as SAM-generated and have their relative paths adjusted on template move.
+        """
+        mappings = {
+            "SAMScriptLocationJobs": {
+                "Etl1": {"ScriptLocation": os.path.join(".aws-sam", "build", "Etl1Job", "job.py")},
+                "Etl2": {"ScriptLocation": os.path.join(".aws-sam", "build", "Etl2Job", "job.py")},
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_root = tmpdir
+            new_root = os.path.join(tmpdir, ".aws-sam", "build")
+            os.makedirs(new_root, exist_ok=True)
+
+            _update_sam_mappings_relative_paths(mappings, original_root, new_root)
+
+            self.assertEqual(
+                mappings["SAMScriptLocationJobs"]["Etl1"]["ScriptLocation"],
+                os.path.join("Etl1Job", "job.py"),
+            )
+            self.assertEqual(
+                mappings["SAMScriptLocationJobs"]["Etl2"]["ScriptLocation"],
+                os.path.join("Etl2Job", "job.py"),
+            )
+
+    def test_updates_serverless_application_location_mapping(self):
+        """Mappings emitted for AWS::Serverless::Application (key 'Location') must be recognized."""
+        mappings = {
+            "SAMLocationApps": {
+                "Pub": {"Location": os.path.join(".aws-sam", "build", "PubApi", "template.yaml")},
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_root = tmpdir
+            new_root = os.path.join(tmpdir, ".aws-sam", "build")
+            os.makedirs(new_root, exist_ok=True)
+
+            _update_sam_mappings_relative_paths(mappings, original_root, new_root)
+
+            self.assertEqual(
+                mappings["SAMLocationApps"]["Pub"]["Location"],
+                os.path.join("PubApi", "template.yaml"),
+            )
+
 
 class Test_resolve_relative_to(TestCase):
     def setUp(self):

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -2164,6 +2164,67 @@ class TestBuildContext_update_foreach_artifact_paths(TestCase):
         # PackageType sibling preserved
         self.assertEqual(body["${Name}Function"]["Properties"]["PackageType"], "Image")
 
+    def test_leaf_collision_across_resource_types_disambiguates_mapping_name(self):
+        """A Serverless::Function (ImageUri) and a Lambda::Function (Code.ImageUri) in the
+        same ForEach body share the same leaf "ImageUri" but different dotted paths.
+        Their generated Mapping names must NOT collide — the resource-key suffix should
+        be applied so neither set of entries silently overwrites the other.
+        """
+        foreach_key = "Fn::ForEach::Funcs"
+        foreach_value = [
+            "Name",
+            ["Alpha", "Beta"],
+            {
+                "${Name}Sam": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {
+                        "ImageUri": "sam-${Name}:latest",
+                        "PackageType": "Image",
+                    },
+                },
+                "${Name}Lambda": {
+                    "Type": "AWS::Lambda::Function",
+                    "Properties": {
+                        "Code": {"ImageUri": "lambda-${Name}:latest"},
+                        "PackageType": "Image",
+                    },
+                },
+            },
+        ]
+        modified_resources = {
+            "AlphaSam": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/sam:Alpha"},
+            },
+            "BetaSam": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/sam:Beta"},
+            },
+            "AlphaLambda": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {"Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/lambda:Alpha"}},
+            },
+            "BetaLambda": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {"Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/lambda:Beta"}},
+            },
+        }
+
+        mappings = self.build_context._update_foreach_artifact_paths(foreach_key, foreach_value, modified_resources)
+
+        # Two distinct Mapping names should exist — one per resource — disambiguated
+        # by the resource-key suffix because both leaf to "ImageUri".
+        sam_image_mappings = sorted(name for name in mappings if name.startswith("SAMImageUriFuncs"))
+        self.assertEqual(
+            len(sam_image_mappings),
+            2,
+            f"Expected two distinct SAMImageUriFuncs* mappings (one per resource type); got {sam_image_mappings}.",
+        )
+        # And neither set of entries should be lost: every collection value appears
+        # exactly once in each of the two distinct mappings.
+        for name in sam_image_mappings:
+            self.assertEqual(set(mappings[name].keys()), {"Alpha", "Beta"})
+
 
 class TestBuildContext_contains_loop_variable(TestCase):
     """Tests for the contains_loop_variable shared function."""

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -2033,6 +2033,137 @@ class TestBuildContext_update_foreach_artifact_paths(TestCase):
         find_in_map = code_uri["Fn::FindInMap"]
         self.assertEqual(find_in_map[1], {"Ref": "Svc"})
 
+    def test_static_dotted_glue_script_location(self):
+        """Static Command.ScriptLocation must be copied via dotted path (no clobbering siblings)."""
+
+        foreach_key = "Fn::ForEach::Jobs"
+        foreach_value = [
+            "Name",
+            ["Etl1", "Etl2"],
+            {
+                "${Name}Job": {
+                    "Type": "AWS::Glue::Job",
+                    "Properties": {
+                        "Command": {"Name": "glueetl", "ScriptLocation": "./scripts/job.py"},
+                    },
+                }
+            },
+        ]
+        modified_resources = {
+            "Etl1Job": {
+                "Type": "AWS::Glue::Job",
+                "Properties": {"Command": {"Name": "glueetl", "ScriptLocation": "../build/Etl1Job/job.py"}},
+            },
+            "Etl2Job": {
+                "Type": "AWS::Glue::Job",
+                "Properties": {"Command": {"Name": "glueetl", "ScriptLocation": "../build/Etl2Job/job.py"}},
+            },
+        }
+
+        mappings = self.build_context._update_foreach_artifact_paths(foreach_key, foreach_value, modified_resources)
+
+        body = foreach_value[2]
+        self.assertEqual(body["${Name}Job"]["Properties"]["Command"]["ScriptLocation"], "../build/Etl1Job/job.py")
+        # Sibling key preserved
+        self.assertEqual(body["${Name}Job"]["Properties"]["Command"]["Name"], "glueetl")
+        # No literal "Command.ScriptLocation" key was created
+        self.assertNotIn("Command.ScriptLocation", body["${Name}Job"]["Properties"])
+        # Static path: no Mapping
+        self.assertEqual(mappings, {})
+
+    def test_dynamic_dotted_glue_script_location_generates_mapping(self):
+        """Dynamic Command.ScriptLocation generates a Mapping with the leaf name and a FindInMap reference."""
+
+        foreach_key = "Fn::ForEach::Jobs"
+        foreach_value = [
+            "Name",
+            ["Etl1", "Etl2"],
+            {
+                "${Name}Job": {
+                    "Type": "AWS::Glue::Job",
+                    "Properties": {
+                        "Command": {"Name": "glueetl", "ScriptLocation": "./scripts/${Name}.py"},
+                    },
+                }
+            },
+        ]
+        modified_resources = {
+            "Etl1Job": {
+                "Type": "AWS::Glue::Job",
+                "Properties": {"Command": {"Name": "glueetl", "ScriptLocation": "Etl1.py"}},
+            },
+            "Etl2Job": {
+                "Type": "AWS::Glue::Job",
+                "Properties": {"Command": {"Name": "glueetl", "ScriptLocation": "Etl2.py"}},
+            },
+        }
+
+        mappings = self.build_context._update_foreach_artifact_paths(foreach_key, foreach_value, modified_resources)
+
+        # Mapping name uses the leaf "ScriptLocation", not "Command.ScriptLocation"
+        self.assertIn("SAMScriptLocationJobs", mappings)
+        self.assertEqual(mappings["SAMScriptLocationJobs"]["Etl1"], {"ScriptLocation": "Etl1.py"})
+        self.assertEqual(mappings["SAMScriptLocationJobs"]["Etl2"], {"ScriptLocation": "Etl2.py"})
+
+        # ScriptLocation should be replaced with Fn::FindInMap at the dotted path
+        body = foreach_value[2]
+        script_location = body["${Name}Job"]["Properties"]["Command"]["ScriptLocation"]
+        self.assertEqual(
+            script_location, {"Fn::FindInMap": ["SAMScriptLocationJobs", {"Ref": "Name"}, "ScriptLocation"]}
+        )
+        # Sibling key preserved
+        self.assertEqual(body["${Name}Job"]["Properties"]["Command"]["Name"], "glueetl")
+        # No literal "Command.ScriptLocation" key
+        self.assertNotIn("Command.ScriptLocation", body["${Name}Job"]["Properties"])
+
+    def test_dynamic_dotted_lambda_image_uri_generates_mapping(self):
+        """Dynamic Code.ImageUri (Lambda image function) generates a leaf-named Mapping."""
+
+        foreach_key = "Fn::ForEach::Funcs"
+        foreach_value = [
+            "Name",
+            ["Alpha", "Beta"],
+            {
+                "${Name}Function": {
+                    "Type": "AWS::Lambda::Function",
+                    "Properties": {
+                        "Code": {"ImageUri": "local-image-${Name}:latest"},
+                        "PackageType": "Image",
+                    },
+                }
+            },
+        ]
+        modified_resources = {
+            "AlphaFunction": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:Alpha"},
+                    "PackageType": "Image",
+                },
+            },
+            "BetaFunction": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:Beta"},
+                    "PackageType": "Image",
+                },
+            },
+        }
+
+        mappings = self.build_context._update_foreach_artifact_paths(foreach_key, foreach_value, modified_resources)
+
+        # Mapping name uses leaf "ImageUri", not "Code.ImageUri"
+        self.assertIn("SAMImageUriFuncs", mappings)
+        self.assertEqual(
+            mappings["SAMImageUriFuncs"]["Alpha"], {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:Alpha"}
+        )
+
+        body = foreach_value[2]
+        image_uri = body["${Name}Function"]["Properties"]["Code"]["ImageUri"]
+        self.assertEqual(image_uri, {"Fn::FindInMap": ["SAMImageUriFuncs", {"Ref": "Name"}, "ImageUri"]})
+        # PackageType sibling preserved
+        self.assertEqual(body["${Name}Function"]["Properties"]["PackageType"], "Image")
+
 
 class TestBuildContext_contains_loop_variable(TestCase):
     """Tests for the contains_loop_variable shared function."""

--- a/tests/unit/commands/buildcmd/test_build_context_language_extensions.py
+++ b/tests/unit/commands/buildcmd/test_build_context_language_extensions.py
@@ -91,6 +91,21 @@ class TestCopyArtifactPaths(TestCase):
         ctx._copy_artifact_paths(original, modified)
         self.assertNotIn("CodeUri", original["Properties"])
 
+    def test_glue_job_dotted_path(self):
+        """Regression: dotted property path (Command.ScriptLocation) must be copied."""
+        ctx = self._make_context()
+        original = {
+            "Type": "AWS::Glue::Job",
+            "Properties": {"Command": {"Name": "glueetl", "ScriptLocation": "./script.py"}},
+        }
+        modified = {
+            "Type": "AWS::Glue::Job",
+            "Properties": {"Command": {"Name": "glueetl", "ScriptLocation": "s3://b/k.py"}},
+        }
+        ctx._copy_artifact_paths(original, modified)
+        self.assertEqual(original["Properties"]["Command"]["ScriptLocation"], "s3://b/k.py")
+        self.assertEqual(original["Properties"]["Command"]["Name"], "glueetl")
+
 
 class TestGetTemplateForOutputForEachExploration(TestCase):
     """

--- a/tests/unit/commands/package/test_package_context.py
+++ b/tests/unit/commands/package/test_package_context.py
@@ -1014,6 +1014,100 @@ class TestPackageContextLanguageExtensions(TestCase):
         # Sibling keys preserved
         self.assertEqual(original_props["Command"]["Name"], "glueetl")
 
+    def test_copy_artifact_uris_for_type_serverless_application(self):
+        """Regression for #9005: Location URI must be copied for AWS::Serverless::Application."""
+        original_props = {"Location": "./PublisherApi/template.yaml"}
+        exported_props = {"Location": "https://s3.amazonaws.com/bucket/abc123.template"}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::Serverless::Application"
+        ))
+        self.assertEqual(original_props["Location"], "https://s3.amazonaws.com/bucket/abc123.template")
+
+    def test_copy_artifact_uris_for_type_cloudformation_stack(self):
+        """TemplateURL must be copied for AWS::CloudFormation::Stack."""
+        original_props = {"TemplateURL": "./child/template.yaml"}
+        exported_props = {"TemplateURL": "https://s3.amazonaws.com/bucket/xyz789.template"}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::CloudFormation::Stack"
+        ))
+        self.assertEqual(original_props["TemplateURL"], "https://s3.amazonaws.com/bucket/xyz789.template")
+
+    def test_copy_artifact_uris_for_type_cloudformation_stackset(self):
+        original_props = {"TemplateURL": "./child.yaml"}
+        exported_props = {"TemplateURL": "https://s3.amazonaws.com/b/k.template"}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::CloudFormation::StackSet"
+        ))
+        self.assertEqual(original_props["TemplateURL"], "https://s3.amazonaws.com/b/k.template")
+
+    def test_copy_artifact_uris_for_type_eb_application_version(self):
+        original_props = {"SourceBundle": "./bundle.zip"}
+        exported_props = {"SourceBundle": {"S3Bucket": "b", "S3Key": "k"}}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::ElasticBeanstalk::ApplicationVersion"
+        ))
+        self.assertEqual(original_props["SourceBundle"], {"S3Bucket": "b", "S3Key": "k"})
+
+    def test_copy_artifact_uris_for_type_appsync_graphql_schema(self):
+        original_props = {"DefinitionS3Location": "./schema.graphql"}
+        exported_props = {"DefinitionS3Location": "s3://b/schema.graphql"}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::AppSync::GraphQLSchema"
+        ))
+        self.assertEqual(original_props["DefinitionS3Location"], "s3://b/schema.graphql")
+
+    def test_copy_artifact_uris_for_type_appsync_resolver_all_three(self):
+        original_props = {
+            "RequestMappingTemplateS3Location": "./req.vtl",
+            "ResponseMappingTemplateS3Location": "./res.vtl",
+            "CodeS3Location": "./code.js",
+        }
+        exported_props = {
+            "RequestMappingTemplateS3Location": "s3://b/req.vtl",
+            "ResponseMappingTemplateS3Location": "s3://b/res.vtl",
+            "CodeS3Location": "s3://b/code.js",
+        }
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::AppSync::Resolver"
+        ))
+        self.assertEqual(original_props["RequestMappingTemplateS3Location"], "s3://b/req.vtl")
+        self.assertEqual(original_props["ResponseMappingTemplateS3Location"], "s3://b/res.vtl")
+        self.assertEqual(original_props["CodeS3Location"], "s3://b/code.js")
+
+    def test_copy_artifact_uris_for_type_appsync_function_configuration(self):
+        original_props = {"CodeS3Location": "./code.js"}
+        exported_props = {"CodeS3Location": "s3://b/code.js"}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::AppSync::FunctionConfiguration"
+        ))
+        self.assertEqual(original_props["CodeS3Location"], "s3://b/code.js")
+
+    def test_copy_artifact_uris_for_type_cloudformation_module_version(self):
+        original_props = {"ModulePackage": "./module.zip"}
+        exported_props = {"ModulePackage": "s3://b/module.zip"}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::CloudFormation::ModuleVersion"
+        ))
+        self.assertEqual(original_props["ModulePackage"], "s3://b/module.zip")
+
+    def test_copy_artifact_uris_for_type_cloudformation_resource_version(self):
+        original_props = {"SchemaHandlerPackage": "./pkg.zip"}
+        exported_props = {"SchemaHandlerPackage": "s3://b/pkg.zip"}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::CloudFormation::ResourceVersion"
+        ))
+        self.assertEqual(original_props["SchemaHandlerPackage"], "s3://b/pkg.zip")
+
+    def test_copy_artifact_uris_for_type_lambda_function_image_dotted(self):
+        # AWS::Lambda::Function has both Code and Code.ImageUri (dotted path)
+        original_props = {"Code": {"ImageUri": "local-tag:latest"}}
+        exported_props = {"Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:tag"}}
+        self.assertTrue(_copy_artifact_uris_for_type(
+            original_props, exported_props, "AWS::Lambda::Function"
+        ))
+        self.assertEqual(original_props["Code"]["ImageUri"],
+                         "111.dkr.ecr.us-east-1.amazonaws.com/r:tag")
+
 
 class TestPackageContextMappingsIntegration(TestCase):
     """Test cases for the complete Mappings transformation integration in _export()"""

--- a/tests/unit/commands/package/test_package_context.py
+++ b/tests/unit/commands/package/test_package_context.py
@@ -1100,6 +1100,113 @@ class TestPackageContextLanguageExtensions(TestCase):
         self.assertTrue(_copy_artifact_uris_for_type(original_props, exported_props, "AWS::Lambda::Function"))
         self.assertEqual(original_props["Code"]["ImageUri"], "111.dkr.ecr.us-east-1.amazonaws.com/r:tag")
 
+    # =========================================================================
+    # Dotted-path Fn::ForEach detection / Mapping / FindInMap behaviors
+    # =========================================================================
+
+    def test_detect_dynamic_glue_script_location_dotted(self):
+        """detect_dynamic_artifact_properties finds dotted Command.ScriptLocation."""
+        template = {
+            "Resources": {
+                "Fn::ForEach::Jobs": [
+                    "Name",
+                    ["Etl1", "Etl2"],
+                    {
+                        "${Name}Job": {
+                            "Type": "AWS::Glue::Job",
+                            "Properties": {
+                                "Command": {"Name": "glueetl", "ScriptLocation": "./scripts/${Name}.py"},
+                            },
+                        }
+                    },
+                ]
+            },
+        }
+
+        dynamic_properties = detect_dynamic_artifact_properties(template)
+
+        self.assertEqual(len(dynamic_properties), 1)
+        prop = dynamic_properties[0]
+        self.assertEqual(prop.property_name, "Command.ScriptLocation")
+        self.assertEqual(prop.property_value, "./scripts/${Name}.py")
+        self.assertEqual(prop.resource_type, "AWS::Glue::Job")
+
+    def test_replace_dynamic_artifact_with_findmap_dotted_glue(self):
+        """_replace_dynamic_artifact_with_findmap writes FindInMap at the dotted path with leaf-name third arg."""
+        from samcli.lib.cfn_language_extensions.models import DynamicArtifactProperty
+
+        resources = {
+            "Fn::ForEach::Jobs": [
+                "Name",
+                ["Etl1", "Etl2"],
+                {
+                    "${Name}Job": {
+                        "Type": "AWS::Glue::Job",
+                        "Properties": {
+                            "Command": {"Name": "glueetl", "ScriptLocation": "./scripts/${Name}.py"},
+                        },
+                    }
+                },
+            ]
+        }
+        prop = DynamicArtifactProperty(
+            foreach_key="Fn::ForEach::Jobs",
+            loop_name="Jobs",
+            loop_variable="Name",
+            collection=["Etl1", "Etl2"],
+            resource_key="${Name}Job",
+            resource_type="AWS::Glue::Job",
+            property_name="Command.ScriptLocation",
+            property_value="./scripts/${Name}.py",
+        )
+
+        result = _replace_dynamic_artifact_with_findmap(resources, prop)
+
+        self.assertTrue(result)
+        body = resources["Fn::ForEach::Jobs"][2]
+        # FindInMap is written at Properties.Command.ScriptLocation, not at a literal "Command.ScriptLocation" key
+        script_location = body["${Name}Job"]["Properties"]["Command"]["ScriptLocation"]
+        self.assertEqual(
+            script_location, {"Fn::FindInMap": ["SAMScriptLocationJobs", {"Ref": "Name"}, "ScriptLocation"]}
+        )
+        self.assertEqual(body["${Name}Job"]["Properties"]["Command"]["Name"], "glueetl")
+        self.assertNotIn("Command.ScriptLocation", body["${Name}Job"]["Properties"])
+
+    def test_generate_artifact_mappings_dotted_lambda_image(self):
+        """_generate_artifact_mappings produces leaf-named Mapping with leaf-keyed value-dict for Code.ImageUri."""
+        from samcli.lib.cfn_language_extensions.models import DynamicArtifactProperty
+
+        prop = DynamicArtifactProperty(
+            foreach_key="Fn::ForEach::Funcs",
+            loop_name="Funcs",
+            loop_variable="Name",
+            collection=["Alpha", "Beta"],
+            resource_key="${Name}Function",
+            resource_type="AWS::Lambda::Function",
+            property_name="Code.ImageUri",
+            property_value="local-image-${Name}:latest",
+        )
+        exported_resources = {
+            "AlphaFunction": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {"Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:Alpha"}},
+            },
+            "BetaFunction": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {"Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:Beta"}},
+            },
+        }
+
+        mappings, _ = _generate_artifact_mappings([prop], "/tmp", exported_resources)
+
+        self.assertIn("SAMImageUriFuncs", mappings)
+        self.assertEqual(
+            mappings["SAMImageUriFuncs"]["Alpha"], {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:Alpha"}
+        )
+        self.assertEqual(
+            mappings["SAMImageUriFuncs"]["Beta"], {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:Beta"}
+        )
+
 
 class TestPackageContextMappingsIntegration(TestCase):
     """Test cases for the complete Mappings transformation integration in _export()"""

--- a/tests/unit/commands/package/test_package_context.py
+++ b/tests/unit/commands/package/test_package_context.py
@@ -977,25 +977,30 @@ class TestPackageContextLanguageExtensions(TestCase):
 
     def test_get_prop_value_flat_key(self):
         from samcli.lib.package.language_extensions_packaging import _get_prop_value
+
         self.assertEqual(_get_prop_value({"CodeUri": "s3://b/k"}, "CodeUri"), "s3://b/k")
 
     def test_get_prop_value_dotted_key(self):
         from samcli.lib.package.language_extensions_packaging import _get_prop_value
+
         props = {"Command": {"ScriptLocation": "s3://b/k.py"}}
         self.assertEqual(_get_prop_value(props, "Command.ScriptLocation"), "s3://b/k.py")
 
     def test_get_prop_value_missing_returns_none(self):
         from samcli.lib.package.language_extensions_packaging import _get_prop_value
+
         self.assertIsNone(_get_prop_value({"CodeUri": "x"}, "Command.ScriptLocation"))
 
     def test_set_prop_value_flat_key(self):
         from samcli.lib.package.language_extensions_packaging import _set_prop_value
+
         props = {"CodeUri": "./src"}
         _set_prop_value(props, "CodeUri", "s3://b/k")
         self.assertEqual(props["CodeUri"], "s3://b/k")
 
     def test_set_prop_value_dotted_key_creates_intermediate(self):
         from samcli.lib.package.language_extensions_packaging import _set_prop_value
+
         props = {"Command": {"Name": "glueetl"}}
         _set_prop_value(props, "Command.ScriptLocation", "s3://b/k.py")
         self.assertEqual(props["Command"]["ScriptLocation"], "s3://b/k.py")
@@ -1018,42 +1023,34 @@ class TestPackageContextLanguageExtensions(TestCase):
         """Regression for #9005: Location URI must be copied for AWS::Serverless::Application."""
         original_props = {"Location": "./PublisherApi/template.yaml"}
         exported_props = {"Location": "https://s3.amazonaws.com/bucket/abc123.template"}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::Serverless::Application"
-        ))
+        self.assertTrue(_copy_artifact_uris_for_type(original_props, exported_props, "AWS::Serverless::Application"))
         self.assertEqual(original_props["Location"], "https://s3.amazonaws.com/bucket/abc123.template")
 
     def test_copy_artifact_uris_for_type_cloudformation_stack(self):
         """TemplateURL must be copied for AWS::CloudFormation::Stack."""
         original_props = {"TemplateURL": "./child/template.yaml"}
         exported_props = {"TemplateURL": "https://s3.amazonaws.com/bucket/xyz789.template"}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::CloudFormation::Stack"
-        ))
+        self.assertTrue(_copy_artifact_uris_for_type(original_props, exported_props, "AWS::CloudFormation::Stack"))
         self.assertEqual(original_props["TemplateURL"], "https://s3.amazonaws.com/bucket/xyz789.template")
 
     def test_copy_artifact_uris_for_type_cloudformation_stackset(self):
         original_props = {"TemplateURL": "./child.yaml"}
         exported_props = {"TemplateURL": "https://s3.amazonaws.com/b/k.template"}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::CloudFormation::StackSet"
-        ))
+        self.assertTrue(_copy_artifact_uris_for_type(original_props, exported_props, "AWS::CloudFormation::StackSet"))
         self.assertEqual(original_props["TemplateURL"], "https://s3.amazonaws.com/b/k.template")
 
     def test_copy_artifact_uris_for_type_eb_application_version(self):
         original_props = {"SourceBundle": "./bundle.zip"}
         exported_props = {"SourceBundle": {"S3Bucket": "b", "S3Key": "k"}}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::ElasticBeanstalk::ApplicationVersion"
-        ))
+        self.assertTrue(
+            _copy_artifact_uris_for_type(original_props, exported_props, "AWS::ElasticBeanstalk::ApplicationVersion")
+        )
         self.assertEqual(original_props["SourceBundle"], {"S3Bucket": "b", "S3Key": "k"})
 
     def test_copy_artifact_uris_for_type_appsync_graphql_schema(self):
         original_props = {"DefinitionS3Location": "./schema.graphql"}
         exported_props = {"DefinitionS3Location": "s3://b/schema.graphql"}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::AppSync::GraphQLSchema"
-        ))
+        self.assertTrue(_copy_artifact_uris_for_type(original_props, exported_props, "AWS::AppSync::GraphQLSchema"))
         self.assertEqual(original_props["DefinitionS3Location"], "s3://b/schema.graphql")
 
     def test_copy_artifact_uris_for_type_appsync_resolver_all_three(self):
@@ -1067,9 +1064,7 @@ class TestPackageContextLanguageExtensions(TestCase):
             "ResponseMappingTemplateS3Location": "s3://b/res.vtl",
             "CodeS3Location": "s3://b/code.js",
         }
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::AppSync::Resolver"
-        ))
+        self.assertTrue(_copy_artifact_uris_for_type(original_props, exported_props, "AWS::AppSync::Resolver"))
         self.assertEqual(original_props["RequestMappingTemplateS3Location"], "s3://b/req.vtl")
         self.assertEqual(original_props["ResponseMappingTemplateS3Location"], "s3://b/res.vtl")
         self.assertEqual(original_props["CodeS3Location"], "s3://b/code.js")
@@ -1077,36 +1072,33 @@ class TestPackageContextLanguageExtensions(TestCase):
     def test_copy_artifact_uris_for_type_appsync_function_configuration(self):
         original_props = {"CodeS3Location": "./code.js"}
         exported_props = {"CodeS3Location": "s3://b/code.js"}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::AppSync::FunctionConfiguration"
-        ))
+        self.assertTrue(
+            _copy_artifact_uris_for_type(original_props, exported_props, "AWS::AppSync::FunctionConfiguration")
+        )
         self.assertEqual(original_props["CodeS3Location"], "s3://b/code.js")
 
     def test_copy_artifact_uris_for_type_cloudformation_module_version(self):
         original_props = {"ModulePackage": "./module.zip"}
         exported_props = {"ModulePackage": "s3://b/module.zip"}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::CloudFormation::ModuleVersion"
-        ))
+        self.assertTrue(
+            _copy_artifact_uris_for_type(original_props, exported_props, "AWS::CloudFormation::ModuleVersion")
+        )
         self.assertEqual(original_props["ModulePackage"], "s3://b/module.zip")
 
     def test_copy_artifact_uris_for_type_cloudformation_resource_version(self):
         original_props = {"SchemaHandlerPackage": "./pkg.zip"}
         exported_props = {"SchemaHandlerPackage": "s3://b/pkg.zip"}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::CloudFormation::ResourceVersion"
-        ))
+        self.assertTrue(
+            _copy_artifact_uris_for_type(original_props, exported_props, "AWS::CloudFormation::ResourceVersion")
+        )
         self.assertEqual(original_props["SchemaHandlerPackage"], "s3://b/pkg.zip")
 
     def test_copy_artifact_uris_for_type_lambda_function_image_dotted(self):
         # AWS::Lambda::Function has both Code and Code.ImageUri (dotted path)
         original_props = {"Code": {"ImageUri": "local-tag:latest"}}
         exported_props = {"Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:tag"}}
-        self.assertTrue(_copy_artifact_uris_for_type(
-            original_props, exported_props, "AWS::Lambda::Function"
-        ))
-        self.assertEqual(original_props["Code"]["ImageUri"],
-                         "111.dkr.ecr.us-east-1.amazonaws.com/r:tag")
+        self.assertTrue(_copy_artifact_uris_for_type(original_props, exported_props, "AWS::Lambda::Function"))
+        self.assertEqual(original_props["Code"]["ImageUri"], "111.dkr.ecr.us-east-1.amazonaws.com/r:tag")
 
 
 class TestPackageContextMappingsIntegration(TestCase):

--- a/tests/unit/commands/package/test_package_context.py
+++ b/tests/unit/commands/package/test_package_context.py
@@ -975,6 +975,33 @@ class TestPackageContextLanguageExtensions(TestCase):
         code_uri = body["${Name}Service"]["Properties"]["CodeUri"]
         self.assertEqual(code_uri, {"Fn::FindInMap": ["SAMCodeUriServices", {"Ref": "Name"}, "CodeUri"]})
 
+    def test_get_prop_value_flat_key(self):
+        from samcli.lib.package.language_extensions_packaging import _get_prop_value
+        self.assertEqual(_get_prop_value({"CodeUri": "s3://b/k"}, "CodeUri"), "s3://b/k")
+
+    def test_get_prop_value_dotted_key(self):
+        from samcli.lib.package.language_extensions_packaging import _get_prop_value
+        props = {"Command": {"ScriptLocation": "s3://b/k.py"}}
+        self.assertEqual(_get_prop_value(props, "Command.ScriptLocation"), "s3://b/k.py")
+
+    def test_get_prop_value_missing_returns_none(self):
+        from samcli.lib.package.language_extensions_packaging import _get_prop_value
+        self.assertIsNone(_get_prop_value({"CodeUri": "x"}, "Command.ScriptLocation"))
+
+    def test_set_prop_value_flat_key(self):
+        from samcli.lib.package.language_extensions_packaging import _set_prop_value
+        props = {"CodeUri": "./src"}
+        _set_prop_value(props, "CodeUri", "s3://b/k")
+        self.assertEqual(props["CodeUri"], "s3://b/k")
+
+    def test_set_prop_value_dotted_key_creates_intermediate(self):
+        from samcli.lib.package.language_extensions_packaging import _set_prop_value
+        props = {"Command": {"Name": "glueetl"}}
+        _set_prop_value(props, "Command.ScriptLocation", "s3://b/k.py")
+        self.assertEqual(props["Command"]["ScriptLocation"], "s3://b/k.py")
+        # Existing keys preserved
+        self.assertEqual(props["Command"]["Name"], "glueetl")
+
 
 class TestPackageContextMappingsIntegration(TestCase):
     """Test cases for the complete Mappings transformation integration in _export()"""

--- a/tests/unit/commands/package/test_package_context.py
+++ b/tests/unit/commands/package/test_package_context.py
@@ -1002,6 +1002,18 @@ class TestPackageContextLanguageExtensions(TestCase):
         # Existing keys preserved
         self.assertEqual(props["Command"]["Name"], "glueetl")
 
+    def test_copy_artifact_uris_for_type_glue_job_dotted_path(self):
+        """Regression: dotted property path (Command.ScriptLocation) must be copied."""
+        original_props = {"Command": {"Name": "glueetl", "ScriptLocation": "./script.py"}}
+        exported_props = {"Command": {"Name": "glueetl", "ScriptLocation": "s3://b/k.py"}}
+
+        result = _copy_artifact_uris_for_type(original_props, exported_props, "AWS::Glue::Job")
+
+        self.assertTrue(result)
+        self.assertEqual(original_props["Command"]["ScriptLocation"], "s3://b/k.py")
+        # Sibling keys preserved
+        self.assertEqual(original_props["Command"]["Name"], "glueetl")
+
 
 class TestPackageContextMappingsIntegration(TestCase):
     """Test cases for the complete Mappings transformation integration in _export()"""

--- a/tests/unit/commands/package/test_package_context.py
+++ b/tests/unit/commands/package/test_package_context.py
@@ -1207,6 +1207,74 @@ class TestPackageContextLanguageExtensions(TestCase):
             mappings["SAMImageUriFuncs"]["Beta"], {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/r:Beta"}
         )
 
+    def test_generate_artifact_mappings_disambiguates_leaf_collision_across_types(self):
+        """Two dotted paths sharing the same leaf (Serverless::Function 'ImageUri' and
+        Lambda::Function 'Code.ImageUri') must not collide into a single Mapping.
+        Without the leaf-keyed collision check the second resource's entries silently
+        overwrite the first's.
+        """
+        from samcli.lib.cfn_language_extensions.models import DynamicArtifactProperty
+
+        sam_prop = DynamicArtifactProperty(
+            foreach_key="Fn::ForEach::Funcs",
+            loop_name="Funcs",
+            loop_variable="Name",
+            collection=["Alpha", "Beta"],
+            resource_key="${Name}Sam",
+            resource_type="AWS::Serverless::Function",
+            property_name="ImageUri",
+            property_value="sam-${Name}:latest",
+        )
+        lambda_prop = DynamicArtifactProperty(
+            foreach_key="Fn::ForEach::Funcs",
+            loop_name="Funcs",
+            loop_variable="Name",
+            collection=["Alpha", "Beta"],
+            resource_key="${Name}Lambda",
+            resource_type="AWS::Lambda::Function",
+            property_name="Code.ImageUri",
+            property_value="lambda-${Name}:latest",
+        )
+        exported_resources = {
+            "AlphaSam": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/sam:Alpha"},
+            },
+            "BetaSam": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/sam:Beta"},
+            },
+            "AlphaLambda": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {"Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/lambda:Alpha"}},
+            },
+            "BetaLambda": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {"Code": {"ImageUri": "111.dkr.ecr.us-east-1.amazonaws.com/lambda:Beta"}},
+            },
+        }
+
+        mappings, _ = _generate_artifact_mappings([sam_prop, lambda_prop], "/tmp", exported_resources)
+
+        # Two distinct Mapping names exist (resource-key suffix applied because leaves collide).
+        sam_image_mappings = sorted(name for name in mappings if name.startswith("SAMImageUriFuncs"))
+        self.assertEqual(
+            len(sam_image_mappings),
+            2,
+            f"Expected two distinct SAMImageUriFuncs* mappings; got {sam_image_mappings}.",
+        )
+        # Both sets of entries are preserved — neither resource's mapping was overwritten.
+        all_values = {entry["ImageUri"] for name in sam_image_mappings for entry in mappings[name].values()}
+        self.assertEqual(
+            all_values,
+            {
+                "111.dkr.ecr.us-east-1.amazonaws.com/sam:Alpha",
+                "111.dkr.ecr.us-east-1.amazonaws.com/sam:Beta",
+                "111.dkr.ecr.us-east-1.amazonaws.com/lambda:Alpha",
+                "111.dkr.ecr.us-east-1.amazonaws.com/lambda:Beta",
+            },
+        )
+
 
 class TestPackageContextMappingsIntegration(TestCase):
     """Test cases for the complete Mappings transformation integration in _export()"""

--- a/tests/unit/lib/cfn_language_extensions/test_models.py
+++ b/tests/unit/lib/cfn_language_extensions/test_models.py
@@ -290,35 +290,40 @@ class TestPackageableResourceArtifactProperties:
 
     def test_includes_existing_serverless_function(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert "CodeUri" in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Serverless::Function"]
         assert "ImageUri" in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Serverless::Function"]
 
     def test_includes_existing_lambda_function_dotted_image(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         props = PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Lambda::Function"]
         assert "Code" in props
         assert "Code.ImageUri" in props
 
     def test_includes_serverless_application(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Serverless::Application"] == ["Location"]
 
     def test_includes_cloudformation_stackset(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::CloudFormation::StackSet"] == ["TemplateURL"]
 
     def test_includes_elasticbeanstalk_application_version(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
-        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::ElasticBeanstalk::ApplicationVersion"] == [
-            "SourceBundle"
-        ]
+
+        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::ElasticBeanstalk::ApplicationVersion"] == ["SourceBundle"]
 
     def test_includes_appsync_graphql_schema(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::AppSync::GraphQLSchema"] == ["DefinitionS3Location"]
 
     def test_includes_appsync_resolver_three_props(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         props = PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::AppSync::Resolver"]
         assert sorted(props) == sorted(
             ["RequestMappingTemplateS3Location", "ResponseMappingTemplateS3Location", "CodeS3Location"]
@@ -326,6 +331,7 @@ class TestPackageableResourceArtifactProperties:
 
     def test_includes_appsync_function_configuration_three_props(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         props = PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::AppSync::FunctionConfiguration"]
         assert sorted(props) == sorted(
             ["RequestMappingTemplateS3Location", "ResponseMappingTemplateS3Location", "CodeS3Location"]
@@ -333,14 +339,17 @@ class TestPackageableResourceArtifactProperties:
 
     def test_includes_glue_job_dotted_path(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Glue::Job"] == ["Command.ScriptLocation"]
 
     def test_includes_cloudformation_module_version(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::CloudFormation::ModuleVersion"] == ["ModulePackage"]
 
     def test_includes_cloudformation_resource_version(self):
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::CloudFormation::ResourceVersion"] == [
             "SchemaHandlerPackage"
         ]
@@ -348,11 +357,13 @@ class TestPackageableResourceArtifactProperties:
     def test_excludes_ecr_repository_repositoryname(self):
         """RepositoryName is a name, not a packaged-artifact URI. Excluded by design."""
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert "AWS::ECR::Repository" not in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
 
     def test_excludes_serverlessrepo_application_metadata(self):
         """ServerlessRepo::Application uses METADATA_WITH_LOCAL_PATHS, not resource props."""
         from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
         assert "AWS::ServerlessRepo::Application" not in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
 
     def test_dict_is_in_sync_with_canonical_lists(self):
@@ -361,8 +372,8 @@ class TestPackageableResourceArtifactProperties:
         from samcli.lib.utils.resources import RESOURCES_WITH_LOCAL_PATHS
 
         for resource_type, props in RESOURCES_WITH_LOCAL_PATHS.items():
-            assert resource_type in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES, (
-                f"{resource_type} from RESOURCES_WITH_LOCAL_PATHS must be in derived dict"
-            )
+            assert (
+                resource_type in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+            ), f"{resource_type} from RESOURCES_WITH_LOCAL_PATHS must be in derived dict"
             for prop in props:
                 assert prop in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES[resource_type]

--- a/tests/unit/lib/cfn_language_extensions/test_models.py
+++ b/tests/unit/lib/cfn_language_extensions/test_models.py
@@ -283,3 +283,86 @@ class TestModuleExports:
 
         context = TemplateProcessingContext(fragment={})
         assert context.fragment == {}
+
+
+class TestPackageableResourceArtifactProperties:
+    """Lock in the derived contents of PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES so future drift fails loudly."""
+
+    def test_includes_existing_serverless_function(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert "CodeUri" in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Serverless::Function"]
+        assert "ImageUri" in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Serverless::Function"]
+
+    def test_includes_existing_lambda_function_dotted_image(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        props = PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Lambda::Function"]
+        assert "Code" in props
+        assert "Code.ImageUri" in props
+
+    def test_includes_serverless_application(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Serverless::Application"] == ["Location"]
+
+    def test_includes_cloudformation_stackset(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::CloudFormation::StackSet"] == ["TemplateURL"]
+
+    def test_includes_elasticbeanstalk_application_version(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::ElasticBeanstalk::ApplicationVersion"] == [
+            "SourceBundle"
+        ]
+
+    def test_includes_appsync_graphql_schema(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::AppSync::GraphQLSchema"] == ["DefinitionS3Location"]
+
+    def test_includes_appsync_resolver_three_props(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        props = PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::AppSync::Resolver"]
+        assert sorted(props) == sorted(
+            ["RequestMappingTemplateS3Location", "ResponseMappingTemplateS3Location", "CodeS3Location"]
+        )
+
+    def test_includes_appsync_function_configuration_three_props(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        props = PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::AppSync::FunctionConfiguration"]
+        assert sorted(props) == sorted(
+            ["RequestMappingTemplateS3Location", "ResponseMappingTemplateS3Location", "CodeS3Location"]
+        )
+
+    def test_includes_glue_job_dotted_path(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::Glue::Job"] == ["Command.ScriptLocation"]
+
+    def test_includes_cloudformation_module_version(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::CloudFormation::ModuleVersion"] == ["ModulePackage"]
+
+    def test_includes_cloudformation_resource_version(self):
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES["AWS::CloudFormation::ResourceVersion"] == [
+            "SchemaHandlerPackage"
+        ]
+
+    def test_excludes_ecr_repository_repositoryname(self):
+        """RepositoryName is a name, not a packaged-artifact URI. Excluded by design."""
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert "AWS::ECR::Repository" not in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
+    def test_excludes_serverlessrepo_application_metadata(self):
+        """ServerlessRepo::Application uses METADATA_WITH_LOCAL_PATHS, not resource props."""
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        assert "AWS::ServerlessRepo::Application" not in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
+    def test_dict_is_in_sync_with_canonical_lists(self):
+        """If RESOURCES_WITH_LOCAL_PATHS gains a new entry, this dict must too."""
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+        from samcli.lib.utils.resources import RESOURCES_WITH_LOCAL_PATHS
+
+        for resource_type, props in RESOURCES_WITH_LOCAL_PATHS.items():
+            assert resource_type in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES, (
+                f"{resource_type} from RESOURCES_WITH_LOCAL_PATHS must be in derived dict"
+            )
+            for prop in props:
+                assert prop in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES[resource_type]

--- a/tests/unit/lib/cfn_language_extensions/test_utils.py
+++ b/tests/unit/lib/cfn_language_extensions/test_utils.py
@@ -76,6 +76,48 @@ class TestIsSamGeneratedMapping(TestCase):
     def test_layers_digit_matches(self):
         self.assertTrue(is_sam_generated_mapping("SAMLayers1stBatch"))
 
+    # Mappings with leaf names derived from dotted artifact paths
+    def test_glue_script_location_mapping_matches(self):
+        # AWS::Glue::Job.Command.ScriptLocation -> leaf "ScriptLocation"
+        self.assertTrue(is_sam_generated_mapping("SAMScriptLocationJobs"))
+
+    def test_lambda_image_uri_mapping_matches(self):
+        # AWS::Lambda::Function.Code.ImageUri -> leaf "ImageUri" (already covered by SAMImageUri)
+        self.assertTrue(is_sam_generated_mapping("SAMImageUriFuncs"))
+
+    # Mappings produced by leaf names from non-dotted artifact paths added by #9005
+    def test_serverless_application_location_mapping_matches(self):
+        self.assertTrue(is_sam_generated_mapping("SAMLocationApps"))
+
+    def test_eb_source_bundle_mapping_matches(self):
+        self.assertTrue(is_sam_generated_mapping("SAMSourceBundleVersions"))
+
+    def test_cfn_module_package_mapping_matches(self):
+        self.assertTrue(is_sam_generated_mapping("SAMModulePackageMods"))
+
+    def test_cfn_resource_version_mapping_matches(self):
+        self.assertTrue(is_sam_generated_mapping("SAMSchemaHandlerPackageRes"))
+
+    # Sync test mirroring test_dict_is_in_sync_with_canonical_lists in test_models.py
+    def test_prefixes_in_sync_with_packageable_artifact_properties(self):
+        """Every leaf in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES must be classifiable
+        as a SAM-generated Mapping prefix. Future additions to the canonical list
+        propagate automatically, so missing one fails this test loudly.
+        """
+        from samcli.lib.cfn_language_extensions.models import PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES
+
+        for resource_type, props in PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES.items():
+            for prop in props:
+                leaf = prop.rsplit(".", 1)[-1]
+                # A Mapping name is SAM<leaf><LoopName>; using "X" as a stand-in loop name.
+                mapping_name = f"SAM{leaf}X"
+                self.assertTrue(
+                    is_sam_generated_mapping(mapping_name),
+                    f"Mapping name {mapping_name!r} (from {resource_type}.{prop}) "
+                    f"is not recognized as SAM-generated; "
+                    f"_SAM_GENERATED_MAPPING_PREFIXES is out of sync.",
+                )
+
 
 class TestIsUnresolvedParamOrPseudoRef(TestCase):
     def _ctx(self, parameters=None) -> TemplateProcessingContext:


### PR DESCRIPTION
## Summary

Fixes #9005 (`sam deploy` failing with `Template file not found at /tmp/<name>/template.yaml` when combining `AWS::LanguageExtensions` with nested `AWS::Serverless::Application`) plus seven sibling latent bugs of the same shape.

**Root cause:** `samcli/lib/cfn_language_extensions/models.py` defined a hand-maintained `PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES` dict that duplicated `RESOURCES_WITH_LOCAL_PATHS` + `RESOURCES_WITH_IMAGE_COMPONENT` from `samcli/lib/utils/resources.py`. The duplicate had drifted by 8 entries — `AWS::Serverless::Application` (the symptom), plus `AWS::CloudFormation::StackSet`, `AWS::ElasticBeanstalk::ApplicationVersion`, three `AWS::AppSync::*` types, `AWS::Glue::Job`, `AWS::CloudFormation::ModuleVersion`, and `AWS::CloudFormation::ResourceVersion`. Each missing entry was a #9005-shaped latent bug.

**Fix:**
- Replace the literal dict with a derivation built from the canonical dicts at module import time, so the two lists can no longer drift.
- Make the merge-step copy logic JMESPath-aware so dotted artifact paths like `AWS::Glue::Job.Command.ScriptLocation` and `AWS::Lambda::Function.Code.ImageUri` work without clobbering sibling keys.
- Apply the JMESPath fix to **all** consumers of `PACKAGEABLE_RESOURCE_ARTIFACT_PROPERTIES`, not just the merge step — including the ForEach dynamic-property detection in `sam_integration.py` and the four call sites in `build_context.py` (`_update_foreach_artifact_paths`, `_count_dynamic_properties`, `_get_artifact_value`, `_collect_dynamic_mapping_entries`). Use the leaf segment for CloudFormation Mapping names and `Fn::FindInMap` keys (which must be alphanumeric) while keeping the dotted form for property addressing.
- Add `_resolve_property_paths` to disambiguate parent vs child paths declared on the same resource type (e.g., `AWS::Lambda::Function` lists both `Code` for ZIP packages and `Code.ImageUri` for image packages).
- Lock in expected behavior with new tests, including a sync-check (`test_dict_is_in_sync_with_canonical_lists`) that fails loudly if the canonical dicts gain an entry the derivation misses.

## Changes

| File | What |
|---|---|
| `samcli/lib/cfn_language_extensions/models.py` | Replace literal dict with `_build_packageable_resource_artifact_properties()` derivation |
| `samcli/lib/package/language_extensions_packaging.py` | New `_get_prop_value` / `_set_prop_value` / `_leaf_prop_name` / `_resolve_property_paths` helpers; switch `_copy_artifact_uris_for_type`, `_compute_mapping_name`, `_replace_dynamic_artifact_with_findmap`, `_find_artifact_uri_for_resource`, and `_generate_artifact_mappings` to use them |
| `samcli/lib/cfn_language_extensions/sam_integration.py` | Route `detect_foreach_dynamic_properties` through `_get_prop_value` / `_resolve_property_paths` so dotted artifacts under Fn::ForEach are detected |
| `samcli/commands/build/build_context.py` | Apply jmespath helpers to `_copy_artifact_paths`, `_update_foreach_artifact_paths`, `_count_dynamic_properties`, `_get_artifact_value`, `_collect_dynamic_mapping_entries`, `_collect_nested_mapping_entry`; use leaf for `SAM…` Mapping name and FindInMap third arg |
| `tests/unit/lib/cfn_language_extensions/test_models.py` | 14 new tests for derived dict contents and canonical-sync check |
| `tests/unit/commands/package/test_package_context.py` | 14 new tests: copy regressions for all newly-included resource types, plus dotted-path detection / FindInMap / Mapping generation |
| `tests/unit/commands/buildcmd/test_build_context_language_extensions.py` | 1 new dotted-path test in `TestCopyArtifactPaths` |
| `tests/unit/commands/buildcmd/test_build_context.py` | 3 new tests for static + dynamic Fn::ForEach over dotted Glue / Lambda image paths |

## Test plan

- [x] `pytest tests/unit/` — 9159 passed, 25 skipped, 0 failures
- [x] Targeted: `pytest tests/unit/commands/buildcmd/ tests/unit/commands/package/ tests/unit/lib/cfn_language_extensions/ tests/unit/commands/_utils/test_template_language_extensions.py` — 2033 passed
- [x] `make lint` — `ruff check samcli schema` clean; `mypy` clean
- [x] Manual: ran `samdev package --resolve-s3` against `language-extensions/tc-026-nested-application/` (parent uses `AWS::LanguageExtensions` + nested `AWS::Serverless::Application` with local `Location: ./PublisherApi/template.yaml`). Output template rewrites `Location` to an `https://s3.us-west-2.amazonaws.com/.../...template` URL; the uploaded nested template has its `CodeUri` rewritten to an `s3://...` URI. End-to-end behavior matches expectation.

