### PR TITLE
fix(tests): move publish templates off deprecated python3.9

### DIFF
--- a/tests/integration/testdata/publish/template_create_app.yaml
+++ b/tests/integration/testdata/publish/template_create_app.yaml
@@ -33,6 +33,6 @@ Resources:
             Path: /hello
           Type: Api
       Handler: main.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.14
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/integration/testdata/publish/template_create_app_version.yaml
+++ b/tests/integration/testdata/publish/template_create_app_version.yaml
@@ -33,6 +33,6 @@ Resources:
             Path: /hello
           Type: Api
       Handler: main.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.14
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/integration/testdata/publish/template_create_app_with_license_body.yaml
+++ b/tests/integration/testdata/publish/template_create_app_with_license_body.yaml
@@ -32,6 +32,6 @@ Resources:
             Path: /hello
           Type: Api
       Handler: main.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.14
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/integration/testdata/publish/template_create_app_with_readme_body.yaml
+++ b/tests/integration/testdata/publish/template_create_app_with_readme_body.yaml
@@ -32,6 +32,6 @@ Resources:
             Path: /hello
           Type: Api
       Handler: main.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.14
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/integration/testdata/publish/template_not_packaged.yaml
+++ b/tests/integration/testdata/publish/template_not_packaged.yaml
@@ -33,6 +33,6 @@ Resources:
             Path: /hello
           Type: Api
       Handler: main.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.14
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31

--- a/tests/integration/testdata/publish/template_update_app.yaml
+++ b/tests/integration/testdata/publish/template_update_app.yaml
@@ -33,6 +33,6 @@ Resources:
             Path: /hello
           Type: Api
       Handler: main.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.14
     Type: AWS::Serverless::Function
 Transform: AWS::Serverless-2016-10-31


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A — found in the 2026-08-31 nightly ([run 33379671789](https://github.com/aws/aws-sam-cli/actions/runs/33379671789)).

#### Why is this change necessary?
All 8 `tests/integration/publish/test_command_integ.py` tests fail because the Serverless Application Repository now refuses the runtime the test templates declare:

```
botocore.errorfactory.BadRequestException: An error occurred (BadRequestException)
when calling the CreateApplication operation: The following runtimes are no longer
supported for creating AWS Lambda functions: [python3.9]
```

This is a real API rejection rather than a flake, so it will keep failing every night until the templates move to a supported runtime.

#### How does it address the issue?
Changes `Runtime: python3.9` to `python3.14` in the six `tests/integration/testdata/publish/` templates. One line each; nothing else.

Scoped deliberately:

- **`tests/integration/validate/test_validate_command.py` keeps `python3.9`.** That test asserts cfn-lint flags *deprecated* runtimes, so 3.9 is the point of it — it passed in the same run and must not be touched.
- Other suites still use `python3.9` in test data (`start_api`, `invoke`, `buildcmd` and others), but those run against local images rather than the control plane and all passed in this run — `deploy`, `package`, `sync-code`, `sync-watch` and `cloud-based-tests` were all green. So the rejection is currently specific to SAR `CreateApplication`, and I have not pre-emptively churned templates that are working.

#### What side effects does this change have?
None expected. `python3.14` is already a supported runtime throughout SAM CLI (`samcli/local/common/runtime_template.py`, `samcli/lib/utils/architecture.py`, `samcli/lib/build/workflow_config.py`, `samcli/local/docker/lambda_image.py`).

Verified before committing:
- The expected-output files these tests compare against (`metadata_*.json`) do not contain the runtime, and `test_command_integ.py` asserts no runtime string, so the change cannot shift an expected value.
- All six templates still parse, with `Resources.HelloWorldFunction.Properties.Runtime` reading `python3.14`.
- `make pr` passes (9401 unit tests, 94.09% coverage).

The publish tests themselves need AWS credentials, so they run in CI rather than locally.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
