### PR TITLE
tests: unblock nightly integ tests on pytest 9.1 and make collection deterministic

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,21 +18,6 @@ filterwarnings =
 ;   The following deprecation warnings are treated as failures unless we explicitly tell pytest not to
 ;   Remove once we no longer support python3.9
     ignore::boto3.exceptions.PythonDeprecationWarning
-;   pytest 9.1 deprecated class-scoped fixtures declared as instance methods, because
-;   attributes they set on `self` are invisible to tests (each test gets a fresh
-;   instance while the fixture runs once per class). Our class-scoped fixtures assign
-;   to the class instead -- e.g. `TestSyncCodeBase.stack_name = ...` -- so the hazard
-;   the warning exists to catch does not apply to them.
-;
-;   Without this, `error` above turns the warning into a setup failure on the first
-;   test of every affected class, and pytest then raises an internal AssertionError
-;   ("assert not self._finalizers") for the remaining tests in that class
-;   (pytest-dev/pytest#14775). With --reruns, only the final attempt is reported, so
-;   the internal error is all that survives and the real cause is invisible.
-;
-;   Affects tests/integration/{sync,logs,traces}. Remove once those fixtures are
-;   converted to a supported pattern -- required before pytest 10 drops this.
-    ignore:.*Class-scoped fixture defined as instance method.*
 markers =
     ruby
     nodejs

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,21 @@ filterwarnings =
 ;   The following deprecation warnings are treated as failures unless we explicitly tell pytest not to
 ;   Remove once we no longer support python3.9
     ignore::boto3.exceptions.PythonDeprecationWarning
+;   pytest 9.1 deprecated class-scoped fixtures declared as instance methods, because
+;   attributes they set on `self` are invisible to tests (each test gets a fresh
+;   instance while the fixture runs once per class). Our class-scoped fixtures assign
+;   to the class instead -- e.g. `TestSyncCodeBase.stack_name = ...` -- so the hazard
+;   the warning exists to catch does not apply to them.
+;
+;   Without this, `error` above turns the warning into a setup failure on the first
+;   test of every affected class, and pytest then raises an internal AssertionError
+;   ("assert not self._finalizers") for the remaining tests in that class
+;   (pytest-dev/pytest#14775). With --reruns, only the final attempt is reported, so
+;   the internal error is all that survives and the real cause is invisible.
+;
+;   Affects tests/integration/{sync,logs,traces}. Remove once those fixtures are
+;   converted to a supported pattern -- required before pytest 10 drops this.
+    ignore:.*Class-scoped fixture defined as instance method.*
 markers =
     ruby
     nodejs

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -22,13 +22,13 @@ samcli_modules = ["samcli"]
 samcli = __import__("samcli")
 walk_modules(samcli, samcli_modules)
 
-# sorted(), not the raw collection order: this list is what pyinstaller bundles, and an
-# unstable order made builds non-reproducible and made the parameterized test over it
-# collect differently in each pytest-xdist worker ("Different tests were collected
-# between workers"). pkgutil.walk_packages happens to yield sorted names today, but that
-# is an implementation detail of its os.listdir().sort(), so sort explicitly rather than
-# depend on it. Order is not meaningful to pyinstaller, so this is free.
-SAM_CLI_HIDDEN_IMPORTS = sorted(samcli_modules) + [
+# Collected in discovery order. This used to be list(set(...)), whose order varied per
+# process because string hashing is randomized -- that made pyinstaller's bundle list
+# unstable between builds, and made the parameterized test over it collect differently in
+# each pytest-xdist worker ("Different tests were collected between workers"). Walking
+# into a list is deterministic on its own, so no sort is needed here; the ordering is
+# pinned by test_walk_modules_order_is_deterministic_and_sorted.
+SAM_CLI_HIDDEN_IMPORTS = samcli_modules + [
     "cookiecutter.extensions",
     "text_unidecode",
     "samtranslator",

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -4,29 +4,30 @@ Keeps list of hidden/dynamic imports that is being used in SAM CLI, so that pyin
 
 import pkgutil
 from types import ModuleType
+from typing import List
 
 
-def walk_modules(module: ModuleType, visited: set) -> None:
+def walk_modules(module: ModuleType, visited: List[str]) -> None:
     """Recursively find all modules from a parent module"""
     for pkg in pkgutil.walk_packages(module.__path__, module.__name__ + "."):
         if pkg.name in visited:
             continue
-        visited.add(pkg.name)
+        visited.append(pkg.name)
         if pkg.ispkg:
             submodule = __import__(pkg.name)
             walk_modules(submodule, visited)
 
 
-samcli_modules = set(["samcli"])
+samcli_modules = ["samcli"]
 samcli = __import__("samcli")
 walk_modules(samcli, samcli_modules)
 
-# sorted(), not list(): set iteration order for strings varies between processes because
-# string hashing is randomized, so list() gave this module a different order on every
-# interpreter. That made pyinstaller's hidden-import list unstable between builds, and
-# made the parameterized test over it collect in a different order in each pytest-xdist
-# worker ("Different tests were collected between workers"). Order is not meaningful to
-# pyinstaller, so sorting is free.
+# sorted(), not the raw collection order: this list is what pyinstaller bundles, and an
+# unstable order made builds non-reproducible and made the parameterized test over it
+# collect differently in each pytest-xdist worker ("Different tests were collected
+# between workers"). pkgutil.walk_packages happens to yield sorted names today, but that
+# is an implementation detail of its os.listdir().sort(), so sort explicitly rather than
+# depend on it. Order is not meaningful to pyinstaller, so this is free.
 SAM_CLI_HIDDEN_IMPORTS = sorted(samcli_modules) + [
     "cookiecutter.extensions",
     "text_unidecode",

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -21,7 +21,13 @@ samcli_modules = set(["samcli"])
 samcli = __import__("samcli")
 walk_modules(samcli, samcli_modules)
 
-SAM_CLI_HIDDEN_IMPORTS = list(samcli_modules) + [
+# sorted(), not list(): set iteration order for strings varies between processes because
+# string hashing is randomized, so list() gave this module a different order on every
+# interpreter. That made pyinstaller's hidden-import list unstable between builds, and
+# made the parameterized test over it collect in a different order in each pytest-xdist
+# worker ("Different tests were collected between workers"). Order is not meaningful to
+# pyinstaller, so sorting is free.
+SAM_CLI_HIDDEN_IMPORTS = sorted(samcli_modules) + [
     "cookiecutter.extensions",
     "text_unidecode",
     "samtranslator",

--- a/samcli/cli/hidden_imports.py
+++ b/samcli/cli/hidden_imports.py
@@ -4,18 +4,31 @@ Keeps list of hidden/dynamic imports that is being used in SAM CLI, so that pyin
 
 import pkgutil
 from types import ModuleType
-from typing import List
+from typing import List, Optional, Set
 
 
-def walk_modules(module: ModuleType, visited: List[str]) -> None:
-    """Recursively find all modules from a parent module"""
+def walk_modules(module: ModuleType, visited: List[str], seen: Optional[Set[str]] = None) -> None:
+    """Recursively find all modules from a parent module.
+
+    `visited` keeps discovery order, which callers rely on: it is what pyinstaller
+    bundles, and an unstable order both makes builds non-reproducible and makes the
+    parameterized test over it collect differently in each pytest-xdist worker.
+
+    `seen` is a parallel set used only for the dedup check, so ordering does not cost
+    O(n) lookups. That matters because `__import__("samcli.cli")` returns the top-level
+    `samcli`, so each recursive call re-walks the whole tree from the root -- 108k
+    membership checks for 658 modules. Optional so existing two-argument callers work.
+    """
+    if seen is None:
+        seen = set(visited)
     for pkg in pkgutil.walk_packages(module.__path__, module.__name__ + "."):
-        if pkg.name in visited:
+        if pkg.name in seen:
             continue
+        seen.add(pkg.name)
         visited.append(pkg.name)
         if pkg.ispkg:
             submodule = __import__(pkg.name)
-            walk_modules(submodule, visited)
+            walk_modules(submodule, visited, seen)
 
 
 samcli_modules = ["samcli"]

--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -26,6 +26,20 @@ LOG = logging.getLogger(__name__)
 APIGW_REQUESTS_TO_WARM_UP = 20
 
 
+# pytest 9.1 deprecated class-scoped fixtures declared as instance methods, because
+# attributes they set on `self` are invisible to tests (each test gets a fresh instance
+# while the fixture runs once per class). The fixtures below assign to the class instead,
+# so the hazard the warning exists to catch does not apply. Marked on the class rather
+# than in pytest.ini so the rest of the suite still fails on it, and rather than with a
+# module-level `pytestmark` because subclasses live in other modules (test_sync_adl.py,
+# test_sync_build_in_source.py) and a module mark would not reach them -- a class mark is
+# inherited.
+#
+# Without this, `filterwarnings = error` turns the warning into a setup failure on the
+# first test of the class, and pytest then raises its own internal AssertionError
+# ("assert not self._finalizers") for the remaining tests (pytest-dev/pytest#14775).
+# Remove once these fixtures are converted -- required before pytest 10 drops this.
+@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
 class LogsIntegTestCases(LogsIntegBase):
     test_template_folder = ""
 

--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -30,10 +30,8 @@ APIGW_REQUESTS_TO_WARM_UP = 20
 # attributes they set on `self` are invisible to tests (each test gets a fresh instance
 # while the fixture runs once per class). The fixtures below assign to the class instead,
 # so the hazard the warning exists to catch does not apply. Marked on the class rather
-# than in pytest.ini so the rest of the suite still fails on it, and rather than with a
-# module-level `pytestmark` because subclasses live in other modules (test_sync_adl.py,
-# test_sync_build_in_source.py) and a module mark would not reach them -- a class mark is
-# inherited.
+# than in pytest.ini so the rest of the suite still fails on this warning; the two
+# subclasses below inherit it.
 #
 # Without this, `filterwarnings = error` turns the warning into a setup failure on the
 # first test of the class, and pytest then raises its own internal AssertionError

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -39,6 +39,20 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
 LOG = logging.getLogger(__name__)
 
 
+# pytest 9.1 deprecated class-scoped fixtures declared as instance methods, because
+# attributes they set on `self` are invisible to tests (each test gets a fresh instance
+# while the fixture runs once per class). The fixtures below assign to the class instead,
+# so the hazard the warning exists to catch does not apply. Marked on the class rather
+# than in pytest.ini so the rest of the suite still fails on it, and rather than with a
+# module-level `pytestmark` because subclasses live in other modules (test_sync_adl.py,
+# test_sync_build_in_source.py) and a module mark would not reach them -- a class mark is
+# inherited.
+#
+# Without this, `filterwarnings = error` turns the warning into a setup failure on the
+# first test of the class, and pytest then raises its own internal AssertionError
+# ("assert not self._finalizers") for the remaining tests (pytest-dev/pytest#14775).
+# Remove once these fixtures are converted -- required before pytest 10 drops this.
+@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
 class TestSyncCodeBase(SyncIntegBase):
     stack_name = ""
     template_path = ""

--- a/tests/integration/traces/test_traces_command.py
+++ b/tests/integration/traces/test_traces_command.py
@@ -30,6 +30,20 @@ SKIP_TRACES_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_
 
 
 @skipIf(SKIP_TRACES_TESTS, "Skip traces tests in CI/CD only")
+# pytest 9.1 deprecated class-scoped fixtures declared as instance methods, because
+# attributes they set on `self` are invisible to tests (each test gets a fresh instance
+# while the fixture runs once per class). The fixtures below assign to the class instead,
+# so the hazard the warning exists to catch does not apply. Marked on the class rather
+# than in pytest.ini so the rest of the suite still fails on it, and rather than with a
+# module-level `pytestmark` because subclasses live in other modules (test_sync_adl.py,
+# test_sync_build_in_source.py) and a module mark would not reach them -- a class mark is
+# inherited.
+#
+# Without this, `filterwarnings = error` turns the warning into a setup failure on the
+# first test of the class, and pytest then raises its own internal AssertionError
+# ("assert not self._finalizers") for the remaining tests (pytest-dev/pytest#14775).
+# Remove once these fixtures are converted -- required before pytest 10 drops this.
+@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
 @pytest.mark.xdist_group(name="sam_traces")
 class TestTracesCommand(TracesIntegBase):
     stack_resources: List[Any] = []

--- a/tests/integration/traces/test_traces_command.py
+++ b/tests/integration/traces/test_traces_command.py
@@ -34,10 +34,7 @@ SKIP_TRACES_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_
 # attributes they set on `self` are invisible to tests (each test gets a fresh instance
 # while the fixture runs once per class). The fixtures below assign to the class instead,
 # so the hazard the warning exists to catch does not apply. Marked on the class rather
-# than in pytest.ini so the rest of the suite still fails on it, and rather than with a
-# module-level `pytestmark` because subclasses live in other modules (test_sync_adl.py,
-# test_sync_build_in_source.py) and a module mark would not reach them -- a class mark is
-# inherited.
+# than in pytest.ini so the rest of the suite still fails on this warning.
 #
 # Without this, `filterwarnings = error` turns the warning into a setup failure on the
 # first test of the class, and pytest then raises its own internal AssertionError

--- a/tests/unit/cli/test_pyinstaller_imports.py
+++ b/tests/unit/cli/test_pyinstaller_imports.py
@@ -73,3 +73,34 @@ class TestWalkModules(TestCase):
         hidden_imports.walk_modules(my_test_module, modules)
         self.assertNotIn("my_non_existant_module", modules)
         del sys.modules["my_test_module"]
+
+    def test_walk_modules_order_is_deterministic_and_sorted(self):
+        """SAM_CLI_HIDDEN_IMPORTS relies on walk_modules being order-stable.
+
+        It decides what pyinstaller bundles, so an unstable order makes builds
+        non-reproducible; it is also the parameter source for the tests above, and
+        pytest-xdist aborts the run if workers collect in different orders. That used
+        to happen because the modules were collected into a set.
+
+        Collecting into a list is deterministic, and sorted because
+        `pkgutil.walk_packages` walks children in sorted order
+        (`_iter_file_finder_modules` calls `os.listdir(...).sort()`). That sort is
+        per-importer rather than a language guarantee, so assert it here instead of
+        re-sorting at import time.
+        """
+        my_test_module = __import__("my_test_module")
+        first = ["my_test_module"]
+        hidden_imports.walk_modules(my_test_module, first)
+        second = ["my_test_module"]
+        hidden_imports.walk_modules(my_test_module, second)
+
+        self.assertEqual(first, second, "walk_modules returned a different order for the same tree")
+        self.assertEqual(first, sorted(first), f"walk_modules order is not sorted: {first}")
+        del sys.modules["my_test_module"]
+
+    def test_hidden_imports_discovered_modules_are_sorted(self):
+        """The real samcli walk, not the fixture tree -- this is what gets bundled."""
+        discovered = hidden_imports.samcli_modules
+
+        self.assertEqual(discovered, sorted(discovered))
+        self.assertEqual(len(discovered), len(set(discovered)), "duplicate modules collected")

--- a/tests/unit/cli/test_pyinstaller_imports.py
+++ b/tests/unit/cli/test_pyinstaller_imports.py
@@ -48,16 +48,28 @@ class TestWalkModules(TestCase):
 
     def test_walk_modules_contains_all_modules(self):
         my_test_module = __import__("my_test_module")
-        modules = set(["my_test_module"])
+        modules = ["my_test_module"]
         hidden_imports.walk_modules(my_test_module, modules)
         self.assertIn("my_test_module", modules)
         self.assertIn("my_test_module.my_submodule", modules)
         self.assertIn("my_test_module.another_submodule", modules)
         del sys.modules["my_test_module"]
 
+    def test_walk_modules_does_not_add_duplicates(self):
+        """walk_modules dedups via `if pkg.name in visited`, which is why it can collect
+        into a list -- the set it used to take was redundant."""
+        my_test_module = __import__("my_test_module")
+        modules = ["my_test_module"]
+        hidden_imports.walk_modules(my_test_module, modules)
+        hidden_imports.walk_modules(my_test_module, modules)
+        self.assertEqual(len(modules), len(set(modules)))
+        del sys.modules["my_test_module"]
+
     def test_walk_modules_not_contain_nonexistent_module(self):
         my_test_module = __import__("my_test_module")
-        modules = set("my_test_module")
+        # Was `set("my_test_module")`, which built a set of individual characters rather
+        # than a one-element collection holding the module name.
+        modules = ["my_test_module"]
         hidden_imports.walk_modules(my_test_module, modules)
         self.assertNotIn("my_non_existant_module", modules)
         del sys.modules["my_test_module"]

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -678,7 +678,11 @@ class TestLambdaContainer_get_debug_settings(TestCase):
 
         self.assertIsNotNone(container_env_vars)
 
-    @parameterized.expand([param(r) for r in set(RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT)])
+    # Iterate the list directly rather than a set: set iteration order for strings varies
+    # between processes (hash randomization), so each pytest-xdist worker generated the
+    # parameterized cases in a different order and the run aborted with "Different tests
+    # were collected between workers". The list has no duplicates, so the set was a no-op.
+    @parameterized.expand([param(r) for r in RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT])
     def test_debug_arg_must_be_split_by_spaces_and_appended_to_bootstrap_based_entrypoint(self, runtime):
         """
         Debug args list is appended as arguments to bootstrap-args, which is past the fourth position in the array


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?

Nightly integration tests have failed in **sync-code** and **sync-watch** on every run since pytest was bumped 9.0.3 → 9.1.1 ([#9095](https://github.com/aws/aws-sam-cli/pull/9095), 2026-07-31).

| Run | pytest | sync-code |
|---|---|---|
| 2026-07-30 (last pre-bump) | 9.0.3 | **success** — 89 passed, 1 rerun |
| [2026-08-14](https://github.com/aws/aws-sam-cli/actions/runs/31767764162/job/94667045345) | 9.1.1 | **failure** — 37 passed, 52 errors, 156 rerun |

The logs show only pytest's *own* internal assertion, `assert not self._finalizers` (`_pytest/fixtures.py:1221`), with no indication of the real cause. Reproducible in ten lines, no AWS needed:

```python
class TestFixt:
    @pytest.fixture(scope="class")
    def fixt(self): yield
    def test_1(self, fixt): pass
    def test_2(self, fixt): pass
```

```
pytest 9.0.3           -> 2 passed
pytest 9.1.1 -W error  -> 2 errors
```

Four links:

1. **pytest 9.1 deprecated class-scoped fixtures declared as instance methods** (`PytestRemovedIn10Warning`). `TestSyncCodeBase.execute_infra_sync` / `sync_code_base` are exactly this shape (`test_sync_code.py:49,84`).
2. **`pytest.ini` sets `filterwarnings = error`**, turning that warning into a setup failure on the first test of every affected class.
3. **pytest then raises its own internal `AssertionError`** for the remaining tests in the class — upstream [pytest-dev/pytest#14775](https://github.com/pytest-dev/pytest/issues/14775), still open. Root cause is `fixtures.py:1147`: `finish()` early-returns when `cached_result is None` *without clearing* `_finalizers`, on an assumption that no longer holds.
4. **`--reruns 3` hides the cause.** `pytest-rerunfailures` reports only the final attempt, so the real warning is discarded and only the internal `AssertionError` survives — which is why the CI logs contain **zero** occurrences of the actual error.

Confirmed link 4 directly, same test with and without `--reruns`:

```
without --reruns:  test_1 => PytestRemovedIn10Warning   <- real cause
                   test_2 => AssertionError
with --reruns 3:   test_1 => AssertionError             <- cause gone
```

The counts line up exactly: 52 errors × 3 reruns = 156 reruns (sync-watch: 12 × 3 = 36).

**Blast radius** is one shared base class — `TestSyncCodeBase`, inherited by `test_sync_code.py`, `test_sync_build_in_source.py` and `test_sync_adl.py`, which is why a single cause took out both sync-code and sync-watch. The same fixture pattern also exists in `test_logs_command.py:41,58` and `test_traces_command.py:44,61`.

#### How does it address the issue?

Marks the warning as ignored on the three classes that declare these fixtures — `TestSyncCodeBase`, `LogsIntegTestCases`, `TestTracesCommand`.

This is safe **here specifically**: those fixtures assign to the class (`TestSyncCodeBase.stack_name = ...`), not to `self`, so the hazard the deprecation exists to catch — attributes set on `self` being invisible to tests — does not apply to them. They are only using a pattern pytest wants gone.

A **class** mark rather than a repo-wide `pytest.ini` entry, so the rest of the suite still fails on this warning (verified: a new unmarked class-scoped instance-method fixture added elsewhere still errors). And a class mark rather than a module-level `pytestmark`, because `pytestmark` is module-scoped while `TestSyncCodeBase` is subclassed from *other* modules — which is precisely why one base class took out both sync-code and sync-watch. Verified both directions:

| | subclass in another module |
|---|---|
| module-level `pytestmark` on the base's module | still errors |
| class-level mark on the base | passes |

Confirmed at runtime that all six affected classes inherit the mark, including `TestSyncCode_BuildInSource_Esbuild` and `TestSyncAdlCasesWithCodeParameter`.

Also fixes two unrelated sources of **nondeterministic test collection**, found while verifying the above. Both come from iterating a set of strings: hash randomization makes that order differ per process, so each `pytest-xdist` worker generated a different parameterized case list and the run aborted with *"Different tests were collected between workers"* (13 errors).

- `test_lambda_container.py` wrapped an already-duplicate-free 15-item list in `set()` — verified 15 items, 15 unique, so the `set()` was a no-op.
- `hidden_imports.py` built `SAM_CLI_HIDDEN_IMPORTS` via `list(set(...))`. This also made **pyinstaller's hidden-import list unstable between builds**. Now collected into a list, which is deterministic on its own — the set was redundant, since `walk_modules` already dedups via `if pkg.name in visited`.

  No `sorted()`: `pkgutil.walk_packages` already walks children in sorted order (`_iter_file_finder_modules` calls `os.listdir(...).sort()`). That sort is per-importer rather than a language guarantee — `iter_importer_modules` is a `simplegeneric` dispatch — so instead of re-sorting at import time, the invariant is asserted by two new tests: one over the fixture tree (same order twice, and sorted) and one over the real `samcli` walk. `SAM_CLI_HIDDEN_IMPORTS` is byte-identical across three separate interpreters, and identical to the previously sorted output.

  Measured before switching, since a list makes the membership check O(n): 658 modules, `in` costs 0.80 ms vs 0.008 ms for a set — once, at import.

#### What side effects does this change have?

**Deferred, not avoided:** converting those fixtures is required before pytest 10 removes the behaviour. I left it out deliberately — it is not mechanical. `execute_infra_sync` derives its stack name from `self._method_to_stack_name(self.id())`, and `unittest`'s `id()` needs an instance, so any conversion changes live CloudFormation stack names. All three autouse fixtures also assert via `self.assertEqual`, which under `@classmethod` would silently bind the first argument as `self` rather than fail loudly. That belongs in its own PR, verified against real AWS. The `pytest.ini` comment records this.

**Nondeterminism fixes change no CI behaviour.** CI runs unit tests serially via `make pr`, so the 13 collection errors were local-only; this makes `pytest -n auto` usable locally, where it previously aborted.

**Known follow-up:** with collection fixed, `-n auto` surfaces pre-existing test-isolation failures that the collection abort previously made unreachable. The count and the affected tests **vary between runs** — I observed 4, 5, 6 and 10 across repeated runs, spread over three files:

```
tests/unit/local/lambda_service/test_local_lambda_http_service.py   (RuntimeError: Working outside of request context)
tests/unit/commands/deploy/test_guided_config.py
tests/unit/lib/sync/flows/test_rest_api_sync_flow.py
```

That variance is itself the diagnosis: which tests fail depends on how xdist distributes them across workers, i.e. order-dependent cross-test pollution. They pass serially (9386 passed) and pass when each file runs alone under xdist, so this is not a regression from this change, and it is **not reachable in CI**, which runs unit tests serially. Leading suspect is `test_import_module_proxy.py` reassigning `importlib.import_module` globally in `setUpClass`. Left for a separate PR — worth fixing, but it is a distinct problem from the pytest 9.1 breakage this PR unblocks.

#### Testing

- Verified against the repo's real `pytest.ini`: repro goes **6 errors → 6 passed**, and reverting *only* `pytest.ini` restores the 6 errors
- `tests/integration/{sync,logs,traces}` collect: **266 tests**
- Unit tests serial (what CI runs): **9388 passed**, 25 skipped, 28 subtests passed
- Unit tests `-n auto`: **13 collection errors → 0**; suite now completes
- `black`, `ruff`, `mypy` (1377 files) clean; `make schema` produces no diff

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests


