### PR TITLE
fix: fall back to an absolute path when relpath crosses drives

### DIFF
--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -399,11 +399,19 @@ def _resolve_relative_to(path, original_root, new_root):
         return None
 
     # Value is definitely a relative path. Change it relative to the destination directory
-    return os.path.relpath(
-        # Resolve the paths to take care of symlinks
-        os.path.normpath(os.path.join(pathlib.Path(original_root).resolve(), path)),
-        pathlib.Path(new_root).resolve(),  # Absolute original path w.r.t ``original_root``
-    )  # Resolve the original path with respect to ``new_root``
+    # Resolve the paths to take care of symlinks
+    absolute_path = os.path.normpath(os.path.join(pathlib.Path(original_root).resolve(), path))
+    try:
+        return os.path.relpath(
+            absolute_path,
+            pathlib.Path(new_root).resolve(),  # Absolute original path w.r.t ``original_root``
+        )  # Resolve the original path with respect to ``new_root``
+    except ValueError:
+        # os.path.relpath raises ValueError when the two paths are on different drives or
+        # UNC mounts, which happens on Windows when the template and the build directory
+        # are not on the same drive. A relative path cannot express that, so fall back to
+        # the absolute path rather than letting the exception escape.
+        return absolute_path
 
 
 def get_template_parameters(template_file):

--- a/tests/unit/commands/_utils/test_template.py
+++ b/tests/unit/commands/_utils/test_template.py
@@ -1,7 +1,9 @@
 import copy
 import os
+import pathlib
+import platform
 import tempfile
-from unittest import TestCase
+from unittest import TestCase, skipIf
 from unittest.mock import patch, mock_open, MagicMock
 import shutil
 
@@ -800,6 +802,19 @@ class Test_resolve_relative_to(TestCase):
         # new_path = /path/from/root/scratchdir/newlink -> /path/from/root/scratchdir/another/destination
         # relative path must be ../../some/srcfoo/bar
         expected_result = os.path.join("..", "..", "some", "src", self.curpath)
+
+        self.assertEqual(result, expected_result)
+
+    @skipIf(platform.system() != "Windows", "Different drives only exist on Windows")
+    def test_must_resolve_relative_to_across_different_drives(self):
+        # os.path.relpath raises ValueError when the two paths are on different drives,
+        # so a template on one drive and a --build-dir on another cannot be expressed
+        # relatively. Fall back to the absolute path rather than crashing.
+        original_root = os.path.join("C:" + os.sep, "src")
+        new_root = os.path.join("D:" + os.sep, "destination")
+        expected_result = os.path.normpath(os.path.join(pathlib.Path(original_root).resolve(), self.curpath))
+
+        result = _resolve_relative_to(self.curpath, original_root, new_root)
 
         self.assertEqual(result, expected_result)
 


### PR DESCRIPTION
Fixes #3474.

`os.path.relpath` raises `ValueError` across drives, so `sam build` crashes when the template and build directory are on different ones. `_resolve_relative_to` now falls back to the absolute path, as @wchengru suggested. Only the crashing case changes.

- [x] Review the generative AI contribution guidelines
- [ ] Add type hints to new functions/methods
- [x] Write/update unit tests
- [ ] Write design document if needed
- [ ] Write/update integration tests
- [ ] Write/update functional tests if needed
- [ ] `make pr` passes
- [ ] `make update-reproducible-reqs` if dependencies were changed
- [ ] Write documentation

Unchecked items do not apply here. Not full `make pr`: `black`, `ruff` and `mypy` are clean, and the three affected suites go 259 to 260 passed, same 3 pre-existing symlink failures. `skipIf`-guarded, so your `windows-latest` matrix runs it.

AI-assisted; I reproduced the crash and ran the tests myself.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
