### PR TITLE
refactor(durable): Remove time scale configuration from emulator container

### DIFF
--- a/samcli/local/docker/durable_functions_emulator_container.py
+++ b/samcli/local/docker/durable_functions_emulator_container.py
@@ -51,13 +51,6 @@ class DurableFunctionsEmulatorContainer:
     ENV_STORE_TYPE = "DURABLE_EXECUTIONS_STORE_TYPE"
 
     """
-    Allow overriding the timescale used by the emulator. For example, if you have
-    a context.wait(3 months), you probably don't want to actually wait 3 months in
-    a local development loop. This lets you override that!
-    """
-    ENV_TIME_SCALE = "DURABLE_EXECUTIONS_TIME_SCALE"
-
-    """
     Capture the logs from the emulator on cleanup - this can be useful for debugging
     what happened, since once the container is gone, the logs are too.
     """
@@ -153,10 +146,6 @@ class DurableFunctionsEmulatorContainer:
         LOG.debug(f"Creating durable functions emulator container with store type: {store_type}")
         return store_type
 
-    def _get_emulator_time_scale(self):
-        """Get the execution time scale from environment variable or use default timescale of 1."""
-        return os.environ.get(self.ENV_TIME_SCALE, "1")
-
     def _get_emulator_data_dir(self):
         """Get the path to the emulator data directory."""
         return os.path.join(os.getcwd(), self._EMULATOR_DATA_DIR_NAME)
@@ -181,9 +170,7 @@ class DurableFunctionsEmulatorContainer:
         """
         Get the environment variables for the emulator container.
         """
-        return {
-            "DURABLE_EXECUTION_TIME_SCALE": self._get_emulator_time_scale(),
-        }
+        return {}
 
     @property
     def _docker_client(self) -> docker.DockerClient:

--- a/tests/unit/local/docker/test_durable_functions_emulator_container.py
+++ b/tests/unit/local/docker/test_durable_functions_emulator_container.py
@@ -300,21 +300,18 @@ class TestDurableFunctionsEmulatorContainer(TestCase):
 
     @parameterized.expand(
         [
-            # (name, env_vars, expected_port, expected_store, expected_scale)
-            ("default_config", {}, 9014, "sqlite", "1"),
-            ("custom_port", {"DURABLE_EXECUTIONS_EMULATOR_PORT": "9999"}, 9999, "sqlite", "1"),
-            ("filesystem_store", {"DURABLE_EXECUTIONS_STORE_TYPE": "filesystem"}, 9014, "filesystem", "1"),
-            ("custom_time_scale", {"DURABLE_EXECUTIONS_TIME_SCALE": "0.5"}, 9014, "sqlite", "0.5"),
+            # (name, env_vars, expected_port, expected_store)
+            ("default_config", {}, 9014, "sqlite"),
+            ("custom_port", {"DURABLE_EXECUTIONS_EMULATOR_PORT": "9999"}, 9999, "sqlite"),
+            ("filesystem_store", {"DURABLE_EXECUTIONS_STORE_TYPE": "filesystem"}, 9014, "filesystem"),
             (
                 "all_custom",
                 {
                     "DURABLE_EXECUTIONS_EMULATOR_PORT": "8888",
                     "DURABLE_EXECUTIONS_STORE_TYPE": "filesystem",
-                    "DURABLE_EXECUTIONS_TIME_SCALE": "2.0",
                 },
                 8888,
                 "filesystem",
-                "2.0",
             ),
         ]
     )
@@ -329,7 +326,6 @@ class TestDurableFunctionsEmulatorContainer(TestCase):
         env_vars,
         expected_port,
         expected_store,
-        expected_scale,
         mock_path_exists,
         mock_getcwd,
         mock_makedirs,
@@ -364,7 +360,7 @@ class TestDurableFunctionsEmulatorContainer(TestCase):
 
             # Verify environment variables
             environment = call_args.kwargs["environment"]
-            self.assertEqual(environment["DURABLE_EXECUTION_TIME_SCALE"], expected_scale)
+            self.assertEqual(environment, {})
 
             # Verify volumes
             volumes = call_args.kwargs["volumes"]


### PR DESCRIPTION
#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->
Related to https://github.com/aws/aws-durable-execution-sdk-python/pull/523

#### Why is this change necessary?
The time scale feature has been removed from the durable execution emulator (see linked SDK PR). The `DURABLE_EXECUTIONS_TIME_SCALE` environment variable and the `DURABLE_EXECUTION_TIME_SCALE` container environment variable are no longer recognized by the emulator, so SAM CLI should stop setting them.

#### How does it address the issue?
- Removes the `ENV_TIME_SCALE` class variable and its docstring
- Removes the `_get_emulator_time_scale()` method
- Updates `_get_emulator_environment()` to return an empty dict
- Updates unit tests to remove time scale assertions and the `custom_time_scale` test case

#### What side effects does this change have?
Users who previously set `DURABLE_EXECUTIONS_TIME_SCALE` will no longer see it forwarded to the emulator container. Since the emulator itself no longer supports this variable, there is no functional impact.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
