### PR TITLE
chore: remove dead Python 2 compatibility code in `env_vars`

### DIFF
--- a/samcli/local/lambdafn/env_vars.py
+++ b/samcli/local/lambdafn/env_vars.py
@@ -2,15 +2,9 @@
 Supplies the environment variables necessary to set up Local Lambda runtime
 """
 
-import sys
-from enum import IntEnum
 from typing import Optional
 
 from samcli.lib.providers.provider import CapacityProviderConfig
-
-
-class Python(IntEnum):
-    TWO = 2
 
 
 class EnvironmentVariables:
@@ -238,13 +232,8 @@ class EnvironmentVariables:
             result = "false"
 
         # value is a scalar type like int, str which can be stringified
-        # do not stringify unicode in Py2, Py3 str supports unicode
-        elif sys.version_info.major > Python.TWO:
-            result = str(value)
-        elif not isinstance(value, unicode):  # noqa: F821 pylint: disable=undefined-variable
-            result = str(value)
         else:
-            result = value
+            result = str(value)
 
         return result
 


### PR DESCRIPTION
Hello. Removing Python 2 compatibility code that was avoiding stringifying `unicode` strings, since Python 2 was deprecated long time ago and this code is now dead.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
