### PR TITLE
fix(tests): derive the sam init parameter guidance from the command

### DIFF
--- a/tests/integration/init/test_init_command.py
+++ b/tests/integration/init/test_init_command.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 
 from samcli.cli.global_config import GlobalConfig
 from samcli.commands.init import cli as init_cmd
+from samcli.commands.init.command import NON_INTERACTIVE_PARAM_COMBINATIONS, REQUIRED_PARAMS_HINT
 from unittest import TestCase, skipIf
 
 from parameterized import parameterized
@@ -672,20 +673,30 @@ class TestBasicInitCommand(TestCase):
         self.assertEqual(result.process.returncode, 0)
 
 
-MISSING_REQUIRED_PARAM_MESSAGE = """Error: Missing required parameters, with --no-interactive set.
-Must provide one of the following required parameter combinations:
-\t--name, --location
-\t--name, --package-type, --base-image
-\t--name, --runtime, --dependency-manager, --app-template
-You can also re-run without the --no-interactive flag to be prompted for required values.
-"""
+# The accepted combinations are re-rendered from the command so that changing them cannot leave
+# these expectations behind, while the wording around them stays written out here to be asserted.
+def _render_combinations(separator: str) -> str:
+    return (
+        separator.join(
+            "\t" + ", ".join(f"--{param.replace('_', '-')}" for param in combination)
+            for combination in NON_INTERACTIVE_PARAM_COMBINATIONS
+        )
+        + "\n"
+    )
 
-INCOMPATIBLE_PARAM_MESSAGE = """Error: You must not provide both the --{0} and --{1} parameters.
-You can run 'sam init' without any options for an interactive initialization flow, or you can provide one of the following required parameter combinations:
-\t--name, --location, or
-\t--name, --package-type, --base-image, or
-\t--name, --runtime, --app-template, --dependency-manager
-"""
+
+MISSING_REQUIRED_PARAM_MESSAGE = (
+    "Error: Missing required parameters, with --no-interactive set.\n"
+    "Must provide one of the following required parameter combinations:\n"
+    + _render_combinations("\n")
+    + REQUIRED_PARAMS_HINT
+)
+
+INCOMPATIBLE_PARAM_MESSAGE = (
+    "Error: You must not provide both the --{0} and --{1} parameters.\n"
+    "You can run 'sam init' without any options for an interactive initialization flow, "
+    "or you can provide one of the following required parameter combinations:\n" + _render_combinations(", or\n")
+)
 
 
 @pytest.mark.xdist_group(name="sam_init")


### PR DESCRIPTION
#### Which issue(s) does this change fix?
N/A — 4 nightly failures, e.g. [run 33379671789](https://github.com/aws/aws-sam-cli/actions/runs/33379671789).

#### Why is this change necessary?
Four `TestInitForParametersCompatibility` tests fail on an expected string that no longer matches what `sam init` prints:

```
expected: --name, --runtime, --app-template, --dependency-manager
actual:   --name, --runtime, --dependency-manager, --app-template
```

#9176 replaced the hand-written `INCOMPATIBLE_PARAMS_HINT` with one generated from `NON_INTERACTIVE_PARAM_COMBINATIONS`, which is also passed as `required_param_lists` — so the hint can no longer drift from the check it describes. That list orders `--dependency-manager` first, so the printed message changed and the test's hardcoded copy was left behind.

It escaped PR CI because that class is `pr_skip` and runs only in the nightly.

#### How does it address the issue?
Rather than restate the new order and wait for the next drift, only the part that drifts is derived. `_render_combinations()` re-renders the accepted combinations from `NON_INTERACTIVE_PARAM_COMBINATIONS`, and the wording around them stays written out in the test so it is still asserted. Both messages share it, with the separator each one uses (`"\n"` for the missing-parameters list, `", or\n"` for the hint).

`MISSING_REQUIRED_PARAM_MESSAGE` was not failing, but it restated the same list and would have drifted next — it only matched because it happened to track a message `ClickMutex` has always generated from that list.

Deliberately not importing the rendered hint wholesale: that would make the assertion self-referential, so a bad edit to the hint's wording or separators would change both sides at once and the tests would stay green. Nothing else in the suite pins that user-facing string.

#### What side effects does this change have?
Verified against the real CLI via `CliRunner` rather than by comparing the constants to themselves — all five messages the tests assert, all exit code 2:

```
app-template/location      exit=2 match=True
runtime/location           exit=2 match=True
base-image/location        exit=2 match=True
package-type/location      exit=2 match=True
missing-required           exit=2 match=True
```

Then confirmed both halves of the intent by mutating the command and re-running with no test change:

```
list reordered to ['name','app_template','dependency_manager','runtime']  -> assertion passes
", or" separator broken to ","                                            -> assertion FAILS
```

The first is the maintenance burden this removes; the second is the wording protection it keeps.

One trade-off worth naming: in the nightly release runs these constants come from the checked-out source while the assertion is against the installed binary, so the tests now also require those two to agree. For a nightly built from the same commit that is the correct expectation, and it replaces a failure mode where a stale copy could disagree with both.

`make pr` passes (9401 unit tests, 94.09% coverage).

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
