### PR TITLE
tests: unblock nightly sync integ tests on pytest 9.1

### DIFF
--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -27,7 +27,7 @@ APIGW_REQUESTS_TO_WARM_UP = 20
 
 
 # Deprecated in pytest 9.1. Fix before pytest 10.
-@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
+@pytest.mark.filterwarnings("ignore::pytest.PytestRemovedIn10Warning")
 class LogsIntegTestCases(LogsIntegBase):
     test_template_folder = ""
 

--- a/tests/integration/logs/test_logs_command.py
+++ b/tests/integration/logs/test_logs_command.py
@@ -26,6 +26,8 @@ LOG = logging.getLogger(__name__)
 APIGW_REQUESTS_TO_WARM_UP = 20
 
 
+# Deprecated in pytest 9.1. Fix before pytest 10.
+@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
 class LogsIntegTestCases(LogsIntegBase):
     test_template_folder = ""
 

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -40,7 +40,7 @@ LOG = logging.getLogger(__name__)
 
 
 # Deprecated in pytest 9.1. Fix before pytest 10.
-@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
+@pytest.mark.filterwarnings("ignore::pytest.PytestRemovedIn10Warning")
 class TestSyncCodeBase(SyncIntegBase):
     stack_name = ""
     template_path = ""

--- a/tests/integration/sync/test_sync_code.py
+++ b/tests/integration/sync/test_sync_code.py
@@ -39,6 +39,8 @@ CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".
 LOG = logging.getLogger(__name__)
 
 
+# Deprecated in pytest 9.1. Fix before pytest 10.
+@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
 class TestSyncCodeBase(SyncIntegBase):
     stack_name = ""
     template_path = ""

--- a/tests/integration/traces/test_traces_command.py
+++ b/tests/integration/traces/test_traces_command.py
@@ -31,7 +31,7 @@ SKIP_TRACES_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_
 
 @skipIf(SKIP_TRACES_TESTS, "Skip traces tests in CI/CD only")
 # Deprecated in pytest 9.1. Fix before pytest 10.
-@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
+@pytest.mark.filterwarnings("ignore::pytest.PytestRemovedIn10Warning")
 @pytest.mark.xdist_group(name="sam_traces")
 class TestTracesCommand(TracesIntegBase):
     stack_resources: List[Any] = []

--- a/tests/integration/traces/test_traces_command.py
+++ b/tests/integration/traces/test_traces_command.py
@@ -30,6 +30,8 @@ SKIP_TRACES_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_
 
 
 @skipIf(SKIP_TRACES_TESTS, "Skip traces tests in CI/CD only")
+# Deprecated in pytest 9.1. Fix before pytest 10.
+@pytest.mark.filterwarnings("ignore:.*Class-scoped fixture defined as instance method.*")
 @pytest.mark.xdist_group(name="sam_traces")
 class TestTracesCommand(TracesIntegBase):
     stack_resources: List[Any] = []


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?

**sync-code** and **sync-watch** have failed on every scheduled integration run since pytest was bumped 9.0.3 → 9.1.1 ([#9095](https://github.com/aws/aws-sam-cli/pull/9095), 2026-07-31).

| Run | pytest | sync-code |
|---|---|---|
| 2026-07-30 (last pre-bump) | 9.0.3 | **success** — 89 passed, 1 rerun |
| [2026-08-14](https://github.com/aws/aws-sam-cli/actions/runs/31767764162/job/94667045345) | 9.1.1 | **failure** — 37 passed, 52 errors, 156 rerun |

The logs show only pytest's *own* internal assertion, `assert not self._finalizers` (`_pytest/fixtures.py:1221`), with nothing pointing at the real cause. Reproducible in ten lines, no AWS needed:

```python
class TestFixt:
    @pytest.fixture(scope="class")
    def fixt(self): yield
    def test_1(self, fixt): pass
    def test_2(self, fixt): pass
```

```
pytest 9.0.3           -> 2 passed
pytest 9.1.1 -W error  -> 2 errors
```

Four links:

1. **pytest 9.1 deprecated class-scoped fixtures declared as instance methods** (`PytestRemovedIn10Warning`). `TestSyncCodeBase.execute_infra_sync` / `sync_code_base` are exactly this shape.
2. **`pytest.ini` sets `filterwarnings = error`**, turning that warning into a setup failure on the first test of every affected class.
3. **pytest then raises its own internal `AssertionError`** for the remaining tests in the class — upstream [pytest-dev/pytest#14775](https://github.com/pytest-dev/pytest/issues/14775), still open. Root cause is `fixtures.py:1147`: `finish()` early-returns when `cached_result is None` *without clearing* `_finalizers`.
4. **`--reruns 3` hides the cause.** `pytest-rerunfailures` reports only the final attempt, so the real warning is discarded and only the internal `AssertionError` survives — which is why the CI logs contain **zero** occurrences of the actual error.

Confirmed link 4 directly, same test with and without `--reruns`:

```
without --reruns:  test_1 => PytestRemovedIn10Warning   <- real cause
                   test_2 => AssertionError
with --reruns 3:   test_1 => AssertionError             <- cause gone
```

The counts line up exactly: 52 errors × 3 reruns = 156 reruns (sync-watch: 12 × 3 = 36).

#### How does it address the issue?

Marks the warning as ignored on the three classes that declare these fixtures — `TestSyncCodeBase`, `LogsIntegTestCases`, `TestTracesCommand`. Six lines total.

Safe **here specifically**: these fixtures assign to the class (`TestSyncCodeBase.stack_name = ...`), not to `self`, so the hazard the deprecation warns about — attributes set on `self` being invisible to tests — does not apply to them.

A **class** mark rather than a `pytest.ini` entry, so the rest of the suite still fails on this warning. And a class mark rather than a module-level `pytestmark`, because `pytestmark` is module-scoped while `TestSyncCodeBase` is subclassed from *other* modules (`test_sync_build_in_source.py`, `test_sync_adl.py`) — which is precisely why one base class took out both sync-code and sync-watch.

#### What side effects does this change have?

**Deferred, not avoided:** converting these fixtures is required before pytest 10 removes the behaviour. Left out on purpose — it is not mechanical. `execute_infra_sync` derives its stack name from `self._method_to_stack_name(self.id())`, and `unittest`'s `id()` needs an instance, so any conversion changes live CloudFormation stack names. All three autouse fixtures also assert via `self.assertEqual`, which under `@classmethod` would bind the first argument as `self` rather than fail loudly. That belongs in its own PR, verified against real AWS.

#### Testing

- Against the repo's real `pytest.ini`, the same parameterized class-scoped shape goes **6 errors → 6 passed** with the mark
- An **unmarked** equivalent still errors, so suite-wide protection is intact
- Confirmed pytest resolves the mark through the MRO for subclasses carrying their own marks (`TestLogsCommandWithRegularStack`)
- `tests/integration/{sync,logs,traces}` collect **266 tests**; `black` and `ruff` clean

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
