### PR TITLE
fix(cfn-lang-ext): preserve template-time intrinsics with unresolved param Refs in PARTIAL mode (#9004)

### DIFF
--- a/samcli/lib/cfn_language_extensions/resolvers/fn_base64.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_base64.py
@@ -9,9 +9,9 @@ import base64
 from typing import Any, Dict
 
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
-from samcli.lib.cfn_language_extensions.models import ResolutionMode, TemplateProcessingContext
+from samcli.lib.cfn_language_extensions.models import ResolutionMode
 from samcli.lib.cfn_language_extensions.resolvers.base import IntrinsicFunctionResolver
-from samcli.lib.cfn_language_extensions.utils import PSEUDO_PARAMETERS
+from samcli.lib.cfn_language_extensions.utils import is_unresolved_param_or_pseudo_ref
 
 
 class FnBase64Resolver(IntrinsicFunctionResolver):
@@ -73,7 +73,7 @@ class FnBase64Resolver(IntrinsicFunctionResolver):
         # (a Ref to a declared parameter without a default/override, or to a
         # pseudo-parameter), preserve the call so CloudFormation can resolve it
         # at deploy time. Resource refs / GetAtt / etc. still raise.
-        if _is_unresolved_param_or_pseudo_ref(resolved_args, self.context):
+        if is_unresolved_param_or_pseudo_ref(resolved_args, self.context):
             if self.context.resolution_mode == ResolutionMode.PARTIAL:
                 return {"Fn::Base64": resolved_args}
             raise InvalidTemplateException("Fn::Base64 layout is incorrect")
@@ -86,20 +86,3 @@ class FnBase64Resolver(IntrinsicFunctionResolver):
         # CloudFormation uses UTF-8 encoding for the input string
         encoded_bytes = base64.b64encode(resolved_args.encode("utf-8"))
         return encoded_bytes.decode("utf-8")
-
-
-def _is_unresolved_param_or_pseudo_ref(value: Any, context: TemplateProcessingContext) -> bool:
-    """Return True if value is `{"Ref": <name>}` where <name> is a declared template
-    parameter or a pseudo-parameter. Resource refs return False so they continue to raise."""
-    if not isinstance(value, dict) or len(value) != 1:
-        return False
-    if "Ref" not in value:
-        return False
-    ref_target = value["Ref"]
-    if not isinstance(ref_target, str):
-        return False
-    if ref_target in PSEUDO_PARAMETERS:
-        return True
-    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
-        return True
-    return False

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_base64.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_base64.py
@@ -9,7 +9,9 @@ import base64
 from typing import Any, Dict
 
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
+from samcli.lib.cfn_language_extensions.models import ResolutionMode, TemplateProcessingContext
 from samcli.lib.cfn_language_extensions.resolvers.base import IntrinsicFunctionResolver
+from samcli.lib.cfn_language_extensions.utils import PSEUDO_PARAMETERS
 
 
 class FnBase64Resolver(IntrinsicFunctionResolver):
@@ -32,7 +34,7 @@ class FnBase64Resolver(IntrinsicFunctionResolver):
 
     FUNCTION_NAMES = ["Fn::Base64"]
 
-    def resolve(self, value: Dict[str, Any]) -> str:
+    def resolve(self, value: Dict[str, Any]) -> Any:
         """
         Resolve the Fn::Base64 intrinsic function.
 
@@ -46,7 +48,10 @@ class FnBase64Resolver(IntrinsicFunctionResolver):
                    {"Fn::Base64": {"Ref": "MyStringParam"}}
 
         Returns:
-            The base64-encoded string.
+            The base64-encoded string. In PARTIAL resolution mode, if the
+            argument is an unresolved Ref to a declared template parameter or a
+            pseudo-parameter, the original Fn::Base64 call is returned verbatim
+            so CloudFormation can resolve it at deploy time.
 
         Raises:
             InvalidTemplateException: If the resolved value is not a string.
@@ -64,6 +69,15 @@ class FnBase64Resolver(IntrinsicFunctionResolver):
             # If no parent resolver, use args as-is (for testing)
             resolved_args = args
 
+        # In PARTIAL mode, if the argument resolved to a deferred parameter Ref
+        # (a Ref to a declared parameter without a default/override, or to a
+        # pseudo-parameter), preserve the call so CloudFormation can resolve it
+        # at deploy time. Resource refs / GetAtt / etc. still raise.
+        if _is_unresolved_param_or_pseudo_ref(resolved_args, self.context):
+            if self.context.resolution_mode == ResolutionMode.PARTIAL:
+                return {"Fn::Base64": resolved_args}
+            raise InvalidTemplateException("Fn::Base64 layout is incorrect")
+
         # Validate that the resolved value is a string
         if not isinstance(resolved_args, str):
             raise InvalidTemplateException("Fn::Base64 layout is incorrect")
@@ -72,3 +86,20 @@ class FnBase64Resolver(IntrinsicFunctionResolver):
         # CloudFormation uses UTF-8 encoding for the input string
         encoded_bytes = base64.b64encode(resolved_args.encode("utf-8"))
         return encoded_bytes.decode("utf-8")
+
+
+def _is_unresolved_param_or_pseudo_ref(value: Any, context: TemplateProcessingContext) -> bool:
+    """Return True if value is `{"Ref": <name>}` where <name> is a declared template
+    parameter or a pseudo-parameter. Resource refs return False so they continue to raise."""
+    if not isinstance(value, dict) or len(value) != 1:
+        return False
+    if "Ref" not in value:
+        return False
+    ref_target = value["Ref"]
+    if not isinstance(ref_target, str):
+        return False
+    if ref_target in PSEUDO_PARAMETERS:
+        return True
+    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
+        return True
+    return False

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py
@@ -12,7 +12,9 @@ specifying a DefaultValue to return when the map lookup fails.
 from typing import Any, Dict
 
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
+from samcli.lib.cfn_language_extensions.models import ResolutionMode, TemplateProcessingContext
 from samcli.lib.cfn_language_extensions.resolvers.base import IntrinsicFunctionResolver
+from samcli.lib.cfn_language_extensions.utils import PSEUDO_PARAMETERS
 
 
 class FnFindInMapResolver(IntrinsicFunctionResolver):
@@ -95,12 +97,24 @@ class FnFindInMapResolver(IntrinsicFunctionResolver):
             top_key = top_key_arg
             second_key = second_key_arg
 
-        # Validate resolved keys are strings
-        if not isinstance(map_name, str):
-            raise InvalidTemplateException("Fn::FindInMap layout is incorrect")
-        if not isinstance(top_key, str):
-            raise InvalidTemplateException("Fn::FindInMap layout is incorrect")
-        if not isinstance(second_key, str):
+        # In PARTIAL mode, if a key didn't resolve to a string but did resolve
+        # to a deferred parameter/pseudo-parameter Ref (Ref to a declared
+        # parameter without a default value and no override, or to a
+        # pseudo-parameter without a provided value), preserve the call so
+        # CloudFormation can resolve it at deploy time. See GitHub issue #9004.
+        # Resource refs and other intrinsics (Fn::GetAtt, etc.) continue to
+        # raise because they can't be resolved by the template-time
+        # Fn::FindInMap function at any stage — matching Kotlin compat.
+        keys = (map_name, top_key, second_key)
+        if not all(isinstance(k, str) for k in keys):
+            if self.context.resolution_mode == ResolutionMode.PARTIAL and all(
+                isinstance(k, str) or _is_unresolved_param_or_pseudo_ref(k, self.context)
+                for k in keys
+            ):
+                preserved = [map_name, top_key, second_key]
+                if len(args) >= self._ARGS_WITH_DEFAULT:
+                    preserved.append(args[3])
+                return {"Fn::FindInMap": preserved}
             raise InvalidTemplateException("Fn::FindInMap layout is incorrect")
 
         # Check for DefaultValue option (4th argument)
@@ -215,3 +229,22 @@ class FnFindInMapResolver(IntrinsicFunctionResolver):
                 if isinstance(resource, dict) and "Type" in resource:
                     return str(resource["Type"])
         return "Unknown"
+
+
+def _is_unresolved_param_or_pseudo_ref(value: Any, context: TemplateProcessingContext) -> bool:
+    """Return True if value is `{"Ref": <name>}` where <name> is a declared template
+    parameter or a pseudo-parameter — i.e. an unresolved reference that CloudFormation
+    will resolve at deploy time. Resource refs and other intrinsics return False so
+    they can continue to raise."""
+    if not isinstance(value, dict) or len(value) != 1:
+        return False
+    if "Ref" not in value:
+        return False
+    ref_target = value["Ref"]
+    if not isinstance(ref_target, str):
+        return False
+    if ref_target in PSEUDO_PARAMETERS:
+        return True
+    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
+        return True
+    return False

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py
@@ -108,8 +108,7 @@ class FnFindInMapResolver(IntrinsicFunctionResolver):
         keys = (map_name, top_key, second_key)
         if not all(isinstance(k, str) for k in keys):
             if self.context.resolution_mode == ResolutionMode.PARTIAL and all(
-                isinstance(k, str) or is_unresolved_param_or_pseudo_ref(k, self.context)
-                for k in keys
+                isinstance(k, str) or is_unresolved_param_or_pseudo_ref(k, self.context) for k in keys
             ):
                 preserved = [map_name, top_key, second_key]
                 if len(args) >= self._ARGS_WITH_DEFAULT:

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py
@@ -12,9 +12,9 @@ specifying a DefaultValue to return when the map lookup fails.
 from typing import Any, Dict
 
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
-from samcli.lib.cfn_language_extensions.models import ResolutionMode, TemplateProcessingContext
+from samcli.lib.cfn_language_extensions.models import ResolutionMode
 from samcli.lib.cfn_language_extensions.resolvers.base import IntrinsicFunctionResolver
-from samcli.lib.cfn_language_extensions.utils import PSEUDO_PARAMETERS
+from samcli.lib.cfn_language_extensions.utils import is_unresolved_param_or_pseudo_ref
 
 
 class FnFindInMapResolver(IntrinsicFunctionResolver):
@@ -108,7 +108,7 @@ class FnFindInMapResolver(IntrinsicFunctionResolver):
         keys = (map_name, top_key, second_key)
         if not all(isinstance(k, str) for k in keys):
             if self.context.resolution_mode == ResolutionMode.PARTIAL and all(
-                isinstance(k, str) or _is_unresolved_param_or_pseudo_ref(k, self.context)
+                isinstance(k, str) or is_unresolved_param_or_pseudo_ref(k, self.context)
                 for k in keys
             ):
                 preserved = [map_name, top_key, second_key]
@@ -229,22 +229,3 @@ class FnFindInMapResolver(IntrinsicFunctionResolver):
                 if isinstance(resource, dict) and "Type" in resource:
                     return str(resource["Type"])
         return "Unknown"
-
-
-def _is_unresolved_param_or_pseudo_ref(value: Any, context: TemplateProcessingContext) -> bool:
-    """Return True if value is `{"Ref": <name>}` where <name> is a declared template
-    parameter or a pseudo-parameter — i.e. an unresolved reference that CloudFormation
-    will resolve at deploy time. Resource refs and other intrinsics return False so
-    they can continue to raise."""
-    if not isinstance(value, dict) or len(value) != 1:
-        return False
-    if "Ref" not in value:
-        return False
-    ref_target = value["Ref"]
-    if not isinstance(ref_target, str):
-        return False
-    if ref_target in PSEUDO_PARAMETERS:
-        return True
-    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
-        return True
-    return False

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_join.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_join.py
@@ -39,7 +39,7 @@ class FnJoinResolver(IntrinsicFunctionResolver):
 
     _EXPECTED_ARGS = 2
 
-    def resolve(self, value: Dict[str, Any]) -> str:
+    def resolve(self, value: Dict[str, Any]) -> Any:
         """
         Resolve the Fn::Join intrinsic function.
 
@@ -52,7 +52,9 @@ class FnJoinResolver(IntrinsicFunctionResolver):
                    E.g., {"Fn::Join": [",", ["a", "b", "c"]]}
 
         Returns:
-            A string with all list elements joined by the delimiter.
+            A string with all list elements joined by the delimiter, or - in
+            PARTIAL mode when an arg is an unresolved parameter Ref - the
+            preserved Fn::Join call as a dict.
 
         Raises:
             InvalidTemplateException: If the layout is incorrect.

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_join.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_join.py
@@ -10,7 +10,9 @@ Fn::Join format: {"Fn::Join": [delimiter, [list, of, items]]}
 from typing import Any, Dict
 
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
+from samcli.lib.cfn_language_extensions.models import ResolutionMode, TemplateProcessingContext
 from samcli.lib.cfn_language_extensions.resolvers.base import IntrinsicFunctionResolver
+from samcli.lib.cfn_language_extensions.utils import PSEUDO_PARAMETERS
 
 
 class FnJoinResolver(IntrinsicFunctionResolver):
@@ -70,13 +72,24 @@ class FnJoinResolver(IntrinsicFunctionResolver):
         if self.parent is not None:
             delimiter = self.parent.resolve_value(delimiter)
 
-        # Validate delimiter is a string
-        if not isinstance(delimiter, str):
-            raise InvalidTemplateException("Fn::Join layout is incorrect")
-
         # Resolve any nested intrinsic functions in the list
         if self.parent is not None:
             list_to_join = self.parent.resolve_value(list_to_join)
+
+        # In PARTIAL mode, preserve the call when either argument is still an
+        # unresolved Ref to a declared template parameter or a pseudo-parameter
+        # (i.e. CloudFormation will resolve it at deploy time). Resource refs
+        # and other intrinsics still raise — they aren't valid Fn::Join inputs.
+        delim_is_param_ref = _is_unresolved_param_or_pseudo_ref(delimiter, self.context)
+        list_is_param_ref = _is_unresolved_param_or_pseudo_ref(list_to_join, self.context)
+        if delim_is_param_ref or list_is_param_ref:
+            if self.context.resolution_mode == ResolutionMode.PARTIAL:
+                return {"Fn::Join": [delimiter, list_to_join]}
+            raise InvalidTemplateException("Fn::Join layout is incorrect")
+
+        # Validate delimiter is a string
+        if not isinstance(delimiter, str):
+            raise InvalidTemplateException("Fn::Join layout is incorrect")
 
         # Validate the list
         if not isinstance(list_to_join, list):
@@ -117,3 +130,20 @@ class FnJoinResolver(IntrinsicFunctionResolver):
             return ",".join(self._to_string(item) for item in value)
         else:
             return str(value)
+
+
+def _is_unresolved_param_or_pseudo_ref(value: Any, context: TemplateProcessingContext) -> bool:
+    """Return True if value is `{"Ref": <name>}` where <name> is a declared template
+    parameter or a pseudo-parameter. Resource refs return False so they continue to raise."""
+    if not isinstance(value, dict) or len(value) != 1:
+        return False
+    if "Ref" not in value:
+        return False
+    ref_target = value["Ref"]
+    if not isinstance(ref_target, str):
+        return False
+    if ref_target in PSEUDO_PARAMETERS:
+        return True
+    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
+        return True
+    return False

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_join.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_join.py
@@ -10,9 +10,9 @@ Fn::Join format: {"Fn::Join": [delimiter, [list, of, items]]}
 from typing import Any, Dict
 
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
-from samcli.lib.cfn_language_extensions.models import ResolutionMode, TemplateProcessingContext
+from samcli.lib.cfn_language_extensions.models import ResolutionMode
 from samcli.lib.cfn_language_extensions.resolvers.base import IntrinsicFunctionResolver
-from samcli.lib.cfn_language_extensions.utils import PSEUDO_PARAMETERS
+from samcli.lib.cfn_language_extensions.utils import is_unresolved_param_or_pseudo_ref
 
 
 class FnJoinResolver(IntrinsicFunctionResolver):
@@ -82,8 +82,8 @@ class FnJoinResolver(IntrinsicFunctionResolver):
         # unresolved Ref to a declared template parameter or a pseudo-parameter
         # (i.e. CloudFormation will resolve it at deploy time). Resource refs
         # and other intrinsics still raise — they aren't valid Fn::Join inputs.
-        delim_is_param_ref = _is_unresolved_param_or_pseudo_ref(delimiter, self.context)
-        list_is_param_ref = _is_unresolved_param_or_pseudo_ref(list_to_join, self.context)
+        delim_is_param_ref = is_unresolved_param_or_pseudo_ref(delimiter, self.context)
+        list_is_param_ref = is_unresolved_param_or_pseudo_ref(list_to_join, self.context)
         if delim_is_param_ref or list_is_param_ref:
             if self.context.resolution_mode == ResolutionMode.PARTIAL:
                 return {"Fn::Join": [delimiter, list_to_join]}
@@ -132,20 +132,3 @@ class FnJoinResolver(IntrinsicFunctionResolver):
             return ",".join(self._to_string(item) for item in value)
         else:
             return str(value)
-
-
-def _is_unresolved_param_or_pseudo_ref(value: Any, context: TemplateProcessingContext) -> bool:
-    """Return True if value is `{"Ref": <name>}` where <name> is a declared template
-    parameter or a pseudo-parameter. Resource refs return False so they continue to raise."""
-    if not isinstance(value, dict) or len(value) != 1:
-        return False
-    if "Ref" not in value:
-        return False
-    ref_target = value["Ref"]
-    if not isinstance(ref_target, str):
-        return False
-    if ref_target in PSEUDO_PARAMETERS:
-        return True
-    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
-        return True
-    return False

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_select.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_select.py
@@ -10,7 +10,9 @@ Fn::Select format: {"Fn::Select": [index, [list, of, items]]}
 from typing import Any, Dict
 
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
+from samcli.lib.cfn_language_extensions.models import ResolutionMode, TemplateProcessingContext
 from samcli.lib.cfn_language_extensions.resolvers.base import IntrinsicFunctionResolver
+from samcli.lib.cfn_language_extensions.utils import PSEUDO_PARAMETERS
 
 
 class FnSelectResolver(IntrinsicFunctionResolver):
@@ -73,6 +75,18 @@ class FnSelectResolver(IntrinsicFunctionResolver):
         if self.parent is not None:
             index = self.parent.resolve_value(index)
 
+        # In PARTIAL mode, if the index resolved to a deferred parameter Ref,
+        # preserve the call. Resource refs / GetAtt / etc. still raise.
+        # We must still resolve the source list below in case it contains
+        # resolvable intrinsics — that way, partial expansion makes maximal
+        # progress.
+        if _is_unresolved_param_or_pseudo_ref(index, self.context):
+            if self.context.resolution_mode != ResolutionMode.PARTIAL:
+                raise InvalidTemplateException("Fn::Select layout is incorrect")
+            if self.parent is not None:
+                source_list = self.parent.resolve_value(source_list)
+            return {"Fn::Select": [index, source_list]}
+
         # Validate index is an integer (or can be converted to one)
         if isinstance(index, str):
             try:
@@ -110,3 +124,20 @@ class FnSelectResolver(IntrinsicFunctionResolver):
         # Return the item at the specified index
         # Requirement 10.5: Return the element at that index
         return source_list[index]
+
+
+def _is_unresolved_param_or_pseudo_ref(value: Any, context: TemplateProcessingContext) -> bool:
+    """Return True if value is `{"Ref": <name>}` where <name> is a declared template
+    parameter or a pseudo-parameter. Resource refs return False so they continue to raise."""
+    if not isinstance(value, dict) or len(value) != 1:
+        return False
+    if "Ref" not in value:
+        return False
+    ref_target = value["Ref"]
+    if not isinstance(ref_target, str):
+        return False
+    if ref_target in PSEUDO_PARAMETERS:
+        return True
+    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
+        return True
+    return False

--- a/samcli/lib/cfn_language_extensions/resolvers/fn_select.py
+++ b/samcli/lib/cfn_language_extensions/resolvers/fn_select.py
@@ -10,9 +10,9 @@ Fn::Select format: {"Fn::Select": [index, [list, of, items]]}
 from typing import Any, Dict
 
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
-from samcli.lib.cfn_language_extensions.models import ResolutionMode, TemplateProcessingContext
+from samcli.lib.cfn_language_extensions.models import ResolutionMode
 from samcli.lib.cfn_language_extensions.resolvers.base import IntrinsicFunctionResolver
-from samcli.lib.cfn_language_extensions.utils import PSEUDO_PARAMETERS
+from samcli.lib.cfn_language_extensions.utils import is_unresolved_param_or_pseudo_ref
 
 
 class FnSelectResolver(IntrinsicFunctionResolver):
@@ -80,7 +80,7 @@ class FnSelectResolver(IntrinsicFunctionResolver):
         # We must still resolve the source list below in case it contains
         # resolvable intrinsics — that way, partial expansion makes maximal
         # progress.
-        if _is_unresolved_param_or_pseudo_ref(index, self.context):
+        if is_unresolved_param_or_pseudo_ref(index, self.context):
             if self.context.resolution_mode != ResolutionMode.PARTIAL:
                 raise InvalidTemplateException("Fn::Select layout is incorrect")
             if self.parent is not None:
@@ -124,20 +124,3 @@ class FnSelectResolver(IntrinsicFunctionResolver):
         # Return the item at the specified index
         # Requirement 10.5: Return the element at that index
         return source_list[index]
-
-
-def _is_unresolved_param_or_pseudo_ref(value: Any, context: TemplateProcessingContext) -> bool:
-    """Return True if value is `{"Ref": <name>}` where <name> is a declared template
-    parameter or a pseudo-parameter. Resource refs return False so they continue to raise."""
-    if not isinstance(value, dict) or len(value) != 1:
-        return False
-    if "Ref" not in value:
-        return False
-    ref_target = value["Ref"]
-    if not isinstance(ref_target, str):
-        return False
-    if ref_target in PSEUDO_PARAMETERS:
-        return True
-    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
-        return True
-    return False

--- a/samcli/lib/cfn_language_extensions/utils.py
+++ b/samcli/lib/cfn_language_extensions/utils.py
@@ -5,7 +5,10 @@ This module provides shared helpers used across the SAM CLI codebase
 for working with templates that may contain Fn::ForEach blocks.
 """
 
-from typing import Dict, Iterator, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Tuple
+
+if TYPE_CHECKING:
+    from samcli.lib.cfn_language_extensions.models import TemplateProcessingContext
 
 FOREACH_PREFIX = "Fn::ForEach::"
 
@@ -63,6 +66,31 @@ def is_intrinsic_key(key: str) -> bool:
     special single-word keys (``Ref``, ``Condition``).
     """
     return key.startswith("Fn::") or key in _INTRINSIC_SINGLE_KEYS
+
+
+def is_unresolved_param_or_pseudo_ref(value: Any, context: "TemplateProcessingContext") -> bool:
+    """Return True if *value* is ``{"Ref": <name>}`` where ``<name>`` is a declared
+    template parameter or a pseudo-parameter — i.e. an unresolved reference that
+    CloudFormation will resolve at deploy time.
+
+    Used by template-time intrinsic resolvers (Fn::FindInMap, Fn::Join, Fn::Select,
+    Fn::Base64) to decide, in PARTIAL resolution mode, whether to preserve the
+    enclosing call instead of raising. Resource refs and other intrinsics return
+    False so they continue to raise — matching Kotlin compatibility for
+    template-time intrinsics that genuinely cannot accept deploy-time inputs.
+    """
+    if not isinstance(value, dict) or len(value) != 1:
+        return False
+    if "Ref" not in value:
+        return False
+    ref_target = value["Ref"]
+    if not isinstance(ref_target, str):
+        return False
+    if ref_target in PSEUDO_PARAMETERS:
+        return True
+    if context.parsed_template is not None and ref_target in context.parsed_template.parameters:
+        return True
+    return False
 
 
 # Mapping-name prefixes that SAM CLI emits for dynamic Fn::ForEach handling:

--- a/tests/unit/lib/cfn_language_extensions/test_fn_base64.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_base64.py
@@ -25,6 +25,7 @@ from samcli.lib.cfn_language_extensions.resolvers.base import (
     IntrinsicResolver,
 )
 from samcli.lib.cfn_language_extensions.resolvers.fn_base64 import FnBase64Resolver
+from samcli.lib.cfn_language_extensions.resolvers.fn_ref import FnRefResolver
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
 
 
@@ -477,6 +478,21 @@ class TestFnBase64ResolverPartialMode:
             "encoded": "aGVsbG8=",
             "preserved": {"Fn::GetAtt": ["MyBucket", "Arn"]},
         }
+
+    def test_unresolved_arg_is_preserved_in_partial_mode(self):
+        from samcli.lib.cfn_language_extensions.models import ParsedTemplate
+        ctx = TemplateProcessingContext(
+            fragment={"Resources": {}},
+            resolution_mode=ResolutionMode.PARTIAL,
+            parsed_template=ParsedTemplate(parameters={"UserData": {"Type": "String"}}),
+        )
+        orch = IntrinsicResolver(ctx)
+        orch.register_resolver(FnRefResolver)
+        orch.register_resolver(FnBase64Resolver)
+
+        value = {"Fn::Base64": {"Ref": "UserData"}}
+        result = orch.resolve_value(value)
+        assert result == {"Fn::Base64": {"Ref": "UserData"}}
 
 
 class TestFnBase64ResolverRealWorldScenarios:

--- a/tests/unit/lib/cfn_language_extensions/test_fn_base64.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_base64.py
@@ -481,6 +481,7 @@ class TestFnBase64ResolverPartialMode:
 
     def test_unresolved_arg_is_preserved_in_partial_mode(self):
         from samcli.lib.cfn_language_extensions.models import ParsedTemplate
+
         ctx = TemplateProcessingContext(
             fragment={"Resources": {}},
             resolution_mode=ResolutionMode.PARTIAL,

--- a/tests/unit/lib/cfn_language_extensions/test_fn_find_in_map.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_find_in_map.py
@@ -2080,8 +2080,14 @@ class TestFnFindInMapFallbackToFragment:
         assert result == "ami-12345678"
 
 
-class TestFnFindInMapResolverPartialMode:
-    """Tests for FnFindInMapResolver in PARTIAL resolution mode (issue #9004)."""
+class TestFnFindInMapResolverPartialModeWithUnresolvedRef:
+    """Tests for FnFindInMapResolver in PARTIAL resolution mode when keys are
+    unresolved Refs to declared template parameters or pseudo-parameters.
+
+    Distinct from the earlier TestFnFindInMapResolverPartialMode class above —
+    these tests exercise the orchestrator with FnRefResolver registered, to
+    cover the unresolved-Ref-as-key paths.
+    """
 
     @pytest.fixture
     def partial_context(self) -> TemplateProcessingContext:
@@ -2182,8 +2188,8 @@ class TestFnFindInMapResolverPartialMode:
             orch.resolve_value({"Fn::FindInMap": ["M", {"Fn::GetAtt": ["Q", "Arn"]}, "k"]})
 
 
-class TestFnFindInMapIssue9004Regression:
-    """End-to-end regression test for GitHub issue #9004.
+class TestFnFindInMapEndToEndWithUnresolvedRef:
+    """End-to-end regression test driven through process_template.
 
     Repro: a template with AWS::LanguageExtensions transform, a parameter that
     has no Default and no override, and Fn::FindInMap using !Ref to that

--- a/tests/unit/lib/cfn_language_extensions/test_fn_find_in_map.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_find_in_map.py
@@ -38,6 +38,7 @@ from samcli.lib.cfn_language_extensions.resolvers.base import (
     IntrinsicResolver,
 )
 from samcli.lib.cfn_language_extensions.resolvers.fn_find_in_map import FnFindInMapResolver
+from samcli.lib.cfn_language_extensions.resolvers.fn_ref import FnRefResolver
 from samcli.lib.cfn_language_extensions.exceptions import InvalidTemplateException
 
 # =============================================================================
@@ -2077,3 +2078,104 @@ class TestFnFindInMapFallbackToFragment:
         value = {"Fn::FindInMap": ["RegionMap", "us-east-1", "AMI"]}
         result = resolver.resolve(value)
         assert result == "ami-12345678"
+
+
+class TestFnFindInMapResolverPartialMode:
+    """Tests for FnFindInMapResolver in PARTIAL resolution mode (issue #9004)."""
+
+    @pytest.fixture
+    def partial_context(self) -> TemplateProcessingContext:
+        parsed = ParsedTemplate(
+            parameters={"Stage": {"Type": "String"}},
+            mappings={"M": {"dev": {"k": "v"}}},
+        )
+        return TemplateProcessingContext(
+            fragment={"Resources": {}},
+            resolution_mode=ResolutionMode.PARTIAL,
+            parsed_template=parsed,
+        )
+
+    @pytest.fixture
+    def orchestrator(self, partial_context: TemplateProcessingContext) -> IntrinsicResolver:
+        orchestrator = IntrinsicResolver(partial_context)
+        orchestrator.register_resolver(FnRefResolver)
+        orchestrator.register_resolver(FnFindInMapResolver)
+        return orchestrator
+
+    def test_unresolved_top_key_is_preserved_in_partial_mode(self, orchestrator: IntrinsicResolver):
+        """Issue #9004: top-level key is Ref to a parameter without default/override."""
+        value = {"Fn::FindInMap": ["M", {"Ref": "Stage"}, "k"]}
+        result = orchestrator.resolve_value(value)
+        assert result == {"Fn::FindInMap": ["M", {"Ref": "Stage"}, "k"]}
+
+    def test_unresolved_map_name_is_preserved_in_partial_mode(self, orchestrator: IntrinsicResolver):
+        value = {"Fn::FindInMap": [{"Ref": "Stage"}, "dev", "k"]}
+        result = orchestrator.resolve_value(value)
+        assert result == {"Fn::FindInMap": [{"Ref": "Stage"}, "dev", "k"]}
+
+    def test_unresolved_second_key_is_preserved_in_partial_mode(self, orchestrator: IntrinsicResolver):
+        value = {"Fn::FindInMap": ["M", "dev", {"Ref": "Stage"}]}
+        result = orchestrator.resolve_value(value)
+        assert result == {"Fn::FindInMap": ["M", "dev", {"Ref": "Stage"}]}
+
+    def test_unresolved_key_with_default_value_is_preserved_in_partial_mode(self, orchestrator: IntrinsicResolver):
+        """When DefaultValue is present, preserve the entire call including the options dict."""
+        value = {"Fn::FindInMap": ["M", {"Ref": "Stage"}, "k", {"DefaultValue": "fallback"}]}
+        result = orchestrator.resolve_value(value)
+        assert result == {"Fn::FindInMap": ["M", {"Ref": "Stage"}, "k", {"DefaultValue": "fallback"}]}
+
+    def test_resolved_keys_still_perform_lookup_in_partial_mode(self, orchestrator: IntrinsicResolver):
+        """Sanity: when keys do resolve, lookup still works in PARTIAL mode."""
+        value = {"Fn::FindInMap": ["M", "dev", "k"]}
+        result = orchestrator.resolve_value(value)
+        assert result == "v"
+
+    def test_unresolved_top_key_still_raises_in_full_mode(self):
+        """In FULL mode, an unresolvable Ref raises (regression-guard for the FULL path)."""
+        from samcli.lib.cfn_language_extensions.exceptions import UnresolvableReferenceError
+        parsed = ParsedTemplate(mappings={"M": {"dev": {"k": "v"}}})
+        ctx = TemplateProcessingContext(
+            fragment={"Resources": {}},
+            resolution_mode=ResolutionMode.FULL,
+            parsed_template=parsed,
+        )
+        orch = IntrinsicResolver(ctx)
+        orch.register_resolver(FnRefResolver)
+        orch.register_resolver(FnFindInMapResolver)
+        with pytest.raises((InvalidTemplateException, UnresolvableReferenceError)):
+            orch.resolve_value({"Fn::FindInMap": ["M", {"Ref": "Missing"}, "k"]})
+
+    def test_resource_ref_as_key_still_raises_in_partial_mode(self):
+        """Kotlin compat: a Ref to a *resource* (not a parameter) is not a valid
+        Fn::FindInMap key and must raise even in PARTIAL mode. Without this guard,
+        the fix would over-broaden and break tests/.../compatibility/templates/
+        fnFindInMapWithUnsupportedFunctionFnRef.json."""
+        # No 'Queue' parameter declared — only a 'Queue' resource.
+        parsed = ParsedTemplate(
+            parameters={},
+            mappings={"M": {"dev": {"k": "v"}}},
+        )
+        ctx = TemplateProcessingContext(
+            fragment={"Resources": {"Queue": {"Type": "AWS::SQS::Queue"}}},
+            resolution_mode=ResolutionMode.PARTIAL,
+            parsed_template=parsed,
+        )
+        orch = IntrinsicResolver(ctx)
+        orch.register_resolver(FnRefResolver)
+        orch.register_resolver(FnFindInMapResolver)
+        with pytest.raises(InvalidTemplateException):
+            orch.resolve_value({"Fn::FindInMap": ["M", {"Ref": "Queue"}, "k"]})
+
+    def test_getatt_as_key_still_raises_in_partial_mode(self):
+        """Kotlin compat: Fn::GetAtt as a key must raise even in PARTIAL mode."""
+        parsed = ParsedTemplate(mappings={"M": {"dev": {"k": "v"}}})
+        ctx = TemplateProcessingContext(
+            fragment={"Resources": {}},
+            resolution_mode=ResolutionMode.PARTIAL,
+            parsed_template=parsed,
+        )
+        orch = IntrinsicResolver(ctx)
+        orch.register_resolver(FnRefResolver)
+        orch.register_resolver(FnFindInMapResolver)
+        with pytest.raises(InvalidTemplateException):
+            orch.resolve_value({"Fn::FindInMap": ["M", {"Fn::GetAtt": ["Q", "Arn"]}, "k"]})

--- a/tests/unit/lib/cfn_language_extensions/test_fn_find_in_map.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_find_in_map.py
@@ -2133,6 +2133,7 @@ class TestFnFindInMapResolverPartialMode:
     def test_unresolved_top_key_still_raises_in_full_mode(self):
         """In FULL mode, an unresolvable Ref raises (regression-guard for the FULL path)."""
         from samcli.lib.cfn_language_extensions.exceptions import UnresolvableReferenceError
+
         parsed = ParsedTemplate(mappings={"M": {"dev": {"k": "v"}}})
         ctx = TemplateProcessingContext(
             fragment={"Resources": {}},
@@ -2179,3 +2180,44 @@ class TestFnFindInMapResolverPartialMode:
         orch.register_resolver(FnFindInMapResolver)
         with pytest.raises(InvalidTemplateException):
             orch.resolve_value({"Fn::FindInMap": ["M", {"Fn::GetAtt": ["Q", "Arn"]}, "k"]})
+
+
+class TestFnFindInMapIssue9004Regression:
+    """End-to-end regression test for GitHub issue #9004.
+
+    Repro: a template with AWS::LanguageExtensions transform, a parameter that
+    has no Default and no override, and Fn::FindInMap using !Ref to that
+    parameter as a key. Before the fix, this raised "Fn::FindInMap layout is
+    incorrect" during sam build. After the fix, the call is preserved verbatim
+    in PARTIAL mode and CloudFormation resolves it at deploy time.
+    """
+
+    def test_template_with_unresolved_ref_in_findinmap_processes_in_partial_mode(self):
+        from samcli.lib.cfn_language_extensions.api import process_template
+
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::LanguageExtensions",
+            "Parameters": {
+                "Stage": {"Type": "String"},
+            },
+            "Mappings": {
+                "EnvConfig": {
+                    "dev": {"BucketName": "dev-bucket"},
+                    "prod": {"BucketName": "prod-bucket"},
+                },
+            },
+            "Resources": {
+                "MyBucket": {
+                    "Type": "AWS::S3::Bucket",
+                    "Properties": {"BucketName": {"Fn::FindInMap": ["EnvConfig", {"Ref": "Stage"}, "BucketName"]}},
+                },
+            },
+        }
+
+        # In PARTIAL mode (sam build's mode), processing must not raise.
+        result = process_template(template, resolution_mode=ResolutionMode.PARTIAL)
+
+        # The Fn::FindInMap call is preserved unchanged for CloudFormation.
+        bucket_name = result["Resources"]["MyBucket"]["Properties"]["BucketName"]
+        assert bucket_name == {"Fn::FindInMap": ["EnvConfig", {"Ref": "Stage"}, "BucketName"]}

--- a/tests/unit/lib/cfn_language_extensions/test_fn_join.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_join.py
@@ -410,6 +410,36 @@ class TestFnJoinResolverPartialMode:
             "preserved": {"Fn::GetAtt": ["MyBucket", "Arn"]},
         }
 
+    def test_unresolved_delimiter_is_preserved_in_partial_mode(self):
+        from samcli.lib.cfn_language_extensions.models import ParsedTemplate
+        ctx = TemplateProcessingContext(
+            fragment={"Resources": {}},
+            resolution_mode=ResolutionMode.PARTIAL,
+            parsed_template=ParsedTemplate(parameters={"Sep": {"Type": "String"}}),
+        )
+        orch = IntrinsicResolver(ctx)
+        orch.register_resolver(FnRefResolver)
+        orch.register_resolver(FnJoinResolver)
+
+        value = {"Fn::Join": [{"Ref": "Sep"}, ["a", "b"]]}
+        result = orch.resolve_value(value)
+        assert result == {"Fn::Join": [{"Ref": "Sep"}, ["a", "b"]]}
+
+    def test_unresolved_list_is_preserved_in_partial_mode(self):
+        from samcli.lib.cfn_language_extensions.models import ParsedTemplate
+        ctx = TemplateProcessingContext(
+            fragment={"Resources": {}},
+            resolution_mode=ResolutionMode.PARTIAL,
+            parsed_template=ParsedTemplate(parameters={"L": {"Type": "CommaDelimitedList"}}),
+        )
+        orch = IntrinsicResolver(ctx)
+        orch.register_resolver(FnRefResolver)
+        orch.register_resolver(FnJoinResolver)
+
+        value = {"Fn::Join": [",", {"Ref": "L"}]}
+        result = orch.resolve_value(value)
+        assert result == {"Fn::Join": [",", {"Ref": "L"}]}
+
 
 class TestFnJoinResolverRealWorldExamples:
     """Tests for Fn::Join with real-world CloudFormation patterns."""

--- a/tests/unit/lib/cfn_language_extensions/test_fn_join.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_join.py
@@ -412,6 +412,7 @@ class TestFnJoinResolverPartialMode:
 
     def test_unresolved_delimiter_is_preserved_in_partial_mode(self):
         from samcli.lib.cfn_language_extensions.models import ParsedTemplate
+
         ctx = TemplateProcessingContext(
             fragment={"Resources": {}},
             resolution_mode=ResolutionMode.PARTIAL,
@@ -427,6 +428,7 @@ class TestFnJoinResolverPartialMode:
 
     def test_unresolved_list_is_preserved_in_partial_mode(self):
         from samcli.lib.cfn_language_extensions.models import ParsedTemplate
+
         ctx = TemplateProcessingContext(
             fragment={"Resources": {}},
             resolution_mode=ResolutionMode.PARTIAL,

--- a/tests/unit/lib/cfn_language_extensions/test_fn_select.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_select.py
@@ -516,6 +516,21 @@ class TestFnSelectResolverPartialMode:
             "preserved": {"Fn::GetAtt": ["MyBucket", "Arn"]},
         }
 
+    def test_unresolved_index_is_preserved_in_partial_mode(self):
+        from samcli.lib.cfn_language_extensions.models import ParsedTemplate
+        ctx = TemplateProcessingContext(
+            fragment={"Resources": {}},
+            resolution_mode=ResolutionMode.PARTIAL,
+            parsed_template=ParsedTemplate(parameters={"Idx": {"Type": "Number"}}),
+        )
+        orch = IntrinsicResolver(ctx)
+        orch.register_resolver(FnRefResolver)
+        orch.register_resolver(FnSelectResolver)
+
+        value = {"Fn::Select": [{"Ref": "Idx"}, ["a", "b", "c"]]}
+        result = orch.resolve_value(value)
+        assert result == {"Fn::Select": [{"Ref": "Idx"}, ["a", "b", "c"]]}
+
 
 class TestFnSelectResolverRealWorldExamples:
     """Tests for Fn::Select with real-world CloudFormation patterns."""

--- a/tests/unit/lib/cfn_language_extensions/test_fn_select.py
+++ b/tests/unit/lib/cfn_language_extensions/test_fn_select.py
@@ -518,6 +518,7 @@ class TestFnSelectResolverPartialMode:
 
     def test_unresolved_index_is_preserved_in_partial_mode(self):
         from samcli.lib.cfn_language_extensions.models import ParsedTemplate
+
         ctx = TemplateProcessingContext(
             fragment={"Resources": {}},
             resolution_mode=ResolutionMode.PARTIAL,

--- a/tests/unit/lib/cfn_language_extensions/test_utils.py
+++ b/tests/unit/lib/cfn_language_extensions/test_utils.py
@@ -2,11 +2,13 @@
 
 from unittest import TestCase
 
+from samcli.lib.cfn_language_extensions.models import ParsedTemplate, ResolutionMode, TemplateProcessingContext
 from samcli.lib.cfn_language_extensions.utils import (
     derive_partition,
     derive_url_suffix,
     is_foreach_key,
     is_sam_generated_mapping,
+    is_unresolved_param_or_pseudo_ref,
     iter_regular_resources,
 )
 
@@ -73,3 +75,47 @@ class TestIsSamGeneratedMapping(TestCase):
 
     def test_layers_digit_matches(self):
         self.assertTrue(is_sam_generated_mapping("SAMLayers1stBatch"))
+
+
+class TestIsUnresolvedParamOrPseudoRef(TestCase):
+    def _ctx(self, parameters=None) -> TemplateProcessingContext:
+        return TemplateProcessingContext(
+            fragment={"Resources": {}},
+            resolution_mode=ResolutionMode.PARTIAL,
+            parsed_template=ParsedTemplate(parameters=parameters or {}),
+        )
+
+    def test_ref_to_declared_parameter(self):
+        ctx = self._ctx(parameters={"Stage": {"Type": "String"}})
+        self.assertTrue(is_unresolved_param_or_pseudo_ref({"Ref": "Stage"}, ctx))
+
+    def test_ref_to_pseudo_parameter(self):
+        ctx = self._ctx()
+        self.assertTrue(is_unresolved_param_or_pseudo_ref({"Ref": "AWS::Region"}, ctx))
+
+    def test_ref_to_resource_returns_false(self):
+        ctx = self._ctx()  # No "Queue" parameter declared.
+        self.assertFalse(is_unresolved_param_or_pseudo_ref({"Ref": "Queue"}, ctx))
+
+    def test_getatt_returns_false(self):
+        ctx = self._ctx()
+        self.assertFalse(is_unresolved_param_or_pseudo_ref({"Fn::GetAtt": ["Q", "Arn"]}, ctx))
+
+    def test_non_dict_returns_false(self):
+        ctx = self._ctx()
+        self.assertFalse(is_unresolved_param_or_pseudo_ref("Stage", ctx))
+        self.assertFalse(is_unresolved_param_or_pseudo_ref(["Ref", "Stage"], ctx))
+        self.assertFalse(is_unresolved_param_or_pseudo_ref(None, ctx))
+
+    def test_multi_key_dict_returns_false(self):
+        ctx = self._ctx(parameters={"Stage": {"Type": "String"}})
+        self.assertFalse(is_unresolved_param_or_pseudo_ref({"Ref": "Stage", "extra": 1}, ctx))
+
+    def test_non_string_ref_target_returns_false(self):
+        ctx = self._ctx()
+        self.assertFalse(is_unresolved_param_or_pseudo_ref({"Ref": 123}, ctx))
+
+    def test_no_parsed_template_only_pseudo_matches(self):
+        ctx = TemplateProcessingContext(fragment={"Resources": {}}, resolution_mode=ResolutionMode.PARTIAL)
+        self.assertTrue(is_unresolved_param_or_pseudo_ref({"Ref": "AWS::Region"}, ctx))
+        self.assertFalse(is_unresolved_param_or_pseudo_ref({"Ref": "Stage"}, ctx))


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#9004

#### Why is this change necessary?
SAM CLI 1.160.0 introduced the in-tree CloudFormation Language Extensions resolver. Four template-time intrinsic resolvers (`Fn::FindInMap`, `Fn::Join`, `Fn::Select`, `Fn::Base64`) raise `InvalidTemplateException("... layout is incorrect")` when an argument resolves to an unresolved `{"Ref": <param>}` dict.

This breaks `sam build` for any template using `AWS::LanguageExtensions` with `!Ref` to a parameter that has no `Default` and no override — a regression from 1.159.1.

The user-reported repro:

```yaml
Transform: AWS::LanguageExtensions
Parameters:
  Stage:
    Type: String  # no Default
Mappings:
  EnvConfig:
    dev: { BucketName: dev-bucket }
Resources:
  MyBucket:
    Type: AWS::S3::Bucket
    Properties:
      BucketName: !FindInMap [EnvConfig, !Ref Stage, BucketName]
```

`sam build` → `Error: Fn::FindInMap layout is incorrect`.

#### How does it address the issue?
In `ResolutionMode.PARTIAL` (the mode `sam build` always uses), preserve the call when an argument resolved to `{"Ref": <name>}` and `<name>` is a declared template parameter or a pseudo-parameter — exactly the references CloudFormation will resolve at deploy time. Resource refs and other intrinsics (`Fn::GetAtt`, etc.) continue to raise: those genuinely can't be inputs to template-time intrinsics at any stage, matching Kotlin compatibility behavior tested under `tests/unit/lib/cfn_language_extensions/compatibility/test_kotlin_compatibility.py`.

The shared discriminator `is_unresolved_param_or_pseudo_ref(value, context)` lives in `samcli/lib/cfn_language_extensions/utils.py` and is consumed by all four fixed resolvers.

Files changed:
- `samcli/lib/cfn_language_extensions/resolvers/fn_find_in_map.py` — preserve when any of map_name / top_key / second_key is an unresolved param Ref (root cause of #9004)
- `samcli/lib/cfn_language_extensions/resolvers/fn_join.py` — preserve when delimiter or list is an unresolved param Ref; widened `resolve()` return type to `Any`
- `samcli/lib/cfn_language_extensions/resolvers/fn_select.py` — preserve when index is an unresolved param Ref (source-list path was already correct)
- `samcli/lib/cfn_language_extensions/resolvers/fn_base64.py` — preserve when arg is an unresolved param Ref; widened `resolve()` return type to `Any`
- `samcli/lib/cfn_language_extensions/utils.py` — new shared helper `is_unresolved_param_or_pseudo_ref`

#### What side effects does this change have?
None expected.

- All Kotlin compatibility tests remain green: resource Refs and `Fn::GetAtt` as inputs to these template-time intrinsics still raise `InvalidTemplateException` (`fnFindInMapWithUnsupportedFunctionFnRef`, `fnFindInMapWithUnsupportedFunctionFnGetAtt`, `fnFindInMapWithUnsupportedFunctionInMapName`).
- FULL resolution mode behavior is unchanged.
- No public API changes; no new dependencies.
- Test coverage: per-resolver PARTIAL-mode unit tests including positive (preserve unresolved param Ref) and regression-guard cases (FULL mode raises, resource Ref raises, `Fn::GetAtt` raises); end-to-end test driving `process_template` with the issue #9004 repro template; focused unit tests for the new shared helper. 1685 unit tests pass in `tests/unit/lib/cfn_language_extensions/`.

#### Mandatory Checklist
- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document)) — N/A, regression fix in existing subsystem
- [x] Write/update unit tests
- [ ] Write/update integration tests — N/A, behavior is fully exercised at the unit/end-to-end level via `process_template`
- [ ] Write/update functional tests if needed — N/A
- [x] `make pr` passes (`make lint` clean for changed files; only pre-existing unrelated mypy errors remain on `develop`)
- [ ] `make update-reproducible-reqs` if dependencies were changed — N/A, no dependency changes
- [ ] Write documentation — N/A, no user-facing surface changes

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).