### PR TITLE
chore: update cfn-lint to use a version greater than 1.51.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     # regex is not a direct dependency of SAM CLI, exclude version 2021.10.8 due to not working on M1 Mac
     "regex!=2021.10.8",
     "tzlocal==5.3.1",
-    "cfn-lint>=1.45,<1.52",
+    "cfn-lint>=1.51.3,<1.52",
     "boto3-stubs[apigateway,cloudformation,ecr,iam,lambda,s3,schemas,secretsmanager,signer,stepfunctions,sts,xray,sqs,kinesis]>=1.41.0",
     "python-dotenv>=1.0,<1.3",
 ]

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -196,9 +196,9 @@ cffi==2.0.0 \
     --hash=sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453 \
     --hash=sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf
     # via cryptography
-cfn-lint==1.51.0 \
-    --hash=sha256:05d2a59708c99363afe3af6ac7325de95a5b37f8eef7728f41ae567d088a61f1 \
-    --hash=sha256:116d4f9c7c7d039e69c01c31fe9ff309ff79f0884c859ea92b353507903dd89e
+cfn-lint==1.51.4 \
+    --hash=sha256:4897321a7d90c6e48859fde0c7c7c3c919815a947ddc85d0584dc12ad5bc544c \
+    --hash=sha256:d37c48645e03abecfd826b8588103b06991abd838fe05c641f2853812289c021
     # via aws-sam-cli (pyproject.toml)
 charset-normalizer==3.4.7 \
     --hash=sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc \

--- a/requirements/reproducible-mac.txt
+++ b/requirements/reproducible-mac.txt
@@ -196,9 +196,9 @@ cffi==2.0.0 \
     --hash=sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453 \
     --hash=sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf
     # via cryptography
-cfn-lint==1.51.0 \
-    --hash=sha256:05d2a59708c99363afe3af6ac7325de95a5b37f8eef7728f41ae567d088a61f1 \
-    --hash=sha256:116d4f9c7c7d039e69c01c31fe9ff309ff79f0884c859ea92b353507903dd89e
+cfn-lint==1.51.4 \
+    --hash=sha256:4897321a7d90c6e48859fde0c7c7c3c919815a947ddc85d0584dc12ad5bc544c \
+    --hash=sha256:d37c48645e03abecfd826b8588103b06991abd838fe05c641f2853812289c021
     # via aws-sam-cli (pyproject.toml)
 charset-normalizer==3.4.7 \
     --hash=sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc \

--- a/requirements/reproducible-win.txt
+++ b/requirements/reproducible-win.txt
@@ -196,9 +196,9 @@ cffi==2.0.0 \
     --hash=sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453 \
     --hash=sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf
     # via cryptography
-cfn-lint==1.51.0 \
-    --hash=sha256:05d2a59708c99363afe3af6ac7325de95a5b37f8eef7728f41ae567d088a61f1 \
-    --hash=sha256:116d4f9c7c7d039e69c01c31fe9ff309ff79f0884c859ea92b353507903dd89e
+cfn-lint==1.51.4 \
+    --hash=sha256:4897321a7d90c6e48859fde0c7c7c3c919815a947ddc85d0584dc12ad5bc544c \
+    --hash=sha256:d37c48645e03abecfd826b8588103b06991abd838fe05c641f2853812289c021
     # via aws-sam-cli (pyproject.toml)
 charset-normalizer==3.4.7 \
     --hash=sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc \


### PR DESCRIPTION
#### Why is this change necessary?
Recent nightly binary test runs have failed because `cfn-lint` is improperly marking certain runtimes as deprecated: https://github.com/aws/aws-sam-cli/actions/runs/27007478241/job/79702587019. This issue was fixed in [v1.51.3](https://github.com/aws-cloudformation/cfn-lint/releases/tag/v1.51.3) with https://github.com/aws-cloudformation/cfn-lint/pull/4532. Because it's a patch change, dependabot doesn't seem to be picking it up, but I'd like to get the binary tests working now.


#### How does it address the issue?
Forces dependency resolution to use a version 1.51.3 or greater of `cfn-lint`

#### What side effects does this change have?
N/a

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
