### PR TITLE
fix: raise on ambiguous resource ID collision across sibling nested stacks

### DIFF
--- a/samcli/commands/local/cli_common/user_exceptions.py
+++ b/samcli/commands/local/cli_common/user_exceptions.py
@@ -47,6 +47,12 @@ class ResourceNotFound(UserException):
     """
 
 
+class AmbiguousResourceIdentifier(UserException):
+    """
+    A bare resource logical ID (without a stack path) matched resources in more than one stack
+    """
+
+
 class InvalidLayerVersionArn(UserException):
     """
     The LayerVersion Arn given in the template is Invalid

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -896,35 +896,40 @@ def get_resource_by_id(
         `sam sync --resource-id`), so that specific case is now a clear, actionable error instead.
     """
     search_all_stacks = not identifier.stack_path and not explicit_nested
-    matches: List[Tuple[Stack, Dict[str, Any]]] = []
+    matches: List[Tuple[Stack, str, Dict[str, Any]]] = []
     for stack in stacks:
         if stack.stack_path == identifier.stack_path or search_all_stacks:
             found_resource = None
+            found_resource_id = None
             for logical_id, resource in stack.resources.items():
                 resource_id = ResourceMetadataNormalizer.get_resource_id(resource, logical_id)
                 if resource_id == identifier.resource_iac_id or (
                     not identifier.stack_path and logical_id == identifier.resource_iac_id
                 ):
                     found_resource = resource
+                    found_resource_id = resource_id
                     break
 
             if found_resource:
                 if not stack.stack_path:
                     # The root stack always takes priority over nested stacks.
                     return cast(Dict[str, Any], found_resource)
-                matches.append((stack, found_resource))
+                matches.append((stack, cast(str, found_resource_id), found_resource))
                 if not search_all_stacks:
                     break
 
     if len(matches) > 1:
-        colliding_paths = [get_full_path(stack.stack_path, identifier.resource_iac_id) for stack, _ in matches]
+        # Build the remediation paths from the *matched* (normalized) resource ID, not the raw
+        # identifier the user typed: for CDK/SamResourceId resources the two can differ, and a
+        # path built from the raw logical ID would never resolve on retry.
+        colliding_paths = [get_full_path(stack.stack_path, resource_id) for stack, resource_id, _ in matches]
         raise AmbiguousResourceIdentifier(
             f"Resource ID '{identifier.resource_iac_id}' is ambiguous: it matches resources in more than one "
             f"nested stack ({', '.join(colliding_paths)}). Qualify it with the full stack path, "
             f"e.g. '{colliding_paths[0]}'."
         )
 
-    return cast(Dict[str, Any], matches[0][1]) if matches else None
+    return cast(Dict[str, Any], matches[0][2]) if matches else None
 
 
 def get_resource_full_path_by_id(stacks: List[Stack], identifier: ResourceIdentifier) -> Optional[str]:
@@ -1091,8 +1096,7 @@ def get_function_build_info(
         loadable = imageuri and check_path_valid_type(imageuri) and Path(imageuri).is_file()
         if not buildable and not loadable:
             LOG.debug(
-                "Skip Building %s function, as it is missing either Dockerfile or DockerContext "
-                "metadata properties.",
+                "Skip Building %s function, as it is missing either Dockerfile or DockerContext metadata properties.",
                 full_path,
             )
             return FunctionBuildInfo.NonBuildableImage

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -11,9 +11,10 @@ from collections import namedtuple
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Union, cast
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Union, cast
 
 from samcli.commands.local.cli_common.user_exceptions import (
+    AmbiguousResourceIdentifier,
     InvalidFunctionPropertyType,
     InvalidLayerVersionArn,
     UnsupportedIntrinsic,
@@ -883,8 +884,19 @@ def get_resource_by_id(
     -------
     Dict
         Resource dict
+
+    Raises
+    ------
+    AmbiguousResourceIdentifier
+        If a bare logical ID (no stack path given) matches resources in more than one *nested*
+        stack, with no match in the root stack to prefer. The root stack, if it has a match, always
+        takes priority (this is relied upon by existing behavior); but silently picking the first
+        nested-stack match in stack-list order when there is no root match - and more than one
+        nested stack collides - could operate on the wrong physical resource (e.g.
+        `sam sync --resource-id`), so that specific case is now a clear, actionable error instead.
     """
     search_all_stacks = not identifier.stack_path and not explicit_nested
+    matches: List[Tuple[Stack, Dict[str, Any]]] = []
     for stack in stacks:
         if stack.stack_path == identifier.stack_path or search_all_stacks:
             found_resource = None
@@ -897,8 +909,22 @@ def get_resource_by_id(
                     break
 
             if found_resource:
-                return cast(Dict[str, Any], found_resource)
-    return None
+                if not stack.stack_path:
+                    # The root stack always takes priority over nested stacks.
+                    return cast(Dict[str, Any], found_resource)
+                matches.append((stack, found_resource))
+                if not search_all_stacks:
+                    break
+
+    if len(matches) > 1:
+        colliding_paths = [get_full_path(stack.stack_path, identifier.resource_iac_id) for stack, _ in matches]
+        raise AmbiguousResourceIdentifier(
+            f"Resource ID '{identifier.resource_iac_id}' is ambiguous: it matches resources in more than one "
+            f"nested stack ({', '.join(colliding_paths)}). Qualify it with the full stack path, "
+            f"e.g. '{colliding_paths[0]}'."
+        )
+
+    return cast(Dict[str, Any], matches[0][1]) if matches else None
 
 
 def get_resource_full_path_by_id(stacks: List[Stack], identifier: ResourceIdentifier) -> Optional[str]:

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -941,7 +941,16 @@ def get_resource_full_path_by_id(stacks: List[Stack], identifier: ResourceIdenti
     -------
     str
         return resource full path
+
+    Raises
+    ------
+    AmbiguousResourceIdentifier
+        If a bare logical ID (no stack path given) matches resources in more than one *nested*
+        stack, with no match in the root stack to prefer. Mirrors the precedence/ambiguity rule
+        enforced by get_resource_by_id, so the two entry points cannot disagree on what a bare ID
+        resolves to.
     """
+    matches: List[str] = []
     for stack in stacks:
         if identifier.stack_path and identifier.stack_path != stack.stack_path:
             continue
@@ -950,8 +959,19 @@ def get_resource_full_path_by_id(stacks: List[Stack], identifier: ResourceIdenti
             if resource_id == identifier.resource_iac_id or (
                 not identifier.stack_path and logical_id == identifier.resource_iac_id
             ):
-                return get_full_path(stack.stack_path, resource_id)
-    return None
+                if not stack.stack_path:
+                    # The root stack always takes priority over nested stacks.
+                    return get_full_path(stack.stack_path, resource_id)
+                matches.append(get_full_path(stack.stack_path, resource_id))
+                break
+
+    if len(matches) > 1:
+        raise AmbiguousResourceIdentifier(
+            f"Resource ID '{identifier.resource_iac_id}' is ambiguous: it matches resources in more than one "
+            f"nested stack ({', '.join(matches)}). Qualify it with the full stack path, e.g. '{matches[0]}'."
+        )
+
+    return matches[0] if matches else None
 
 
 def get_resource_ids_by_type(stacks: List[Stack], resource_type: str) -> List[ResourceIdentifier]:

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -954,6 +954,18 @@ def get_resource_full_path_by_id(stacks: List[Stack], identifier: ResourceIdenti
         stack, with no match in the root stack to prefer. Mirrors the precedence/ambiguity rule
         enforced by get_resource_by_id, so the two entry points cannot disagree on what a bare ID
         resolves to.
+
+        Note this function is also used outside `sam sync --resource-id` (package_context,
+        guided_context, image_repository_validation, all mapping a user-supplied image function
+        ID to an image repository URI): an ambiguous match there means the wrong function could
+        silently receive the wrong image repository, which is the same "operates on the wrong
+        physical resource" hazard this function exists to prevent for sync, so raising here is
+        intentional rather than sync-specific. This is a deliberately *stricter* policy than
+        `SamFunctionProvider.get()` (used by e.g. `sam local invoke`), which instead warns and
+        picks the alphabetically-first match; that entry point resolves a *running* local
+        function for interactive use, where a warning is recoverable, whereas the callers of this
+        function feed the result into a deploy/package/validation decision without a further
+        confirmation step.
     """
     matches: List[str] = []
     for stack in stacks:

--- a/tests/unit/commands/local/lib/test_provider.py
+++ b/tests/unit/commands/local/lib/test_provider.py
@@ -913,6 +913,67 @@ class TestGetResourceFullPathByID(TestCase):
         self.assertEqual(expected_full_path, full_path)
 
 
+class TestGetResourceFullPathByIDAmbiguousNestedStacks(TestCase):
+    """
+    Regression tests mirroring TestGetResourceByIDAmbiguousNestedStacks: get_resource_full_path_by_id
+    must apply the same root-stack-priority and nested-stack-ambiguity rules as get_resource_by_id,
+    so the two entry points cannot disagree on what a bare resource ID resolves to.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.root_stack = MagicMock()
+        self.root_stack.stack_path = ""
+        self.root_stack.resources = {}
+
+        self.nested_stack_a = MagicMock()
+        self.nested_stack_a.stack_path = "NestedStackA"
+        self.nested_stack_a.resources = {"Function1": {"Properties": "BodyA"}}
+
+        self.nested_stack_b = MagicMock()
+        self.nested_stack_b.stack_path = "NestedStackB"
+        self.nested_stack_b.resources = {"Function1": {"Properties": "BodyB"}}
+
+    def test_raises_when_two_sibling_nested_stacks_collide(self):
+        resource_identifier = MagicMock()
+        resource_identifier.stack_path = ""
+        resource_identifier.resource_iac_id = "Function1"
+
+        with self.assertRaises(AmbiguousResourceIdentifier):
+            get_resource_full_path_by_id(
+                [self.root_stack, self.nested_stack_a, self.nested_stack_b], resource_identifier
+            )
+
+    def test_does_not_raise_when_only_one_nested_stack_matches(self):
+        resource_identifier = MagicMock()
+        resource_identifier.stack_path = ""
+        resource_identifier.resource_iac_id = "Function1"
+
+        result = get_resource_full_path_by_id([self.root_stack, self.nested_stack_a], resource_identifier)
+        self.assertEqual(result, "NestedStackA/Function1")
+
+    def test_does_not_raise_when_explicitly_qualified_with_stack_path(self):
+        resource_identifier = MagicMock()
+        resource_identifier.stack_path = "NestedStackA"
+        resource_identifier.resource_iac_id = "Function1"
+
+        result = get_resource_full_path_by_id(
+            [self.root_stack, self.nested_stack_a, self.nested_stack_b], resource_identifier
+        )
+        self.assertEqual(result, "NestedStackA/Function1")
+
+    def test_root_stack_takes_priority_over_nested_match(self):
+        self.root_stack.resources = {"Function1": {"Properties": "RootBody"}}
+        resource_identifier = MagicMock()
+        resource_identifier.stack_path = ""
+        resource_identifier.resource_iac_id = "Function1"
+
+        result = get_resource_full_path_by_id(
+            [self.nested_stack_a, self.nested_stack_b, self.root_stack], resource_identifier
+        )
+        self.assertEqual(result, "Function1")
+
+
 class TestGetStack(TestCase):
     root_stack = Stack("", "Root", "template.yaml", None, {})
     child_stack = Stack("Root", "Child", "root_stack/template.yaml", None, {})

--- a/tests/unit/commands/local/lib/test_provider.py
+++ b/tests/unit/commands/local/lib/test_provider.py
@@ -701,6 +701,45 @@ class TestGetResourceByIDAmbiguousNestedStacks(TestCase):
         )
         self.assertEqual(result, self.nested_stack_a.resources["Function1"])
 
+    def test_ambiguity_error_suggests_a_path_that_actually_resolves_for_cdk_resources(self):
+        """Regression test: the collision message must be built from the *normalized* resource ID
+        (ResourceMetadataNormalizer.get_resource_id, e.g. from a CDK resource's SamResourceId
+        metadata), not the raw logical ID the user typed. Otherwise, for a bare logical ID that
+        only matches via the SamResourceId fallback, the suggested qualified path
+        ('NestedStackA/<logicalId>') can never resolve, since a stack-qualified lookup only
+        matches on the normalized ID -- sending the user to a dead end.
+        """
+        nested_stack_a = MagicMock()
+        nested_stack_a.stack_path = "NestedStackA"
+        nested_stack_a.resources = {
+            "Function1": {"Properties": "BodyA", "Metadata": {"SamResourceId": "Function1-x"}},
+        }
+        nested_stack_b = MagicMock()
+        nested_stack_b.stack_path = "NestedStackB"
+        nested_stack_b.resources = {
+            "Function1": {"Properties": "BodyB", "Metadata": {"SamResourceId": "Function1-x"}},
+        }
+
+        resource_identifier = MagicMock()
+        resource_identifier.stack_path = ""
+        resource_identifier.resource_iac_id = "Function1"
+
+        with self.assertRaises(AmbiguousResourceIdentifier) as ctx:
+            get_resource_by_id([self.root_stack, nested_stack_a, nested_stack_b], resource_identifier, False)
+
+        message = str(ctx.exception)
+        self.assertIn("NestedStackA/Function1-x", message)
+        self.assertIn("NestedStackB/Function1-x", message)
+        # The un-resolvable, raw-logical-ID-qualified form must not appear as the suggestion.
+        self.assertNotIn("NestedStackA/Function1'", message)
+
+        # And the suggested qualified path must actually resolve.
+        qualified_identifier = MagicMock()
+        qualified_identifier.stack_path = "NestedStackA"
+        qualified_identifier.resource_iac_id = "Function1-x"
+        result = get_resource_by_id([self.root_stack, nested_stack_a, nested_stack_b], qualified_identifier, False)
+        self.assertEqual(result, nested_stack_a.resources["Function1"])
+
 
 class TestGetResourceIDsByType(TestCase):
     def setUp(self) -> None:

--- a/tests/unit/commands/local/lib/test_provider.py
+++ b/tests/unit/commands/local/lib/test_provider.py
@@ -21,6 +21,7 @@ from samcli.lib.providers.provider import (
     FunctionBuildInfo,
 )
 from samcli.commands.local.cli_common.user_exceptions import (
+    AmbiguousResourceIdentifier,
     InvalidLayerVersionArn,
     UnsupportedIntrinsic,
     InvalidFunctionPropertyType,
@@ -650,6 +651,55 @@ class TestGetResourceByID(TestCase):
             [self.root_stack, self.nested_stack, self.nested_nested_stack], resource_identifier, False
         )
         self.assertEqual(result, None)
+
+
+class TestGetResourceByIDAmbiguousNestedStacks(TestCase):
+    """
+    Regression tests: a bare (unqualified) resource ID that matches resources in more than one
+    *nested* stack, with no root-stack resource to prefer, used to silently return whichever
+    stack happened to come first in the input list - which could point sync/invoke/logs operations
+    at the wrong deployed physical resource. This must now raise AmbiguousResourceIdentifier instead.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.root_stack = MagicMock()
+        self.root_stack.stack_path = ""
+        self.root_stack.resources = {}
+
+        self.nested_stack_a = MagicMock()
+        self.nested_stack_a.stack_path = "NestedStackA"
+        self.nested_stack_a.resources = {"Function1": {"Properties": "BodyA"}}
+
+        self.nested_stack_b = MagicMock()
+        self.nested_stack_b.stack_path = "NestedStackB"
+        self.nested_stack_b.resources = {"Function1": {"Properties": "BodyB"}}
+
+    def test_raises_when_two_sibling_nested_stacks_collide(self):
+        resource_identifier = MagicMock()
+        resource_identifier.stack_path = ""
+        resource_identifier.resource_iac_id = "Function1"
+
+        with self.assertRaises(AmbiguousResourceIdentifier):
+            get_resource_by_id([self.root_stack, self.nested_stack_a, self.nested_stack_b], resource_identifier, False)
+
+    def test_does_not_raise_when_only_one_nested_stack_matches(self):
+        resource_identifier = MagicMock()
+        resource_identifier.stack_path = ""
+        resource_identifier.resource_iac_id = "Function1"
+
+        result = get_resource_by_id([self.root_stack, self.nested_stack_a], resource_identifier, False)
+        self.assertEqual(result, self.nested_stack_a.resources["Function1"])
+
+    def test_does_not_raise_when_explicitly_qualified_with_stack_path(self):
+        resource_identifier = MagicMock()
+        resource_identifier.stack_path = "NestedStackA"
+        resource_identifier.resource_iac_id = "Function1"
+
+        result = get_resource_by_id(
+            [self.root_stack, self.nested_stack_a, self.nested_stack_b], resource_identifier, False
+        )
+        self.assertEqual(result, self.nested_stack_a.resources["Function1"])
 
 
 class TestGetResourceIDsByType(TestCase):


### PR DESCRIPTION
Fixes #9185.

## Which issue(s) does this change fix?

#9185

## Scope note (added after review)

`get_resource_by_id()` and `get_resource_full_path_by_id()` are also used outside `sam sync`
--- `package_context.py`, `guided_context.py`, and `image_repository_validation.py` all call
`get_resource_full_path_by_id()` to map a user-supplied `--image-repositories` function ID to a
repository URI. The new `AmbiguousResourceIdentifier` therefore now also reaches
`sam package`/`sam deploy --guided`/image-repository validation for a template with two sibling
nested stacks sharing a logical ID that a user references there, not just the `sam sync
--resource-id` path this PR was originally scoped around. This is intentional (see the extended
docstring on `get_resource_full_path_by_id`): mapping an image repository to the wrong function is
the same "operates on the wrong resource" hazard motivating this whole change, and unlike `sam
sync`'s interactive usage there is no further confirmation step before it's baked into a deploy.
Flagging explicitly since it widens this PR's user-facing blast radius beyond the issue it was
filed against.

## Why is this change necessary?

`get_resource_by_id()` (`samcli/lib/providers/provider.py`) resolves a bare, unqualified resource logical ID (e.g. what \`sam sync --resource-id Function1\` and the underlying file-watch/code-trigger machinery for \`sam sync --watch\` use) by searching every stack and returning the first match, with no check for ambiguity:

```python
for stack in stacks:
    if stack.stack_path == identifier.stack_path or search_all_stacks:
        ...
        if found_resource:
            return cast(Dict[str, Any], found_resource)   # first match wins, silently
```

If two different **nested** stacks both contain a resource with the same logical ID, and there's no root-stack resource with that ID to prefer, this silently returns whichever stack happens to come first in the internal stack list — no error, no warning. Since \`sam sync\` bypasses full CloudFormation deployment and pushes local code changes directly to the resolved physical resource, an ambiguous \`--resource-id\` can silently push code to the wrong live, deployed Lambda function (or other resource).

## What does this change do?

Changes \`get_resource_by_id\` to detect this specific case and raise a new \`AmbiguousResourceIdentifier\` (a \`UserException\`, matching the existing \`ResourceNotFound\` etc. in \`samcli/commands/local/cli_common/user_exceptions.py\`) with a message telling the user how to disambiguate using the existing \`Stack/ResourceId\` identifier syntax that \`ResourceIdentifier\` already parses.

Importantly, this **preserves** the existing, intentional, and already-tested precedence rule that a root-stack resource always wins over a same-named nested-stack resource for a bare ID (see \`TestGetResourceByID::test_get_resource_by_id_implicit_root\`, which deliberately constructs a root-vs-nested collision and asserts root wins — that test still passes unchanged). The new error only fires for the previously-unhandled case: no root match, and two or more *nested* stacks collide.

## Description of how you validated changes

Added \`TestGetResourceByIDAmbiguousNestedStacks\` to \`tests/unit/commands/local/lib/test_provider.py\`:
- raises \`AmbiguousResourceIdentifier\` when two sibling nested stacks both have a matching resource and there's no root match
- does not raise when only one nested stack matches
- does not raise when the caller explicitly qualifies the ID with a stack path

All 118 tests in \`tests/unit/commands/local/lib/test_provider.py\` pass (115 existing + 3 new), including all pre-existing root/nested precedence tests, unchanged. Also ran the full \`tests/unit/lib/sync/\`, \`tests/unit/lib/utils/test_resource_trigger.py\`, \`tests/unit/lib/utils/test_code_trigger_factory.py\`, \`tests/unit/lib/utils/test_resource_type_based_factory.py\`, and \`tests/unit/lib/providers/\` suites (374 passed, 4 skipped, all pre-existing skips) — no regressions in any of \`get_resource_by_id\`'s call sites. \`black --check\` clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md) doc
- [x] Local run of \`brazil-build test\`/\`pytest\` passes for the affected tests (ran via a local venv + pytest directly)
- [x] Added unit tests covering the new behavior
- [ ] Added integration tests (not applicable — internal resolver bug, fully covered by unit tests; the failure mode requires two nested stacks with a colliding logical ID, which is exercised by the new unit test fixtures)
- [x] Did not modify or add to generated files

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
