### PR TITLE
tests: move provided.al2 to the deprecated lint list and stop rerunning a non-rerun-safe sync test

### DIFF
--- a/tests/integration/sync/test_sync_adl.py
+++ b/tests/integration/sync/test_sync_adl.py
@@ -2,6 +2,8 @@ import json
 import os.path
 from unittest import skipIf
 
+import pytest
+
 from samcli.commands._utils.experimental import set_experimental, ExperimentalFlag
 from samcli.lib.utils.resources import AWS_LAMBDA_FUNCTION, AWS_LAMBDA_LAYERVERSION
 from tests.integration.sync.sync_integ_base import SyncIntegBase
@@ -16,6 +18,8 @@ class TestSyncAdlCasesWithCodeParameter(TestSyncCodeBase):
     folder = "code"
     dependency_layer = True
 
+    # Not rerun-safe: it edits test data in place and the class-scoped infra sync is not redone.
+    @pytest.mark.flaky(reruns=0)
     def test_sync_code_function_without_dependencies(self):
         # CFN Api call here to collect all the stack resources
         self.stack_resources = self._get_stacks(TestSyncCode.stack_name)

--- a/tests/integration/validate/test_validate_command.py
+++ b/tests/integration/validate/test_validate_command.py
@@ -162,6 +162,7 @@ class TestValidate(TestCase):
             ("ruby3.2",),
             ("dotnet6",),
             ("nodejs20.x"),
+            ("provided.al2",),
         ]
     )
     def test_lint_deprecated_runtimes(self, runtime):
@@ -215,7 +216,6 @@ class TestValidate(TestCase):
             "java8.al2",
             "nodejs22.x",
             "nodejs24.x",
-            "provided.al2",
             "provided.al2023",
             "python3.10",
             "python3.11",


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A

#### Why is this change necessary?

Two failures from last night's integration runs ([32094973517](https://github.com/aws/aws-sam-cli/actions/runs/32094973517), [32122795247](https://github.com/aws/aws-sam-cli/actions/runs/32122795247)).

For context, the pytest 9.1 unblock (#9189) landed cleanly — `sync-code` passes again, and `other-and-e2e` went from **135 errors → 0** (all 81 nested-stack logs tests now run). These two are the unrelated leftovers.

**1. `test_lint_supported_runtimes` — fails in both runs, systematic**

cfn-lint marks `provided.al2` EOL as of **2026-07-31**, so `sam validate --lint` now exits 1 while the test asserts 0:

```
W2531: Runtime 'provided.al2' was deprecated on '2026-07-31'.
Error: Linting failed. At least one linting rule was matched to the provided template.
```

A time bomb rather than a flake — it began failing after that date and fails every run until fixed.

**2. `TestSyncAdlCasesWithCodeParameter.test_sync_code_function_without_dependencies` — sync-watch**

Reruns cannot help this test and actively hide why it failed. It edits test data in place (`update_file` writes over `code/before/python_function_no_deps/app.py`) and the class-scoped fixture that deploys the stack does not re-run, so once attempt 1 has mutated the tree the retries run against inconsistent state.

That is exactly what the reported error was. The function came back:

```
Unable to import module 'app': No module named 'numpy'
```

so `_get_lambda_response` returned `None` (error payloads have no `body`) and the failure surfaced as `TypeError: the JSON object must be str, bytes or bytearray, not NoneType` — three wasted deploy cycles and none of the original cause. Pre-bump this job had 0 reruns and the test passed.

#### How does it address the issue?

**`provided.al2`** moves out of `supported_runtimes` and into `test_lint_deprecated_runtimes`, which derives the expected code (`W2531`/`E2531`/`E2533`) from cfn-lint's `LmbdRuntimeLifecycle.json` **by date** — so it needs no further edits as the runtime moves through create-block and update-block. Same treatment as `ruby3.2` in #8883 and `nodejs20.x` in #8947, except those were deleted rather than moved.

I checked the rest of the list: only `provided.al2` is flagged today. `java8.al2` is still clean and is the likely next one.

**The sync test** gets `@pytest.mark.flaky(reruns=0)`, so it reports the real first-attempt failure immediately instead of a misleading artifact three deploys later. Transient invoke flakes are still covered — `_get_lambda_response` retries internally.

#### What side effects does this change have?

`reruns=0` means a genuine pre-mutation flake in that one test now fails the build rather than being retried. That is the intended trade: the test cannot pass on a rerun anyway, so the retries only cost time and obscure the cause.

Worth flagging for a follow-up: **26** `update_file` calls write into `code/before` — `test_sync_adl.py` (6), `test_sync_code.py` (2), `test_sync_watch.py` (20) — so the same rerun-unsafety applies wherever one of those fails after mutating. Only the test that actually failed is marked here; making them rerun-safe (restoring the tree, or re-running the infra sync) is a larger change and belongs on its own.

#### Testing

- With `SAM_CLI_DEV=1` (as CI sets), `test_lint_supported_runtimes` and all 7 `test_lint_deprecated_runtimes` cases pass — **8 passed**. Note a local run without `SAM_CLI_DEV` tests the *installed* `sam`, whose older bundled cfn-lint does not flag `provided.al2`
- Verified `reruns=0` is honoured: 1 attempt versus 4 for an unmarked test
- `tests/integration/{sync,validate}` collect 153 tests; `black` and `ruff` clean

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
