### PR TITLE
chore: drop unreachable pre Python 3.9 md5 fallback in `hash`

### DIFF
--- a/samcli/lib/utils/hash.py
+++ b/samcli/lib/utils/hash.py
@@ -4,21 +4,13 @@ Hash calculation utilities for files and directories.
 
 import hashlib
 import os
-import sys
 from typing import Any, List, Optional, cast
 
 BLOCK_SIZE = 4096
-# earliest python version to support usedforsecurity option for hashlib.md5 is 3.9
-# https://docs.python.org/3/library/hashlib.html#hash-algorithms
-_MAJOR_PYTHON_VERSION = 3
-_MINOR_PYTHON_VERSION = 9
 
 
 def _get_md5():
-    if sys.version_info.major >= _MAJOR_PYTHON_VERSION and sys.version_info.minor >= _MINOR_PYTHON_VERSION:
-        return hashlib.md5(usedforsecurity=False)
-    else:
-        return hashlib.md5()
+    return hashlib.md5(usedforsecurity=False)
 
 
 def file_checksum(file_name: str, hash_generator: Any = None) -> str:

--- a/tests/unit/lib/utils/test_hash.py
+++ b/tests/unit/lib/utils/test_hash.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import shutil
-import sys
 import tempfile
 from unittest import TestCase
 from unittest.mock import patch
@@ -127,7 +126,4 @@ class TestHash(TestCase):
     @patch("samcli.lib.utils.hash.hashlib")
     def test_md5_instantiation(self, patched_hashlib):
         str_checksum("dummy-data")
-        if sys.version_info.major >= 3 and sys.version_info.minor >= 9:
-            patched_hashlib.md5.assert_called_with(usedforsecurity=False)
-        else:
-            patched_hashlib.md5.assert_called_with()
+        patched_hashlib.md5.assert_called_with(usedforsecurity=False)


### PR DESCRIPTION
Hello. Removing fallback for Python <3.9 missing `usedforsecurity` option in `hashlib.md5`.
Since project is targeting Python >= 3.10, this code is dead and can be safely removed.

https://github.com/aws/aws-sam-cli/blob/9101836ddcb9f532d45746751d20322daf833e21/pyproject.toml#L10

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
