### PR TITLE
fix(local-apigw): treat authorizer resource ARNs as literals, not regex

### DIFF
--- a/samcli/local/apigw/authorizers/lambda_authorizer.py
+++ b/samcli/local/apigw/authorizers/lambda_authorizer.py
@@ -387,8 +387,10 @@ class LambdaAuthorizer(Authorizer):
             resource_list = resource if isinstance(resource, list) else [resource]
 
             for resource_arn in resource_list:
-                # form a regular expression from the possible wildcard resource ARN
-                regex_method_arn = resource_arn.replace("*", ".*").replace("?", ".")
+                # form a regular expression from the possible wildcard resource ARN;
+                # escape it first so that regex syntax in the ARN itself (such as the
+                # "$" in the HTTP API "$default" stage) is matched literally
+                regex_method_arn = re.escape(resource_arn).replace(r"\*", ".*").replace(r"\?", ".")
                 regex_method_arn += "$"
 
                 if re.match(regex_method_arn, method_arn):

--- a/tests/unit/local/apigw/test_lambda_authorizer.py
+++ b/tests/unit/local/apigw/test_lambda_authorizer.py
@@ -455,6 +455,66 @@ class TestLambdaAuthorizer(TestCase):
 
         self.assertEqual(result, expected_result)
 
+    @parameterized.expand(
+        [
+            (  # HTTP API "$default" stage, wildcard resource
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/$default/*",
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/$default/GET/hello",
+                True,
+            ),
+            (  # authorizer echoes the method ARN it was given back verbatim
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/$default/GET/hello",
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/$default/GET/hello",
+                True,
+            ),
+            (  # a "[" in the path must not be read as a character set
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/a[b",
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/a[b",
+                True,
+            ),
+            (  # a "(" in the path must not be read as a group
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/x(y",
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/x(y",
+                True,
+            ),
+            (  # "." is a literal, not a wildcard
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/a.c",
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/abc",
+                False,
+            ),
+            (  # a different stage is still denied
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/$default/*",
+                "arn:aws:execute-api:us-east-1:123456789012:1234567890/prod/GET/hello",
+                False,
+            ),
+        ]
+    )
+    def test_is_resource_authorized_treats_arn_as_literal(self, resource_arn, method_arn, expected_result):
+        auth = LambdaAuthorizer(
+            "my auth",
+            Mock(),
+            Mock(),
+            [],
+            Mock(),
+            Mock(),
+            Mock(),
+        )
+        response = {
+            "policyDocument": {
+                "Statement": [
+                    {
+                        "Action": ["execute-api:Invoke"],
+                        "Effect": "Allow",
+                        "Resource": resource_arn,
+                    }
+                ]
+            },
+        }
+
+        result = auth._is_resource_authorized(response, method_arn)
+
+        self.assertEqual(result, expected_result)
+
 
 class TestLambdaAuthorizerIamPolicyValidator(TestCase):
     @parameterized.expand(


### PR DESCRIPTION
**What's broken**

`sam local start-api` returns 403 for requests a Lambda authorizer explicitly allows, whenever the resource ARN contains a regex metacharacter. The everyday case is the HTTP API `$default` stage:

```python
# authorizer handler
return {"principalId": "user", "policyDocument": {"Statement": [{
    "Action": "execute-api:Invoke", "Effect": "Allow",
    "Resource": "arn:aws:execute-api:us-east-1:123456789012:abc123/$default/*",
}]}}
```

```
$ sam local start-api
$ curl localhost:3000/hello
{"message":"User is not authorized to access this resource"}
```

It fails even when the authorizer echoes back the exact `methodArn` it was handed — the most common example in AWS's own docs. Deployed API Gateway allows the same request, so this is a pure local/deployed divergence.

A `[` or `(` in the path is worse — the request dies with `re.PatternError: unterminated character set`.

**Why it happens**

`_is_resource_authorized` builds a regex directly from the ARN, escaping nothing but the wildcards:

```python
regex_method_arn = resource_arn.replace("*", ".*").replace("?", ".")
regex_method_arn += "$"
```

So `$` becomes an end-of-string anchor, `.` matches any character, and `[` / `(` are unbalanced syntax.

**The fix**

`re.escape()` the ARN first, then translate the two IAM wildcards:

```python
regex_method_arn = re.escape(resource_arn).replace(r"\*", ".*").replace(r"\?", ".")
```

`*` and `?` keep working; everything else in the ARN is matched literally. This also stops `.` from over-matching — `.../GET/a.c` no longer authorizes `.../GET/abc`.

**The test**

`test_is_resource_authorized_treats_arn_as_literal` in `tests/unit/local/apigw/test_lambda_authorizer.py` — six cases covering `$default`, an echoed method ARN, `[`, `(`, literal `.`, and a stage that should still be denied. Five of six fail on `develop`:

```
$ pytest tests/unit/local/apigw/test_lambda_authorizer.py -k treats_arn_as_literal   # before
5 failed, 1 passed

$ pytest tests/unit/local/apigw                                                      # after
286 passed
```

`black --check` clean on both files.
