### PR TITLE
test: fix expected SubType for `wait_for_callback` in tests

### DIFF
--- a/tests/integration/testdata/durable/functions/wait_for_callback/expected_history.json
+++ b/tests/integration/testdata/durable/functions/wait_for_callback/expected_history.json
@@ -12,7 +12,7 @@
   },
   {
     "EventType": "ContextStarted",
-    "SubType": "RunInChildContext",
+    "SubType": "WaitForCallback",
     "EventId": 2,
     "Name": "external_call",
     "ContextStartedDetails": {}
@@ -60,7 +60,7 @@
   },
   {
     "EventType": "ContextSucceeded",
-    "SubType": "RunInChildContext",
+    "SubType": "WaitForCallback",
     "EventId": 8,
     "Name": "external_call",
     "ContextSucceededDetails": {

--- a/tests/integration/testdata/durable/functions/wait_for_callback/expected_history_failure.json
+++ b/tests/integration/testdata/durable/functions/wait_for_callback/expected_history_failure.json
@@ -12,7 +12,7 @@
   },
   {
     "EventType": "ContextStarted",
-    "SubType": "RunInChildContext",
+    "SubType": "WaitForCallback",
     "EventId": 2,
     "Name": "external_call",
     "ContextStartedDetails": {}
@@ -60,7 +60,7 @@
   },
   {
     "EventType": "ContextFailed",
-    "SubType": "RunInChildContext",
+    "SubType": "WaitForCallback",
     "EventId": 8,
     "Name": "external_call",
     "ContextFailedDetails": {


### PR DESCRIPTION
Expect `WaitForCallback` instead of `RunInChildContext` subtype.

#### Which issue(s) does this change fix?
Durable Functions changed the subtype for `wait_for_callback()` in their last version: https://github.com/aws/aws-durable-execution-sdk-python/pull/476


#### Why is this change necessary?
Tests were failing

#### How does it address the issue?
Update the tests to check for the new values coming from the durable-functions SDK.

#### What side effects does this change have?
Nothing. Just tests. 

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [x] Write/update integration tests
- [ ] Write/update functional tests if needed
- [x] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
