### PR TITLE
fix(sync): keep the watch alive when the definition file cannot be read

### DIFF
--- a/samcli/lib/utils/definition_validator.py
+++ b/samcli/lib/utils/definition_validator.py
@@ -1,16 +1,19 @@
 """DefinitionValidator for Validating YAML and JSON Files"""
 
 import logging
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 import yaml
 from watchdog.events import FileOpenedEvent, FileSystemEvent
 
-from samcli.lib.utils.retry import retry
 from samcli.yamlhelper import parse_yaml_file
 
 LOG = logging.getLogger(__name__)
+
+FILE_READ_ATTEMPTS = 3
+FILE_READ_RETRY_DELAY = 0.1
 
 
 class DefinitionValidator:
@@ -95,13 +98,22 @@ It may be locked by another process. The change will not be synced until the fil
             return False
         return True
 
-    @retry(exc=OSError, exc_raise=OSError, exc_raise_msg="File cannot be read.")
     def _parse_file(self) -> Dict[str, Any]:
-        """Read and parse the definition file, retrying while it is unreadable.
+        """Read and parse the definition file, retrying while it is locked by another process.
 
         Returns
         -------
         Dict[str, Any]
             Parsed content of the definition file.
         """
-        return parse_yaml_file(str(self._path))
+        remaining_attempts = FILE_READ_ATTEMPTS
+        delay = FILE_READ_RETRY_DELAY
+        while True:
+            try:
+                return parse_yaml_file(str(self._path))
+            except PermissionError:
+                remaining_attempts -= 1
+                if not remaining_attempts:
+                    raise
+                time.sleep(delay)
+                delay *= 2

--- a/samcli/lib/utils/definition_validator.py
+++ b/samcli/lib/utils/definition_validator.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 import yaml
 from watchdog.events import FileOpenedEvent, FileSystemEvent
 
+from samcli.lib.utils.retry import retry
 from samcli.yamlhelper import parse_yaml_file
 
 LOG = logging.getLogger(__name__)
@@ -75,7 +76,7 @@ class DefinitionValidator:
             return False
 
         try:
-            self._data = parse_yaml_file(str(self._path))
+            self._data = self._parse_file()
         except (ValueError, yaml.YAMLError) as e:
             LOG.debug(
                 "File %s failed to validate due to it file cannot be parsed. \
@@ -84,4 +85,23 @@ Please verify that file is in the correct json or yaml format.",
                 exc_info=e,
             )
             return False
+        except OSError as e:
+            LOG.warning(
+                "File %s failed to validate because it cannot be read. \
+It may be locked by another process. The change will not be synced until the file is saved again.",
+                self._path,
+                exc_info=e,
+            )
+            return False
         return True
+
+    @retry(exc=OSError, exc_raise=OSError, exc_raise_msg="File cannot be read.")
+    def _parse_file(self) -> Dict[str, Any]:
+        """Read and parse the definition file, retrying while it is unreadable.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Parsed content of the definition file.
+        """
+        return parse_yaml_file(str(self._path))

--- a/samcli/lib/utils/definition_validator.py
+++ b/samcli/lib/utils/definition_validator.py
@@ -91,7 +91,7 @@ Please verify that file is in the correct json or yaml format.",
         except OSError as e:
             LOG.warning(
                 "File %s failed to validate because it cannot be read. \
-It may be locked by another process. The change will not be synced until the file is saved again.",
+The change will not be synced until the file is saved again.",
                 self._path,
                 exc_info=e,
             )

--- a/tests/unit/lib/utils/test_definition_validator.py
+++ b/tests/unit/lib/utils/test_definition_validator.py
@@ -69,3 +69,19 @@ class TestDefinitionValidator(TestCase):
         validator = DefinitionValidator(self.path, detect_change=True, initialize_data=True)
         event = FileOpenedEvent("src_path")
         self.assertFalse(validator.validate_change(event))
+
+    @patch("samcli.lib.utils.retry.time.sleep")
+    @patch("samcli.lib.utils.definition_validator.parse_yaml_file")
+    def test_detect_change_retries_unreadable_file(self, parse_yaml_file_mock, sleep_mock):
+        parse_yaml_file_mock.side_effect = [{"A": 1}, PermissionError(13, "Permission denied"), {"B": 1}]
+
+        validator = DefinitionValidator(self.path, detect_change=True, initialize_data=True)
+        self.assertTrue(validator.validate_change())
+
+    @patch("samcli.lib.utils.retry.time.sleep")
+    @patch("samcli.lib.utils.definition_validator.parse_yaml_file")
+    def test_detect_change_unreadable_file(self, parse_yaml_file_mock, sleep_mock):
+        parse_yaml_file_mock.side_effect = PermissionError(13, "Permission denied")
+
+        validator = DefinitionValidator(self.path, detect_change=True, initialize_data=False)
+        self.assertFalse(validator.validate_change())

--- a/tests/unit/lib/utils/test_definition_validator.py
+++ b/tests/unit/lib/utils/test_definition_validator.py
@@ -70,18 +70,28 @@ class TestDefinitionValidator(TestCase):
         event = FileOpenedEvent("src_path")
         self.assertFalse(validator.validate_change(event))
 
-    @patch("samcli.lib.utils.retry.time.sleep")
+    @patch("samcli.lib.utils.definition_validator.time.sleep")
     @patch("samcli.lib.utils.definition_validator.parse_yaml_file")
-    def test_detect_change_retries_unreadable_file(self, parse_yaml_file_mock, sleep_mock):
+    def test_detect_change_retries_locked_file(self, parse_yaml_file_mock, sleep_mock):
         parse_yaml_file_mock.side_effect = [{"A": 1}, PermissionError(13, "Permission denied"), {"B": 1}]
 
         validator = DefinitionValidator(self.path, detect_change=True, initialize_data=True)
         self.assertTrue(validator.validate_change())
 
-    @patch("samcli.lib.utils.retry.time.sleep")
+    @patch("samcli.lib.utils.definition_validator.time.sleep")
     @patch("samcli.lib.utils.definition_validator.parse_yaml_file")
-    def test_detect_change_unreadable_file(self, parse_yaml_file_mock, sleep_mock):
+    def test_detect_change_locked_file(self, parse_yaml_file_mock, sleep_mock):
         parse_yaml_file_mock.side_effect = PermissionError(13, "Permission denied")
 
         validator = DefinitionValidator(self.path, detect_change=True, initialize_data=False)
         self.assertFalse(validator.validate_change())
+        self.assertEqual(parse_yaml_file_mock.call_count, 3)
+
+    @patch("samcli.lib.utils.definition_validator.time.sleep")
+    @patch("samcli.lib.utils.definition_validator.parse_yaml_file")
+    def test_detect_change_unreadable_file(self, parse_yaml_file_mock, sleep_mock):
+        parse_yaml_file_mock.side_effect = IsADirectoryError(21, "Is a directory")
+
+        validator = DefinitionValidator(self.path, detect_change=True, initialize_data=False)
+        self.assertFalse(validator.validate_change())
+        self.assertEqual(parse_yaml_file_mock.call_count, 1)


### PR DESCRIPTION
#### Which issue(s) does this change fix?
#9173

#### Why is this change necessary?
`sam sync --watch` stops noticing template edits after a single read failure. Editors that save atomically briefly hold the file, so the watchdog read can hit `PermissionError: [Errno 13]` on Windows. `DefinitionValidator.validate_file` only catches `ValueError` and `yaml.YAMLError`, so the `OSError` travels up through `_validator_wrapper` into watchdog's dispatch loop and kills the observer thread. Code sync carries on, so nothing tells the user that infra sync is dead until they restart `sam sync`.

Reproduced by making `parse_yaml_file` raise `PermissionError` once for a real `TemplateTrigger` and `HandlerObserver`: the traceback matches the one in the issue, the observer thread is gone afterwards, and later template writes fire no callback.

#### How does it address the issue?
`validate_file` now retries the read up to three times on `PermissionError`, backing off 0.1s then 0.2s, which covers the millisecond-scale lock an atomic save takes. If the file is still locked, or the read fails for any other `OSError`, it logs a warning naming the file and returns `False`, the same way it already handles an unparseable file, so the observer keeps running.

#### What side effects does this change have?
A locked file costs up to 0.3s in watchdog's dispatch thread before the read gives up, which delays other watched resources for that long since they share the thread. Only `PermissionError` is retried, so any other read failure still returns immediately.

A definition file that stays unreadable now produces a warning per file event instead of a crash. `TemplateTrigger.validate_template` also changes at sync startup: a read failure there used to abort `sam sync --watch`, and now raises `InvalidTemplateFile`, which `WatchManager` already catches and reports the same way it reports an unparseable template.

#### Mandatory Checklist
**PRs will only be reviewed after checklist is complete**

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/aws-sam-cli/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Add input/output [type hints](https://docs.python.org/3/library/typing.html) to new functions/methods
- [x] Write design document if needed ([Do I need to write a design document?](https://github.com/aws/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.md#design-document))
- [x] Write/update unit tests
- [x] Write/update integration tests
- [x] Write/update functional tests if needed
- [x] `make pr` passes
- [x] `make update-reproducible-reqs` if dependencies were changed
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
