### PR TITLE
ci: unpin durable functions emulator image tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,6 @@ jobs:
         run: pytest -vv ${{ matrix.tests_config.params }}
         env:
           FORCE_RUN_DOCKER_TEST: ${{ matrix.tests_config.name == 'durable-functions' && '1' || '' }}
-          DURABLE_EXECUTIONS_EMULATOR_IMAGE_TAG: ${{ matrix.tests_config.name == 'durable-functions' && 'v1.1.1' || '' }}
 
   smoke-and-functional-tests:
     name: ${{ matrix.tests_config.name }} / ${{ matrix.tests_config.os }} / ${{ matrix.python }}


### PR DESCRIPTION
## Summary
- Drops the hard-coded `DURABLE_EXECUTIONS_EMULATOR_IMAGE_TAG: v1.1.1` from the durable-functions matrix entry in `.github/workflows/build.yml`.
- With the env var unset, `DurableFunctionsEmulatorContainer._get_emulator_image_tag()` falls back to `latest`, so CI now exercises the most recent published emulator image instead of being pinned to v1.1.1.

## Test plan
- [ ] `durable-functions` job on this PR pulls `public.ecr.aws/durable-functions/aws-durable-execution-emulator:latest` and the suite passes.
- [ ] Other matrix entries (which never set the var) are unaffected.