### PR TITLE
fix(tests): accept '/' in durable execution ARN regex

### DIFF
--- a/tests/integration/durable_integ_base.py
+++ b/tests/integration/durable_integ_base.py
@@ -152,7 +152,7 @@ class DurableIntegBase(TestCase):
 
         self.assertIn("Execution Summary:", stdout_str, f"Expected execution summary in output: {stdout_str}")
 
-        arn_match = re.search(r"ARN:\s+([a-f0-9-]+)", stdout_str)
+        arn_match = re.search(r"ARN:\s+(\S+)", stdout_str)
         self.assertIsNotNone(arn_match, f"Could not find ARN in output: {stdout_str}")
         execution_arn = arn_match.group(1) if arn_match else ""
 


### PR DESCRIPTION
### Issue #, if available

Fixes #9037

### Description of changes

`DurableIntegBase.assert_invoke_output` parsed the ARN line of `sam local
invoke` output with `[a-f0-9-]+`, which truncates at the first `/`.
After [aws-durable-execution-sdk-python-testing#216](https://github.com/aws/aws-durable-execution-sdk-python-testing/pull/216) the
emulator returns `<uuid>/<invocation-id>`, so subsequent `sam local execution
history|stop|get` calls in the same test received only the leading UUID
and 404'd.

Switching to `\S+` captures the full ARN as printed and remains
backwards-compatible with the old UUID-only form.

### Description of how you validated changes

- Re-ran `assert_invoke_output` against the exact stdout captured in the
  failing CI run; the patched regex extracts the full
  `<uuid>/<invocation-id>` ARN. Old UUID-only stdout still extracts
  cleanly.
- `make pr` (init, schema, black-check, lint, test-all) — all green
  locally on Python 3.11.11 (9241 passed, 25 skipped, coverage 94.17%).
  Full integration suite runs in CI on this PR.

### Checklist

- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods (n/a — test-only change)
- [x] Write design document if the changes are not straightforward (n/a)
- [x] Write/update tests (test-only change; no source change)
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed (n/a)
- [x] Write documentation (n/a)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.