### PR TITLE
fix: switch from bitnami to docker/library for golang images

### DIFF
--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/hello_world/Dockerfile
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/hello_world/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.26 as build-image
+FROM public.ecr.aws/docker/library/golang:1.16 as build-image
 
 RUN go env -w GOPROXY=direct
 

--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/hello_world/Dockerfile
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_local_backend/hello_world/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/golang:1.16 as build-image
+FROM public.ecr.aws/docker/library/golang:1.26 as build-image
 
 RUN go env -w GOPROXY=direct
 

--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/hello_world/Dockerfile
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/hello_world/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.26 as build-image
+FROM public.ecr.aws/docker/library/golang:1.16 as build-image
 
 RUN go env -w GOPROXY=direct
 

--- a/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/hello_world/Dockerfile
+++ b/tests/integration/testdata/buildcmd/terraform/image_based_lambda_functions_s3_backend/hello_world/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/golang:1.16 as build-image
+FROM public.ecr.aws/docker/library/golang:1.26 as build-image
 
 RUN go env -w GOPROXY=direct
 


### PR DESCRIPTION
#### Which issue(s) does this change fix?
https://github.com/aws/aws-sam-cli/actions/runs/27292125532/job/80630281341


#### Why is this change necessary?
https://aws.amazon.com/blogs/containers/bitnami-image-removal-from-ecr-public/

'bitnami' just removed all it's images from ECR, so our terraform tests that reference them in Dockerfiles are now breaking.

#### How does it address the issue?
Change to a different golang base image that's on ECR: public.ecr.aws/docker/library/golang.


#### What side effects does this change have?
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
