### PR TITLE
fix: reduce make parallelism to -j4 in macOS installer build

### DIFF
--- a/installer/pyinstaller/build-mac.sh
+++ b/installer/pyinstaller/build-mac.sh
@@ -62,9 +62,9 @@ cd openssl-"$openssl_version"
 # Openssl configure https://wiki.openssl.org/index.php/Compilation_and_Installation
 ./Configure --prefix=/usr/local --openssldir=/usr/local/openssl no-ssl3 no-ssl3-method no-zlib ${openssl_config_arch} enable-ec_nistp_64_gcc_128
 
-make -j8
+make -j4
 # install_sw installs OpenSSL without manual pages
-sudo make -j8 install_sw
+sudo make -j4 install_sw
 cd ..
 
 # Copying aws-sam-cli source code
@@ -95,8 +95,8 @@ cd Python-"$python_version"
 ./configure \
     --enable-shared \
     --with-openssl=/usr/local
-make -j8
-sudo make -j8 install
+make -j4
+sudo make -j4 install
 cd ..
 
 echo "Installing Python Libraries"


### PR DESCRIPTION
## Summary
- Reduce `make -j8` to `make -j4` for OpenSSL and Python compilation in `build-mac.sh`

## Problem
After replacing the Mac x86 dedicated host (hardware failure), `make -j8` consistently fails with a race condition:
```
clang: error: no such file or directory: 'libcrypto.a'
```
The parallel link step starts before the static library is ready. This manifests on the new host hardware but not on the old one (different scheduling behavior).

## Fix
Reduce parallelism from 8 to 4 for both OpenSSL and Python builds. Still faster than serial, but eliminates the race. The arm64 instance builds fine at -j8 (different architecture, different timing) but -j4 is safe for both.

## Test plan
- [ ] Nightly release pipeline passes Build stage on Mac x86
- [ ] No impact on arm64 builds (they already succeed)