### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ![SAM CLI Version](https://img.shields.io/github/release/aws/aws-sam-cli.svg?label=CLI%20Version)
 ![Install](https://img.shields.io/badge/brew-aws/tap/aws--sam--cli-orange)
 ![pip](https://img.shields.io/badge/pip-aws--sam--cli-9cf)
+[![software health](https://img.shields.io/endpoint?url=https%3A%2F%2Finspect.software%2Fbadge%2Fv1%2Faws%2Faws-sam-cli.json)](https://inspect.software/software/aws/aws-sam-cli)
 
 [Installation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) | [Blogs](https://serverlessland.com/blog?tag=AWS%20SAM) | [Videos](https://serverlessland.com/video?tag=AWS%20SAM) | [AWS Docs](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) | [Roadmap](https://github.com/aws/aws-sam-cli/wiki/SAM-CLI-Roadmap) | [Try It Out](https://s12d.com/jKo46elk) | [Slack Us](https://join.slack.com/t/awsdevelopers/shared_invite/zt-yryddays-C9fkWrmguDv0h2EEDzCqvw)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![SAM CLI Version](https://img.shields.io/github/release/aws/aws-sam-cli.svg?label=CLI%20Version)
 ![Install](https://img.shields.io/badge/brew-aws/tap/aws--sam--cli-orange)
 ![pip](https://img.shields.io/badge/pip-aws--sam--cli-9cf)
-[![software health](https://img.shields.io/endpoint?url=https%3A%2F%2Finspect.software%2Fbadge%2Fv1%2Faws%2Faws-sam-cli.json)](https://inspect.software/software/aws/aws-sam-cli)
+[![software health](https://img.shields.io/badge/software%20health-AAA-177b5e)](https://inspect.software/software/aws/aws-sam-cli)
 
 [Installation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) | [Blogs](https://serverlessland.com/blog?tag=AWS%20SAM) | [Videos](https://serverlessland.com/video?tag=AWS%20SAM) | [AWS Docs](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) | [Roadmap](https://github.com/aws/aws-sam-cli/wiki/SAM-CLI-Roadmap) | [Try It Out](https://s12d.com/jKo46elk) | [Slack Us](https://join.slack.com/t/awsdevelopers/shared_invite/zt-yryddays-C9fkWrmguDv0h2EEDzCqvw)
 


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
This project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). The badge makes that standing objectively visible. The index is a free public good, and ratings cannot be bought.

**Technical details** (revised after review — see the discussion below):
- **No runtime dependency:** a static shields.io badge in the same `/badge/` form as the `brew` and `pip` badges already in this README. The label, value and colour are literal text committed in the file; nothing is fetched from inspect.software when the README or the PyPI page renders.
- **Changing it requires a PR here:** the rating is fixed text, not a live value. It does not update on its own — refreshing it would mean a new pull request to this repository.
- **Transparent:** links to the [full report](https://inspect.software/software/aws/aws-sam-cli), based on the open [methodology](https://inspect.software/methodology). The report stays current regardless of the badge.

Earlier revisions of this PR used a mutable image and then a shields.io `endpoint` badge; both let content be resolved at render time by an outside service, which the review objected to. That is no longer the case.

If you prefer to keep the README minimal, feel free to close this PR without replying. The report remains publicly available and up to date either way.
