### PR TITLE
fix: SamConfig.get_all() mutates shared document, leaking one command's params into another's

### DIFF
--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -89,9 +89,9 @@ class SamConfig:
         config_content = self.document.get(env, {})
         params = config_content.get(self.to_key(cmd_names), {}).get(section, {})
         if DEFAULT_GLOBAL_CMDNAME in config_content:
-            global_params = config_content.get(DEFAULT_GLOBAL_CMDNAME, {}).get(section, {})
-            global_params.update(params.copy())
-            params = global_params.copy()
+            global_params = dict(config_content.get(DEFAULT_GLOBAL_CMDNAME, {}).get(section, {}))
+            global_params.update(params)
+            params = global_params
         return params
 
     def put(self, cmd_names, section, key, value, env=DEFAULT_ENV):

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -178,6 +178,41 @@ class TestSamConfig(TestCase):
             self.samconfig.document["myEnv"][DEFAULT_GLOBAL_CMDNAME]["mySection"], {"testKey": "ValueFromGlobal"}
         )
 
+    def test_get_all_does_not_leak_command_params_into_global_across_calls(self):
+        """Regression test: a prior get_all() call for one command must not pollute the
+        global section that a later get_all() call for a different command inherits from.
+        """
+        self._update_samconfig(
+            cmd_names=[DEFAULT_GLOBAL_CMDNAME],
+            section="parameters",
+            key="stack_name",
+            value="global-stack",
+            env="myEnv",
+        )
+        self._update_samconfig(
+            cmd_names=["deploy"], section="parameters", key="stack_name", value="deploy-only-stack", env="myEnv"
+        )
+        self._update_samconfig(cmd_names=["deploy"], section="parameters", key="region", value="us-east-1", env="myEnv")
+
+        self.assertEqual(
+            {"stack_name": "deploy-only-stack", "region": "us-east-1"},
+            self.samconfig.get_all(cmd_names=["deploy"], section="parameters", env="myEnv"),
+        )
+
+        # "build" has no command-specific parameters, so it must resolve to only the
+        # true global default. It must not inherit "deploy"'s command-specific values.
+        self.assertEqual(
+            {"stack_name": "global-stack"},
+            self.samconfig.get_all(cmd_names=["build"], section="parameters", env="myEnv"),
+        )
+
+        # Calling get_all() for "deploy" again must still return deploy's own values,
+        # not a further-corrupted mix.
+        self.assertEqual(
+            {"stack_name": "deploy-only-stack", "region": "us-east-1"},
+            self.samconfig.get_all(cmd_names=["deploy"], section="parameters", env="myEnv"),
+        )
+
     def test_check_config_get(self):
         self._setup_config()
         self.assertEqual(


### PR DESCRIPTION
### Which issue(s) does this change fix?

Fixes #9181

### Why is this change necessary?

`SamConfig.get_all()` merged the current command's section-specific parameters into the `[global]` section using a **live reference** into `self.document` rather than a copy:

```python
global_params = config_content.get(DEFAULT_GLOBAL_CMDNAME, {}).get(section, {})
global_params.update(params.copy())
params = global_params.copy()
```

`global_params` here is the actual dict stored inside `self.document["<env>"]["global"][section]`. Calling `.update()` on it permanently writes the current command's values into the shared global section. Since `self.document` is cached across calls (`_read()` only re-reads from disk when `self.document` is falsy), this corruption persists in memory for the lifetime of the `SamConfig` instance.

The result: if a `SamConfig` object is reused across multiple `get_all()` calls for different commands (a valid, documented use of the public API — `get_all()` takes `cmd_names` per call for exactly this purpose), a later command silently inherits an earlier command's parameter values instead of the true global default.

### How does this change work?

Copy the global-section dict before merging into it, instead of mutating the dict stored in `self.document`:

```python
global_params = dict(config_content.get(DEFAULT_GLOBAL_CMDNAME, {}).get(section, {}))
global_params.update(params)
params = global_params
```

### What tests ran and what were the results?

Added a regression test, `test_get_all_does_not_leak_command_params_into_global_across_calls`, in `tests/unit/lib/samconfig/test_samconfig.py`. It fails against the pre-fix code (reproducing the exact leak: `build`'s resolved config wrongly includes `deploy`'s `stack_name`/`region`) and passes after the fix.

Full unit suite (`tests/unit`) passes: 9387 passed, 25 skipped.
`mypy` on the changed file: clean.

### Checklist

- [x] Add/update tests for this change
- [x] `make pr` passes locally (unit tests + mypy on changed files; full local `make pr` target run via `pytest tests/unit -q` and scoped `mypy`)
- [x] Write a clear PR title and description

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*