### PR TITLE
test: assert CDK warning on stderr in package/deploy/validate integ t…

### DIFF
--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -1412,7 +1412,8 @@ to create a managed default bucket, or run sam deploy --guided",
         )
 
         deploy_process_execute = self.run_command(deploy_command_list)
-        self.assertIn(warning_message, deploy_process_execute.stdout)
+        # The CDK warning is emitted on stderr so it does not pollute the --output json stdout stream.
+        self.assertIn(warning_message, deploy_process_execute.stderr)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-dynamodb-error.yaml"])

--- a/tests/integration/package/test_package_command_zip.py
+++ b/tests/integration/package/test_package_command_zip.py
@@ -707,9 +707,9 @@ class TestPackageZip(PackageIntegBase):
             s3_bucket=self.s3_bucket.name, s3_prefix=self.s3_prefix, template_file=template_path
         )
 
-        process = Popen(command_list, stdout=PIPE)
+        process = Popen(command_list, stdout=PIPE, stderr=PIPE)
         try:
-            stdout, _ = process.communicate(timeout=TIMEOUT)
+            stdout, stderr = process.communicate(timeout=TIMEOUT)
         except TimeoutExpired:
             process.kill()
             raise
@@ -721,5 +721,6 @@ class TestPackageZip(PackageIntegBase):
             encoding="utf-8",
         )
 
-        self.assertIn(warning_message, stdout)
+        # The CDK warning is emitted on stderr so it does not pollute the --output json stdout stream.
+        self.assertIn(warning_message, stderr)
         self.assertIn("{bucket_name}".format(bucket_name=self.s3_bucket.name), process_stdout.decode("utf-8"))

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -124,7 +124,8 @@ class TestValidate(TestCase):
         template_file = "aws-serverless-function-cdk.yaml"
         template_path = test_data_path.joinpath(template_file)
         command_result = run_command(self.command_list(template_file=template_path))
-        output = command_result.stdout.decode("utf-8")
+        # The CDK warning is emitted on stderr so it does not pollute the --output json stdout stream.
+        output = command_result.stderr.decode("utf-8")
 
         warning_message = (
             f"Warning: CDK apps are not officially supported with this command.{os.linesep}"


### PR DESCRIPTION
…ests

The output json integration (#9172) moved the CDK not-supported warning from stdout to stderr so it does not pollute the machine-readable --output json stdout stream. Three integration tests still asserted the warning on stdout and now fail on develop:
 - package/test_package_command_zip.py::test_package_logs_warning_for_cdk_project
 - deploy/test_deploy_command.py::test_deploy_logs_warning_with_cdk_project
 - validate/test_validate_command.py::test_validate_logs_warning_for_cdk_project

Update each to assert the warning on stderr (capturing stderr in the package test's Popen). Test-only change; product behavior is unchanged.

#### Which issue(s) does this change fix?
<!-- Use the format #<issue-number>, e.g. #42 -->


#### Why is this change necessary?


#### How does it address the issue?


#### What side effects does this change have?


#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [ ] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [ ] Write/update unit tests
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
