### PR TITLE
chore: update openssl version to 3.3.7

### DIFF
--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -38,7 +38,7 @@ fi
 
 set -eux
 
-yum install -y libffi-devel perl-IPC-Cmd
+yum install -y libffi-devel perl-IPC-Cmd perl-Time-Piece
 
 echo "Making Folders"
 mkdir -p .build/src

--- a/installer/pyinstaller/build-linux.sh
+++ b/installer/pyinstaller/build-linux.sh
@@ -16,7 +16,7 @@ if [ "$python_version" = "" ]; then
 fi
 
 if [ "$openssl_version" = "" ]; then
-    openssl_version="3.3.3";
+    openssl_version="3.3.7";
 fi
 
 if [ "$zlib_version" = "" ]; then

--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -30,7 +30,7 @@ if [ "$python_library_zip_filename" = "" ]; then
 fi
 
 if [ "$openssl_version" = "" ]; then
-    openssl_version="3.3.1";
+    openssl_version="3.3.7";
 fi
 
 if [ "$python_version" = "" ]; then


### PR DESCRIPTION
#9078

Update openssl in the pyinstaller script to use 3.3.7.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
